### PR TITLE
Support for basic count(*), min, max functions

### DIFF
--- a/pgdog/src/backend/databases.rs
+++ b/pgdog/src/backend/databases.rs
@@ -44,7 +44,7 @@ pub fn reconnect() {
     replace_databases(databases().duplicate());
 }
 
-/// Iniitialize the databases for the first time.
+/// Initialize the databases for the first time.
 pub fn init() {
     let config = config();
     replace_databases(from_config(&config));

--- a/pgdog/src/backend/pool/connection/buffer.rs
+++ b/pgdog/src/backend/pool/connection/buffer.rs
@@ -4,9 +4,7 @@ use std::{cmp::Ordering, collections::VecDeque};
 
 use crate::{
     frontend::router::parser::{Aggregate, AggregateTarget, OrderBy},
-    net::messages::{
-        data_row::Column, DataRow, Datum, FromBytes, Message, Protocol, RowDescription, ToBytes,
-    },
+    net::messages::{DataRow, Datum, FromBytes, Message, Protocol, RowDescription, ToBytes},
 };
 
 /// Sort and aggregate rows received from multiple shards.

--- a/pgdog/src/backend/pool/connection/buffer.rs
+++ b/pgdog/src/backend/pool/connection/buffer.rs
@@ -1,6 +1,6 @@
 //! Buffer messages to sort and aggregate them later.
 
-use std::{cmp::Ordering, collections::VecDeque, i64};
+use std::{cmp::Ordering, collections::VecDeque};
 
 use crate::{
     frontend::router::parser::{Aggregate, AggregateTarget, OrderBy},

--- a/pgdog/src/backend/pool/connection/buffer.rs
+++ b/pgdog/src/backend/pool/connection/buffer.rs
@@ -1,20 +1,22 @@
-//! Buffer messages to sort them later.
+//! Buffer messages to sort and aggregate them later.
 
 use std::{cmp::Ordering, collections::VecDeque};
 
 use crate::{
-    frontend::router::parser::OrderBy,
-    net::messages::{DataRow, FromBytes, Message, Protocol, RowDescription, ToBytes},
+    frontend::router::parser::{Aggregate, AggregateTarget, OrderBy},
+    net::messages::{
+        data_row::Column, DataRow, Datum, FromBytes, Message, Protocol, RowDescription, ToBytes,
+    },
 };
 
-/// Sort rows received from multiple shards.
+/// Sort and aggregate rows received from multiple shards.
 #[derive(Default, Debug)]
-pub(super) struct SortBuffer {
+pub(super) struct Buffer {
     buffer: VecDeque<DataRow>,
     full: bool,
 }
 
-impl SortBuffer {
+impl Buffer {
     /// Add message to buffer.
     pub(super) fn add(&mut self, message: Message) -> Result<(), super::Error> {
         let dr = DataRow::from_bytes(message.to_bytes()?)?;
@@ -32,7 +34,7 @@ impl SortBuffer {
 
     /// Sort the buffer.
     pub(super) fn sort(&mut self, columns: &[OrderBy], rd: &RowDescription) {
-        // Calculate column indecies once since
+        // Calculate column indecies once, since
         // fetching indecies by name is O(n).
         let mut cols = vec![];
         for column in columns {
@@ -79,6 +81,52 @@ impl SortBuffer {
         self.buffer.make_contiguous().sort_by(order_by);
     }
 
+    /// Execute aggregate functions.
+    ///
+    /// This function is the entrypoint for aggregation, so if you're reading this,
+    /// understand that this will be a WIP for a while. Some (many) assumptions are made
+    /// about queries and they will be tested (and adjusted) over time.
+    ///
+    /// Some aggregates will require query rewriting. This information will need to be passed in,
+    /// and extra columns fetched from Postgres removed from the final result.
+    pub(super) fn aggregate(
+        &mut self,
+        aggregates: &[Aggregate],
+        rd: &RowDescription,
+    ) -> Result<(), super::Error> {
+        let buffer: VecDeque<DataRow> = self.buffer.drain(0..).collect();
+        let mut result = DataRow::new();
+
+        for aggregate in aggregates {
+            match aggregate {
+                // COUNT(*) are summed across shards. This is the easiest of the aggregates,
+                // yet it's probably the most common one.
+                //
+                // TODO: If there is a GROUP BY clause, we need to sum across specified columns.
+                Aggregate::Count(AggregateTarget::Star(index)) => {
+                    let mut count = Datum::Bigint(0);
+                    for row in &buffer {
+                        let column = row.get_column(*index, rd)?;
+                        if let Some(column) = column {
+                            count = count + column.value;
+                        }
+                    }
+
+                    result.insert(*index, count);
+                }
+                _ => (),
+            }
+        }
+
+        if !result.is_empty() {
+            self.buffer.push_back(result);
+        } else {
+            self.buffer = buffer;
+        }
+
+        Ok(())
+    }
+
     /// Take messages from buffer.
     pub(super) fn take(&mut self) -> Option<Message> {
         if self.full {
@@ -86,6 +134,15 @@ impl SortBuffer {
         } else {
             None
         }
+    }
+
+    pub(super) fn len(&self) -> usize {
+        self.buffer.len()
+    }
+
+    #[allow(dead_code)]
+    pub(super) fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 }
 
@@ -96,7 +153,7 @@ mod test {
 
     #[test]
     fn test_sort_buffer() {
-        let mut buf = SortBuffer::default();
+        let mut buf = Buffer::default();
         let rd = RowDescription::new(&[Field::bigint("one"), Field::text("two")]);
         let columns = [OrderBy::Asc(1), OrderBy::Desc(2)];
 
@@ -120,5 +177,27 @@ mod test {
         }
 
         assert_eq!(i, 26);
+    }
+
+    #[test]
+    fn test_aggregate_buffer() {
+        let mut buf = Buffer::default();
+        let rd = RowDescription::new(&[Field::bigint("count")]);
+        let agg = [Aggregate::Count(AggregateTarget::Star(0))];
+
+        for _ in 0..6 {
+            let mut dr = DataRow::new();
+            dr.add(15_i64);
+            buf.add(dr.message().unwrap()).unwrap();
+        }
+
+        buf.aggregate(&agg, &rd).unwrap();
+        buf.full();
+
+        assert_eq!(buf.len(), 1);
+        let row = buf.take().unwrap();
+        let dr = DataRow::from_bytes(row.to_bytes().unwrap()).unwrap();
+        let count = dr.get::<i64>(0, Format::Text).unwrap();
+        assert_eq!(count, 15 * 6);
     }
 }

--- a/pgdog/src/backend/pool/connection/mod.rs
+++ b/pgdog/src/backend/pool/connection/mod.rs
@@ -21,8 +21,8 @@ use super::{
 use std::{mem::replace, time::Duration};
 
 mod binding;
+mod buffer;
 mod multi_shard;
-mod sort_buffer;
 
 use binding::Binding;
 use multi_shard::MultiShard;

--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -349,7 +349,7 @@ impl Server {
         let error = messages.iter().find(|m| m.code() == 'E');
         if let Some(error) = error {
             let error = ErrorResponse::from_bytes(error.to_bytes()?)?;
-            return Err(Error::ExecutionError(error));
+            Err(Error::ExecutionError(error))
         } else {
             Ok(messages)
         }

--- a/pgdog/src/frontend/router/parser/aggregate.rs
+++ b/pgdog/src/frontend/router/parser/aggregate.rs
@@ -22,36 +22,21 @@ impl Aggregate {
         let mut aggs = vec![];
 
         for (idx, node) in stmt.target_list.iter().enumerate() {
-            match &node.node {
-                Some(NodeEnum::ResTarget(ref res)) => match &res.val {
-                    Some(node) => match &node.node {
-                        Some(NodeEnum::FuncCall(func)) => {
-                            if let Some(name) = func.funcname.first() {
-                                if let Some(NodeEnum::String(protobuf::String { sval })) =
-                                    &name.node
+            if let Some(NodeEnum::ResTarget(ref res)) = &node.node {
+                if let Some(node) = &res.val {
+                    if let Some(NodeEnum::FuncCall(func)) = &node.node {
+                        if let Some(name) = func.funcname.first() {
+                            if let Some(NodeEnum::String(protobuf::String { sval })) = &name.node {
+                                if sval.as_str() == "count"
+                                    && func.args.is_empty()
+                                    && stmt.group_clause.is_empty()
                                 {
-                                    match sval.as_str() {
-                                        "count" => {
-                                            if func.args.is_empty() && stmt.group_clause.is_empty()
-                                            {
-                                                aggs.push(Aggregate::Count(AggregateTarget::Star(
-                                                    idx,
-                                                )));
-                                            }
-                                        }
-
-                                        _ => (),
-                                    }
+                                    aggs.push(Aggregate::Count(AggregateTarget::Star(idx)));
                                 }
                             }
                         }
-
-                        _ => (),
-                    },
-
-                    _ => (),
-                },
-                _ => (),
+                    }
+                }
             }
         }
 

--- a/pgdog/src/frontend/router/parser/aggregate.rs
+++ b/pgdog/src/frontend/router/parser/aggregate.rs
@@ -18,6 +18,7 @@ pub enum Aggregate {
 }
 
 impl Aggregate {
+    /// Figure out what aggregates are present and which ones PgDog supports.
     pub fn parse(stmt: &SelectStmt) -> Result<Vec<Self>, Error> {
         let mut aggs = vec![];
 
@@ -27,11 +28,26 @@ impl Aggregate {
                     if let Some(NodeEnum::FuncCall(func)) = &node.node {
                         if let Some(name) = func.funcname.first() {
                             if let Some(NodeEnum::String(protobuf::String { sval })) = &name.node {
-                                if sval.as_str() == "count"
-                                    && func.args.is_empty()
-                                    && stmt.group_clause.is_empty()
-                                {
-                                    aggs.push(Aggregate::Count(AggregateTarget::Star(idx)));
+                                match sval.as_str() {
+                                    "count" => {
+                                        if stmt.group_clause.is_empty() {
+                                            aggs.push(Aggregate::Count(AggregateTarget::Star(idx)));
+                                        }
+                                    }
+
+                                    "max" => {
+                                        if stmt.group_clause.is_empty() {
+                                            aggs.push(Aggregate::Max(AggregateTarget::Star(idx)));
+                                        }
+                                    }
+
+                                    "min" => {
+                                        if stmt.group_clause.is_empty() {
+                                            aggs.push(Aggregate::Min(AggregateTarget::Star(idx)));
+                                        }
+                                    }
+
+                                    _ => {}
                                 }
                             }
                         }

--- a/pgdog/src/frontend/router/parser/aggregate.rs
+++ b/pgdog/src/frontend/router/parser/aggregate.rs
@@ -1,0 +1,60 @@
+use pg_query::protobuf::{self, SelectStmt};
+use pg_query::NodeEnum;
+
+use super::Error;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum AggregateTarget {
+    Column(String, usize),
+    Star(usize),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Aggregate {
+    Count(AggregateTarget),
+    Max(AggregateTarget),
+    Min(AggregateTarget),
+    Avg(AggregateTarget),
+}
+
+impl Aggregate {
+    pub fn parse(stmt: &SelectStmt) -> Result<Vec<Self>, Error> {
+        let mut aggs = vec![];
+
+        for (idx, node) in stmt.target_list.iter().enumerate() {
+            match &node.node {
+                Some(NodeEnum::ResTarget(ref res)) => match &res.val {
+                    Some(node) => match &node.node {
+                        Some(NodeEnum::FuncCall(func)) => {
+                            if let Some(name) = func.funcname.first() {
+                                if let Some(NodeEnum::String(protobuf::String { sval })) =
+                                    &name.node
+                                {
+                                    match sval.as_str() {
+                                        "count" => {
+                                            if func.args.is_empty() && stmt.group_clause.is_empty()
+                                            {
+                                                aggs.push(Aggregate::Count(AggregateTarget::Star(
+                                                    idx,
+                                                )));
+                                            }
+                                        }
+
+                                        _ => (),
+                                    }
+                                }
+                            }
+                        }
+
+                        _ => (),
+                    },
+
+                    _ => (),
+                },
+                _ => (),
+            }
+        }
+
+        Ok(aggs)
+    }
+}

--- a/pgdog/src/frontend/router/parser/mod.rs
+++ b/pgdog/src/frontend/router/parser/mod.rs
@@ -1,5 +1,6 @@
 //! Query parser.
 
+pub mod aggregate;
 pub mod cache;
 pub mod column;
 pub mod comment;
@@ -16,6 +17,7 @@ pub mod tuple;
 pub mod value;
 pub mod where_clause;
 
+pub use aggregate::{Aggregate, AggregateTarget};
 pub use cache::Cache;
 pub use column::Column;
 pub use copy::CopyParser;

--- a/pgdog/src/frontend/router/parser/query.rs
+++ b/pgdog/src/frontend/router/parser/query.rs
@@ -10,7 +10,7 @@ use crate::{
     net::messages::{Bind, CopyData},
 };
 
-use super::{Cache, CopyParser, Error, Insert, Key, Route, WhereClause};
+use super::{Aggregate, Cache, CopyParser, Error, Insert, Key, Route, WhereClause};
 
 use once_cell::sync::Lazy;
 use pg_query::{
@@ -250,7 +250,9 @@ impl QueryParser {
             None
         };
 
-        Ok(Command::Query(Route::select(shard, &order_by)))
+        let aggregates = Aggregate::parse(stmt)?;
+
+        Ok(Command::Query(Route::select(shard, &order_by, &aggregates)))
     }
 
     /// Parse the `ORDER BY` clause of a `SELECT` statement.

--- a/pgdog/src/frontend/router/parser/route.rs
+++ b/pgdog/src/frontend/router/parser/route.rs
@@ -1,4 +1,4 @@
-use super::OrderBy;
+use super::{Aggregate, OrderBy};
 
 /// Path a query should take and any transformations
 /// that should be applied along the way.
@@ -7,6 +7,7 @@ pub struct Route {
     shard: Option<usize>,
     read: bool,
     order_by: Vec<OrderBy>,
+    aggregate: Vec<Aggregate>,
 }
 
 impl Default for Route {
@@ -17,11 +18,12 @@ impl Default for Route {
 
 impl Route {
     /// SELECT query.
-    pub fn select(shard: Option<usize>, order_by: &[OrderBy]) -> Self {
+    pub fn select(shard: Option<usize>, order_by: &[OrderBy], aggregate: &[Aggregate]) -> Self {
         Self {
             shard,
             order_by: order_by.to_vec(),
             read: true,
+            aggregate: aggregate.to_vec(),
         }
     }
 
@@ -31,6 +33,7 @@ impl Route {
             shard,
             read: true,
             order_by: vec![],
+            aggregate: vec![],
         }
     }
 
@@ -40,6 +43,7 @@ impl Route {
             shard,
             read: false,
             order_by: vec![],
+            aggregate: vec![],
         }
     }
 
@@ -65,7 +69,15 @@ impl Route {
         &self.order_by
     }
 
+    pub fn aggregate(&self) -> &[Aggregate] {
+        &self.aggregate
+    }
+
     pub fn set_shard(&mut self, shard: usize) {
         self.shard = Some(shard);
+    }
+
+    pub fn should_buffer(&self) -> bool {
+        !self.order_by().is_empty() || !self.aggregate().is_empty()
     }
 }

--- a/pgdog/src/net/messages/data_types/interval.rs
+++ b/pgdog/src/net/messages/data_types/interval.rs
@@ -14,6 +14,29 @@ pub struct Interval {
     millis: i16,
 }
 
+impl Add for Interval {
+    type Output = Interval;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        // Postgres will figure it out.
+        Self {
+            years: self.years + rhs.years,
+            months: self.months + rhs.months,
+            days: self.days + rhs.days,
+            hours: self.hours + rhs.hours,
+            minutes: self.minutes + rhs.minutes,
+            seconds: self.seconds + rhs.seconds,
+            millis: self.millis + rhs.millis,
+        }
+    }
+}
+
+impl ToDataRowColumn for Interval {
+    fn to_data_row_column(&self) -> Bytes {
+        self.encode(Format::Text).unwrap()
+    }
+}
+
 macro_rules! parser {
     ($name:tt, $typ:ty) => {
         pub(super) fn $name(s: &str) -> Result<$typ, ParseIntError> {

--- a/pgdog/src/net/messages/data_types/mod.rs
+++ b/pgdog/src/net/messages/data_types/mod.rs
@@ -55,7 +55,13 @@ impl ToDataRowColumn for Datum {
             Bigint(val) => val.to_data_row_column(),
             Integer(val) => (*val as i64).to_data_row_column(),
             SmallInt(val) => (*val as i64).to_data_row_column(),
-            _ => todo!(),
+            Interval(interval) => interval.to_data_row_column(),
+            Text(text) => text.to_data_row_column(),
+            Timestamp(t) => t.to_data_row_column(),
+            TimestampTz(tz) => tz.to_data_row_column(),
+            Uuid(uuid) => uuid.to_data_row_column(),
+            Numeric(num) => num.to_data_row_column(),
+            Null => Bytes::new(),
         }
     }
 }
@@ -70,8 +76,9 @@ impl Add for Datum {
             (Bigint(a), Bigint(b)) => Bigint(a + b),
             (Integer(a), Integer(b)) => Integer(a + b),
             (SmallInt(a), SmallInt(b)) => SmallInt(a + b),
-
-            _ => todo!(),
+            (Interval(a), Interval(b)) => Interval(a + b),
+            (Numeric(a), Numeric(b)) => Numeric(a + b),
+            _ => Datum::Null, // Might be good to raise an error.
         }
     }
 }

--- a/pgdog/src/net/messages/data_types/mod.rs
+++ b/pgdog/src/net/messages/data_types/mod.rs
@@ -1,4 +1,6 @@
-use super::{bind::Format, Error};
+use std::ops::Add;
+
+use super::{bind::Format, Error, ToDataRowColumn};
 use ::uuid::Uuid;
 use bytes::Bytes;
 
@@ -43,6 +45,35 @@ pub enum Datum {
     Numeric(Numeric),
     /// NULL.
     Null,
+}
+
+impl ToDataRowColumn for Datum {
+    fn to_data_row_column(&self) -> Bytes {
+        use Datum::*;
+
+        match self {
+            Bigint(val) => val.to_data_row_column(),
+            Integer(val) => (*val as i64).to_data_row_column(),
+            SmallInt(val) => (*val as i64).to_data_row_column(),
+            _ => todo!(),
+        }
+    }
+}
+
+impl Add for Datum {
+    type Output = Datum;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        use Datum::*;
+
+        match (self, rhs) {
+            (Bigint(a), Bigint(b)) => Bigint(a + b),
+            (Integer(a), Integer(b)) => Integer(a + b),
+            (SmallInt(a), SmallInt(b)) => SmallInt(a + b),
+
+            _ => todo!(),
+        }
+    }
 }
 
 impl Datum {

--- a/pgdog/src/net/messages/data_types/numeric.rs
+++ b/pgdog/src/net/messages/data_types/numeric.rs
@@ -33,6 +33,16 @@ impl DerefMut for Numeric {
     }
 }
 
+impl Add for Numeric {
+    type Output = Numeric;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Numeric {
+            data: self.data + rhs.data,
+        }
+    }
+}
+
 impl Ord for Numeric {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         match self.partial_cmp(other) {
@@ -67,5 +77,11 @@ impl FromDataType for Numeric {
             Format::Text => Ok(Bytes::copy_from_slice(self.data.to_string().as_bytes())),
             Format::Binary => Ok(Bytes::copy_from_slice(self.data.to_be_bytes().as_slice())),
         }
+    }
+}
+
+impl ToDataRowColumn for Numeric {
+    fn to_data_row_column(&self) -> Bytes {
+        self.encode(Format::Text).unwrap()
     }
 }

--- a/pgdog/src/net/messages/data_types/timestamp.rs
+++ b/pgdog/src/net/messages/data_types/timestamp.rs
@@ -16,6 +16,12 @@ pub struct Timestamp {
     pub offset: Option<i8>,
 }
 
+impl ToDataRowColumn for Timestamp {
+    fn to_data_row_column(&self) -> Bytes {
+        self.encode(Format::Text).unwrap()
+    }
+}
+
 impl Display for Timestamp {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(

--- a/pgdog/src/net/messages/data_types/timestamptz.rs
+++ b/pgdog/src/net/messages/data_types/timestamptz.rs
@@ -36,6 +36,12 @@ impl DerefMut for TimestampTz {
     }
 }
 
+impl ToDataRowColumn for TimestampTz {
+    fn to_data_row_column(&self) -> Bytes {
+        self.encode(Format::Text).unwrap()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/pgdog/src/net/messages/data_types/uuid.rs
+++ b/pgdog/src/net/messages/data_types/uuid.rs
@@ -22,3 +22,9 @@ impl FromDataType for Uuid {
         }
     }
 }
+
+impl ToDataRowColumn for Uuid {
+    fn to_data_row_column(&self) -> Bytes {
+        self.encode(Format::Text).unwrap()
+    }
+}


### PR DESCRIPTION
### Feature

Add support for basic usage of `COUNT(*)`, `MAX(column)`, and `MIN(column)`. Things that don't work yet:

- `GROUP BY`
- Processing supported and unsupported aggregates in the same query

### Example

```sql
SELECT COUNT(*), MIN(id), MAX(id) FROM users;
```

Related: #40 