### PR TITLE
Mirroring traffic

### DIFF
--- a/pgdog.toml
+++ b/pgdog.toml
@@ -37,7 +37,7 @@ name = "mirror"
 host = "127.0.0.1"
 port = 5432
 role = "primary"
-mirror_of = "pgdog"
+# mirror_of = "pgdog"
 
 
 
@@ -85,12 +85,14 @@ name = "pgdog_sharded"
 host = "127.0.0.1"
 database_name = "shard_0"
 shard = 0
+mirror_of = "pgdog"
 
 [[databases]]
 name = "pgdog_sharded"
 host = "127.0.0.1"
 database_name = "shard_1"
 shard = 1
+mirror_of = "pgdog"
 
 # [[databases]]
 # name = "failover"

--- a/pgdog.toml
+++ b/pgdog.toml
@@ -32,6 +32,12 @@ host = "127.0.0.1"
 port = 5432
 role = "primary"
 
+[[databases]]
+name = "mirror"
+host = "127.0.0.1"
+port = 5432
+role = "primary"
+
 
 # [[databases]]
 # name = "pgdog"

--- a/pgdog.toml
+++ b/pgdog.toml
@@ -37,6 +37,8 @@ name = "mirror"
 host = "127.0.0.1"
 port = 5432
 role = "primary"
+mirror_of = "pgdog"
+
 
 
 # [[databases]]
@@ -90,19 +92,19 @@ host = "127.0.0.1"
 database_name = "shard_1"
 shard = 1
 
-[[databases]]
-name = "failover"
-host = "127.0.0.1"
-port = 5435
-role = "primary"
-database_name = "pgdog"
+# [[databases]]
+# name = "failover"
+# host = "127.0.0.1"
+# port = 5435
+# role = "primary"
+# database_name = "pgdog"
 
-[[databases]]
-name = "failover"
-host = "127.0.0.1"
-port = 5436
-role = "replica"
-database_name = "pgdog"
+# [[databases]]
+# name = "failover"
+# host = "127.0.0.1"
+# port = 5436
+# role = "replica"
+# database_name = "pgdog"
 
 #
 # Read/write access to theses tables will be automatically

--- a/pgdog.toml
+++ b/pgdog.toml
@@ -32,13 +32,6 @@ host = "127.0.0.1"
 port = 5432
 role = "primary"
 
-[[databases]]
-name = "mirror"
-host = "127.0.0.1"
-port = 5432
-role = "primary"
-# mirror_of = "pgdog"
-
 
 
 # [[databases]]
@@ -93,20 +86,6 @@ host = "127.0.0.1"
 database_name = "shard_1"
 shard = 1
 mirror_of = "pgdog"
-
-# [[databases]]
-# name = "failover"
-# host = "127.0.0.1"
-# port = 5435
-# role = "primary"
-# database_name = "pgdog"
-
-# [[databases]]
-# name = "failover"
-# host = "127.0.0.1"
-# port = 5436
-# role = "replica"
-# database_name = "pgdog"
 
 #
 # Read/write access to theses tables will be automatically

--- a/pgdog/src/backend/pool/cluster.rs
+++ b/pgdog/src/backend/pool/cluster.rs
@@ -30,11 +30,12 @@ pub struct PoolConfig {
 pub struct Cluster {
     name: String,
     shards: Vec<Shard>,
+    user: String,
     password: String,
     pooler_mode: PoolerMode,
     sharded_tables: ShardedTables,
     replication_sharding: Option<String>,
-    mirrors: Vec<Cluster>,
+    mirror_of: Option<String>,
 }
 
 /// Sharding configuration from the cluster.
@@ -56,10 +57,12 @@ pub struct ClusterConfig<'a> {
     pub name: &'a str,
     pub shards: &'a [ClusterShardConfig],
     pub lb_strategy: LoadBalancingStrategy,
+    pub user: &'a str,
     pub password: &'a str,
     pub pooler_mode: PoolerMode,
     pub sharded_tables: ShardedTables,
     pub replication_sharding: Option<String>,
+    pub mirror_of: Option<&'a str>,
 }
 
 impl<'a> ClusterConfig<'a> {
@@ -68,15 +71,18 @@ impl<'a> ClusterConfig<'a> {
         user: &'a User,
         shards: &'a [ClusterShardConfig],
         sharded_tables: ShardedTables,
+        mirror_of: Option<&'a str>,
     ) -> Self {
         Self {
             name: &user.database,
             password: user.password(),
+            user: &user.name,
             replication_sharding: user.replication_sharding.clone(),
             pooler_mode: user.pooler_mode.unwrap_or(general.pooler_mode),
             lb_strategy: general.load_balancing_strategy,
             shards,
             sharded_tables,
+            mirror_of,
         }
     }
 }
@@ -88,10 +94,12 @@ impl Cluster {
             name,
             shards,
             lb_strategy,
+            user,
             password,
             pooler_mode,
             sharded_tables,
             replication_sharding,
+            mirror_of,
         } = config;
 
         Self {
@@ -101,10 +109,11 @@ impl Cluster {
                 .collect(),
             name: name.to_owned(),
             password: password.to_owned(),
+            user: user.to_owned(),
             pooler_mode,
             sharded_tables,
             replication_sharding,
-            mirrors: vec![],
+            mirror_of: mirror_of.map(|s| s.to_owned()),
         }
     }
 
@@ -145,11 +154,12 @@ impl Cluster {
         Self {
             shards: self.shards.iter().map(|s| s.duplicate()).collect(),
             name: self.name.clone(),
+            user: self.user.clone(),
             password: self.password.clone(),
             pooler_mode: self.pooler_mode,
             sharded_tables: self.sharded_tables.clone(),
             replication_sharding: self.replication_sharding.clone(),
-            mirrors: self.mirrors.clone(),
+            mirror_of: self.mirror_of.clone(),
         }
     }
 
@@ -165,6 +175,11 @@ impl Cluster {
     /// Get all shards.
     pub fn shards(&self) -> &[Shard] {
         &self.shards
+    }
+
+    /// Mirrors getter.
+    pub fn mirror_of(&self) -> Option<&str> {
+        self.mirror_of.as_ref().map(|s| s.as_str())
     }
 
     /// Plugin input.
@@ -216,6 +231,16 @@ impl Cluster {
     /// Get the password the user should use to connect to the database.
     pub fn password(&self) -> &str {
         &self.password
+    }
+
+    /// User name.
+    pub fn user(&self) -> &str {
+        &self.user
+    }
+
+    /// Cluster name (database name).
+    pub fn name(&self) -> &str {
+        &self.name
     }
 
     /// Get pooler mode.

--- a/pgdog/src/backend/pool/cluster.rs
+++ b/pgdog/src/backend/pool/cluster.rs
@@ -34,6 +34,7 @@ pub struct Cluster {
     pooler_mode: PoolerMode,
     sharded_tables: ShardedTables,
     replication_sharding: Option<String>,
+    mirrors: Vec<Cluster>,
 }
 
 /// Sharding configuration from the cluster.
@@ -103,6 +104,7 @@ impl Cluster {
             pooler_mode,
             sharded_tables,
             replication_sharding,
+            mirrors: vec![],
         }
     }
 
@@ -147,6 +149,7 @@ impl Cluster {
             pooler_mode: self.pooler_mode,
             sharded_tables: self.sharded_tables.clone(),
             replication_sharding: self.replication_sharding.clone(),
+            mirrors: self.mirrors.clone(),
         }
     }
 

--- a/pgdog/src/backend/pool/connection/binding.rs
+++ b/pgdog/src/backend/pool/connection/binding.rs
@@ -188,6 +188,16 @@ impl Binding {
         }
     }
 
+    pub(super) fn has_more_messages(&self) -> bool {
+        match self {
+            Binding::Admin(admin) => admin.done(),
+            Binding::Server(Some(server)) => server.has_more_messages(),
+            Binding::MultiShard(servers, _state) => servers.iter().all(|s| s.has_more_messages()),
+            Binding::Replication(Some(server), _) => server.has_more_messages(),
+            _ => false,
+        }
+    }
+
     /// Execute a query on all servers.
     pub(super) async fn execute(&mut self, query: &str) -> Result<(), Error> {
         match self {

--- a/pgdog/src/backend/pool/connection/binding.rs
+++ b/pgdog/src/backend/pool/connection/binding.rs
@@ -188,16 +188,6 @@ impl Binding {
         }
     }
 
-    pub(super) fn has_more_messages(&self) -> bool {
-        match self {
-            Binding::Admin(admin) => admin.done(),
-            Binding::Server(Some(server)) => server.has_more_messages(),
-            Binding::MultiShard(servers, _state) => servers.iter().all(|s| s.has_more_messages()),
-            Binding::Replication(Some(server), _) => server.has_more_messages(),
-            _ => false,
-        }
-    }
-
     /// Execute a query on all servers.
     pub(super) async fn execute(&mut self, query: &str) -> Result<(), Error> {
         match self {

--- a/pgdog/src/backend/pool/connection/mirror.rs
+++ b/pgdog/src/backend/pool/connection/mirror.rs
@@ -1,40 +1,127 @@
-use crate::{
-    backend::{pool::Request, Cluster},
-    frontend::{router::Route, Buffer},
-};
+use std::sync::Arc;
+
+use tokio::select;
+use tokio::sync::Notify;
+use tokio::{spawn, sync::mpsc::*};
+use tracing::error;
+
+use crate::backend::Cluster;
+use crate::frontend::{PreparedStatements, Router};
+use crate::{backend::pool::Request, frontend::Buffer};
 
 use super::Connection;
 use super::Error;
 
 #[derive(Clone, Debug)]
 pub(crate) struct MirrorRequest {
-    pub(super) route: Route,
     pub(super) request: Request,
     pub(super) buffer: Buffer,
 }
 
+impl MirrorRequest {
+    pub(crate) fn new(buffer: &Buffer) -> Self {
+        Self {
+            request: Request::default(),
+            buffer: buffer.clone(),
+        }
+    }
+}
+
+#[derive(Debug)]
 pub(crate) struct Mirror {
     connection: Connection,
+    router: Router,
+    cluster: Cluster,
+    prepared_statements: PreparedStatements,
 }
 
 impl Mirror {
+    pub(crate) fn new(cluster: &Cluster) -> Result<MirrorHandler, Error> {
+        let connection = Connection::new(cluster.user(), cluster.name(), false)?;
+        let shutdown = Arc::new(Notify::new());
+
+        let mut mirror = Self {
+            connection,
+            router: Router::new(),
+            prepared_statements: PreparedStatements::new(),
+            cluster: cluster.clone(),
+        };
+
+        let (tx, mut rx) = channel(128);
+        let handler = MirrorHandler {
+            tx,
+            shutdown: shutdown.clone(),
+        };
+
+        spawn(async move {
+            loop {
+                select! {
+                    _ = shutdown.notified() => {
+                        break;
+                    }
+
+                    req = rx.recv() => {
+                        if let Some(req) = req {
+                            // TODO: timeout these.
+                            if let Err(err) = mirror.handle(&req).await {
+                                error!("mirror error: {}", err);
+                                mirror.connection.disconnect();
+                            }
+                        }
+                    }
+
+                    message = mirror.connection.read() => {
+                        if let Err(err) = message {
+                            error!("mirror error: {}", err);
+                            mirror.connection.disconnect();
+                        }
+
+                        if mirror.connection.done() {
+                            mirror.connection.disconnect();
+                            mirror.router.reset();
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(handler)
+    }
+
     pub(crate) async fn handle(&mut self, request: &MirrorRequest) -> Result<(), Error> {
         if !self.connection.connected() {
+            // TODO: handle parsing errors.
+            if let Err(err) = self.router.query(
+                &request.buffer,
+                &self.cluster,
+                &mut self.prepared_statements,
+            ) {
+                error!("mirror query parse error: {}", err);
+                return Ok(()); // Drop request.
+            }
+
             self.connection
-                .connect(&request.request, &request.route)
+                .connect(&request.request, &self.router.route())
                 .await?;
         }
 
-        self.connection.send(&request.buffer).await?;
-
-        while self.connection.has_more_messages() {
-            let _ = self.connection.read().await?;
-        }
-
-        if self.connection.done() {
-            self.connection.disconnect();
-        }
+        // TODO: handle streaming.
+        self.connection
+            .handle_buffer(&request.buffer, &mut self.router, false)
+            .await?;
 
         Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct MirrorHandler {
+    pub(super) tx: Sender<MirrorRequest>,
+    shutdown: Arc<Notify>,
+}
+
+impl Drop for MirrorHandler {
+    fn drop(&mut self) {
+        self.shutdown.notify_one();
     }
 }

--- a/pgdog/src/backend/pool/connection/mirror.rs
+++ b/pgdog/src/backend/pool/connection/mirror.rs
@@ -1,0 +1,40 @@
+use crate::{
+    backend::{pool::Request, Cluster},
+    frontend::{router::Route, Buffer},
+};
+
+use super::Connection;
+use super::Error;
+
+#[derive(Clone, Debug)]
+pub(crate) struct MirrorRequest {
+    pub(super) route: Route,
+    pub(super) request: Request,
+    pub(super) buffer: Buffer,
+}
+
+pub(crate) struct Mirror {
+    connection: Connection,
+}
+
+impl Mirror {
+    pub(crate) async fn handle(&mut self, request: &MirrorRequest) -> Result<(), Error> {
+        if !self.connection.connected() {
+            self.connection
+                .connect(&request.request, &request.route)
+                .await?;
+        }
+
+        self.connection.send(&request.buffer).await?;
+
+        while self.connection.has_more_messages() {
+            let _ = self.connection.read().await?;
+        }
+
+        if self.connection.done() {
+            self.connection.disconnect();
+        }
+
+        Ok(())
+    }
+}

--- a/pgdog/src/backend/pool/connection/mod.rs
+++ b/pgdog/src/backend/pool/connection/mod.rs
@@ -2,6 +2,7 @@
 
 use mirror::{MirrorHandler, MirrorRequest};
 use tokio::time::sleep;
+use tracing::debug;
 
 use crate::{
     admin::backend::Backend,
@@ -257,9 +258,15 @@ impl Connection {
                 self.cluster = Some(cluster);
                 self.mirrors = databases
                     .mirrors(user)?
+                    .unwrap_or(&[])
                     .into_iter()
                     .map(|mirror| Mirror::new(&mirror))
                     .collect::<Result<Vec<_>, Error>>()?;
+                debug!(
+                    r#"database "{}" has {} mirrors"#,
+                    self.cluster()?.name(),
+                    self.mirrors.len()
+                );
             }
 
             _ => (),

--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -340,6 +340,7 @@ impl Server {
                     _ => (),
                 }
             }
+            'G' => self.stats.copy_mode(),
             '1' => self.stats.parse_complete(),
             '2' => self.stats.bind_complete(),
             _ => (),
@@ -398,7 +399,7 @@ impl Server {
     pub fn has_more_messages(&self) -> bool {
         !matches!(
             self.stats.state,
-            State::Idle | State::IdleInTransaction | State::TransactionError
+            State::Idle | State::IdleInTransaction | State::TransactionError | State::CopyMode
         ) || !self.prepared_statements.done()
     }
 

--- a/pgdog/src/backend/stats.rs
+++ b/pgdog/src/backend/stats.rs
@@ -144,6 +144,10 @@ impl Stats {
         self.last_checkout.parse += 1;
     }
 
+    pub fn copy_mode(&mut self) {
+        self.state(State::CopyMode);
+    }
+
     pub fn bind_complete(&mut self) {
         self.total.bind += 1;
         self.last_checkout.bind += 1;

--- a/pgdog/src/config/mod.rs
+++ b/pgdog/src/config/mod.rs
@@ -547,6 +547,8 @@ pub struct Database {
     pub statement_timeout: Option<u64>,
     /// Idle timeout.
     pub idle_timeout: Option<u64>,
+    /// Mirror of another database.
+    pub mirror_of: Option<String>,
 }
 
 impl Database {

--- a/pgdog/src/config/mod.rs
+++ b/pgdog/src/config/mod.rs
@@ -324,6 +324,9 @@ pub struct General {
     /// Idle timeout.
     #[serde(default = "General::idle_timeout")]
     pub idle_timeout: u64,
+    /// Mirror queue size.
+    #[serde(default = "General::mirror_queue")]
+    pub mirror_queue: usize,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
@@ -383,6 +386,7 @@ impl Default for General {
             checkout_timeout: Self::checkout_timeout(),
             dry_run: bool::default(),
             idle_timeout: Self::idle_timeout(),
+            mirror_queue: Self::mirror_queue(),
         }
     }
 }
@@ -458,6 +462,10 @@ impl General {
 
     fn checkout_timeout() -> u64 {
         Duration::from_secs(5).as_millis() as u64
+    }
+
+    fn mirror_queue() -> usize {
+        128
     }
 
     /// Get shutdown timeout as a duration.

--- a/pgdog/src/frontend/client/inner.rs
+++ b/pgdog/src/frontend/client/inner.rs
@@ -108,6 +108,18 @@ impl Inner {
         self.backend.disconnect();
     }
 
+    pub(super) async fn handle_buffer(
+        &mut self,
+        buffer: &Buffer,
+        streaming: bool,
+    ) -> Result<(), Error> {
+        self.backend
+            .handle_buffer(buffer, &mut self.router, streaming)
+            .await?;
+
+        Ok(())
+    }
+
     /// Connect to a backend (or multiple).
     pub(super) async fn connect(&mut self, request: &Request) -> Result<(), BackendError> {
         // Use currently determined route.

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -178,6 +178,8 @@ impl Client {
             stream_buffer: BytesMut::new(),
         };
 
+        drop(conn);
+
         if client.admin {
             // Admin clients are not waited on during shutdown.
             spawn(async move {

--- a/pgdog/src/frontend/listener.rs
+++ b/pgdog/src/frontend/listener.rs
@@ -41,8 +41,8 @@ impl Listener {
 
     /// Listen for client connections and handle them.
     pub async fn listen(&mut self) -> Result<(), Error> {
-        let listener = TcpListener::bind(&self.addr).await?;
         info!("🐕 PgDog listening on {}", self.addr);
+        let listener = TcpListener::bind(&self.addr).await?;
         let comms = comms();
         let shutdown_signal = comms.shutting_down();
         let mut sighup = Sighup::new()?;

--- a/pgdog/src/frontend/router/mod.rs
+++ b/pgdog/src/frontend/router/mod.rs
@@ -16,6 +16,7 @@ pub use parser::{Command, QueryParser, Route};
 use super::{Buffer, PreparedStatements};
 
 /// Query router.
+#[derive(Debug)]
 pub struct Router {
     query_parser: QueryParser,
 }

--- a/pgdog/src/state.rs
+++ b/pgdog/src/state.rs
@@ -24,6 +24,8 @@ pub enum State {
     PreparedStatementError,
     /// Processing server reply.
     ReceivingData,
+    /// Copy started
+    CopyMode,
 }
 
 impl std::fmt::Display for State {
@@ -40,6 +42,7 @@ impl std::fmt::Display for State {
             ParseComplete => write!(f, "parse complete"),
             PreparedStatementError => write!(f, "prepared statement error"),
             ReceivingData => write!(f, "receiving data"),
+            CopyMode => write!(f, "copy mode"),
         }
     }
 }

--- a/pgdog/tests/pgbench.sh
+++ b/pgdog/tests/pgbench.sh
@@ -4,4 +4,4 @@
 #
 export PGPORT=${1:-6432}
 PGPASSWORD=pgdog pgbench -i -h 127.0.0.1 -U pgdog pgdog
-PGPASSWORD=pgdog pgbench -P 1 -h 127.0.0.1 -U pgdog pgdog -c 500 -t 60000 --protocol extended -S
+PGPASSWORD=pgdog pgbench -P 1 -h 127.0.0.1 -U pgdog pgdog -c 20 -t 1000000 --protocol extended -S

--- a/users.toml
+++ b/users.toml
@@ -11,6 +11,11 @@ database = "pgdog"
 password = "pgdog"
 
 [[users]]
+name = "pgdog"
+database = "mirror"
+password = "pgdog"
+
+[[users]]
 name = "pgdog_replication"
 database = "pgdog"
 password = "pgdog"

--- a/users.toml
+++ b/users.toml
@@ -11,11 +11,6 @@ database = "pgdog"
 password = "pgdog"
 
 [[users]]
-name = "pgdog"
-database = "mirror"
-password = "pgdog"
-
-[[users]]
 name = "pgdog_replication"
 database = "pgdog"
 password = "pgdog"
@@ -34,9 +29,4 @@ min_pool_size = 0
 [[users]]
 name = "pgdog"
 database = "pgdog_sharded"
-password = "pgdog"
-
-[[users]]
-name = "pgdog"
-database = "failover"
 password = "pgdog"


### PR DESCRIPTION
### Description

Allow for databases to mirror traffic from other databases. This allows testing different databases with production traffic.