### PR TITLE
fix: Update frontend/client/mod.rs with conditional module import in debug build

### DIFF
--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -10,6 +10,7 @@ use super::{Buffer, Command, Comms, Error, PreparedStatements};
 use crate::auth::scram::Server;
 use crate::backend::pool::{Connection, Request};
 use crate::config::config;
+#[cfg(debug_assertions)]
 use crate::frontend::QueryLogger;
 use crate::net::messages::{
     Authentication, BackendKeyData, CommandComplete, ErrorResponse, Message, ParseComplete,


### PR DESCRIPTION
As `QueryLogger` is only available in debug mode, ran into issue while
compiling `PgDog` in `release` mode:

`cargo build --release`

```
error[E0432]: unresolved import `crate::frontend::QueryLogger`
  --> pgdog/src/frontend/client/mod.rs:13:5
   |
13 | use crate::frontend::QueryLogger;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `QueryLogger` in `frontend`
   |
note: found an item that was configured out
  --> pgdog/src/frontend/mod.rs:22:23
   |
22 | pub use query_logger::QueryLogger;
   |                       ^^^^^^^^^^^
note: the item is gated here
  --> pgdog/src/frontend/mod.rs:21:1
   |
21 | #[cfg(debug_assertions)]
   | ^^^^^^^^^^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0432`.
error: could not compile `pgdog` (bin "pgdog") due to 1 previous error
```