### PR TITLE
Save server connections on reload

### DIFF
--- a/examples/mastodon/fk.py
+++ b/examples/mastodon/fk.py
@@ -1,0 +1,77 @@
+import psycopg
+from psycopg import ClientCursor
+from logging import getLogger, DEBUG
+
+logger = getLogger(__name__)
+logger.setLevel(DEBUG)
+
+tables = """SELECT table_name FROM information_schema.tables WHERE table_schema='public'"""
+
+foreign_key = """
+SELECT
+    r.table_name
+FROM information_schema.constraint_column_usage       u
+INNER JOIN information_schema.referential_constraints fk
+           ON u.constraint_catalog = fk.unique_constraint_catalog
+               AND u.constraint_schema = fk.unique_constraint_schema
+               AND u.constraint_name = fk.unique_constraint_name
+INNER JOIN information_schema.key_column_usage        r
+           ON r.constraint_catalog = fk.constraint_catalog
+               AND r.constraint_schema = fk.constraint_schema
+               AND r.constraint_name = fk.constraint_name
+WHERE
+    u.column_name::TEXT = %s::TEXT AND
+    u.table_catalog = 'mastodon_development' AND
+    u.table_schema = 'public' AND
+    u.table_name::TEXT = %s::TEXT
+"""
+
+table_columns = """SELECT column_name
+  FROM information_schema.columns
+ WHERE table_schema = 'public'
+   AND table_name  = %s
+   AND column_name LIKE '%%id'
+     ;"""
+
+def get_fks(table, cur, checked):
+    if table in checked:
+        return []
+
+    cur.execute(table_columns, [table])
+    columns = cur.fetchall()
+
+    foreign_keys = []
+
+    for column in columns:
+        column = column[0]
+        cur.execute(foreign_key, [column, table])
+        fks = cur.fetchall()
+        foreign_keys = foreign_keys + fks
+    checked.add(table)
+
+    if not foreign_keys:
+        return foreign_keys
+
+    result = foreign_keys
+
+    for fk in foreign_keys:
+        result += get_fks(fk[0], cur, checked)
+
+    return result
+
+if __name__ == "__main__":
+    conn = psycopg.connect("dbname=mastodon_development", cursor_factory=ClientCursor)
+    cur = conn.cursor()
+
+    cur.execute(tables)
+    tables = cur.fetchall()
+    foreign_keys = []
+
+    for table in tables:
+        checked = set()
+        table = table[0]
+        cur.execute(foreign_key, ["id", table])
+        fks = get_fks(table, cur, checked)
+        foreign_keys.append((table, len(fks)))
+    sorted_keys = sorted(foreign_keys, key=lambda table: table[1])
+    print(sorted_keys[-1])

--- a/integration/dev-server.sh
+++ b/integration/dev-server.sh
@@ -4,5 +4,5 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source ${SCRIPT_DIR}/setup.sh
 source ${SCRIPT_DIR}/toxi/setup.sh
 pushd ${SCRIPT_DIR}/../
-cargo watch --shell "cargo run --release -- --config integration/pgdog.toml --users integration/users.toml"
+cargo watch --shell "cargo run -- --config integration/pgdog.toml --users integration/users.toml"
 popd

--- a/integration/rust/Cargo.toml
+++ b/integration/rust/Cargo.toml
@@ -12,3 +12,4 @@ sqlx = { version = "*", features = ["postgres", "runtime-tokio", "tls-native-tls
 tokio = { version = "1", features = ["full"]}
 futures-util = "*"
 uuid  = "*"
+serial_test = "3"

--- a/integration/rust/tests/integration/fake_transactions.rs
+++ b/integration/rust/tests/integration/fake_transactions.rs
@@ -1,7 +1,9 @@
 use rust::setup::{admin_sqlx, connections_sqlx};
+use serial_test::serial;
 use sqlx::{Executor, Pool, Postgres, Row};
 
 #[tokio::test]
+#[serial]
 async fn test_fake_transactions() {
     let conn = connections_sqlx().await.into_iter().skip(1).next().unwrap();
     let admin = admin_sqlx().await;

--- a/integration/rust/tests/integration/reload.rs
+++ b/integration/rust/tests/integration/reload.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use rust::setup::{admin_tokio, connection_failover};
+use rust::setup::{admin_tokio, backends, connection_failover};
 use sqlx::Executor;
 use tokio::time::sleep;
 
@@ -9,9 +9,22 @@ async fn test_reload() {
     let admin = admin_tokio().await;
     let conn = connection_failover().await;
 
+    conn.execute("SET application_name TO 'test_reload'")
+        .await
+        .unwrap();
+
+    let backends_before = backends("test_reload", &conn).await;
+
+    assert!(!backends_before.is_empty());
+
     for _ in 0..5 {
         conn.execute("SELECT 1").await.unwrap();
         admin.simple_query("RELOAD").await.unwrap();
-        sleep(Duration::from_millis(100)).await;
+        sleep(Duration::from_millis(50)).await;
     }
+
+    let backends_after = backends("test_reload", &conn).await;
+
+    let some_survived = backends_after.iter().any(|b| backends_before.contains(b));
+    assert!(some_survived);
 }

--- a/integration/rust/tests/integration/reload.rs
+++ b/integration/rust/tests/integration/reload.rs
@@ -1,17 +1,21 @@
 use std::time::Duration;
 
 use rust::setup::{admin_tokio, backends, connection_failover};
+use serial_test::serial;
 use sqlx::Executor;
 use tokio::time::sleep;
 
 #[tokio::test]
+#[serial]
 async fn test_reload() {
+    sleep(Duration::from_secs(1)).await;
     let admin = admin_tokio().await;
     let conn = connection_failover().await;
 
     conn.execute("SET application_name TO 'test_reload'")
         .await
         .unwrap();
+    conn.execute("SELECT 1").await.unwrap();
 
     let backends_before = backends("test_reload", &conn).await;
 
@@ -27,4 +31,28 @@ async fn test_reload() {
 
     let some_survived = backends_after.iter().any(|b| backends_before.contains(b));
     assert!(some_survived);
+}
+
+#[tokio::test]
+#[serial]
+async fn test_reconnect() {
+    let admin = admin_tokio().await;
+    let conn = connection_failover().await;
+
+    conn.execute("SET application_name TO 'test_reconnect'")
+        .await
+        .unwrap();
+
+    let backends_before = backends("test_reconnect", &conn).await;
+
+    assert!(!backends_before.is_empty());
+
+    conn.execute("SELECT 1").await.unwrap();
+    admin.simple_query("RECONNECT").await.unwrap();
+    sleep(Duration::from_millis(50)).await;
+
+    let backends_after = backends("test_reconnect", &conn).await;
+
+    let none_survived = backends_after.iter().any(|b| backends_before.contains(b));
+    assert!(!none_survived);
 }

--- a/pgdog.toml
+++ b/pgdog.toml
@@ -5,12 +5,13 @@
 [general]
 host = "0.0.0.0"
 port = 6432
-shutdown_timeout = 1_000
+shutdown_timeout = 5_000
 openmetrics_port = 9090
 query_timeout = 1_000
 checkout_timeout = 1_000
 connect_timeout = 1_000
 passthrough_auth = "enabled_plain"
+idle_timeout = 30_000
 # dry_run = true
 
 #

--- a/pgdog/src/backend/pool/cluster.rs
+++ b/pgdog/src/backend/pool/cluster.rs
@@ -118,6 +118,23 @@ impl Cluster {
         shard.replica(request).await
     }
 
+    /// The two clusters have the same databases.
+    pub(crate) fn can_move_conns_to(&self, other: &Cluster) -> bool {
+        self.shards.len() == other.shards.len()
+            && self
+                .shards
+                .iter()
+                .zip(other.shards.iter())
+                .all(|(a, b)| a.can_move_conns_to(b))
+    }
+
+    /// Move connections from cluster to another, saving them.
+    pub(crate) fn move_conns_to(&self, other: &Cluster) {
+        for (from, to) in self.shards.iter().zip(other.shards.iter()) {
+            from.move_conns_to(to);
+        }
+    }
+
     /// Create new identical cluster connection pool.
     ///
     /// This will allocate new server connections. Use when reloading configuration

--- a/pgdog/src/backend/pool/config.rs
+++ b/pgdog/src/backend/pool/config.rs
@@ -149,6 +149,9 @@ impl Config {
             connect_timeout: general.connect_timeout,
             query_timeout: general.query_timeout,
             checkout_timeout: general.checkout_timeout,
+            idle_timeout: user
+                .idle_timeout
+                .unwrap_or(database.idle_timeout.unwrap_or(general.idle_timeout)),
             ..Default::default()
         }
     }

--- a/pgdog/src/backend/pool/inner.rs
+++ b/pgdog/src/backend/pool/inner.rs
@@ -38,7 +38,7 @@ pub(super) struct Inner {
     /// The pool has been changed and connections should be returned
     /// to the new pool.
     moved: Option<Pool>,
-    id: i64,
+    id: u64,
 }
 
 impl std::fmt::Debug for Inner {
@@ -56,7 +56,7 @@ impl std::fmt::Debug for Inner {
 
 impl Inner {
     /// New inner structure.
-    pub(super) fn new(config: Config, id: i64) -> Self {
+    pub(super) fn new(config: Config, id: u64) -> Self {
         Self {
             conns: VecDeque::new(),
             taken: Vec::new(),

--- a/pgdog/src/backend/pool/inner.rs
+++ b/pgdog/src/backend/pool/inner.rs
@@ -217,6 +217,11 @@ impl Inner {
         self.conns.push_back(conn);
     }
 
+    #[inline]
+    pub(super) fn set_taken(&mut self, taken: Vec<Mapping>) {
+        self.taken = taken;
+    }
+
     /// Dump all idle connections.
     #[inline]
     pub(super) fn dump_idle(&mut self) {
@@ -226,9 +231,12 @@ impl Inner {
     /// Take all idle connections and tell active ones to
     /// be returned to a different pool instance.
     #[inline]
-    pub(super) fn move_conns_to(&mut self, destination: &Pool) -> Vec<Server> {
+    pub(super) fn move_conns_to(&mut self, destination: &Pool) -> (Vec<Server>, Vec<Mapping>) {
         self.moved = Some(destination.clone());
-        std::mem::take(&mut self.conns).into_iter().collect()
+        let idle = std::mem::take(&mut self.conns).into_iter().collect();
+        let taken = std::mem::take(&mut self.taken);
+
+        (idle, taken)
     }
 
     #[inline]

--- a/pgdog/src/backend/pool/replicas.rs
+++ b/pgdog/src/backend/pool/replicas.rs
@@ -54,6 +54,25 @@ impl Replicas {
         }
     }
 
+    /// Move connections from this replica set to another.
+    pub fn move_conns_to(&self, destination: &Replicas) {
+        assert_eq!(self.pools.len(), destination.pools.len());
+
+        for (from, to) in self.pools.iter().zip(destination.pools.iter()) {
+            from.move_conns_to(to);
+        }
+    }
+
+    /// The two replica sets are referring to the same databases.
+    pub fn can_move_conns_to(&self, destination: &Replicas) -> bool {
+        self.pools.len() == destination.pools.len()
+            && self
+                .pools
+                .iter()
+                .zip(destination.pools.iter())
+                .all(|(a, b)| a.can_move_conns_to(b))
+    }
+
     /// How many replicas we are connected to.
     pub fn len(&self) -> usize {
         self.pools.len()

--- a/pgdog/src/backend/pool/shard.rs
+++ b/pgdog/src/backend/pool/shard.rs
@@ -49,6 +49,33 @@ impl Shard {
         }
     }
 
+    /// Move pool connections from self to destination.
+    /// This shuts down my pool.
+    pub fn move_conns_to(&self, destination: &Shard) {
+        if let Some(ref primary) = self.primary {
+            if let Some(ref other) = destination.primary {
+                primary.move_conns_to(other);
+            }
+        }
+
+        self.replicas.move_conns_to(&destination.replicas);
+    }
+
+    /// The two shards have the same databases.
+    pub(crate) fn can_move_conns_to(&self, other: &Shard) -> bool {
+        if let Some(ref primary) = self.primary {
+            if let Some(ref other) = other.primary {
+                if !primary.can_move_conns_to(other) {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        }
+
+        self.replicas.can_move_conns_to(&other.replicas)
+    }
+
     /// Create new identical connection pool.
     pub fn duplicate(&self) -> Self {
         Self {

--- a/pgdog/src/config/mod.rs
+++ b/pgdog/src/config/mod.rs
@@ -322,6 +322,9 @@ pub struct General {
     /// Dry run for sharding. Parse the query, route to shard 0.
     #[serde(default)]
     pub dry_run: bool,
+    /// Idle timeout.
+    #[serde(default = "General::idle_timeout")]
+    pub idle_timeout: u64,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
@@ -380,6 +383,7 @@ impl Default for General {
             query_timeout: Self::default_query_timeout(),
             checkout_timeout: Self::checkout_timeout(),
             dry_run: bool::default(),
+            idle_timeout: Self::idle_timeout(),
         }
     }
 }
@@ -423,6 +427,10 @@ impl General {
 
     fn rollback_timeout() -> u64 {
         5_000
+    }
+
+    fn idle_timeout() -> u64 {
+        Duration::from_secs(60).as_millis() as u64
     }
 
     fn default_query_timeout() -> u64 {
@@ -538,6 +546,8 @@ pub struct Database {
     pub pooler_mode: Option<PoolerMode>,
     /// Statement timeout.
     pub statement_timeout: Option<u64>,
+    /// Idle timeout.
+    pub idle_timeout: Option<u64>,
 }
 
 impl Database {
@@ -647,6 +657,8 @@ pub struct User {
     pub replication_mode: bool,
     /// Sharding into this database.
     pub replication_sharding: Option<String>,
+    /// Idle timeout.
+    pub idle_timeout: Option<u64>,
 }
 
 impl User {

--- a/pgdog/src/frontend/listener.rs
+++ b/pgdog/src/frontend/listener.rs
@@ -81,7 +81,9 @@ impl Listener {
                 }
 
                 _ = sighup.listen() => {
-                    reload()?;
+                    if let Err(err) = reload() {
+                        error!("configuration reload error: {}", err);
+                    }
                 }
 
                 _ = self.shutdown.notified() => {

--- a/pgdog/src/frontend/listener.rs
+++ b/pgdog/src/frontend/listener.rs
@@ -3,18 +3,18 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use tokio::net::{TcpListener, TcpStream};
-use tokio::signal::ctrl_c;
-use tokio::sync::Notify;
-use tokio::time::timeout;
-use tokio::{select, spawn};
-
-use crate::backend::databases::{databases, shutdown};
+use crate::backend::databases::{databases, reload, shutdown};
 use crate::config::config;
 use crate::net::messages::BackendKeyData;
 use crate::net::messages::{hello::SslReply, Startup};
 use crate::net::tls::acceptor;
 use crate::net::{tweak, Stream};
+use crate::sighup::Sighup;
+use tokio::net::{TcpListener, TcpStream};
+use tokio::signal::ctrl_c;
+use tokio::sync::Notify;
+use tokio::time::timeout;
+use tokio::{select, spawn};
 
 use tracing::{error, info, warn};
 
@@ -45,6 +45,7 @@ impl Listener {
         info!("🐕 PgDog listening on {}", self.addr);
         let comms = comms();
         let shutdown_signal = comms.shutting_down();
+        let mut sighup = Sighup::new()?;
 
         loop {
             let comms = comms.clone();
@@ -77,6 +78,10 @@ impl Listener {
 
                 _ = ctrl_c() => {
                     self.start_shutdown();
+                }
+
+                _ = sighup.listen() => {
+                    reload()?;
                 }
 
                 _ = self.shutdown.notified() => {

--- a/pgdog/src/main.rs
+++ b/pgdog/src/main.rs
@@ -19,6 +19,7 @@ pub mod config;
 pub mod frontend;
 pub mod net;
 pub mod plugin;
+pub mod sighup;
 pub mod state;
 pub mod stats;
 #[cfg(feature = "tui")]

--- a/pgdog/src/sighup.rs
+++ b/pgdog/src/sighup.rs
@@ -1,0 +1,27 @@
+#[cfg(target_family = "unix")]
+use tokio::signal::unix::*;
+
+pub struct Sighup {
+    #[cfg(target_family = "unix")]
+    sig: Signal,
+}
+
+impl Sighup {
+    pub(crate) fn new() -> std::io::Result<Self> {
+        let sig = signal(SignalKind::hangup())?;
+        Ok(Self { sig })
+    }
+
+    pub(crate) async fn listen(&mut self) {
+        #[cfg(target_family = "unix")]
+        self.sig.recv().await;
+
+        #[cfg(not(target_family = "unix"))]
+        loop {
+            use std::time::Duration;
+            use tokio::time::sleep;
+
+            sleep(Duration::MAX).await;
+        }
+    }
+}

--- a/pgdog/src/sighup.rs
+++ b/pgdog/src/sighup.rs
@@ -7,9 +7,15 @@ pub struct Sighup {
 }
 
 impl Sighup {
+    #[cfg(target_family = "unix")]
     pub(crate) fn new() -> std::io::Result<Self> {
         let sig = signal(SignalKind::hangup())?;
         Ok(Self { sig })
+    }
+
+    #[cfg(not(target_family = "unix"))]
+    pub(crate) fn new() -> std::io::Result<Self> {
+        Self {}
     }
 
     pub(crate) async fn listen(&mut self) {


### PR DESCRIPTION
### Features

- Preserve server connections when reloading config with no cluster topology changes.
- Listen for `SIGHUP` and reload config.