### PR TITLE
Send SET queries to primary

### DIFF
--- a/integration/pgbench/dev.sh
+++ b/integration/pgbench/dev.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-
+set -e
 export PGPASSWORD=pgdog
 
 pgbench -i -h 127.0.0.1 -U pgdog -p 6432 pgdog

--- a/integration/rust/tests/integration/reload.rs
+++ b/integration/rust/tests/integration/reload.rs
@@ -42,6 +42,7 @@ async fn test_reconnect() {
     conn.execute("SET application_name TO 'test_reconnect'")
         .await
         .unwrap();
+    conn.execute("SELECT 1").await.unwrap(); // Trigger param update.
 
     let backends_before = backends("test_reconnect", &conn).await;
 

--- a/pgdog/src/backend/databases.rs
+++ b/pgdog/src/backend/databases.rs
@@ -353,8 +353,7 @@ pub(crate) fn new_pool(
             0 => None,
             1 => mirrors_of
                 .first()
-                .map(|s| s.as_ref().map(|s| s.as_str()))
-                .flatten(),
+                .and_then(|s| s.as_ref().map(|s| s.as_str())),
             _ => {
                 warn!(
                     "database \"{}\" has different \"mirror_of\" settings, disabling mirroring",

--- a/pgdog/src/backend/pool/cluster.rs
+++ b/pgdog/src/backend/pool/cluster.rs
@@ -179,7 +179,7 @@ impl Cluster {
 
     /// Mirrors getter.
     pub fn mirror_of(&self) -> Option<&str> {
-        self.mirror_of.as_ref().map(|s| s.as_str())
+        self.mirror_of.as_deref()
     }
 
     /// Plugin input.

--- a/pgdog/src/backend/pool/connection/mod.rs
+++ b/pgdog/src/backend/pool/connection/mod.rs
@@ -199,12 +199,12 @@ impl Connection {
                 if self.connect(request, &Route::read(Some(0))).await.is_err() {
                     self.connect(request, &Route::write(Some(0))).await?;
                 };
-                let params = self
-                    .server()?
-                    .params()
-                    .iter()
-                    .map(ParameterStatus::from)
-                    .collect();
+                let mut params = vec![];
+                for param in self.server()?.params().iter() {
+                    if let Some(value) = param.1.as_str() {
+                        params.push(ParameterStatus::from((param.0.as_str(), value)));
+                    }
+                }
                 self.disconnect();
                 Ok(params)
             }

--- a/pgdog/src/backend/pool/connection/mod.rs
+++ b/pgdog/src/backend/pool/connection/mod.rs
@@ -275,8 +275,8 @@ impl Connection {
                 self.mirrors = databases
                     .mirrors(user)?
                     .unwrap_or(&[])
-                    .into_iter()
-                    .map(|mirror| Mirror::new(&mirror))
+                    .iter()
+                    .map(Mirror::new)
                     .collect::<Result<Vec<_>, Error>>()?;
                 debug!(
                     r#"database "{}" has {} mirrors"#,

--- a/pgdog/src/config/convert.rs
+++ b/pgdog/src/config/convert.rs
@@ -5,7 +5,11 @@ use super::User;
 
 impl User {
     pub(crate) fn from_params(params: &Parameters, password: &Password) -> Result<Self, Error> {
-        let user = params.get("user").ok_or(Error::IncompleteStartup)?;
+        let user = params
+            .get("user")
+            .ok_or(Error::IncompleteStartup)?
+            .as_str()
+            .ok_or(Error::IncompleteStartup)?;
         let database = params.get_default("database", user);
         let password = password.password().ok_or(Error::IncompleteStartup)?;
 

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -555,7 +555,6 @@ impl Client {
             .await?;
         inner.done(self.in_transaction);
         debug!("set");
-        println!("{:?}", self.params);
         Ok(())
     }
 }

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -342,7 +342,7 @@ impl Client {
                 // TODO: Handling session variables requires a lot more work,
                 // e.g. we need to track RESET as well.
                 Some(Command::Set { name, value }) => {
-                    self.params.insert(name, value);
+                    self.params.insert(name, value.clone());
                     self.set(inner).await?;
                     return Ok(false);
                 }
@@ -555,6 +555,7 @@ impl Client {
             .await?;
         inner.done(self.in_transaction);
         debug!("set");
+        println!("{:?}", self.params);
         Ok(())
     }
 }

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -554,6 +554,7 @@ impl Client {
             .send_flush(&ReadyForQuery::in_transaction(self.in_transaction))
             .await?;
         inner.done(self.in_transaction);
+        inner.comms.update_params(&self.params);
         debug!("set");
         Ok(())
     }

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -39,6 +39,7 @@ pub struct Client {
     addr: SocketAddr,
     stream: Stream,
     id: BackendKeyData,
+    connect_params: Parameters,
     params: Parameters,
     comms: Comms,
     admin: bool,
@@ -189,7 +190,8 @@ impl Client {
             admin,
             streaming: false,
             shard,
-            params,
+            params: params.clone(),
+            connect_params: params,
             prepared_statements: PreparedStatements::new(),
             in_transaction: false,
             timeouts: Timeouts::from_config(&config.config.general),
@@ -339,19 +341,11 @@ impl Client {
                 }
                 // TODO: Handling session variables requires a lot more work,
                 // e.g. we need to track RESET as well.
-                // Some(Command::Set { name, value }) => {
-                //     self.params.insert(name, value);
-                //     self.stream.send(&CommandComplete::new("SET")).await?;
-                //     self.stream
-                //         .send_flush(&ReadyForQuery::in_transaction(self.in_transaction))
-                //         .await?;
-                //     let state = inner.stats.state;
-                //     if state == State::Active {
-                //         inner.stats.state = State::Idle;
-                //     }
-
-                //     return Ok(false);
-                // }
+                Some(Command::Set { name, value }) => {
+                    self.params.insert(name, value);
+                    self.set(inner).await?;
+                    return Ok(false);
+                }
                 _ => (),
             };
 
@@ -550,6 +544,17 @@ impl Client {
         messages.push(ReadyForQuery::idle().message()?);
         self.stream.send_many(&messages).await?;
         debug!("transaction ended");
+        Ok(())
+    }
+
+    /// Handle SET command.
+    async fn set(&mut self, mut inner: InnerBorrow<'_>) -> Result<(), Error> {
+        self.stream.send(&CommandComplete::new("SET")).await?;
+        self.stream
+            .send_flush(&ReadyForQuery::in_transaction(self.in_transaction))
+            .await?;
+        inner.done(self.in_transaction);
+        debug!("set");
         Ok(())
     }
 }

--- a/pgdog/src/frontend/router/parser/command.rs
+++ b/pgdog/src/frontend/router/parser/command.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::frontend::buffer::BufferedQuery;
+use crate::{frontend::buffer::BufferedQuery, net::parameter::ParameterValue};
 
 #[derive(Debug, Clone)]
 pub enum Command {
@@ -10,7 +10,7 @@ pub enum Command {
     RollbackTransaction,
     StartReplication,
     ReplicationMeta,
-    Set { name: String, value: String },
+    Set { name: String, value: ParameterValue },
     PreparedStatement(Prepare),
     Rewrite(String),
 }

--- a/pgdog/src/frontend/router/parser/query.rs
+++ b/pgdog/src/frontend/router/parser/query.rs
@@ -704,7 +704,7 @@ impl QueryParser {
 mod test {
     use crate::net::{
         messages::{parse::Parse, Parameter},
-        Format, ParameterStatus,
+        Format,
     };
 
     use super::{super::Shard, *};

--- a/pgdog/src/frontend/router/parser/query.rs
+++ b/pgdog/src/frontend/router/parser/query.rs
@@ -955,4 +955,10 @@ mod test {
         assert!(!qp.routed);
         assert!(qp.in_transaction);
     }
+
+    #[test]
+    fn test_insert_do_update() {
+        let route = query!("INSERT INTO foo (id) VALUES ($1::UUID) ON CONFLICT (id) DO UPDATE SET id = excluded.id RETURNING id");
+        assert!(route.is_write())
+    }
 }

--- a/pgdog/src/frontend/router/parser/query.rs
+++ b/pgdog/src/frontend/router/parser/query.rs
@@ -263,7 +263,7 @@ impl QueryParser {
                 if self.routed {
                     return command;
                 } else {
-                    Ok(Command::Query(Route::read(Shard::All)))
+                    Ok(Command::Query(Route::write(Shard::All)))
                 }
             }
             // COPY statements.

--- a/pgdog/src/net/messages/hello.rs
+++ b/pgdog/src/net/messages/hello.rs
@@ -1,6 +1,10 @@
 //! Startup, SSLRequest messages.
 
-use crate::net::{c_string, parameter::Parameters, Error};
+use crate::net::{
+    c_string,
+    parameter::{ParameterValue, Parameters},
+    Error,
+};
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use tokio::io::{AsyncRead, AsyncReadExt};
 use tracing::debug;
@@ -88,7 +92,7 @@ impl Startup {
     pub fn parameter(&self, name: &str) -> Option<&str> {
         match self {
             Startup::Ssl | Startup::Cancel { .. } => None,
-            Startup::Startup { params } => params.get(name).map(|s| s.as_str()),
+            Startup::Startup { params } => params.get(name).map(|s| s.as_str()).flatten(),
         }
     }
 
@@ -141,11 +145,13 @@ impl super::ToBytes for Startup {
                 let mut params_buf = BytesMut::new();
 
                 for (name, value) in params.deref() {
-                    params_buf.put_slice(name.as_bytes());
-                    params_buf.put_u8(0);
+                    if let ParameterValue::String(value) = value {
+                        params_buf.put_slice(name.as_bytes());
+                        params_buf.put_u8(0);
 
-                    params_buf.put_slice(value.as_bytes());
-                    params_buf.put_u8(0);
+                        params_buf.put(value.as_bytes());
+                        params_buf.put_u8(0);
+                    }
                 }
 
                 let mut payload = Payload::new();

--- a/pgdog/src/net/messages/hello.rs
+++ b/pgdog/src/net/messages/hello.rs
@@ -92,7 +92,7 @@ impl Startup {
     pub fn parameter(&self, name: &str) -> Option<&str> {
         match self {
             Startup::Ssl | Startup::Cancel { .. } => None,
-            Startup::Startup { params } => params.get(name).map(|s| s.as_str()).flatten(),
+            Startup::Startup { params } => params.get(name).and_then(|s| s.as_str()),
         }
     }
 

--- a/pgdog/src/net/parameter.rs
+++ b/pgdog/src/net/parameter.rs
@@ -1,7 +1,8 @@
 //! Startup parameter.
 
 use std::{
-    collections::HashMap,
+    collections::BTreeMap,
+    fmt::Display,
     ops::{Deref, DerefMut},
 };
 
@@ -43,17 +44,84 @@ pub struct MergeResult {
     pub changed_params: usize,
 }
 
+#[derive(Debug, Clone)]
+pub enum ParameterValue {
+    String(String),
+    Tuple(Vec<String>),
+}
+
+impl PartialEq for ParameterValue {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::String(a), Self::String(b)) => a.eq(b),
+            (Self::Tuple(a), Self::Tuple(b)) => a.eq(b),
+            _ => false,
+        }
+    }
+}
+
+impl PartialEq<String> for ParameterValue {
+    fn eq(&self, other: &String) -> bool {
+        if let Self::String(s) = self {
+            s.eq(other)
+        } else {
+            false
+        }
+    }
+}
+
+impl Display for ParameterValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::String(s) => write!(f, "'{}'", s),
+            Self::Tuple(t) => write!(
+                f,
+                "{}",
+                t.iter()
+                    .map(|s| format!("'{}'", s))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+        }
+    }
+}
+
+impl From<&str> for ParameterValue {
+    fn from(value: &str) -> Self {
+        Self::String(value.to_string())
+    }
+}
+
+impl From<String> for ParameterValue {
+    fn from(value: String) -> Self {
+        Self::String(value)
+    }
+}
+
+impl ParameterValue {
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            Self::String(s) => Some(s.as_str()),
+            _ => None,
+        }
+    }
+}
+
 /// List of parameters.
 #[derive(Default, Debug, Clone, PartialEq)]
 pub struct Parameters {
-    params: HashMap<String, String>,
+    params: BTreeMap<String, ParameterValue>,
 }
 
 impl Parameters {
     /// Lowercase all param names.
-    pub fn insert(&mut self, name: impl ToString, value: impl ToString) -> Option<String> {
+    pub fn insert(
+        &mut self,
+        name: impl ToString,
+        value: impl Into<ParameterValue>,
+    ) -> Option<ParameterValue> {
         let name = name.to_string().to_lowercase();
-        self.params.insert(name, value.to_string())
+        self.params.insert(name, value.into())
     }
 
     /// Merge params from self into other, generating the queries
@@ -74,7 +142,7 @@ impl Parameters {
         }
 
         for (k, v) in &different {
-            other.insert(k.to_string(), v.to_string());
+            other.insert(k.to_string(), (*v).clone());
         }
 
         let queries = if different.is_empty() {
@@ -83,7 +151,7 @@ impl Parameters {
             let mut queries = vec![];
 
             for (k, v) in different {
-                queries.push(Query::new(format!(r#"SET "{}" TO '{}'"#, k, v)));
+                queries.push(Query::new(format!(r#"SET "{}" TO {}"#, k, v)));
             }
 
             queries
@@ -97,7 +165,7 @@ impl Parameters {
 
     /// Get self-declared shard number.
     pub fn shard(&self) -> Option<usize> {
-        if let Some(application_name) = self.get("application_name") {
+        if let Some(ParameterValue::String(application_name)) = self.get("application_name") {
             if application_name.starts_with("pgdog_shard_") {
                 application_name
                     .replace("pgdog_shard_", "")
@@ -115,17 +183,19 @@ impl Parameters {
     pub fn get_required(&self, name: &str) -> Result<&str, Error> {
         self.get(name)
             .map(|s| s.as_str())
+            .flatten()
             .ok_or(Error::MissingParameter(name.into()))
     }
 
     /// Get parameter value or returned a default value if it doesn't exist.
     pub fn get_default<'a>(&'a self, name: &str, default_value: &'a str) -> &'a str {
-        self.get(name).map_or(default_value, |p| p)
+        self.get(name)
+            .map_or(default_value, |p| p.as_str().unwrap_or(default_value))
     }
 }
 
 impl Deref for Parameters {
-    type Target = HashMap<String, String>;
+    type Target = BTreeMap<String, ParameterValue>;
 
     fn deref(&self) -> &Self::Target {
         &self.params
@@ -141,7 +211,10 @@ impl DerefMut for Parameters {
 impl From<Vec<Parameter>> for Parameters {
     fn from(value: Vec<Parameter>) -> Self {
         Self {
-            params: value.into_iter().map(|p| (p.name, p.value)).collect(),
+            params: value
+                .into_iter()
+                .map(|p| (p.name, ParameterValue::String(p.value)))
+                .collect(),
         }
     }
 }
@@ -162,6 +235,8 @@ impl From<&Parameters> for Vec<Parameter> {
 
 #[cfg(test)]
 mod test {
+    use crate::net::parameter::ParameterValue;
+
     use super::Parameters;
 
     #[test]
@@ -169,15 +244,24 @@ mod test {
         let mut me = Parameters::default();
         me.insert("application_name", "something");
         me.insert("TimeZone", "UTC");
+        me.insert(
+            "search_path",
+            ParameterValue::Tuple(vec!["$user".into(), "public".into()]),
+        );
 
         let mut other = Parameters::default();
         other.insert("TimeZone", "UTC");
 
         let diff = me.merge(&mut other);
-        assert_eq!(diff.changed_params, 1);
+        assert_eq!(diff.changed_params, 2);
+        assert_eq!(diff.queries.len(), 2);
         assert_eq!(
             diff.queries[0].query(),
             r#"SET "application_name" TO 'something'"#
+        );
+        assert_eq!(
+            diff.queries[1].query(),
+            r#"SET "search_path" TO '$user', 'public'"#,
         );
     }
 }

--- a/pgdog/src/net/parameter.rs
+++ b/pgdog/src/net/parameter.rs
@@ -182,8 +182,7 @@ impl Parameters {
     /// Get parameter value or returned an error.
     pub fn get_required(&self, name: &str) -> Result<&str, Error> {
         self.get(name)
-            .map(|s| s.as_str())
-            .flatten()
+            .and_then(|s| s.as_str())
             .ok_or(Error::MissingParameter(name.into()))
     }
 


### PR DESCRIPTION
### Description

#157 

When the first query inside a transaction is `SET`, send the transaction to the primary. PgDog needs to execute this query, but we don't have enough information on whether the transaction will read or write. To be safe, send it to the primary.

This PR also makes PgDog handle `SET` queries internally without assigning them to a server. Until a client runs an actual query.