### PR TITLE
Log query cache stats in dry run mode

### DIFF
--- a/pgdog/src/main.rs
+++ b/pgdog/src/main.rs
@@ -100,14 +100,17 @@ async fn pgdog() -> Result<(), Box<dyn std::error::Error>> {
         tokio::spawn(async move { stats::http_server::server(openmetrics_port).await });
     }
 
+    let stats_logger = stats::StatsLogger::new();
+
     if general.dry_run {
-        stats::StatsLogger::new().spawn();
+        stats_logger.spawn();
     }
 
     let mut listener = Listener::new(format!("{}:{}", general.host, general.port));
     listener.listen().await?;
 
     info!("🐕 pgDog is shutting down");
+    stats_logger.shutdown();
 
     // Any shutdown routines go below.
     plugin::shutdown();

--- a/pgdog/src/main.rs
+++ b/pgdog/src/main.rs
@@ -100,6 +100,10 @@ async fn pgdog() -> Result<(), Box<dyn std::error::Error>> {
         tokio::spawn(async move { stats::http_server::server(openmetrics_port).await });
     }
 
+    if general.dry_run {
+        stats::StatsLogger::new().spawn();
+    }
+
     let mut listener = Listener::new(format!("{}:{}", general.host, general.port));
     listener.listen().await?;
 

--- a/pgdog/src/stats/logger.rs
+++ b/pgdog/src/stats/logger.rs
@@ -1,0 +1,41 @@
+use std::{sync::Arc, time::Duration};
+
+use tokio::{select, spawn, sync::Notify, time::sleep};
+use tracing::info;
+
+use crate::frontend::router::parser::Cache;
+
+#[derive(Debug, Clone)]
+pub struct Logger {
+    interval: Duration,
+    shutdown: Arc<Notify>,
+}
+
+impl Logger {
+    pub fn new() -> Self {
+        Self {
+            interval: Duration::from_secs(10),
+            shutdown: Arc::new(Notify::new()),
+        }
+    }
+
+    pub fn spawn(&self) {
+        let me = self.clone();
+
+        spawn(async move {
+            loop {
+                select! {
+                    _ = sleep(me.interval) => {
+                        let stats = Cache::stats();
+
+                        info!(
+                            "[query cache stats] direct: {}, multi: {}, hits: {}, misses: {}, size: {}, direct hit rate: {:.3}%",
+                            stats.direct, stats.multi, stats.hits, stats.misses, stats.size, (stats.direct as f64 / std::cmp::max(stats.direct + stats.multi, 1) as f64 * 100.0)
+                        );
+                    }
+                    _ = me.shutdown.notified() => break,
+                }
+            }
+        });
+    }
+}

--- a/pgdog/src/stats/logger.rs
+++ b/pgdog/src/stats/logger.rs
@@ -19,6 +19,10 @@ impl Logger {
         }
     }
 
+    pub fn shutdown(&self) {
+        self.shutdown.notify_one();
+    }
+
     pub fn spawn(&self) {
         let me = self.clone();
 

--- a/pgdog/src/stats/mod.rs
+++ b/pgdog/src/stats/mod.rs
@@ -4,8 +4,10 @@ pub mod http_server;
 pub mod open_metric;
 pub mod pools;
 pub use open_metric::*;
+pub mod logger;
 pub mod query_cache;
 
 pub use clients::Clients;
+pub use logger::Logger as StatsLogger;
 pub use pools::{PoolMetric, Pools};
 pub use query_cache::QueryCache;


### PR DESCRIPTION
### Description

When in dry run mode, log query cache stats directly to console so it's easier to debug (no monitoring agent required).