### PR TITLE
Release connection before doing I/O

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,9 +92,9 @@ jobs:
           bash integration/toxi/setup.sh
       - name: Build PgDog
         run: cargo build --release
-      - name: Run JS
+      - name: JavaScript
         run: bash integration/js/pg_tests/run.sh
-      - name: Run Toxi
+      - name: Toxi
         run: bash integration/toxi/run.sh
       - name: Python
         run: bash integration/python/run.sh

--- a/pgdog.toml
+++ b/pgdog.toml
@@ -13,7 +13,7 @@ connect_timeout = 1_000
 passthrough_auth = "enabled_plain"
 idle_timeout = 30_000
 prepared_statements = "disabled"
-default_pool_size = 1
+default_pool_size = 10
 # dry_run = true
 workers = 0
 

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -409,19 +409,10 @@ impl Client {
             inner.stats.idle(self.in_transaction);
         }
 
-        trace!("[{}] <- {:#?}", self.addr, message);
-
-        if flush || async_flush || streaming {
-            self.stream.send_flush(&message).await?;
-            if async_flush {
-                inner.is_async = false;
-            }
-        } else {
-            self.stream.send(&message).await?;
-        }
-
         inner.stats.sent(len);
 
+        // Release the connection back into the pool
+        // before flushing data to client.
         if inner.backend.done() {
             let changed_params = inner.backend.changed_params();
             if inner.transaction_mode() {
@@ -441,12 +432,24 @@ impl Client {
                 }
                 inner.comms.update_params(&self.params);
             }
-            if inner.comms.offline() && !self.admin {
-                return Ok(true);
-            }
         }
 
-        Ok(false)
+        trace!("[{}] <- {:#?}", self.addr, message);
+
+        if flush || async_flush || streaming {
+            self.stream.send_flush(&message).await?;
+            if async_flush {
+                inner.is_async = false;
+            }
+        } else {
+            self.stream.send(&message).await?;
+        }
+
+        if inner.comms.offline() && !self.admin {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 
     /// Buffer extended protocol messages until client requests a sync.

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -445,11 +445,13 @@ impl Client {
             self.stream.send(&message).await?;
         }
 
-        if inner.comms.offline() && !self.admin {
-            Ok(true)
-        } else {
-            Ok(false)
+        if inner.backend.done() {
+            if inner.comms.offline() && !self.admin {
+                return Ok(true);
+            }
         }
+
+        Ok(false)
     }
 
     /// Buffer extended protocol messages until client requests a sync.

--- a/pgdog/src/net/stream.rs
+++ b/pgdog/src/net/stream.rs
@@ -186,6 +186,11 @@ impl Stream {
         bytes.put_u8(code);
         bytes.put_i32(len);
 
+        // Length must be at least 4 bytes.
+        if len < 4 {
+            return Err(crate::net::Error::Eof);
+        }
+
         bytes.resize(len as usize + 1, 0); // self + 1 byte for the message code
 
         self.read_exact(&mut bytes[5..]).await?;


### PR DESCRIPTION
### Optimizations

- Release server connection back into the pool before doing I/O.
- Don't allocate a `Vec` for multi-shard transactions.

### Bugs

- Ensure the message we receive is at least 4 bytes long (as per spec).