### PR TITLE
SHOW pgdog.shards command

### DIFF
--- a/integration/ruby/crud_spec.rb
+++ b/integration/ruby/crud_spec.rb
@@ -1,0 +1,107 @@
+
+require_relative 'rspec_helper'
+require 'pp'
+
+require 'active_record/migration'
+
+# --- Migration Helper ---
+def migrate_tables
+  ActiveRecord::Schema.define do
+    suppress_messages do
+      create_table :customers, if_not_exists: true, id: :bigserial do |t|
+        t.string :name, null: false
+        t.string :email, null: false
+        t.timestamps
+      end
+      add_index :customers, :email, unique: true, if_not_exists: true
+
+      create_table :orders, if_not_exists: true, id: :bigserial do |t|
+        t.references :customer, null: false, foreign_key: true, type: :bigint
+        t.decimal :amount, null: false
+        t.datetime :order_date, null: false
+        t.timestamps
+      end
+    end
+  end
+end
+
+def drop_tables
+  ActiveRecord::Schema.define do
+    suppress_messages do
+      drop_table :orders, if_exists: true
+      drop_table :customers, if_exists: true
+    end
+  end
+end
+
+# --- Model Definitions ---
+class Customer < ActiveRecord::Base
+  has_many :orders, dependent: :destroy
+  validates :name, presence: true
+  validates :email, presence: true, uniqueness: true
+end
+
+class Order < ActiveRecord::Base
+  belongs_to :customer
+  validates :amount, presence: true
+  validates :order_date, presence: true
+end
+
+# --- Test Suite ---
+describe 'CRUD and Join for Customer and Order', type: :model do
+  before(:all) do
+    ActiveRecord::Base.establish_connection(
+      adapter: 'postgresql',
+      host: '127.0.0.1',
+      port: 6432,
+      database: "pgdog_sharded",
+      password: 'pgdog',
+      user: 'pgdog',
+      prepared_statements: true
+    )
+
+    migrate_tables
+
+    Order.delete_all
+    Customer.delete_all
+  end
+
+  after(:all) do
+    Order.delete_all
+    Customer.delete_all
+    drop_tables
+  end
+
+  it 'does full CRUD and join' do
+    # CREATE Customer
+    customer = Customer.create!(name: 'Bob', email: 'bob@example.com')
+    expect(customer.id).to be_present
+
+    # CREATE Order
+    order = Order.create!(customer: customer, amount: 123.45, order_date: Time.now)
+    expect(order.id).to be_present
+
+    # SELECT with JOIN by customer_id
+    joined = Order.joins(:customer).where(customer_id: customer.id, id: order.id)
+    expect(joined.count).to eq(1)
+    expect(joined.first.customer.name).to eq('Bob')
+    expect(joined.first.amount.to_f).to eq(123.45)
+
+    # UPDATE Order amount (by customer_id)
+    order.update!(amount: 200.00)
+    order.reload
+    expect(order.amount.to_f).to eq(200.00)
+
+    # Confirm update with join
+    joined = Order.joins(:customer).where(customer_id: customer.id, id: order.id)
+    expect(joined.first.amount.to_f).to eq(200.00)
+
+    # DELETE order (by customer_id)
+    order.destroy
+    expect(Order.where(id: order.id, customer_id: customer.id)).to be_empty
+
+    # Confirm order is deleted (join returns no rows)
+    joined = Order.joins(:customer).where(customer_id: customer.id, id: order.id)
+    expect(joined).to be_empty
+  end
+end

--- a/pgdog/src/frontend/router/parser/command.rs
+++ b/pgdog/src/frontend/router/parser/command.rs
@@ -13,6 +13,7 @@ pub enum Command {
     Set { name: String, value: ParameterValue },
     PreparedStatement(Prepare),
     Rewrite(String),
+    Shards(usize),
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/sdk/ruby/pgdog/lib/pgdog.rb
+++ b/sdk/ruby/pgdog/lib/pgdog.rb
@@ -30,6 +30,17 @@ class PgDog
     end
   end
 
+  # Get the number of configured shards
+  #
+  # Can only work outside of a transaction, because
+  # a started transaction is most likely already routed to a shard
+  # and the PgDog query parser won't be used.
+  def self.shards
+    PgDog.check_transaction
+    shards = ActiveRecord::Base.connection.execute "SHOW \"pgdog.shards\""
+    return shards[0]["shards"].to_i
+  end
+
   # Get currently set shard, if any.
   def self.shard
     shard = self.connection.execute "SELECT current_setting('pgdog.shard', true)"

--- a/sdk/ruby/pgdog/pgdog.gemspec
+++ b/sdk/ruby/pgdog/pgdog.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "pgdog"
-  s.version     = "0.1.1"
+  s.version     = "0.1.2"
   s.summary     = "PgDog plugin for Ruby on Rails."
   s.description = "Add routing hints to the application to enable direct-to-shard transaction routing in ambiguous contexts."
   s.authors     = ["Lev Kokotov"]

--- a/sdk/ruby/pgdog/spec/pgdog_spec.rb
+++ b/sdk/ruby/pgdog/spec/pgdog_spec.rb
@@ -46,4 +46,9 @@ describe "basics" do
       }.to raise_error /Transaction already started/
     end
   end
+
+  it "can get the number of shards" do
+    shards = PgDog.shards
+    expect(shards).to eq(2)
+  end
 end


### PR DESCRIPTION
### Description
- Add `SHOW pgdog.shards` command so clients can find out how many shards are currently configured in the proxy.