### PR TITLE
Make auth type configurable

### DIFF
--- a/pgdog/src/backend/pool/connection/mirror.rs
+++ b/pgdog/src/backend/pool/connection/mirror.rs
@@ -66,7 +66,7 @@ impl Mirror {
                         if let Some(req) = req {
                             // TODO: timeout these.
                             if let Err(err) = mirror.handle(&req).await {
-                                if !matches!(err, Error::Pool(PoolError::Offline)) {
+                                if !matches!(err, Error::Pool(PoolError::Offline | PoolError::AllReplicasDown)) {
                                     error!("mirror error: {}", err);
                                 }
 

--- a/pgdog/src/config/mod.rs
+++ b/pgdog/src/config/mod.rs
@@ -327,6 +327,8 @@ pub struct General {
     /// Mirror queue size.
     #[serde(default = "General::mirror_queue")]
     pub mirror_queue: usize,
+    #[serde(default)]
+    pub auth_type: AuthType,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
@@ -355,6 +357,24 @@ pub enum PassthoughAuth {
     Disabled,
     Enabled,
     EnabledPlain,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthType {
+    Md5,
+    #[default]
+    Scram,
+}
+
+impl AuthType {
+    pub fn md5(&self) -> bool {
+        matches!(self, Self::Md5)
+    }
+
+    pub fn scram(&self) -> bool {
+        matches!(self, Self::Scram)
+    }
 }
 
 impl Default for General {
@@ -387,6 +407,7 @@ impl Default for General {
             dry_run: bool::default(),
             idle_timeout: Self::idle_timeout(),
             mirror_queue: Self::mirror_queue(),
+            auth_type: AuthType::default(),
         }
     }
 }

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -96,8 +96,8 @@ impl Client {
         } else {
             conn.cluster()?.password()
         };
-
-        let auth_ok = if stream.is_tls() {
+        let auth_md5 = config.config.general.auth_type.md5();
+        let auth_ok = if stream.is_tls() || auth_md5 {
             let md5 = md5::Client::new(user, password);
             stream.send_flush(&md5.challenge()).await?;
             let password = Password::from_bytes(stream.read().await?.to_bytes()?)?;


### PR DESCRIPTION
### Description

- Make `auth_type` configurable. If your app makes lots of new connections and is latency sensitive, use `md5`. Otherwise, `scram` works it's just pretty slow (on purpose).
- Check for all replicas down in mirror.