### PR TITLE
Respect manual bans

### DIFF
--- a/pgdog/src/backend/pool/pool_impl.rs
+++ b/pgdog/src/backend/pool/pool_impl.rs
@@ -207,7 +207,7 @@ impl Pool {
     /// Send a cancellation request if the client is connected to a server.
     pub async fn cancel(&self, id: &BackendKeyData) -> Result<(), super::super::Error> {
         if let Some(server) = self.peer(id) {
-            Server::cancel("127.0.0.1:5432", &server).await?;
+            Server::cancel(self.addr(), &server).await?;
         }
 
         Ok(())

--- a/pgdog/src/backend/pool/pool_impl.rs
+++ b/pgdog/src/backend/pool/pool_impl.rs
@@ -84,7 +84,7 @@ impl Pool {
                 // return error.
                 if unban {
                     unban = false;
-                    guard.ban = None;
+                    guard.maybe_unban();
                 }
 
                 if guard.banned() {

--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -182,8 +182,8 @@ impl Server {
     }
 
     /// Request query cancellation for the given backend server identifier.
-    pub async fn cancel(addr: &str, id: &BackendKeyData) -> Result<(), Error> {
-        let mut stream = TcpStream::connect(addr).await?;
+    pub async fn cancel(addr: &Address, id: &BackendKeyData) -> Result<(), Error> {
+        let mut stream = TcpStream::connect(addr.addr()).await?;
         stream
             .write_all(
                 &Startup::Cancel {


### PR DESCRIPTION
### Bug fixes
- Respect manual ban in primary unban logic.
- Remove hardcoded localhost address from query cancellation.