### PR TITLE
Fix reload

### DIFF
--- a/pgdog/src/backend/databases.rs
+++ b/pgdog/src/backend/databases.rs
@@ -17,6 +17,7 @@ use crate::{
 
 use super::{
     pool::{Address, ClusterConfig, Config},
+    reload_notify,
     replication::ReplicationConfig,
     Cluster, ClusterShardConfig, Error, ShardedTables,
 };
@@ -38,6 +39,7 @@ pub fn replace_databases(new_databases: Databases, reload: bool) {
     // to ensure zero downtime for clients.
     let old_databases = databases();
     let new_databases = Arc::new(new_databases);
+    reload_notify::started();
     if reload {
         // Move whatever connections we can over to new pools.
         old_databases.move_conns_to(&new_databases);
@@ -45,6 +47,7 @@ pub fn replace_databases(new_databases: Databases, reload: bool) {
     new_databases.launch();
     DATABASES.store(new_databases);
     old_databases.shutdown();
+    reload_notify::done();
 }
 
 /// Re-create all connections.

--- a/pgdog/src/backend/mod.rs
+++ b/pgdog/src/backend/mod.rs
@@ -5,6 +5,7 @@ pub mod error;
 pub mod pool;
 pub mod prepared_statements;
 pub mod protocol;
+pub mod reload_notify;
 pub mod replication;
 pub mod schema;
 pub mod server;

--- a/pgdog/src/backend/reload_notify.rs
+++ b/pgdog/src/backend/reload_notify.rs
@@ -1,0 +1,33 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use once_cell::sync::Lazy;
+use tokio::sync::{futures::Notified, Notify};
+
+static RELOAD_NOTIFY: Lazy<ReloadNotify> = Lazy::new(|| ReloadNotify {
+    notify: Notify::new(),
+    ready: AtomicBool::new(true),
+});
+
+pub(crate) fn ready() -> Option<Notified<'static>> {
+    let notified = RELOAD_NOTIFY.notify.notified();
+    if RELOAD_NOTIFY.ready.load(Ordering::Relaxed) {
+        None
+    } else {
+        Some(notified)
+    }
+}
+
+pub(super) fn started() {
+    RELOAD_NOTIFY.ready.store(false, Ordering::Relaxed);
+}
+
+pub(super) fn done() {
+    RELOAD_NOTIFY.ready.store(true, Ordering::Relaxed);
+    RELOAD_NOTIFY.notify.notify_waiters();
+}
+
+#[derive(Debug)]
+struct ReloadNotify {
+    notify: Notify,
+    ready: AtomicBool,
+}


### PR DESCRIPTION
### Description

- Config reloads weren't atomic, causing some clients to hit offline pools. Fixed with a combination of Notify and AtomicBool.