### PR TITLE
Reduce allocs around prepared statements cache

### DIFF
--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -440,7 +440,7 @@ impl Server {
             .parse(name)
             .ok_or(Error::PreparedStatementMissing(name.to_string()))?;
 
-        debug!("preparing \"{}\" [{}]", parse.name, self.addr());
+        debug!("preparing \"{}\" [{}]", parse.name(), self.addr());
 
         self.send(vec![parse.message()?, Flush.message()?]).await?;
         let response = self.read().await?;

--- a/pgdog/src/frontend/buffer.rs
+++ b/pgdog/src/frontend/buffer.rs
@@ -208,7 +208,7 @@ impl BufferedQuery {
     pub fn query(&self) -> &str {
         match self {
             Self::Query(query) => query.query(),
-            Self::Prepared(query) => &query.query,
+            Self::Prepared(parse) => parse.query(),
         }
     }
 }

--- a/pgdog/src/frontend/prepared_statements/mod.rs
+++ b/pgdog/src/frontend/prepared_statements/mod.rs
@@ -53,9 +53,9 @@ impl PreparedStatements {
     /// Register prepared statement with the global cache.
     fn insert(&mut self, parse: Parse) -> Parse {
         let (_new, name) = { self.global.lock().insert(&parse) };
-        self.local.insert(parse.name.clone(), name.clone());
+        self.local.insert(parse.name().to_owned(), name.clone());
 
-        Parse::named(name, parse.query)
+        parse.rename(&name)
     }
 
     /// Get global statement counter.
@@ -63,7 +63,7 @@ impl PreparedStatements {
         self.local.get(name)
     }
 
-    /// Number of prepared stamenets in the local cache.
+    /// Number of prepared statements in the local cache.
     pub fn len(&self) -> usize {
         self.local.len()
     }

--- a/pgdog/src/frontend/prepared_statements/rewrite.rs
+++ b/pgdog/src/frontend/prepared_statements/rewrite.rs
@@ -37,7 +37,7 @@ impl<'a> Rewrite<'a> {
             Ok(message.message()?)
         } else {
             let parse = self.statements.insert(parse);
-            self.requests.push(PreparedRequest::new(&parse.name, true));
+            self.requests.push(PreparedRequest::new(parse.name(), true));
             Ok(parse.message()?)
         }
     }
@@ -97,8 +97,8 @@ mod test {
         let parse = Parse::from_bytes(rewrite.rewrite(parse).unwrap().to_bytes().unwrap()).unwrap();
 
         assert!(!parse.anonymous());
-        assert_eq!(parse.name, "__pgdog_1");
-        assert_eq!(parse.query, "SELECT * FROM users");
+        assert_eq!(parse.name(), "__pgdog_1");
+        assert_eq!(parse.query(), "SELECT * FROM users");
         let requests = rewrite.requests();
         let request = requests.first().unwrap();
         assert_eq!(request.name(), "__pgdog_1");
@@ -143,7 +143,7 @@ mod test {
         let parse = Parse::from_bytes(rewrite.rewrite(parse).unwrap().to_bytes().unwrap()).unwrap();
 
         assert!(parse.anonymous());
-        assert_eq!(parse.query, "SELECT * FROM users");
+        assert_eq!(parse.query(), "SELECT * FROM users");
 
         assert!(statements.is_empty());
         assert!(statements.global.lock().is_empty());

--- a/pgdog/src/frontend/router/parser/query.rs
+++ b/pgdog/src/frontend/router/parser/query.rs
@@ -138,7 +138,7 @@ impl QueryParser {
 
         let ast = match query {
             BufferedQuery::Prepared(query) => {
-                Cache::get().parse(&query.query).map_err(Error::PgQuery)?
+                Cache::get().parse(query.query()).map_err(Error::PgQuery)?
             }
             // Don't cache simple queries, they contain parameter values.
             BufferedQuery::Query(query) => Arc::new(parse(query.query()).map_err(Error::PgQuery)?),


### PR DESCRIPTION
### Features
- Use `Arc` in Parse to avoid unnecessary re-allocations when checking the prepared statement cache.