### PR TITLE
Populate git hash version in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 FROM ubuntu:latest AS builder
 
 RUN apt update && \
-    apt install -y build-essential cmake clang curl pkg-config libssl-dev
+    apt install -y build-essential cmake clang curl pkg-config libssl-dev git
 
 # Install Rust.
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 
 COPY . /build
+COPY .git /build/.git
 WORKDIR /build
 
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh


### PR DESCRIPTION
### Description

- Include .git folder in Docker builder so build.rs can extract the git commit correctly.