### PR TITLE
Multi-tenant

### DIFF
--- a/pgdog.toml
+++ b/pgdog.toml
@@ -106,3 +106,6 @@ fingerprint = "f4814b6fadabc4c1" #[17618446160277259457]
 
 [[manual_query]]
 fingerprint = "04dc05f480b702d3"
+
+[multi_tenant]
+column = "tenant_id"

--- a/pgdog/src/backend/databases.rs
+++ b/pgdog/src/backend/databases.rs
@@ -363,8 +363,14 @@ pub(crate) fn new_pool(
             }
         };
 
-        let cluster_config =
-            ClusterConfig::new(general, user, &shard_configs, sharded_tables, mirror_of);
+        let cluster_config = ClusterConfig::new(
+            general,
+            user,
+            &shard_configs,
+            sharded_tables,
+            mirror_of,
+            config.multi_tenant(),
+        );
 
         Some((
             User {

--- a/pgdog/src/backend/pool/cluster.rs
+++ b/pgdog/src/backend/pool/cluster.rs
@@ -3,7 +3,7 @@
 use parking_lot::RwLock;
 use std::sync::Arc;
 use tokio::spawn;
-use tracing::{debug, error, info};
+use tracing::{error, info};
 
 use crate::{
     backend::{
@@ -18,7 +18,6 @@ use crate::{
 use super::{Address, Config, Error, Guard, Request, Shard};
 use crate::config::LoadBalancingStrategy;
 
-use std::ffi::CString;
 
 #[derive(Clone, Debug)]
 /// Database configuration.

--- a/pgdog/src/backend/pool/cluster.rs
+++ b/pgdog/src/backend/pool/cluster.rs
@@ -1,12 +1,17 @@
 //! A collection of replicas and a primary.
 
+use parking_lot::RwLock;
+use std::sync::Arc;
+use tokio::spawn;
+use tracing::{debug, error, info};
+
 use crate::{
     backend::{
         databases::databases,
         replication::{ReplicationConfig, ShardedColumn},
-        ShardedTables,
+        Schema, ShardedTables,
     },
-    config::{General, PoolerMode, ShardedTable, User},
+    config::{General, MultiTenant, PoolerMode, ShardedTable, User},
     net::messages::BackendKeyData,
 };
 
@@ -36,6 +41,8 @@ pub struct Cluster {
     sharded_tables: ShardedTables,
     replication_sharding: Option<String>,
     mirror_of: Option<String>,
+    schema: Arc<RwLock<Schema>>,
+    multi_tenant: Option<MultiTenant>,
 }
 
 /// Sharding configuration from the cluster.
@@ -63,6 +70,7 @@ pub struct ClusterConfig<'a> {
     pub sharded_tables: ShardedTables,
     pub replication_sharding: Option<String>,
     pub mirror_of: Option<&'a str>,
+    pub multi_tenant: &'a Option<MultiTenant>,
 }
 
 impl<'a> ClusterConfig<'a> {
@@ -72,6 +80,7 @@ impl<'a> ClusterConfig<'a> {
         shards: &'a [ClusterShardConfig],
         sharded_tables: ShardedTables,
         mirror_of: Option<&'a str>,
+        multi_tenant: &'a Option<MultiTenant>,
     ) -> Self {
         Self {
             name: &user.database,
@@ -83,6 +92,7 @@ impl<'a> ClusterConfig<'a> {
             shards,
             sharded_tables,
             mirror_of,
+            multi_tenant,
         }
     }
 }
@@ -100,6 +110,7 @@ impl Cluster {
             sharded_tables,
             replication_sharding,
             mirror_of,
+            multi_tenant,
         } = config;
 
         Self {
@@ -114,6 +125,8 @@ impl Cluster {
             sharded_tables,
             replication_sharding,
             mirror_of: mirror_of.map(|s| s.to_owned()),
+            schema: Arc::new(RwLock::new(Schema::default())),
+            multi_tenant: multi_tenant.clone(),
         }
     }
 
@@ -160,6 +173,8 @@ impl Cluster {
             sharded_tables: self.sharded_tables.clone(),
             replication_sharding: self.replication_sharding.clone(),
             mirror_of: self.mirror_of.clone(),
+            schema: self.schema.clone(),
+            multi_tenant: self.multi_tenant.clone(),
         }
     }
 
@@ -180,52 +195,6 @@ impl Cluster {
     /// Mirrors getter.
     pub fn mirror_of(&self) -> Option<&str> {
         self.mirror_of.as_deref()
-    }
-
-    /// Plugin input.
-    ///
-    /// # Safety
-    ///
-    /// This allocates, so make sure to call `Config::drop` when you're done.
-    ///
-    pub unsafe fn plugin_config(&self) -> Result<pgdog_plugin::bindings::Config, Error> {
-        use pgdog_plugin::bindings::{Config, DatabaseConfig, Role_PRIMARY, Role_REPLICA};
-        let mut databases: Vec<DatabaseConfig> = vec![];
-        let name = CString::new(self.name.as_str()).map_err(|_| Error::NullBytes)?;
-
-        for (index, shard) in self.shards.iter().enumerate() {
-            if let Some(ref primary) = shard.primary {
-                // Ignore hosts with null bytes.
-                let host = if let Ok(host) = CString::new(primary.addr().host.as_str()) {
-                    host
-                } else {
-                    continue;
-                };
-                databases.push(DatabaseConfig::new(
-                    host,
-                    primary.addr().port,
-                    Role_PRIMARY,
-                    index,
-                ));
-            }
-
-            for replica in shard.replicas.pools() {
-                // Ignore hosts with null bytes.
-                let host = if let Ok(host) = CString::new(replica.addr().host.as_str()) {
-                    host
-                } else {
-                    continue;
-                };
-                databases.push(DatabaseConfig::new(
-                    host,
-                    replica.addr().port,
-                    Role_REPLICA,
-                    index,
-                ));
-            }
-        }
-
-        Ok(Config::new(name, &databases, self.shards.len()))
     }
 
     /// Get the password the user should use to connect to the database.
@@ -280,6 +249,11 @@ impl Cluster {
         true
     }
 
+    /// Multi-tenant config.
+    pub fn multi_tenant(&self) -> &Option<MultiTenant> {
+        &self.multi_tenant
+    }
+
     /// Get replication configuration for this cluster.
     pub fn replication_sharding_config(&self) -> Option<ReplicationConfig> {
         self.replication_sharding
@@ -295,11 +269,36 @@ impl Cluster {
         }
     }
 
+    /// Update schema from primary.
+    async fn update_schema(&self) -> Result<(), crate::backend::Error> {
+        let mut server = self.primary(0, &Request::default()).await?;
+        let schema = Schema::load(&mut server).await?;
+        info!(
+            "loaded {} tables from schema [{}]",
+            schema.tables().len(),
+            server.addr()
+        );
+        *self.schema.write() = schema;
+        Ok(())
+    }
+
+    /// Get currently loaded schema.
+    pub fn schema(&self) -> Schema {
+        self.schema.read().clone()
+    }
+
     /// Launch the connection pools.
     pub(crate) fn launch(&self) {
         for shard in self.shards() {
             shard.launch();
         }
+
+        let me = self.clone();
+        spawn(async move {
+            if let Err(err) = me.update_schema().await {
+                error!("error loading schema: {}", err);
+            }
+        });
     }
 
     /// Shutdown the connection pools.

--- a/pgdog/src/backend/pool/cluster.rs
+++ b/pgdog/src/backend/pool/cluster.rs
@@ -280,6 +280,10 @@ impl Cluster {
         Ok(())
     }
 
+    fn load_schema(&self) -> bool {
+        self.multi_tenant.is_some()
+    }
+
     /// Get currently loaded schema.
     pub fn schema(&self) -> Schema {
         self.schema.read().clone()
@@ -291,12 +295,14 @@ impl Cluster {
             shard.launch();
         }
 
-        let me = self.clone();
-        spawn(async move {
-            if let Err(err) = me.update_schema().await {
-                error!("error loading schema: {}", err);
-            }
-        });
+        if self.load_schema() {
+            let me = self.clone();
+            spawn(async move {
+                if let Err(err) = me.update_schema().await {
+                    error!("error loading schema: {}", err);
+                }
+            });
+        }
     }
 
     /// Shutdown the connection pools.

--- a/pgdog/src/backend/pool/cluster.rs
+++ b/pgdog/src/backend/pool/cluster.rs
@@ -18,7 +18,6 @@ use crate::{
 use super::{Address, Config, Error, Guard, Request, Shard};
 use crate::config::LoadBalancingStrategy;
 
-
 #[derive(Clone, Debug)]
 /// Database configuration.
 pub struct PoolConfig {

--- a/pgdog/src/backend/schema/mod.rs
+++ b/pgdog/src/backend/schema/mod.rs
@@ -44,7 +44,6 @@ impl Schema {
             .pop()
             .unwrap_or(String::from("$user, public"))
             .split(",")
-            .into_iter()
             .map(|p| p.trim().replace("\"", ""))
             .collect();
 

--- a/pgdog/src/backend/schema/mod.rs
+++ b/pgdog/src/backend/schema/mod.rs
@@ -3,6 +3,7 @@ pub mod columns;
 pub mod relation;
 
 use std::collections::HashMap;
+use std::sync::Arc;
 use tracing::debug;
 
 pub use relation::Relation;
@@ -14,7 +15,7 @@ static SETUP: &str = include_str!("setup.sql");
 /// Load schema from database.
 #[derive(Debug, Clone, Default)]
 pub struct Schema {
-    relations: HashMap<(String, String), Relation>,
+    relations: Arc<HashMap<(String, String), Relation>>,
 }
 
 impl Schema {
@@ -31,7 +32,9 @@ impl Schema {
             })
             .collect();
 
-        Ok(Self { relations })
+        Ok(Self {
+            relations: Arc::new(relations),
+        })
     }
 
     /// Load schema from primary database.
@@ -68,7 +71,7 @@ impl Schema {
                     .iter()
                     .filter(|table| table.schema() != "pgdog")
                 {
-                    let column_match = schema_table.columns.iter().find(|column| {
+                    let column_match = schema_table.columns.values().find(|column| {
                         column.column_name == table.column && column.data_type == "bigint"
                     });
                     if let Some(column_match) = column_match {

--- a/pgdog/src/config/mod.rs
+++ b/pgdog/src/config/mod.rs
@@ -954,7 +954,7 @@ retries = 5
 [[plugins]]
 name = "pgdog_routing"
 
-[[multi_tenant]]
+[multi_tenant]
 column = "tenant_id"
 "#;
 

--- a/pgdog/src/config/mod.rs
+++ b/pgdog/src/config/mod.rs
@@ -118,6 +118,10 @@ impl ConfigAndUsers {
             warn!("admin password has been randomly generated");
         }
 
+        if config.multi_tenant.is_some() {
+            info!("multi-tenant protection enabled");
+        }
+
         let users: Users = if let Ok(users) = read_to_string(users_path) {
             let mut users: Users = toml::from_str(&users)?;
             users.check(&config);
@@ -157,6 +161,8 @@ pub struct Config {
     /// TCP settings
     #[serde(default)]
     pub tcp: Tcp,
+    /// Multi-tenant
+    pub multi_tenant: Option<MultiTenant>,
     /// Servers.
     #[serde(default)]
     pub databases: Vec<Database>,
@@ -249,6 +255,11 @@ impl Config {
                 );
             }
         }
+    }
+
+    /// Multi-tenanncy is enabled.
+    pub fn multi_tenant(&self) -> &Option<MultiTenant> {
+        &self.multi_tenant
     }
 }
 
@@ -907,6 +918,12 @@ impl Tcp {
     }
 }
 
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+#[serde(rename_all = "snake_case")]
+pub struct MultiTenant {
+    pub column: String,
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -936,6 +953,9 @@ retries = 5
 
 [[plugins]]
 name = "pgdog_routing"
+
+[[multi_tenant]]
+column = "tenant_id"
 "#;
 
         let config: Config = toml::from_str(source).unwrap();
@@ -949,5 +969,6 @@ name = "pgdog_routing"
         );
         assert_eq!(config.tcp.time().unwrap(), Duration::from_millis(1000));
         assert_eq!(config.tcp.retries().unwrap(), 5);
+        assert_eq!(config.multi_tenant.unwrap().column, "tenant_id");
     }
 }

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -9,7 +9,7 @@ use tokio::time::timeout;
 use tokio::{select, spawn};
 use tracing::{debug, error, info, trace};
 
-use super::{Buffer, Command, Comms, Error, PreparedStatements};
+use super::{Buffer, Command, Comms, Error, PreparedStatements, RouterContext};
 use crate::auth::{md5, scram::Server};
 use crate::backend::{
     databases,
@@ -292,8 +292,12 @@ impl Client {
         }
 
         let connected = inner.connected();
-        let command = match inner.command(&mut self.protocol_buffer, &mut self.prepared_statements)
-        {
+
+        let command = match inner.command(
+            &mut self.protocol_buffer,
+            &mut self.prepared_statements,
+            &self.params,
+        ) {
             Ok(command) => command,
             Err(err) => {
                 self.stream

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -9,7 +9,7 @@ use tokio::time::timeout;
 use tokio::{select, spawn};
 use tracing::{debug, error, info, trace};
 
-use super::{Buffer, Command, Comms, Error, PreparedStatements, RouterContext};
+use super::{Buffer, Command, Comms, Error, PreparedStatements};
 use crate::auth::{md5, scram::Server};
 use crate::backend::{
     databases,

--- a/pgdog/src/frontend/mod.rs
+++ b/pgdog/src/frontend/mod.rs
@@ -21,4 +21,5 @@ pub use prepared_statements::{PreparedStatements, Rewrite};
 #[cfg(debug_assertions)]
 pub use query_logger::QueryLogger;
 pub use router::{Command, Router};
+pub use router::{RouterContext, SearchPath};
 pub use stats::Stats;

--- a/pgdog/src/frontend/router/context.rs
+++ b/pgdog/src/frontend/router/context.rs
@@ -1,8 +1,8 @@
 use super::Error;
 use crate::{
-    backend::{Cluster, Schema},
+    backend::Cluster,
     frontend::{
-        buffer::BufferedQuery, router::search_path::SearchPath, Buffer, PreparedStatements,
+        buffer::BufferedQuery, Buffer, PreparedStatements,
     },
     net::{Bind, Parameters},
 };

--- a/pgdog/src/frontend/router/context.rs
+++ b/pgdog/src/frontend/router/context.rs
@@ -1,0 +1,42 @@
+use super::Error;
+use crate::{
+    backend::{Cluster, Schema},
+    frontend::{
+        buffer::BufferedQuery, router::search_path::SearchPath, Buffer, PreparedStatements,
+    },
+    net::{Bind, Parameters},
+};
+
+#[derive(Debug)]
+pub struct RouterContext<'a> {
+    /// Prepared statements.
+    pub prepared_statements: &'a mut PreparedStatements,
+    /// Bound parameters to the query.
+    pub bind: Option<&'a Bind>,
+    /// Query we're looking it.
+    pub query: Option<BufferedQuery>,
+    /// Cluster configuration.
+    pub cluster: &'a Cluster,
+    /// Client parameters, e.g. search_path.
+    pub params: &'a Parameters,
+}
+
+impl<'a> RouterContext<'a> {
+    pub fn new(
+        buffer: &'a Buffer,
+        cluster: &'a Cluster,
+        stmt: &'a mut PreparedStatements,
+        params: &'a Parameters,
+    ) -> Result<Self, Error> {
+        let query = buffer.query()?;
+        let bind = buffer.parameters()?;
+
+        Ok(Self {
+            query,
+            bind,
+            params,
+            prepared_statements: stmt,
+            cluster,
+        })
+    }
+}

--- a/pgdog/src/frontend/router/context.rs
+++ b/pgdog/src/frontend/router/context.rs
@@ -1,9 +1,7 @@
 use super::Error;
 use crate::{
     backend::Cluster,
-    frontend::{
-        buffer::BufferedQuery, Buffer, PreparedStatements,
-    },
+    frontend::{buffer::BufferedQuery, Buffer, PreparedStatements},
     net::{Bind, Parameters},
 };
 

--- a/pgdog/src/frontend/router/mod.rs
+++ b/pgdog/src/frontend/router/mod.rs
@@ -1,6 +1,5 @@
 //! Query router.
 
-use crate::backend::Cluster;
 
 pub mod context;
 pub mod copy;
@@ -15,7 +14,7 @@ pub use copy::CopyRow;
 pub use error::Error;
 pub use parser::{Command, QueryParser, Route};
 
-use super::{Buffer, PreparedStatements};
+use super::Buffer;
 pub use context::RouterContext;
 pub use search_path::SearchPath;
 

--- a/pgdog/src/frontend/router/mod.rs
+++ b/pgdog/src/frontend/router/mod.rs
@@ -2,11 +2,13 @@
 
 use crate::backend::Cluster;
 
+pub mod context;
 pub mod copy;
 pub mod error;
 pub mod parser;
 pub mod request;
 pub mod round_robin;
+pub mod search_path;
 pub mod sharding;
 
 pub use copy::CopyRow;
@@ -14,6 +16,8 @@ pub use error::Error;
 pub use parser::{Command, QueryParser, Route};
 
 use super::{Buffer, PreparedStatements};
+pub use context::RouterContext;
+pub use search_path::SearchPath;
 
 /// Query router.
 #[derive(Debug)]
@@ -46,15 +50,8 @@ impl Router {
     /// previous route is preserved. This is useful in case the client
     /// doesn't supply enough information in the buffer, e.g. just issued
     /// a Describe request to a previously submitted Parse.
-    pub fn query(
-        &mut self,
-        buffer: &Buffer,
-        cluster: &Cluster,
-        prepared_statements: &mut PreparedStatements,
-    ) -> Result<&Command, Error> {
-        Ok(self
-            .query_parser
-            .parse(buffer, cluster, prepared_statements)?)
+    pub fn query(&mut self, context: RouterContext) -> Result<&Command, Error> {
+        Ok(self.query_parser.parse(context)?)
     }
 
     /// Parse CopyData messages and shard them.

--- a/pgdog/src/frontend/router/mod.rs
+++ b/pgdog/src/frontend/router/mod.rs
@@ -1,6 +1,5 @@
 //! Query router.
 
-
 pub mod context;
 pub mod copy;
 pub mod error;

--- a/pgdog/src/frontend/router/parser/error.rs
+++ b/pgdog/src/frontend/router/parser/error.rs
@@ -42,4 +42,7 @@ pub enum Error {
 
     #[error("set shard syntax error")]
     SetShard,
+
+    #[error("no multi tenant id")]
+    MultiTenantId,
 }

--- a/pgdog/src/frontend/router/parser/key.rs
+++ b/pgdog/src/frontend/router/parser/key.rs
@@ -8,4 +8,6 @@ pub enum Key {
     /// A constant value, e.g. "1", "2", or "'value'"
     /// which can be parsed from the query text.
     Constant(String),
+    /// Null check on a column.
+    Null,
 }

--- a/pgdog/src/frontend/router/parser/mod.rs
+++ b/pgdog/src/frontend/router/parser/mod.rs
@@ -11,6 +11,7 @@ pub mod csv;
 pub mod error;
 pub mod insert;
 pub mod key;
+pub mod multi_tenant;
 pub mod order_by;
 pub mod prepare;
 pub mod query;

--- a/pgdog/src/frontend/router/parser/multi_tenant.rs
+++ b/pgdog/src/frontend/router/parser/multi_tenant.rs
@@ -1,0 +1,72 @@
+use std::sync::Arc;
+
+use pg_query::{protobuf::UpdateStmt, NodeEnum, ParseResult};
+
+use super::Error;
+use crate::{
+    backend::{schema::relation::TABLES, Schema},
+    config::MultiTenant,
+    frontend::router::parser::{Table, WhereClause},
+};
+
+pub struct MultiTenantCheck<'a> {
+    config: &'a MultiTenant,
+    schema: Schema,
+    ast: &'a ParseResult,
+}
+
+impl<'a> MultiTenantCheck<'a> {
+    pub fn new(config: &'a MultiTenant, schema: Schema, ast: &'a ParseResult) -> Self {
+        Self {
+            config,
+            schema,
+            ast,
+        }
+    }
+
+    pub fn run(&self) -> Result<(), Error> {
+        let stmt = self
+            .ast
+            .protobuf
+            .stmts
+            .first()
+            .map(|s| s.stmt.as_ref())
+            .flatten();
+
+        match stmt.map(|n| n.node.as_ref()).flatten() {
+            Some(NodeEnum::UpdateStmt(stmt)) => {
+                let table = stmt
+                    .relation
+                    .as_ref()
+                    .map(Table::from)
+                    .ok_or(Error::MultiTenantId)?;
+                let schema_table = self.schema.table(&table.name, Some("pgdog"));
+
+                println!("{:?}, {:?}", schema_table, table);
+                println!("{:?}", self.schema);
+
+                if let Some(schema_table) = schema_table {
+                    let has_tenant_id = schema_table.columns().contains_key(&self.config.column);
+                    if !has_tenant_id {
+                        return Ok(());
+                    }
+                    let where_clause = WhereClause::new(Some(&table.name), &stmt.where_clause)
+                        .ok_or(Error::MultiTenantId)?;
+                    let missing_column = where_clause
+                        .keys(Some(&table.name), &self.config.column)
+                        .is_empty();
+                    return if !missing_column {
+                        Ok(())
+                    } else {
+                        Err(Error::MultiTenantId)
+                    };
+                }
+            }
+            Some(NodeEnum::SelectStmt(stmt)) => {}
+            Some(NodeEnum::DeleteStmt(stmt)) => {}
+
+            _ => (),
+        }
+        Ok(())
+    }
+}

--- a/pgdog/src/frontend/router/parser/multi_tenant.rs
+++ b/pgdog/src/frontend/router/parser/multi_tenant.rs
@@ -1,26 +1,38 @@
-use std::sync::Arc;
+use pg_query::{NodeEnum, ParseResult};
 
-use pg_query::{protobuf::UpdateStmt, NodeEnum, ParseResult};
-
-use super::Error;
+use super::{where_clause, Error};
 use crate::{
-    backend::{schema::relation::TABLES, Schema},
+    backend::Schema,
     config::MultiTenant,
-    frontend::router::parser::{Table, WhereClause},
+    frontend::{
+        router::parser::{Table, WhereClause},
+        SearchPath,
+    },
+    net::Parameters,
 };
 
 pub struct MultiTenantCheck<'a> {
+    user: &'a str,
     config: &'a MultiTenant,
     schema: Schema,
     ast: &'a ParseResult,
+    parameters: &'a Parameters,
 }
 
 impl<'a> MultiTenantCheck<'a> {
-    pub fn new(config: &'a MultiTenant, schema: Schema, ast: &'a ParseResult) -> Self {
+    pub fn new(
+        user: &'a str,
+        config: &'a MultiTenant,
+        schema: Schema,
+        ast: &'a ParseResult,
+        parameters: &'a Parameters,
+    ) -> Self {
         Self {
             config,
             schema,
             ast,
+            parameters,
+            user,
         }
     }
 
@@ -35,38 +47,52 @@ impl<'a> MultiTenantCheck<'a> {
 
         match stmt.map(|n| n.node.as_ref()).flatten() {
             Some(NodeEnum::UpdateStmt(stmt)) => {
-                let table = stmt
-                    .relation
-                    .as_ref()
-                    .map(Table::from)
-                    .ok_or(Error::MultiTenantId)?;
-                let schema_table = self.schema.table(&table.name, Some("pgdog"));
-
-                println!("{:?}, {:?}", schema_table, table);
-                println!("{:?}", self.schema);
-
-                if let Some(schema_table) = schema_table {
-                    let has_tenant_id = schema_table.columns().contains_key(&self.config.column);
-                    if !has_tenant_id {
-                        return Ok(());
-                    }
-                    let where_clause = WhereClause::new(Some(&table.name), &stmt.where_clause)
-                        .ok_or(Error::MultiTenantId)?;
-                    let missing_column = where_clause
-                        .keys(Some(&table.name), &self.config.column)
-                        .is_empty();
-                    return if !missing_column {
-                        Ok(())
-                    } else {
-                        Err(Error::MultiTenantId)
-                    };
+                let table = stmt.relation.as_ref().map(Table::from);
+                let where_clause = WhereClause::new(table.map(|t| t.name), &stmt.where_clause);
+                if let Some(table) = table {
+                    self.check(table, where_clause)?;
                 }
             }
-            Some(NodeEnum::SelectStmt(stmt)) => {}
+            Some(NodeEnum::SelectStmt(stmt)) => {
+                let table = Table::try_from(&stmt.from_clause).ok();
+                let where_clause = WhereClause::new(table.map(|t| t.name), &stmt.where_clause);
+
+                if let Some(table) = table {
+                    self.check(table, where_clause)?;
+                }
+            }
             Some(NodeEnum::DeleteStmt(stmt)) => {}
 
             _ => (),
         }
+        Ok(())
+    }
+
+    fn check(&self, table: Table, where_clause: Option<WhereClause>) -> Result<(), Error> {
+        let search_path = SearchPath::new(self.user, &self.parameters, &self.schema);
+        let schemas = search_path.resolve();
+
+        for schema in schemas {
+            let schema_table = self
+                .schema
+                .get(&(schema.to_owned(), table.name.to_string()));
+            if let Some(schema_table) = schema_table {
+                let has_tenant_id = schema_table.columns().contains_key(&self.config.column);
+                if !has_tenant_id {
+                    continue;
+                }
+
+                let check = where_clause
+                    .as_ref()
+                    .and_then(|w| Some(!w.keys(Some(table.name), &self.config.column).is_empty()));
+                if let Some(true) = check {
+                    return Ok(());
+                } else {
+                    return Err(Error::MultiTenantId);
+                }
+            }
+        }
+
         Ok(())
     }
 }

--- a/pgdog/src/frontend/router/parser/query.rs
+++ b/pgdog/src/frontend/router/parser/query.rs
@@ -16,7 +16,7 @@ use crate::{
             sharding::{shard_param, shard_str, shard_value, Centroids},
             CopyRow,
         },
-        Buffer, PreparedStatements,
+        PreparedStatements,
     },
     net::{
         messages::{Bind, CopyData, Vector},
@@ -72,7 +72,7 @@ impl QueryParser {
     pub fn parse(&mut self, context: RouterContext) -> Result<&Command, Error> {
         if let Some(ref query) = context.query {
             self.command = self.query(
-                &query,
+                query,
                 context.cluster,
                 context.bind,
                 context.prepared_statements,
@@ -743,7 +743,7 @@ mod test {
     };
 
     use super::{super::Shard, *};
-    use crate::frontend::RouterContext;
+    use crate::frontend::{Buffer, RouterContext};
     use crate::net::messages::Query;
     use crate::net::Parameters;
 

--- a/pgdog/src/frontend/router/parser/query.rs
+++ b/pgdog/src/frontend/router/parser/query.rs
@@ -170,7 +170,9 @@ impl QueryParser {
                 cache.record_command(query, &route)?;
             }
 
-            return Ok(self.command.clone());
+            if multi_tenant.is_none() {
+                return Ok(self.command.clone());
+            }
         }
 
         let mut shard = Shard::All;

--- a/pgdog/src/frontend/router/parser/route.rs
+++ b/pgdog/src/frontend/router/parser/route.rs
@@ -157,4 +157,9 @@ impl Route {
         self.read = !lock;
         self
     }
+
+    pub fn set_read(mut self, read: bool) -> Self {
+        self.read = read;
+        self
+    }
 }

--- a/pgdog/src/frontend/router/parser/table.rs
+++ b/pgdog/src/frontend/router/parser/table.rs
@@ -21,6 +21,28 @@ impl<'a> TryFrom<&'a Node> for Table<'a> {
     }
 }
 
+impl<'a> TryFrom<&'a Vec<Node>> for Table<'a> {
+    type Error = ();
+
+    fn try_from(value: &'a Vec<Node>) -> Result<Self, Self::Error> {
+        let name = value
+            .first()
+            .and_then(|node| {
+                node.node.as_ref().map(|node| match node {
+                    NodeEnum::RangeVar(var) => Some(if let Some(ref alias) = var.alias {
+                        alias.aliasname.as_str()
+                    } else {
+                        var.relname.as_str()
+                    }),
+                    _ => None,
+                })
+            })
+            .flatten()
+            .ok_or(())?;
+        Ok(Self { name, schema: None })
+    }
+}
+
 impl<'a> From<&'a RangeVar> for Table<'a> {
     fn from(range_var: &'a RangeVar) -> Self {
         let name = if let Some(ref alias) = range_var.alias {

--- a/pgdog/src/frontend/router/parser/where_clause.rs
+++ b/pgdog/src/frontend/router/parser/where_clause.rs
@@ -145,8 +145,7 @@ impl<'a> WhereClause<'a> {
                     let left = null_test
                         .arg
                         .as_ref()
-                        .map(|node| Self::parse(table_name, node).pop())
-                        .flatten();
+                        .and_then(|node| Self::parse(table_name, node).pop());
 
                     if let Some(Output::Column(c)) = left {
                         keys.push(Output::NullCheck(c));
@@ -203,7 +202,7 @@ impl<'a> WhereClause<'a> {
                 let table = if let Some(table) = table {
                     Some(table)
                 } else {
-                    table_name.map(|t| t)
+                    table_name
                 };
 
                 if let Some(name) = name {

--- a/pgdog/src/frontend/router/search_path.rs
+++ b/pgdog/src/frontend/router/search_path.rs
@@ -1,5 +1,5 @@
 use crate::{
-    backend::{Cluster, Schema},
+    backend::Schema,
     net::{parameter::ParameterValue, Parameters},
 };
 

--- a/pgdog/src/frontend/router/search_path.rs
+++ b/pgdog/src/frontend/router/search_path.rs
@@ -1,0 +1,53 @@
+use crate::{
+    backend::{Cluster, Schema},
+    net::{parameter::ParameterValue, Parameters},
+};
+
+#[derive(Debug)]
+pub struct SearchPath<'a> {
+    search_path: &'a [String],
+    user: &'a str,
+}
+
+impl<'a> SearchPath<'a> {
+    /// Return a list of schemas the tables the user can see.
+    pub(crate) fn resolve(&'a self) -> Vec<&'a str> {
+        let mut schemas = vec![];
+
+        for path in self.search_path {
+            match path.as_str() {
+                "$user" => schemas.push(self.user),
+                path => schemas.push(path),
+            }
+        }
+
+        schemas
+    }
+
+    pub(crate) fn new(user: &'a str, params: &'a Parameters, schema: &'a Schema) -> Self {
+        let default_path = schema.search_path();
+        let search_path = match params.get("search_path") {
+            Some(ParameterValue::Tuple(overriden)) => overriden.as_slice(),
+            _ => default_path,
+        };
+        Self { search_path, user }
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+
+    #[test]
+    fn test_search_path() {
+        let param = vec!["$user".into(), "public".into()];
+        let user = "pgdog";
+        let resolver = SearchPath {
+            search_path: &param,
+            user,
+        };
+        let res = resolver.resolve();
+        assert_eq!(res, vec!["pgdog", "public"]);
+    }
+}


### PR DESCRIPTION
### Description

- Support for checking `tenant_id` on all queries that touch tables with that column. The column is configurable in `pgdog.toml`. This protects the app from forgetting to include the tenant ID in a query.
- Fix bug around routing `SET` inside a transaction: if the cluster is read-only, send it to a replica. #162 