### PR TITLE
Trust auth

### DIFF
--- a/integration/rust/tests/integration/auth.rs
+++ b/integration/rust/tests/integration/auth.rs
@@ -1,0 +1,38 @@
+use rust::setup::admin_sqlx;
+use serial_test::serial;
+use sqlx::{Connection, Executor, PgConnection, Row};
+
+#[tokio::test]
+#[serial]
+async fn test_auth() {
+    let admin = admin_sqlx().await;
+    let bad_password = "postgres://pgdog:skjfhjk23h4234@127.0.0.1:6432/pgdog";
+
+    admin.execute("SET auth_type TO 'trust'").await.unwrap();
+    assert_auth("trust").await;
+
+    let mut any_password = PgConnection::connect(bad_password).await.unwrap();
+    any_password.execute("SELECT 1").await.unwrap();
+
+    admin.execute("SET auth_type TO 'scram'").await.unwrap();
+    assert_auth("scram").await;
+
+    assert!(PgConnection::connect(bad_password).await.is_err());
+}
+
+async fn assert_auth(expected: &str) {
+    let admin = admin_sqlx().await;
+    let rows = admin.fetch_all("SHOW CONFIG").await.unwrap();
+    let mut found = false;
+    for row in rows {
+        let name: String = row.get(0);
+        let value: String = row.get(1);
+
+        if name == "auth_type" {
+            found = true;
+            assert_eq!(value, expected);
+        }
+    }
+
+    assert!(found);
+}

--- a/integration/rust/tests/integration/mod.rs
+++ b/integration/rust/tests/integration/mod.rs
@@ -1,3 +1,4 @@
+pub mod auth;
 pub mod fake_transactions;
 pub mod reload;
 pub mod syntax_error;

--- a/integration/rust/tests/sqlx/bad_auth.rs
+++ b/integration/rust/tests/sqlx/bad_auth.rs
@@ -1,6 +1,8 @@
+use serial_test::serial;
 use sqlx::{Connection, PgConnection};
 
 #[tokio::test]
+#[serial]
 async fn test_bad_auth() {
     for user in ["pgdog", "pgdog_bad_user"] {
         for password in ["bad_password", "another_password", ""] {

--- a/pgdog/src/admin/error.rs
+++ b/pgdog/src/admin/error.rs
@@ -21,4 +21,10 @@ pub enum Error {
 
     #[error("{0}")]
     Backend(Box<crate::backend::Error>),
+
+    #[error("parse int")]
+    ParseInt(#[from] std::num::ParseIntError),
+
+    #[error("{0}")]
+    Config(#[from] crate::config::error::Error),
 }

--- a/pgdog/src/admin/parser.rs
+++ b/pgdog/src/admin/parser.rs
@@ -131,7 +131,7 @@ impl Parser {
             // TODO: This is not ready yet. We have a race and
             // also the changed settings need to be propagated
             // into the pools.
-            // "set" => ParseResult::Set(Set::parse(&sql)?),
+            "set" => ParseResult::Set(Set::parse(&sql)?),
             command => {
                 debug!("unknown admin command: {}", command);
                 return Err(Error::Syntax);

--- a/pgdog/src/backend/databases.rs
+++ b/pgdog/src/backend/databases.rs
@@ -6,7 +6,8 @@ use std::sync::Arc;
 
 use arc_swap::ArcSwap;
 use once_cell::sync::Lazy;
-use parking_lot::Mutex;
+use parking_lot::lock_api::MutexGuard;
+use parking_lot::{Mutex, RawMutex};
 use tracing::{info, warn};
 
 use crate::{
@@ -25,6 +26,11 @@ use super::{
 static DATABASES: Lazy<ArcSwap<Databases>> =
     Lazy::new(|| ArcSwap::from_pointee(Databases::default()));
 static LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+/// Sync databases during modification.
+pub fn lock() -> MutexGuard<'static, RawMutex, ()> {
+    LOCK.lock()
+}
 
 /// Get databases handle.
 ///

--- a/pgdog/src/config/mod.rs
+++ b/pgdog/src/config/mod.rs
@@ -36,7 +36,11 @@ pub fn config() -> Arc<ConfigAndUsers> {
 
 /// Load the configuration file from disk.
 pub fn load(config: &PathBuf, users: &PathBuf) -> Result<ConfigAndUsers, Error> {
-    let mut config = ConfigAndUsers::load(config, users)?;
+    let config = ConfigAndUsers::load(config, users)?;
+    set(config)
+}
+
+pub fn set(mut config: ConfigAndUsers) -> Result<ConfigAndUsers, Error> {
     config.config.check();
     for table in config.config.sharded_tables.iter_mut() {
         table.load_centroids()?;

--- a/pgdog/src/config/mod.rs
+++ b/pgdog/src/config/mod.rs
@@ -365,6 +365,7 @@ pub enum AuthType {
     Md5,
     #[default]
     Scram,
+    Trust,
 }
 
 impl AuthType {


### PR DESCRIPTION
### Description 
- Fix #148 
- Enable `SET` admin database command to modify some settings at runtime. This is mostly for testing, I wouldn't use it in prod because the changes don't persist across restarts.