### PR TITLE
Remove memory allocations from Parse

### DIFF
--- a/pgdog/src/frontend/prepared_statements/global_cache.rs
+++ b/pgdog/src/frontend/prepared_statements/global_cache.rs
@@ -1,6 +1,7 @@
+use bytes::Bytes;
+
 use crate::net::messages::{Parse, RowDescription};
 use std::collections::hash_map::{Entry, HashMap};
-use std::sync::Arc;
 
 // Format the globally unique prepared statement
 // name based on the counter.
@@ -29,8 +30,8 @@ impl Statement {
 ///
 #[derive(Debug, Clone, PartialEq, Hash, Eq)]
 struct CacheKey {
-    query: Arc<String>,
-    data_types: Arc<Vec<i32>>,
+    query: Bytes,
+    data_types: Bytes,
     version: usize,
 }
 

--- a/pgdog/src/net/messages/parse.rs
+++ b/pgdog/src/net/messages/parse.rs
@@ -209,5 +209,7 @@ mod test {
         assert_eq!(parse.name(), "__pgdog_1");
         assert_eq!(parse.query(), "SELECT * FROM users");
         assert_eq!(parse.data_types().len(), 0);
+
+        assert!(Parse::new_anonymous("SELECT 1").anonymous());
     }
 }

--- a/pgdog/src/net/messages/parse.rs
+++ b/pgdog/src/net/messages/parse.rs
@@ -50,7 +50,7 @@ impl Parse {
 
     /// Anonymous prepared statement.
     pub fn anonymous(&self) -> bool {
-        self.name.is_empty()
+        self.name.len() == 1 // Just the null byte.
     }
 
     pub fn query(&self) -> &str {

--- a/pgdog/src/net/messages/parse.rs
+++ b/pgdog/src/net/messages/parse.rs
@@ -1,7 +1,10 @@
 //! Parse (F) message.
 
-use crate::net::c_string_buf;
-use std::sync::Arc;
+use crate::net::c_string_buf_len;
+use std::io::Cursor;
+use std::mem::size_of;
+use std::str::from_utf8;
+use std::str::from_utf8_unchecked;
 
 use super::code;
 use super::prelude::*;
@@ -10,32 +13,27 @@ use super::prelude::*;
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Default)]
 pub struct Parse {
     /// Prepared statement name.
-    name: Arc<String>,
+    name: Bytes,
     /// Prepared statement query.
-    query: Arc<String>,
+    query: Bytes,
     /// List of data types if any are declared.
-    data_types: Arc<Vec<i32>>,
+    data_types: Bytes,
     /// Original payload.
     original: Option<Bytes>,
 }
 
 impl Parse {
     pub fn len(&self) -> usize {
-        self.name.len() + 1
-        + self.query.len() + 1
-        + 2 // number of params
-        + self.data_types().len() * 4
-        + 4 // len
-        + 1 // code
+        self.name.len() + self.query.len() + self.data_types.len() + 5
     }
 
     /// New anonymous prepared statement.
     #[cfg(test)]
     pub fn new_anonymous(query: &str) -> Self {
         Self {
-            name: Arc::new("".into()),
-            query: Arc::new(query.to_string()),
-            data_types: Arc::new(vec![]),
+            name: Bytes::from("\0"),
+            query: Bytes::from(query.to_owned() + "\0"),
+            data_types: Bytes::copy_from_slice(&0i16.to_be_bytes()),
             original: None,
         }
     }
@@ -43,9 +41,9 @@ impl Parse {
     /// New prepared statement.
     pub fn named(name: impl ToString, query: impl ToString) -> Self {
         Self {
-            name: Arc::new(name.to_string()),
-            query: Arc::new(query.to_string()),
-            data_types: Arc::new(vec![]),
+            name: Bytes::from(name.to_string() + "\0"),
+            query: Bytes::from(query.to_string() + "\0"),
+            data_types: Bytes::copy_from_slice(&0i16.to_be_bytes()),
             original: None,
         }
     }
@@ -56,31 +54,65 @@ impl Parse {
     }
 
     pub fn query(&self) -> &str {
-        &self.query
+        // SAFETY: We check that this is valid UTF-8 in Self::from_bytes.
+        unsafe { from_utf8_unchecked(&self.query[0..self.query.len() - 1]) }
     }
 
     /// Get query reference.
-    pub fn query_ref(&self) -> Arc<String> {
+    pub fn query_ref(&self) -> Bytes {
         self.query.clone()
     }
 
     pub fn name(&self) -> &str {
-        &self.name
+        // SAFETY: We check that this is valid UTF-8 in Self::from_bytes.
+        unsafe { from_utf8_unchecked(&self.name[0..self.name.len() - 1]) }
     }
 
     pub fn rename(&self, name: &str) -> Parse {
         let mut parse = self.clone();
-        parse.name = Arc::new(name.to_owned());
+        parse.name = Bytes::from(name.to_string() + "\0");
         parse.original = None;
         parse
     }
 
-    pub fn data_types(&self) -> &[i32] {
-        &self.data_types
+    pub fn data_types(&self) -> DataTypesIter<'_> {
+        DataTypesIter {
+            data_types: &self.data_types,
+            offset: 0,
+        }
     }
 
-    pub fn data_types_ref(&self) -> Arc<Vec<i32>> {
+    pub fn data_types_ref(&self) -> Bytes {
         self.data_types.clone()
+    }
+}
+
+#[derive(Debug)]
+pub struct DataTypesIter<'a> {
+    data_types: &'a Bytes,
+    offset: usize,
+}
+
+impl DataTypesIter<'_> {
+    pub fn len(&self) -> usize {
+        (self.data_types.len() - size_of::<i16>()) / size_of::<i32>()
+    }
+}
+
+impl Iterator for DataTypesIter<'_> {
+    type Item = i32;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let pos = self.offset * size_of::<i32>() + size_of::<i16>();
+        self.offset += 1;
+        let mut cursor = Cursor::new(self.data_types);
+        cursor.advance(pos);
+
+        if cursor.remaining() >= size_of::<i32>() {
+            Some(cursor.get_i32())
+        } else {
+            None
+        }
     }
 }
 
@@ -89,15 +121,20 @@ impl FromBytes for Parse {
         let original = bytes.clone();
         code!(bytes, 'P');
         let _len = bytes.get_i32();
-        let name = c_string_buf(&mut bytes);
-        let query = c_string_buf(&mut bytes);
-        let params = bytes.get_i16() as usize;
-        let data_types = (0..params).map(|_| bytes.get_i32()).collect::<Vec<_>>();
+        let name_len = c_string_buf_len(&mut bytes);
+        let name = bytes.split_to(name_len);
+        let query_len = c_string_buf_len(&mut bytes);
+        let query = bytes.split_to(query_len);
+        let data_types = bytes;
+
+        // Validate we got valid UTF-8.
+        from_utf8(&name[0..name.len() - 1])?;
+        from_utf8(&query[0..query.len() - 1])?;
 
         Ok(Self {
-            name: Arc::new(name),
-            query: Arc::new(query),
-            data_types: Arc::new(data_types),
+            name,
+            query,
+            data_types,
             original: Some(original),
         })
     }
@@ -113,13 +150,9 @@ impl ToBytes for Parse {
         let mut payload = Payload::named(self.code());
         payload.reserve(self.len());
 
-        payload.put_string(&self.name);
-        payload.put_string(&self.query);
-        payload.put_i16(self.data_types.len() as i16);
-
-        for type_ in self.data_types() {
-            payload.put_i32(*type_);
-        }
+        payload.put(self.name.clone());
+        payload.put(self.query.clone());
+        payload.put(self.data_types.clone());
 
         Ok(payload.freeze())
     }
@@ -133,6 +166,8 @@ impl Protocol for Parse {
 
 #[cfg(test)]
 mod test {
+    use bytes::BytesMut;
+
     use super::*;
 
     #[test]
@@ -140,5 +175,39 @@ mod test {
         let parse = Parse::named("test", "SELECT $1");
         let b = parse.to_bytes().unwrap();
         assert_eq!(parse.len(), b.len());
+    }
+
+    #[test]
+    fn test_parse_from_bytes() {
+        let mut parse = Parse::named("__pgdog_1", "SELECT * FROM users");
+        let mut data_types = BytesMut::new();
+        data_types.put_i16(3);
+        data_types.put_i32(1);
+        data_types.put_i32(2);
+        data_types.put_i32(3);
+        parse.data_types = data_types.freeze();
+
+        let iter = parse.data_types();
+        assert_eq!(iter.len(), 3);
+        for (i, v) in iter.enumerate() {
+            assert_eq!(i as i32 + 1, v);
+        }
+
+        assert_eq!(parse.name(), "__pgdog_1");
+        assert_eq!(parse.query(), "SELECT * FROM users");
+        assert_eq!(&parse.query[..], b"SELECT * FROM users\0");
+        assert_eq!(&parse.name[..], b"__pgdog_1\0");
+        assert_eq!(parse.to_bytes().unwrap().len(), parse.len());
+
+        let mut b = BytesMut::new();
+        b.put_u8(b'P');
+        b.put_i32(0); // Doesn't matter
+        b.put(Bytes::from("__pgdog_1\0"));
+        b.put(Bytes::from("SELECT * FROM users\0"));
+        b.put_i16(0);
+        let parse = Parse::from_bytes(b.freeze()).unwrap();
+        assert_eq!(parse.name(), "__pgdog_1");
+        assert_eq!(parse.query(), "SELECT * FROM users");
+        assert_eq!(parse.data_types().len(), 0);
     }
 }


### PR DESCRIPTION
### Description
- Remove memory allocations from parsing `Parse` messages.