### PR TITLE
Show query cache

### DIFF
--- a/pgdog/src/admin/mod.rs
+++ b/pgdog/src/admin/mod.rs
@@ -15,6 +15,7 @@ pub mod show_clients;
 pub mod show_config;
 pub mod show_peers;
 pub mod show_pools;
+pub mod show_query_cache;
 pub mod show_servers;
 
 pub use error::Error;

--- a/pgdog/src/admin/mod.rs
+++ b/pgdog/src/admin/mod.rs
@@ -11,6 +11,7 @@ pub mod pause;
 pub mod prelude;
 pub mod reconnect;
 pub mod reload;
+pub mod reset_query_cache;
 pub mod show_clients;
 pub mod show_config;
 pub mod show_peers;

--- a/pgdog/src/admin/parser.rs
+++ b/pgdog/src/admin/parser.rs
@@ -2,9 +2,9 @@
 
 use super::{
     pause::Pause, prelude::Message, reconnect::Reconnect, reload::Reload,
-    show_clients::ShowClients, show_config::ShowConfig, show_peers::ShowPeers,
-    show_pools::ShowPools, show_query_cache::ShowQueryCache, show_servers::ShowServers, Command,
-    Error,
+    reset_query_cache::ResetQueryCache, show_clients::ShowClients, show_config::ShowConfig,
+    show_peers::ShowPeers, show_pools::ShowPools, show_query_cache::ShowQueryCache,
+    show_servers::ShowServers, Command, Error,
 };
 
 use tracing::debug;
@@ -20,6 +20,7 @@ pub enum ParseResult {
     ShowServers(ShowServers),
     ShowPeers(ShowPeers),
     ShowQueryCache(ShowQueryCache),
+    ResetQueryCache(ResetQueryCache),
 }
 
 impl ParseResult {
@@ -37,6 +38,7 @@ impl ParseResult {
             ShowServers(show_servers) => show_servers.execute().await,
             ShowPeers(show_peers) => show_peers.execute().await,
             ShowQueryCache(show_query_cache) => show_query_cache.execute().await,
+            ResetQueryCache(reset_query_cache) => reset_query_cache.execute().await,
         }
     }
 
@@ -54,6 +56,7 @@ impl ParseResult {
             ShowServers(show_servers) => show_servers.name(),
             ShowPeers(show_peers) => show_peers.name(),
             ShowQueryCache(show_query_cache) => show_query_cache.name(),
+            ResetQueryCache(reset_query_cache) => reset_query_cache.name(),
         }
     }
 }
@@ -78,6 +81,13 @@ impl Parser {
                 "servers" => ParseResult::ShowServers(ShowServers::parse(&sql)?),
                 "peers" => ParseResult::ShowPeers(ShowPeers::parse(&sql)?),
                 "query_cache" => ParseResult::ShowQueryCache(ShowQueryCache::parse(&sql)?),
+                command => {
+                    debug!("unknown admin show command: '{}'", command);
+                    return Err(Error::Syntax);
+                }
+            },
+            "reset" => match iter.next().ok_or(Error::Syntax)?.trim() {
+                "query_cache" => ParseResult::ResetQueryCache(ResetQueryCache::parse(&sql)?),
                 command => {
                     debug!("unknown admin show command: '{}'", command);
                     return Err(Error::Syntax);

--- a/pgdog/src/admin/parser.rs
+++ b/pgdog/src/admin/parser.rs
@@ -3,7 +3,8 @@
 use super::{
     pause::Pause, prelude::Message, reconnect::Reconnect, reload::Reload,
     show_clients::ShowClients, show_config::ShowConfig, show_peers::ShowPeers,
-    show_pools::ShowPools, show_servers::ShowServers, Command, Error,
+    show_pools::ShowPools, show_query_cache::ShowQueryCache, show_servers::ShowServers, Command,
+    Error,
 };
 
 use tracing::debug;
@@ -18,6 +19,7 @@ pub enum ParseResult {
     ShowConfig(ShowConfig),
     ShowServers(ShowServers),
     ShowPeers(ShowPeers),
+    ShowQueryCache(ShowQueryCache),
 }
 
 impl ParseResult {
@@ -34,6 +36,7 @@ impl ParseResult {
             ShowConfig(show_config) => show_config.execute().await,
             ShowServers(show_servers) => show_servers.execute().await,
             ShowPeers(show_peers) => show_peers.execute().await,
+            ShowQueryCache(show_query_cache) => show_query_cache.execute().await,
         }
     }
 
@@ -50,6 +53,7 @@ impl ParseResult {
             ShowConfig(show_config) => show_config.name(),
             ShowServers(show_servers) => show_servers.name(),
             ShowPeers(show_peers) => show_peers.name(),
+            ShowQueryCache(show_query_cache) => show_query_cache.name(),
         }
     }
 }
@@ -73,6 +77,7 @@ impl Parser {
                 "config" => ParseResult::ShowConfig(ShowConfig::parse(&sql)?),
                 "servers" => ParseResult::ShowServers(ShowServers::parse(&sql)?),
                 "peers" => ParseResult::ShowPeers(ShowPeers::parse(&sql)?),
+                "query_cache" => ParseResult::ShowQueryCache(ShowQueryCache::parse(&sql)?),
                 command => {
                     debug!("unknown admin show command: '{}'", command);
                     return Err(Error::Syntax);

--- a/pgdog/src/admin/prelude.rs
+++ b/pgdog/src/admin/prelude.rs
@@ -1,4 +1,4 @@
 pub use super::Command;
 pub use super::Error;
-pub use crate::net::messages::Message;
+pub use crate::net::messages::{DataRow, Field, Message, Protocol, RowDescription};
 pub use async_trait::async_trait;

--- a/pgdog/src/admin/reset_query_cache.rs
+++ b/pgdog/src/admin/reset_query_cache.rs
@@ -1,0 +1,22 @@
+//! RESET QUERY_CACHE.
+use crate::frontend::router::parser::Cache;
+
+use super::prelude::*;
+
+pub struct ResetQueryCache;
+
+#[async_trait]
+impl Command for ResetQueryCache {
+    fn name(&self) -> String {
+        "RESET QUERY CACHE".into()
+    }
+
+    fn parse(_: &str) -> Result<Self, Error> {
+        Ok(Self)
+    }
+
+    async fn execute(&self) -> Result<Vec<Message>, Error> {
+        Cache::reset();
+        Ok(vec![])
+    }
+}

--- a/pgdog/src/admin/show_query_cache.rs
+++ b/pgdog/src/admin/show_query_cache.rs
@@ -1,0 +1,47 @@
+//! SHOW QUERY CACHE;
+
+use crate::frontend::router::parser::Cache;
+
+use super::prelude::*;
+
+pub struct ShowQueryCache {
+    filter: String,
+}
+
+#[async_trait::async_trait]
+impl Command for ShowQueryCache {
+    fn name(&self) -> String {
+        "SHOW QUERY CACHE".into()
+    }
+
+    fn parse(sql: &str) -> Result<Self, Error> {
+        Ok(Self {
+            filter: sql
+                .split(" ")
+                .skip(2)
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_lowercase())
+                .collect::<Vec<String>>()
+                .join(" "),
+        })
+    }
+
+    async fn execute(&self) -> Result<Vec<Message>, Error> {
+        let queries = Cache::queries();
+        let mut messages =
+            vec![RowDescription::new(&[Field::text("query"), Field::numeric("hits")]).message()?];
+
+        for query in queries {
+            if !self.filter.is_empty() {
+                if !query.0.to_lowercase().contains(&self.filter) {
+                    continue;
+                }
+            }
+            let mut data_row = DataRow::new();
+            data_row.add(query.0).add(query.1.hits);
+            messages.push(data_row.message()?);
+        }
+
+        Ok(messages)
+    }
+}

--- a/pgdog/src/admin/show_query_cache.rs
+++ b/pgdog/src/admin/show_query_cache.rs
@@ -8,7 +8,7 @@ pub struct ShowQueryCache {
     filter: String,
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Command for ShowQueryCache {
     fn name(&self) -> String {
         "SHOW QUERY CACHE".into()


### PR DESCRIPTION
### Featuers
- Add `SHOW QUERY_CACHE` admin command to list queries stored in the query parser cache.
- Track hit and miss rates globally and on each query in the query cache.
- Add `RESET QUERY_CACHE` to remove all queries from the cache.
