### PR TITLE
Use replicas

### DIFF
--- a/integration/toxi/rspec_helper.rb
+++ b/integration/toxi/rspec_helper.rb
@@ -3,6 +3,7 @@
 require 'toxiproxy'
 require 'pg'
 require 'concurrent'
+require 'active_record'
 
 def conn
   PG.connect 'postgres://pgdog:pgdog@127.0.0.1:6432/failover'

--- a/integration/toxi/toxi_spec.rb
+++ b/integration/toxi/toxi_spec.rb
@@ -154,6 +154,9 @@ describe 'tcp' do
     end
 
     it 'primary ban is ignored' do
+      banned = admin.exec('SHOW POOLS').select do |pool|
+        pool['database'] == 'failover'
+      end.select { |item| item['banned'] == 'f' }
       Toxiproxy[:primary].toxic(:reset_peer).apply do
         c = conn
         c.exec 'BEGIN'

--- a/integration/toxi/toxi_spec.rb
+++ b/integration/toxi/toxi_spec.rb
@@ -19,7 +19,6 @@ def ar_conn(db, prepared)
   )
 end
 
-
 def warm_up
   conn.exec 'SELECT 1'
   admin.exec 'RECONNECT'
@@ -75,7 +74,7 @@ shared_examples 'minimal errors' do |role, toxic|
 
   it 'active record works' do
     # Create connection pool.
-    ar_conn("failover", true)
+    ar_conn('failover', true)
     # Connect (the pool is lazy)
     Sharded.where(id: 1).first
     errors = 0
@@ -83,11 +82,9 @@ shared_examples 'minimal errors' do |role, toxic|
     # that we currently route to primary.
     Toxiproxy[role].toxic(toxic).apply do
       25.times do
-        begin
-          Sharded.where(id: 1).first
-        rescue StandardError
-          errors += 1
-        end
+        Sharded.where(id: 1).first
+      rescue StandardError
+        errors += 1
       end
     end
     expect(errors).to eq(1)
@@ -156,36 +153,34 @@ describe 'tcp' do
       end
     end
 
-    it "primary ban is ignored" do
+    it 'primary ban is ignored' do
       Toxiproxy[:primary].toxic(:reset_peer).apply do
-        begin
-          c = conn
-          c.exec "BEGIN"
-          c.exec "CREATE TABLE test(id BIGINT)"
-          c.exec "ROLLBACK"
-        rescue StandardError
-        end
+        c = conn
+        c.exec 'BEGIN'
+        c.exec 'CREATE TABLE test(id BIGINT)'
+        c.exec 'ROLLBACK'
+      rescue StandardError
       end
-      banned = admin.exec("SHOW POOLS").select do |pool|
-        pool["database"] == "failover" && pool["role"] == "primary"
+      banned = admin.exec('SHOW POOLS').select do |pool|
+        pool['database'] == 'failover' && pool['role'] == 'primary'
       end
-      expect(banned[0]["banned"]).to eq("t")
+      expect(banned[0]['banned']).to eq('t')
 
       c = conn
-      c.exec "BEGIN"
-      c.exec "CREATE TABLE test(id BIGINT)"
-      c.exec "SELECT * FROM test"
-      c.exec "ROLLBACK"
+      c.exec 'BEGIN'
+      c.exec 'CREATE TABLE test(id BIGINT)'
+      c.exec 'SELECT * FROM test'
+      c.exec 'ROLLBACK'
 
-      banned = admin.exec("SHOW POOLS").select do |pool|
-        pool["database"] == "failover" && pool["role"] == "primary"
+      banned = admin.exec('SHOW POOLS').select do |pool|
+        pool['database'] == 'failover' && pool['role'] == 'primary'
       end
-      expect(banned[0]["banned"]).to eq("t")
+      expect(banned[0]['banned']).to eq('t')
     end
 
     it 'active record works' do
       # Create connection pool.
-      ar_conn("failover", true)
+      ar_conn('failover', true)
       # Connect (the pool is lazy)
       Sharded.where(id: 1).first
       errors = 0
@@ -193,11 +188,9 @@ describe 'tcp' do
       # that we currently route to primary.
       Toxiproxy[:primary].toxic(:reset_peer).apply do
         25.times do
-          begin
-            Sharded.where(id: 1).first
-          rescue StandardError
-            errors += 1
-          end
+          Sharded.where(id: 1).first
+        rescue StandardError
+          errors += 1
         end
       end
       expect(errors).to eq(1)

--- a/integration/toxi/toxi_spec.rb
+++ b/integration/toxi/toxi_spec.rb
@@ -2,6 +2,24 @@
 
 require_relative 'rspec_helper'
 
+class Sharded < ActiveRecord::Base
+  self.table_name = 'sharded'
+  self.primary_key = 'id'
+end
+
+def ar_conn(db, prepared)
+  ActiveRecord::Base.establish_connection(
+    adapter: 'postgresql',
+    host: '127.0.0.1',
+    port: 6432,
+    database: db,
+    password: 'pgdog',
+    user: 'pgdog',
+    prepared_statements: prepared
+  )
+end
+
+
 def warm_up
   conn.exec 'SELECT 1'
   admin.exec 'RECONNECT'
@@ -53,6 +71,26 @@ shared_examples 'minimal errors' do |role, toxic|
       threads.each(&:join)
     end
     expect(errors).to be < 25 # 5% error rate (instead of 100%)
+  end
+
+  it 'active record works' do
+    # Create connection pool.
+    ar_conn("failover", true)
+    # Connect (the pool is lazy)
+    Sharded.where(id: 1).first
+    errors = 0
+    # Can't ban primary because it issues SET queries
+    # that we currently route to primary.
+    Toxiproxy[role].toxic(toxic).apply do
+      25.times do
+        begin
+          Sharded.where(id: 1).first
+        rescue StandardError
+          errors += 1
+        end
+      end
+    end
+    expect(errors).to eq(1)
   end
 end
 
@@ -116,6 +154,53 @@ describe 'tcp' do
           expect(banned.size).to eq(0)
         end
       end
+    end
+
+    it "primary ban is ignored" do
+      Toxiproxy[:primary].toxic(:reset_peer).apply do
+        begin
+          c = conn
+          c.exec "BEGIN"
+          c.exec "CREATE TABLE test(id BIGINT)"
+          c.exec "ROLLBACK"
+        rescue StandardError
+        end
+      end
+      banned = admin.exec("SHOW POOLS").select do |pool|
+        pool["database"] == "failover" && pool["role"] == "primary"
+      end
+      expect(banned[0]["banned"]).to eq("t")
+
+      c = conn
+      c.exec "BEGIN"
+      c.exec "CREATE TABLE test(id BIGINT)"
+      c.exec "SELECT * FROM test"
+      c.exec "ROLLBACK"
+
+      banned = admin.exec("SHOW POOLS").select do |pool|
+        pool["database"] == "failover" && pool["role"] == "primary"
+      end
+      expect(banned[0]["banned"]).to eq("t")
+    end
+
+    it 'active record works' do
+      # Create connection pool.
+      ar_conn("failover", true)
+      # Connect (the pool is lazy)
+      Sharded.where(id: 1).first
+      errors = 0
+      # Can't ban primary because it issues SET queries
+      # that we currently route to primary.
+      Toxiproxy[:primary].toxic(:reset_peer).apply do
+        25.times do
+          begin
+            Sharded.where(id: 1).first
+          rescue StandardError
+            errors += 1
+          end
+        end
+      end
+      expect(errors).to eq(1)
     end
   end
 end

--- a/pgdog/src/backend/pool/inner.rs
+++ b/pgdog/src/backend/pool/inner.rs
@@ -127,7 +127,7 @@ impl Inner {
         let client_needs = below_max && !self.waiting.is_empty() && self.conns.is_empty();
         let maintenance_on = self.online && !self.paused;
 
-        !self.banned() && maintenance_on && (maintain_min || client_needs)
+        maintenance_on && (maintain_min || client_needs)
     }
 
     /// Check if the pool ban should be removed.

--- a/pgdog/src/backend/pool/shard.rs
+++ b/pgdog/src/backend/pool/shard.rs
@@ -32,7 +32,7 @@ impl Shard {
         self.primary
             .as_ref()
             .ok_or(Error::NoPrimary)?
-            .get(request)
+            .get_forced(request)
             .await
     }
 

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -319,7 +319,7 @@ impl Client {
                 }
                 Err(err) => {
                     if err.no_server() {
-                        error!("connection pool is down");
+                        error!("connection pool is down [{}]", self.addr);
                         self.stream.error(ErrorResponse::connection()).await?;
                         return Ok(false);
                     } else {

--- a/pgdog/src/frontend/router/parser/query.rs
+++ b/pgdog/src/frontend/router/parser/query.rs
@@ -287,7 +287,7 @@ impl QueryParser {
     }
 
     fn set(_stmt: &VariableSetStmt) -> Result<Command, Error> {
-        Ok(Command::Query(Route::write(Shard::All)))
+        Ok(Command::Query(Route::read(Shard::All)))
     }
 
     fn select(


### PR DESCRIPTION
### Features
- Bypass ban for primary pool if it's a write.
- Add ActiveRecord tests
- Route `SET` queries to replicas (no primary requirement for running Rails)