### PR TITLE
Allow empty passwords

### DIFF
--- a/integration/complex/passthrough_auth/run.sh
+++ b/integration/complex/passthrough_auth/run.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
-set -ex
+set -e
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 export PGPASSWORD=pgdog
 export PGPORT=6432
 export PGHOST=127.0.0.1
 
+killall -TERM pgdog 2> /dev/null || true
 
 ${SCRIPT_DIR}/../../../target/release/pgdog \
     --config ${SCRIPT_DIR}/pgdog-enabled.toml \
@@ -17,6 +18,13 @@ if ! psql -U pgdog1 pgdog -c 'SELECT 1' > /dev/null; then
 fi
 
 psql -U pgdog pgdog -c 'SELECT 1' > /dev/null
+
+statement_timeout=$(psql -U pgdog1 pgdog -c 'SHOW statement_timeout' -t)
+
+if [[ "$statement_timeout" != *"100ms"* ]]; then
+    echo "AutoDB didn't pick up setting from users.toml"
+    exit 1
+fi
 
 killall -TERM pgdog
 

--- a/integration/complex/passthrough_auth/users.toml
+++ b/integration/complex/passthrough_auth/users.toml
@@ -2,3 +2,8 @@
 name = "pgdog"
 database = "pgdog"
 password = "pgdog"
+
+[[users]]
+name = "pgdog1"
+database = "pgdog"
+statement_timeout = 100

--- a/integration/rust/tests/sqlx/bad_auth.rs
+++ b/integration/rust/tests/sqlx/bad_auth.rs
@@ -3,7 +3,7 @@ use sqlx::{Connection, PgConnection};
 #[tokio::test]
 async fn test_bad_auth() {
     for user in ["pgdog", "pgdog_bad_user"] {
-        for password in ["bad_password", "another_password"] {
+        for password in ["bad_password", "another_password", ""] {
             for db in ["random_db", "pgdog"] {
                 let err = PgConnection::connect(&format!(
                     "postgres://{}:{}@127.0.0.1:6432/{}",

--- a/pgdog/src/backend/databases.rs
+++ b/pgdog/src/backend/databases.rs
@@ -72,9 +72,16 @@ pub fn reload() -> Result<(), Error> {
 }
 
 /// Add new user to pool.
-pub(crate) fn add(user: &crate::config::User) {
+pub(crate) fn add(mut user: crate::config::User) {
     let config = config();
-    let pool = new_pool(user, &config.config);
+    for existing in &config.users.users {
+        if existing.name == user.name && existing.database == user.database {
+            let mut existing = existing.clone();
+            existing.password = user.password.clone();
+            user = existing;
+        }
+    }
+    let pool = new_pool(&user, &config.config);
     if let Some((user, cluster)) = pool {
         let _lock = LOCK.lock();
         let databases = (*databases()).clone();
@@ -156,7 +163,11 @@ impl Databases {
 
     /// Check if a cluster exists, quickly.
     pub fn exists(&self, user: impl ToUser) -> bool {
-        self.databases.get(&user.to_user()).is_some()
+        if let Some(cluster) = self.databases.get(&user.to_user()) {
+            !cluster.password().is_empty()
+        } else {
+            false
+        }
     }
 
     /// Get a cluster for the user/database pair if it's configured.

--- a/pgdog/src/backend/pool/address.rs
+++ b/pgdog/src/backend/pool/address.rs
@@ -42,7 +42,7 @@ impl Address {
             } else if let Some(password) = user.server_password.clone() {
                 password
             } else {
-                user.password.clone()
+                user.password().to_string()
             },
         }
     }
@@ -74,7 +74,7 @@ mod test {
 
         let user = User {
             name: "pgdog".into(),
-            password: "hunter2".into(),
+            password: Some("hunter2".into()),
             database: "pgdog".into(),
             ..Default::default()
         };

--- a/pgdog/src/backend/pool/cluster.rs
+++ b/pgdog/src/backend/pool/cluster.rs
@@ -70,7 +70,7 @@ impl<'a> ClusterConfig<'a> {
     ) -> Self {
         Self {
             name: &user.database,
-            password: &user.password,
+            password: user.password(),
             replication_sharding: user.replication_sharding.clone(),
             pooler_mode: user.pooler_mode.unwrap_or(general.pooler_mode),
             lb_strategy: general.load_balancing_strategy,

--- a/pgdog/src/backend/pool/config.rs
+++ b/pgdog/src/backend/pool/config.rs
@@ -124,18 +124,28 @@ impl Config {
     }
 
     /// Create from database/user configuration.
-    pub fn new(general: &General, _database: &Database, user: &User) -> Self {
+    pub fn new(general: &General, database: &Database, user: &User) -> Self {
         Config {
-            min: user.min_pool_size.unwrap_or(general.min_pool_size),
-            max: user.pool_size.unwrap_or(general.default_pool_size),
+            min: database
+                .min_pool_size
+                .unwrap_or(user.min_pool_size.unwrap_or(general.min_pool_size)),
+            max: database
+                .pool_size
+                .unwrap_or(user.pool_size.unwrap_or(general.default_pool_size)),
             healthcheck_interval: general.healthcheck_interval,
             idle_healthcheck_interval: general.idle_healthcheck_interval,
             idle_healthcheck_delay: general.idle_healthcheck_delay,
             ban_timeout: general.ban_timeout,
             rollback_timeout: general.rollback_timeout,
-            statement_timeout: user.statement_timeout,
+            statement_timeout: if let Some(statement_timeout) = database.statement_timeout {
+                Some(statement_timeout)
+            } else {
+                user.statement_timeout
+            },
             replication_mode: user.replication_mode,
-            pooler_mode: user.pooler_mode.unwrap_or(general.pooler_mode),
+            pooler_mode: database
+                .pooler_mode
+                .unwrap_or(user.pooler_mode.unwrap_or(general.pooler_mode)),
             connect_timeout: general.connect_timeout,
             query_timeout: general.query_timeout,
             checkout_timeout: general.checkout_timeout,

--- a/pgdog/src/config/convert.rs
+++ b/pgdog/src/config/convert.rs
@@ -12,7 +12,7 @@ impl User {
         Ok(Self {
             name: user.to_owned(),
             database: database.to_owned(),
-            password: password.to_owned(),
+            password: Some(password.to_owned()),
             ..Default::default()
         })
     }

--- a/pgdog/src/config/mod.rs
+++ b/pgdog/src/config/mod.rs
@@ -507,6 +507,14 @@ pub struct Database {
     // Maximum number of connections to this database from this pooler.
     // #[serde(default = "Database::max_connections")]
     // pub max_connections: usize,
+    /// Pool size for this database pools, overriding `default_pool_size`.
+    pub pool_size: Option<usize>,
+    /// Minimum pool size for this database pools, overriding `min_pool_size`.
+    pub min_pool_size: Option<usize>,
+    /// Pooler mode.
+    pub pooler_mode: Option<PoolerMode>,
+    /// Statement timeout.
+    pub statement_timeout: Option<u64>,
 }
 
 impl Database {
@@ -576,7 +584,7 @@ pub struct User {
     /// Database name, from pgdog.toml.
     pub database: String,
     /// User's password.
-    pub password: String,
+    pub password: Option<String>,
     /// Pool size for this user pool, overriding `default_pool_size`.
     pub pool_size: Option<usize>,
     /// Minimum pool size for this user pool, overriding `min_pool_size`.
@@ -594,6 +602,16 @@ pub struct User {
     pub replication_mode: bool,
     /// Sharding into this database.
     pub replication_sharding: Option<String>,
+}
+
+impl User {
+    pub fn password(&self) -> &str {
+        if let Some(ref s) = self.password {
+            s.as_str()
+        } else {
+            ""
+        }
+    }
 }
 
 /// Admin database settings.

--- a/pgdog/src/config/mod.rs
+++ b/pgdog/src/config/mod.rs
@@ -117,7 +117,7 @@ impl ConfigAndUsers {
 
         let users: Users = if let Ok(users) = read_to_string(users_path) {
             let mut users: Users = toml::from_str(&users)?;
-            users.check();
+            users.check(&config);
             info!("loaded \"{}\"", users_path.display());
             users
         } else {
@@ -576,9 +576,16 @@ impl Users {
         users
     }
 
-    pub fn check(&mut self) {
+    pub fn check(&mut self, config: &Config) {
         for user in &mut self.users {
             if user.password().is_empty() {
+                if !config.general.passthrough_auth() {
+                    warn!(
+                        "user \"{}\" doesn't have a password and passthrough auth is disabled",
+                        user.name
+                    );
+                }
+
                 if let Some(min_pool_size) = user.min_pool_size {
                     if min_pool_size > 0 {
                         warn!("user \"{}\" (database \"{}\") doesn't have a password configured, \

--- a/pgdog/src/config/url.rs
+++ b/pgdog/src/config/url.rs
@@ -42,7 +42,7 @@ impl From<&Url> for User {
 
         User {
             name: user,
-            password,
+            password: Some(password),
             database: database_name(value),
             ..Default::default()
         }

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -75,7 +75,7 @@ impl Client {
             let password = Password::from_bytes(password.to_bytes()?)?;
             let user = config::User::from_params(&params, &password).ok();
             if let Some(user) = user {
-                databases::add(&user);
+                databases::add(user);
             }
         }
 

--- a/users.toml
+++ b/users.toml
@@ -11,6 +11,12 @@ database = "pgdog"
 password = "pgdog"
 
 [[users]]
+name = "lev"
+database = "pgdog"
+pool_size = 20
+statement_timeout = 100
+
+[[users]]
 name = "pgdog_replication"
 database = "pgdog"
 password = "pgdog"

--- a/users.toml
+++ b/users.toml
@@ -11,12 +11,6 @@ database = "pgdog"
 password = "pgdog"
 
 [[users]]
-name = "lev"
-database = "pgdog"
-pool_size = 20
-statement_timeout = 100
-
-[[users]]
 name = "pgdog_replication"
 database = "pgdog"
 password = "pgdog"


### PR DESCRIPTION
### Features
- Passthrough auth users can be specified in `users.toml` without the password. User settings will be picked up as if the user had a password.
- All user-specific settings can be now be specified on the database in `pgdog.toml`. User settings continue to take highest priority, database settings are next, and general settings are lowest priority.