### PR TITLE
Add limited GROUP BY support

### DIFF
--- a/pgdog/src/backend/pool/connection/aggregate.rs
+++ b/pgdog/src/backend/pool/connection/aggregate.rs
@@ -46,14 +46,6 @@ impl<'a> Accumulator<'a> {
                     target,
                     datum: Datum::Bigint(0),
                 },
-                AggregateFunction::Max => Accumulator {
-                    target,
-                    datum: Datum::Bigint(i64::MIN),
-                },
-                AggregateFunction::Min => Accumulator {
-                    target,
-                    datum: Datum::Bigint(i64::MAX),
-                },
                 _ => Accumulator {
                     target,
                     datum: Datum::Null,
@@ -68,12 +60,20 @@ impl<'a> Accumulator<'a> {
             match self.target.function() {
                 AggregateFunction::Count => self.datum = self.datum.clone() + column.value,
                 AggregateFunction::Max => {
-                    if self.datum < column.value {
+                    if !self.datum.is_null() {
+                        if self.datum < column.value {
+                            self.datum = column.value;
+                        }
+                    } else {
                         self.datum = column.value;
                     }
                 }
                 AggregateFunction::Min => {
-                    if self.datum > column.value {
+                    if !self.datum.is_null() {
+                        if self.datum > column.value {
+                            self.datum = column.value;
+                        }
+                    } else {
                         self.datum = column.value;
                     }
                 }

--- a/pgdog/src/backend/pool/connection/aggregate.rs
+++ b/pgdog/src/backend/pool/connection/aggregate.rs
@@ -1,0 +1,137 @@
+//! Aggregate buffer.
+
+use std::collections::{HashMap, VecDeque};
+
+use crate::{
+    frontend::router::parser::{Aggregate, AggregateFunction, AggregateTarget},
+    net::messages::{DataRow, Datum, RowDescription},
+};
+
+use super::Error;
+
+/// GROUP BY <columns>
+#[derive(Hash, PartialEq, Eq, PartialOrd, Ord, Debug)]
+struct Grouping {
+    columns: Vec<(usize, Datum)>,
+}
+
+impl Grouping {
+    fn new(row: &DataRow, group_by: &[usize], rd: &RowDescription) -> Result<Self, Error> {
+        let mut columns = vec![];
+        for idx in group_by {
+            let column = row.get_column(idx.clone(), rd)?;
+            if let Some(column) = column {
+                columns.push((idx.clone(), column.value));
+            }
+        }
+
+        Ok(Self { columns })
+    }
+}
+
+/// The aggregate accumulator.
+#[derive(Debug)]
+struct Accumulator<'a> {
+    target: &'a AggregateTarget,
+    datum: Datum,
+}
+
+impl<'a> Accumulator<'a> {
+    pub fn from_aggregate(aggregate: &'a Aggregate) -> Vec<Self> {
+        aggregate
+            .targets()
+            .iter()
+            .map(|target| match target.function() {
+                AggregateFunction::Count => Accumulator {
+                    target,
+                    datum: Datum::Bigint(0),
+                },
+                AggregateFunction::Max => Accumulator {
+                    target,
+                    datum: Datum::Bigint(i64::MIN),
+                },
+                AggregateFunction::Min => Accumulator {
+                    target,
+                    datum: Datum::Bigint(i64::MAX),
+                },
+                _ => Accumulator {
+                    target,
+                    datum: Datum::Null,
+                },
+            })
+            .collect()
+    }
+
+    fn accumulate(&mut self, row: &DataRow, rd: &RowDescription) -> Result<(), Error> {
+        let column = row.get_column(self.target.column(), rd)?;
+        if let Some(column) = column {
+            match self.target.function() {
+                AggregateFunction::Count => self.datum = self.datum.clone() + column.value,
+                AggregateFunction::Max => {
+                    if self.datum < column.value {
+                        self.datum = column.value;
+                    }
+                }
+                AggregateFunction::Min => {
+                    if self.datum > column.value {
+                        self.datum = column.value;
+                    }
+                }
+                _ => (),
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct Aggregates<'a> {
+    rows: &'a VecDeque<DataRow>,
+    mappings: HashMap<Grouping, Vec<Accumulator<'a>>>,
+    rd: &'a RowDescription,
+    aggregate: &'a Aggregate,
+}
+
+impl<'a> Aggregates<'a> {
+    pub(super) fn new(
+        rows: &'a VecDeque<DataRow>,
+        rd: &'a RowDescription,
+        aggregate: &'a Aggregate,
+    ) -> Self {
+        Self {
+            rows,
+            rd,
+            mappings: HashMap::new(),
+            aggregate,
+        }
+    }
+
+    pub(super) fn aggregate(mut self) -> Result<VecDeque<DataRow>, Error> {
+        for row in self.rows {
+            let grouping = Grouping::new(&row, &self.aggregate.group_by(), &self.rd)?;
+            let entry = self
+                .mappings
+                .entry(grouping)
+                .or_insert_with(|| Accumulator::from_aggregate(&self.aggregate));
+
+            for aggregate in entry {
+                aggregate.accumulate(&row, &self.rd)?;
+            }
+        }
+
+        let mut rows = VecDeque::new();
+        for (grouping, accumulator) in self.mappings {
+            let mut row = DataRow::new();
+            for (idx, datum) in grouping.columns {
+                row.insert(idx, datum);
+            }
+            for acc in accumulator {
+                row.insert(acc.target.column(), acc.datum);
+            }
+            rows.push_back(row);
+        }
+
+        Ok(rows)
+    }
+}

--- a/pgdog/src/backend/pool/connection/aggregate.rs
+++ b/pgdog/src/backend/pool/connection/aggregate.rs
@@ -19,9 +19,9 @@ impl Grouping {
     fn new(row: &DataRow, group_by: &[usize], rd: &RowDescription) -> Result<Self, Error> {
         let mut columns = vec![];
         for idx in group_by {
-            let column = row.get_column(idx.clone(), rd)?;
+            let column = row.get_column(*idx, rd)?;
             if let Some(column) = column {
-                columns.push((idx.clone(), column.value));
+                columns.push((*idx, column.value));
             }
         }
 
@@ -109,14 +109,14 @@ impl<'a> Aggregates<'a> {
 
     pub(super) fn aggregate(mut self) -> Result<VecDeque<DataRow>, Error> {
         for row in self.rows {
-            let grouping = Grouping::new(&row, &self.aggregate.group_by(), &self.rd)?;
+            let grouping = Grouping::new(row, self.aggregate.group_by(), self.rd)?;
             let entry = self
                 .mappings
                 .entry(grouping)
-                .or_insert_with(|| Accumulator::from_aggregate(&self.aggregate));
+                .or_insert_with(|| Accumulator::from_aggregate(self.aggregate));
 
             for aggregate in entry {
-                aggregate.accumulate(&row, &self.rd)?;
+                aggregate.accumulate(row, self.rd)?;
             }
         }
 

--- a/pgdog/src/backend/pool/connection/buffer.rs
+++ b/pgdog/src/backend/pool/connection/buffer.rs
@@ -3,9 +3,11 @@
 use std::{cmp::Ordering, collections::VecDeque};
 
 use crate::{
-    frontend::router::parser::{Aggregate, AggregateTarget, OrderBy},
-    net::messages::{DataRow, Datum, FromBytes, Message, Protocol, RowDescription, ToBytes},
+    frontend::router::parser::{Aggregate, OrderBy},
+    net::messages::{DataRow, FromBytes, Message, Protocol, RowDescription, ToBytes},
 };
+
+use super::Aggregates;
 
 /// Sort and aggregate rows received from multiple shards.
 #[derive(Default, Debug)]
@@ -89,63 +91,15 @@ impl Buffer {
     /// and extra columns fetched from Postgres removed from the final result.
     pub(super) fn aggregate(
         &mut self,
-        aggregates: &[Aggregate],
+        aggregate: &Aggregate,
         rd: &RowDescription,
     ) -> Result<(), super::Error> {
         let buffer: VecDeque<DataRow> = self.buffer.drain(0..).collect();
-        let mut result = DataRow::new();
-
-        for aggregate in aggregates {
-            match aggregate {
-                // COUNT(*) are summed across shards. This is the easiest of the aggregates,
-                // yet it's probably the most common one.
-                //
-                // TODO: If there is a GROUP BY clause, we need to sum across specified columns.
-                Aggregate::Count(AggregateTarget::Star(index)) => {
-                    let mut count = Datum::Bigint(0);
-                    for row in &buffer {
-                        let column = row.get_column(*index, rd)?;
-                        if let Some(column) = column {
-                            count = count + column.value;
-                        }
-                    }
-
-                    result.insert(*index, count);
-                }
-
-                Aggregate::Max(AggregateTarget::Star(index)) => {
-                    let mut max = Datum::Bigint(i64::MIN);
-                    for row in &buffer {
-                        let column = row.get_column(*index, rd)?;
-                        if let Some(column) = column {
-                            if max < column.value {
-                                max = column.value;
-                            }
-                        }
-                    }
-
-                    result.insert(*index, max);
-                }
-
-                Aggregate::Min(AggregateTarget::Star(index)) => {
-                    let mut min = Datum::Bigint(i64::MAX);
-                    for row in &buffer {
-                        let column = row.get_column(*index, rd)?;
-                        if let Some(column) = column {
-                            if min > column.value {
-                                min = column.value;
-                            }
-                        }
-                    }
-
-                    result.insert(*index, min);
-                }
-                _ => (),
-            }
-        }
+        let aggregates = Aggregates::new(&buffer, rd, aggregate);
+        let result = aggregates.aggregate()?;
 
         if !result.is_empty() {
-            self.buffer.push_back(result);
+            self.buffer = result;
         } else {
             self.buffer = buffer;
         }
@@ -209,7 +163,7 @@ mod test {
     fn test_aggregate_buffer() {
         let mut buf = Buffer::default();
         let rd = RowDescription::new(&[Field::bigint("count")]);
-        let agg = [Aggregate::Count(AggregateTarget::Star(0))];
+        let agg = Aggregate::new_count(0);
 
         for _ in 0..6 {
             let mut dr = DataRow::new();
@@ -225,5 +179,33 @@ mod test {
         let dr = DataRow::from_bytes(row.to_bytes().unwrap()).unwrap();
         let count = dr.get::<i64>(0, Format::Text).unwrap();
         assert_eq!(count, 15 * 6);
+    }
+
+    #[test]
+    fn test_aggregate_buffer_group_by() {
+        let mut buf = Buffer::default();
+        let rd = RowDescription::new(&[Field::bigint("count"), Field::text("email")]);
+        let agg = Aggregate::new_count_group_by(0, &[1]);
+        let emails = ["test@test.com", "admin@test.com"];
+
+        for email in emails {
+            for _ in 0..6 {
+                let mut dr = DataRow::new();
+                dr.add(15_i64);
+                dr.add(email);
+                buf.add(dr.message().unwrap()).unwrap();
+            }
+        }
+
+        buf.aggregate(&agg, &rd).unwrap();
+        buf.full();
+
+        assert_eq!(buf.len(), 2);
+        for _ in &emails {
+            let row = buf.take().unwrap();
+            let dr = DataRow::from_bytes(row.to_bytes().unwrap()).unwrap();
+            let count = dr.get::<i64>(0, Format::Text).unwrap();
+            assert_eq!(count, 15 * 6);
+        }
     }
 }

--- a/pgdog/src/backend/pool/connection/buffer.rs
+++ b/pgdog/src/backend/pool/connection/buffer.rs
@@ -94,7 +94,7 @@ impl Buffer {
         aggregate: &Aggregate,
         rd: &RowDescription,
     ) -> Result<(), super::Error> {
-        let buffer: VecDeque<DataRow> = self.buffer.drain(0..).collect();
+        let buffer: VecDeque<DataRow> = std::mem::take(&mut self.buffer);
         if aggregate.is_empty() {
             self.buffer = buffer;
         } else {

--- a/pgdog/src/backend/pool/connection/buffer.rs
+++ b/pgdog/src/backend/pool/connection/buffer.rs
@@ -95,13 +95,17 @@ impl Buffer {
         rd: &RowDescription,
     ) -> Result<(), super::Error> {
         let buffer: VecDeque<DataRow> = self.buffer.drain(0..).collect();
-        let aggregates = Aggregates::new(&buffer, rd, aggregate);
-        let result = aggregates.aggregate()?;
-
-        if !result.is_empty() {
-            self.buffer = result;
-        } else {
+        if aggregate.is_empty() {
             self.buffer = buffer;
+        } else {
+            let aggregates = Aggregates::new(&buffer, rd, aggregate);
+            let result = aggregates.aggregate()?;
+
+            if !result.is_empty() {
+                self.buffer = result;
+            } else {
+                self.buffer = buffer;
+            }
         }
 
         Ok(())

--- a/pgdog/src/backend/pool/connection/mod.rs
+++ b/pgdog/src/backend/pool/connection/mod.rs
@@ -20,10 +20,12 @@ use super::{
 
 use std::{mem::replace, time::Duration};
 
-mod binding;
-mod buffer;
-mod multi_shard;
+pub mod aggregate;
+pub mod binding;
+pub mod buffer;
+pub mod multi_shard;
 
+use aggregate::Aggregates;
 use binding::Binding;
 use multi_shard::MultiShard;
 

--- a/pgdog/src/frontend/router/parser/aggregate.rs
+++ b/pgdog/src/frontend/router/parser/aggregate.rs
@@ -1,26 +1,59 @@
-use pg_query::protobuf::{self, SelectStmt};
+use pg_query::protobuf::Integer;
+use pg_query::protobuf::{self, a_const::Val, SelectStmt};
 use pg_query::NodeEnum;
 
 use super::Error;
 
 #[derive(Debug, Clone, PartialEq)]
-pub enum AggregateTarget {
-    Column(String, usize),
-    Star(usize),
+pub struct AggregateTarget {
+    column: usize,
+    function: AggregateFunction,
+}
+
+impl AggregateTarget {
+    pub fn function(&self) -> &AggregateFunction {
+        &self.function
+    }
+
+    pub fn column(&self) -> usize {
+        self.column
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub enum Aggregate {
-    Count(AggregateTarget),
-    Max(AggregateTarget),
-    Min(AggregateTarget),
-    Avg(AggregateTarget),
+pub enum AggregateFunction {
+    Count,
+    Max,
+    Min,
+    Avg,
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct Aggregate {
+    targets: Vec<AggregateTarget>,
+    group_by: Vec<usize>,
 }
 
 impl Aggregate {
     /// Figure out what aggregates are present and which ones PgDog supports.
-    pub fn parse(stmt: &SelectStmt) -> Result<Vec<Self>, Error> {
-        let mut aggs = vec![];
+    pub fn parse(stmt: &SelectStmt) -> Result<Self, Error> {
+        let mut targets = vec![];
+        let group_by = stmt
+            .group_clause
+            .iter()
+            .map(|node| {
+                node.node.as_ref().map(|node| match node {
+                    NodeEnum::AConst(aconst) => aconst.val.as_ref().map(|val| match val {
+                        Val::Ival(Integer { ival }) => Some(*ival as usize - 1), // We use 0-indexed arrays, Postgres uses 1-indexed.
+                        _ => None,
+                    }),
+                    _ => None,
+                })
+            })
+            .flatten()
+            .flatten()
+            .flatten()
+            .collect::<Vec<_>>();
 
         for (idx, node) in stmt.target_list.iter().enumerate() {
             if let Some(NodeEnum::ResTarget(ref res)) = &node.node {
@@ -30,21 +63,24 @@ impl Aggregate {
                             if let Some(NodeEnum::String(protobuf::String { sval })) = &name.node {
                                 match sval.as_str() {
                                     "count" => {
-                                        if stmt.group_clause.is_empty() {
-                                            aggs.push(Aggregate::Count(AggregateTarget::Star(idx)));
-                                        }
+                                        targets.push(AggregateTarget {
+                                            column: idx,
+                                            function: AggregateFunction::Count,
+                                        });
                                     }
 
                                     "max" => {
-                                        if stmt.group_clause.is_empty() {
-                                            aggs.push(Aggregate::Max(AggregateTarget::Star(idx)));
-                                        }
+                                        targets.push(AggregateTarget {
+                                            column: idx,
+                                            function: AggregateFunction::Max,
+                                        });
                                     }
 
                                     "min" => {
-                                        if stmt.group_clause.is_empty() {
-                                            aggs.push(Aggregate::Min(AggregateTarget::Star(idx)));
-                                        }
+                                        targets.push(AggregateTarget {
+                                            column: idx,
+                                            function: AggregateFunction::Min,
+                                        });
                                     }
 
                                     _ => {}
@@ -56,6 +92,42 @@ impl Aggregate {
             }
         }
 
-        Ok(aggs)
+        Ok(Self { targets, group_by })
+    }
+
+    pub fn targets(&self) -> &[AggregateTarget] {
+        &self.targets
+    }
+
+    pub fn group_by(&self) -> &[usize] {
+        &self.group_by
+    }
+
+    pub fn new_count(column: usize) -> Self {
+        Self {
+            targets: vec![AggregateTarget {
+                function: AggregateFunction::Count,
+                column,
+            }],
+            group_by: vec![],
+        }
+    }
+
+    pub fn new_count_group_by(column: usize, group_by: &[usize]) -> Self {
+        Self {
+            targets: vec![AggregateTarget {
+                function: AggregateFunction::Count,
+                column,
+            }],
+            group_by: group_by.to_vec(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn len(&self) -> usize {
+        self.targets.len()
     }
 }

--- a/pgdog/src/frontend/router/parser/aggregate.rs
+++ b/pgdog/src/frontend/router/parser/aggregate.rs
@@ -41,7 +41,7 @@ impl Aggregate {
         let group_by = stmt
             .group_clause
             .iter()
-            .map(|node| {
+            .filter_map(|node| {
                 node.node.as_ref().map(|node| match node {
                     NodeEnum::AConst(aconst) => aconst.val.as_ref().map(|val| match val {
                         Val::Ival(Integer { ival }) => Some(*ival as usize - 1), // We use 0-indexed arrays, Postgres uses 1-indexed.
@@ -50,7 +50,6 @@ impl Aggregate {
                     _ => None,
                 })
             })
-            .flatten()
             .flatten()
             .flatten()
             .collect::<Vec<_>>();

--- a/pgdog/src/frontend/router/parser/mod.rs
+++ b/pgdog/src/frontend/router/parser/mod.rs
@@ -17,7 +17,7 @@ pub mod tuple;
 pub mod value;
 pub mod where_clause;
 
-pub use aggregate::{Aggregate, AggregateTarget};
+pub use aggregate::{Aggregate, AggregateFunction, AggregateTarget};
 pub use cache::Cache;
 pub use column::Column;
 pub use copy::CopyParser;

--- a/pgdog/src/frontend/router/parser/route.rs
+++ b/pgdog/src/frontend/router/parser/route.rs
@@ -7,7 +7,7 @@ pub struct Route {
     shard: Option<usize>,
     read: bool,
     order_by: Vec<OrderBy>,
-    aggregate: Vec<Aggregate>,
+    aggregate: Aggregate,
 }
 
 impl Default for Route {
@@ -18,12 +18,12 @@ impl Default for Route {
 
 impl Route {
     /// SELECT query.
-    pub fn select(shard: Option<usize>, order_by: &[OrderBy], aggregate: &[Aggregate]) -> Self {
+    pub fn select(shard: Option<usize>, order_by: &[OrderBy], aggregate: &Aggregate) -> Self {
         Self {
             shard,
             order_by: order_by.to_vec(),
             read: true,
-            aggregate: aggregate.to_vec(),
+            aggregate: aggregate.clone(),
         }
     }
 
@@ -33,7 +33,7 @@ impl Route {
             shard,
             read: true,
             order_by: vec![],
-            aggregate: vec![],
+            aggregate: Aggregate::default(),
         }
     }
 
@@ -43,7 +43,7 @@ impl Route {
             shard,
             read: false,
             order_by: vec![],
-            aggregate: vec![],
+            aggregate: Aggregate::default(),
         }
     }
 
@@ -69,7 +69,7 @@ impl Route {
         &self.order_by
     }
 
-    pub fn aggregate(&self) -> &[Aggregate] {
+    pub fn aggregate(&self) -> &Aggregate {
         &self.aggregate
     }
 

--- a/pgdog/src/net/messages/data_row.rs
+++ b/pgdog/src/net/messages/data_row.rs
@@ -2,72 +2,110 @@
 
 use super::{code, prelude::*, Datum, Format, FromDataType, Numeric, RowDescription};
 use bytes::BytesMut;
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
+
+#[derive(Debug, Clone)]
+pub struct Data {
+    data: Bytes,
+    is_null: bool,
+}
+
+impl Deref for Data {
+    type Target = Bytes;
+
+    fn deref(&self) -> &Self::Target {
+        &self.data
+    }
+}
+
+impl DerefMut for Data {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.data
+    }
+}
+
+impl From<Bytes> for Data {
+    fn from(value: Bytes) -> Self {
+        Self {
+            data: value,
+            is_null: false,
+        }
+    }
+}
+
+impl Data {
+    pub fn null() -> Self {
+        Self {
+            data: Bytes::new(),
+            is_null: true,
+        }
+    }
+}
 
 /// DataRow message.
 #[derive(Debug, Clone)]
 pub struct DataRow {
-    columns: Vec<Bytes>,
+    columns: Vec<Data>,
 }
 
 /// Convert value to data row column
 /// using text formatting.
 pub trait ToDataRowColumn {
-    fn to_data_row_column(&self) -> Bytes;
+    fn to_data_row_column(&self) -> Data;
 }
 
 impl ToDataRowColumn for String {
-    fn to_data_row_column(&self) -> Bytes {
-        Bytes::copy_from_slice(self.as_bytes())
+    fn to_data_row_column(&self) -> Data {
+        Bytes::copy_from_slice(self.as_bytes()).into()
     }
 }
 
 impl ToDataRowColumn for &String {
-    fn to_data_row_column(&self) -> Bytes {
-        Bytes::copy_from_slice(self.as_bytes())
+    fn to_data_row_column(&self) -> Data {
+        Bytes::copy_from_slice(self.as_bytes()).into()
     }
 }
 
 impl ToDataRowColumn for &str {
-    fn to_data_row_column(&self) -> Bytes {
-        Bytes::copy_from_slice(self.as_bytes())
+    fn to_data_row_column(&self) -> Data {
+        Bytes::copy_from_slice(self.as_bytes()).into()
     }
 }
 
 impl ToDataRowColumn for i64 {
-    fn to_data_row_column(&self) -> Bytes {
-        Bytes::copy_from_slice(self.to_string().as_bytes())
+    fn to_data_row_column(&self) -> Data {
+        Bytes::copy_from_slice(self.to_string().as_bytes()).into()
     }
 }
 
 impl ToDataRowColumn for usize {
-    fn to_data_row_column(&self) -> Bytes {
-        Bytes::copy_from_slice(self.to_string().as_bytes())
+    fn to_data_row_column(&self) -> Data {
+        Bytes::copy_from_slice(self.to_string().as_bytes()).into()
     }
 }
 
 impl ToDataRowColumn for u64 {
-    fn to_data_row_column(&self) -> Bytes {
-        Bytes::copy_from_slice(self.to_string().as_bytes())
+    fn to_data_row_column(&self) -> Data {
+        Bytes::copy_from_slice(self.to_string().as_bytes()).into()
     }
 }
 
 impl ToDataRowColumn for bool {
-    fn to_data_row_column(&self) -> Bytes {
-        Bytes::copy_from_slice(if *self { b"t" } else { b"f" })
+    fn to_data_row_column(&self) -> Data {
+        Bytes::copy_from_slice(if *self { b"t" } else { b"f" }).into()
     }
 }
 
 impl ToDataRowColumn for f64 {
-    fn to_data_row_column(&self) -> Bytes {
+    fn to_data_row_column(&self) -> Data {
         let number = format!("{:.5}", self);
-        Bytes::copy_from_slice(number.as_bytes())
+        Bytes::copy_from_slice(number.as_bytes()).into()
     }
 }
 
 impl ToDataRowColumn for u128 {
-    fn to_data_row_column(&self) -> Bytes {
-        Bytes::copy_from_slice(self.to_string().as_bytes())
+    fn to_data_row_column(&self) -> Data {
+        Bytes::copy_from_slice(self.to_string().as_bytes()).into()
     }
 }
 
@@ -93,7 +131,7 @@ impl DataRow {
     /// columns will be prefilled with NULLs.
     pub fn insert(&mut self, index: usize, value: impl ToDataRowColumn) -> &mut Self {
         while self.columns.len() <= index {
-            self.columns.push(Bytes::new());
+            self.columns.push(Data::null());
         }
         self.columns[index] = value.to_data_row_column();
         self
@@ -111,7 +149,7 @@ impl DataRow {
     /// Get data for column at index.
     #[inline]
     pub fn column(&self, index: usize) -> Option<Bytes> {
-        self.columns.get(index).cloned()
+        self.columns.get(index).cloned().map(|d| d.data)
     }
 
     /// Get integer at index with text/binary encoding.
@@ -207,6 +245,7 @@ impl FromBytes for DataRow {
 
                 column.freeze()
             })
+            .map(Data::from)
             .collect();
 
         Ok(Self { columns })
@@ -219,8 +258,12 @@ impl ToBytes for DataRow {
         payload.put_i16(self.columns.len() as i16);
 
         for column in &self.columns {
-            payload.put_i32(column.len() as i32);
-            payload.put(&column[..]);
+            if column.is_null {
+                payload.put_i32(-1);
+            } else {
+                payload.put_i32(column.len() as i32);
+                payload.put(&column[..]);
+            }
         }
 
         Ok(payload.freeze())

--- a/pgdog/src/net/messages/data_row.rs
+++ b/pgdog/src/net/messages/data_row.rs
@@ -98,8 +98,7 @@ impl ToDataRowColumn for bool {
 
 impl ToDataRowColumn for f64 {
     fn to_data_row_column(&self) -> Data {
-        let number = format!("{:.5}", self);
-        Bytes::copy_from_slice(number.as_bytes()).into()
+        Bytes::copy_from_slice(self.to_string().as_bytes()).into()
     }
 }
 

--- a/pgdog/src/net/messages/data_types/interval.rs
+++ b/pgdog/src/net/messages/data_types/interval.rs
@@ -3,7 +3,7 @@ use std::num::ParseIntError;
 use super::*;
 use bytes::Bytes;
 
-#[derive(Eq, PartialEq, Ord, PartialOrd, Default, Debug, Clone)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Default, Debug, Clone, Hash)]
 pub struct Interval {
     years: i64,
     months: i8,

--- a/pgdog/src/net/messages/data_types/interval.rs
+++ b/pgdog/src/net/messages/data_types/interval.rs
@@ -1,5 +1,7 @@
 use std::num::ParseIntError;
 
+use crate::net::messages::data_row::Data;
+
 use super::*;
 use bytes::Bytes;
 
@@ -32,8 +34,8 @@ impl Add for Interval {
 }
 
 impl ToDataRowColumn for Interval {
-    fn to_data_row_column(&self) -> Bytes {
-        self.encode(Format::Text).unwrap()
+    fn to_data_row_column(&self) -> Data {
+        self.encode(Format::Text).unwrap().into()
     }
 }
 

--- a/pgdog/src/net/messages/data_types/mod.rs
+++ b/pgdog/src/net/messages/data_types/mod.rs
@@ -23,7 +23,7 @@ pub trait FromDataType: Sized + PartialOrd + Ord + PartialEq {
     fn encode(&self, encoding: Format) -> Result<Bytes, Error>;
 }
 
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub enum Datum {
     /// BIGINT.
     Bigint(i64),

--- a/pgdog/src/net/messages/data_types/mod.rs
+++ b/pgdog/src/net/messages/data_types/mod.rs
@@ -1,6 +1,6 @@
 use std::ops::Add;
 
-use super::{bind::Format, Error, ToDataRowColumn};
+use super::{bind::Format, data_row::Data, Error, ToDataRowColumn};
 use ::uuid::Uuid;
 use bytes::Bytes;
 
@@ -48,7 +48,7 @@ pub enum Datum {
 }
 
 impl ToDataRowColumn for Datum {
-    fn to_data_row_column(&self) -> Bytes {
+    fn to_data_row_column(&self) -> Data {
         use Datum::*;
 
         match self {
@@ -61,7 +61,7 @@ impl ToDataRowColumn for Datum {
             TimestampTz(tz) => tz.to_data_row_column(),
             Uuid(uuid) => uuid.to_data_row_column(),
             Numeric(num) => num.to_data_row_column(),
-            Null => Bytes::new(),
+            Null => Data::null(),
         }
     }
 }

--- a/pgdog/src/net/messages/data_types/mod.rs
+++ b/pgdog/src/net/messages/data_types/mod.rs
@@ -78,6 +78,8 @@ impl Add for Datum {
             (SmallInt(a), SmallInt(b)) => SmallInt(a + b),
             (Interval(a), Interval(b)) => Interval(a + b),
             (Numeric(a), Numeric(b)) => Numeric(a + b),
+            (Datum::Null, b) => b,
+            (a, Datum::Null) => a,
             _ => Datum::Null, // Might be good to raise an error.
         }
     }
@@ -102,6 +104,10 @@ impl Datum {
             DataType::TimestampTz => Ok(Datum::TimestampTz(TimestampTz::decode(bytes, encoding)?)),
             _ => Ok(Datum::Null),
         }
+    }
+
+    pub fn is_null(&self) -> bool {
+        matches!(self, Datum::Null)
     }
 }
 

--- a/pgdog/src/net/messages/data_types/numeric.rs
+++ b/pgdog/src/net/messages/data_types/numeric.rs
@@ -6,6 +6,8 @@ use std::{
 
 use bytes::Buf;
 
+use crate::net::messages::data_row::Data;
+
 use super::*;
 
 /// We don't expect NaN's so we're going to implement Ord for this below.
@@ -89,7 +91,7 @@ impl FromDataType for Numeric {
 }
 
 impl ToDataRowColumn for Numeric {
-    fn to_data_row_column(&self) -> Bytes {
-        self.encode(Format::Text).unwrap()
+    fn to_data_row_column(&self) -> Data {
+        self.encode(Format::Text).unwrap().into()
     }
 }

--- a/pgdog/src/net/messages/data_types/numeric.rs
+++ b/pgdog/src/net/messages/data_types/numeric.rs
@@ -1,5 +1,6 @@
 use std::{
     cmp::Ordering,
+    hash::Hash,
     ops::{Deref, DerefMut},
 };
 
@@ -11,6 +12,13 @@ use super::*;
 #[derive(PartialEq, Copy, Clone, Debug)]
 pub struct Numeric {
     data: f64,
+}
+
+impl Hash for Numeric {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        // We don't expect NaNs from Postgres.
+        self.data.to_bits().hash(state);
+    }
 }
 
 impl PartialOrd for Numeric {

--- a/pgdog/src/net/messages/data_types/timestamp.rs
+++ b/pgdog/src/net/messages/data_types/timestamp.rs
@@ -4,7 +4,7 @@ use super::*;
 
 use super::interval::bigint;
 
-#[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Default)]
+#[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Default, Hash)]
 pub struct Timestamp {
     pub year: i64,
     pub month: i8,

--- a/pgdog/src/net/messages/data_types/timestamp.rs
+++ b/pgdog/src/net/messages/data_types/timestamp.rs
@@ -17,8 +17,8 @@ pub struct Timestamp {
 }
 
 impl ToDataRowColumn for Timestamp {
-    fn to_data_row_column(&self) -> Bytes {
-        self.encode(Format::Text).unwrap()
+    fn to_data_row_column(&self) -> Data {
+        self.encode(Format::Text).unwrap().into()
     }
 }
 

--- a/pgdog/src/net/messages/data_types/timestamptz.rs
+++ b/pgdog/src/net/messages/data_types/timestamptz.rs
@@ -2,7 +2,7 @@ use std::ops::{Deref, DerefMut};
 
 use super::*;
 
-#[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Default)]
+#[derive(Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq, Default, Hash)]
 pub struct TimestampTz {
     timestamp: Timestamp,
 }

--- a/pgdog/src/net/messages/data_types/timestamptz.rs
+++ b/pgdog/src/net/messages/data_types/timestamptz.rs
@@ -37,8 +37,8 @@ impl DerefMut for TimestampTz {
 }
 
 impl ToDataRowColumn for TimestampTz {
-    fn to_data_row_column(&self) -> Bytes {
-        self.encode(Format::Text).unwrap()
+    fn to_data_row_column(&self) -> Data {
+        self.encode(Format::Text).unwrap().into()
     }
 }
 

--- a/pgdog/src/net/messages/data_types/uuid.rs
+++ b/pgdog/src/net/messages/data_types/uuid.rs
@@ -24,7 +24,7 @@ impl FromDataType for Uuid {
 }
 
 impl ToDataRowColumn for Uuid {
-    fn to_data_row_column(&self) -> Bytes {
-        self.encode(Format::Text).unwrap()
+    fn to_data_row_column(&self) -> Data {
+        self.encode(Format::Text).unwrap().into()
     }
 }


### PR DESCRIPTION
### Feature

- Add `GROUP BY` support to aggregates. This works currently without rewriting queries, so the `GROUP BY` clause must use references to columns present in the result, e.g. `GROUP BY 3, 4`.
- Support NULLs in `DataRow` message building.

#40 