### PR TITLE
Openmetrics prefix

### DIFF
--- a/examples/demo/src/main.rs
+++ b/examples/demo/src/main.rs
@@ -1,9 +1,8 @@
-use colored::{ColoredString, Colorize};
+use colored::Colorize;
 use std::{
     io::{Write, stdin, stdout},
     process::{Command, Stdio, exit},
 };
-use which::which;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
@@ -53,12 +52,6 @@ fn input() -> String {
     };
     println!("");
     input
-}
-
-fn step() {
-    let input = input();
-    let input: usize = input.parse().unwrap();
-    demo(input);
 }
 
 fn command(info: &str, cmd: &mut Command) -> bool {

--- a/pgdog.toml
+++ b/pgdog.toml
@@ -6,7 +6,7 @@ host = "0.0.0.0"
 port = 6432
 shutdown_timeout = 5_000
 openmetrics_port = 9090
-openmetrics_prefix = "pgdog."
+openmetrics_namespace = "pgdog."
 idle_healthcheck_delay = 2342343243
 read_write_strategy = "conservative"
 

--- a/pgdog.toml
+++ b/pgdog.toml
@@ -6,6 +6,7 @@ host = "0.0.0.0"
 port = 6432
 shutdown_timeout = 5_000
 openmetrics_port = 9090
+openmetrics_prefix = "pgdog."
 idle_healthcheck_delay = 2342343243
 read_write_strategy = "conservative"
 

--- a/pgdog/src/config/mod.rs
+++ b/pgdog/src/config/mod.rs
@@ -326,6 +326,8 @@ pub struct General {
     pub query_log: Option<PathBuf>,
     /// Enable OpenMetrics server on this port.
     pub openmetrics_port: Option<u16>,
+    /// OpenMetrics prefix.
+    pub openmetrics_prefix: Option<String>,
     /// Prepared statatements support.
     #[serde(default)]
     pub prepared_statements: PreparedStatements,
@@ -436,6 +438,7 @@ impl Default for General {
             broadcast_port: Self::broadcast_port(),
             query_log: None,
             openmetrics_port: None,
+            openmetrics_prefix: None,
             prepared_statements: PreparedStatements::default(),
             passthrough_auth: PassthoughAuth::default(),
             connect_timeout: Self::default_connect_timeout(),

--- a/pgdog/src/config/mod.rs
+++ b/pgdog/src/config/mod.rs
@@ -327,7 +327,7 @@ pub struct General {
     /// Enable OpenMetrics server on this port.
     pub openmetrics_port: Option<u16>,
     /// OpenMetrics prefix.
-    pub openmetrics_prefix: Option<String>,
+    pub openmetrics_namespace: Option<String>,
     /// Prepared statatements support.
     #[serde(default)]
     pub prepared_statements: PreparedStatements,
@@ -438,7 +438,7 @@ impl Default for General {
             broadcast_port: Self::broadcast_port(),
             query_log: None,
             openmetrics_port: None,
-            openmetrics_prefix: None,
+            openmetrics_namespace: None,
             prepared_statements: PreparedStatements::default(),
             passthrough_auth: PassthoughAuth::default(),
             connect_timeout: Self::default_connect_timeout(),

--- a/pgdog/src/stats/open_metric.rs
+++ b/pgdog/src/stats/open_metric.rs
@@ -110,7 +110,7 @@ impl std::fmt::Display for Metric {
         let prefix = config
             .config
             .general
-            .openmetrics_prefix
+            .openmetrics_namespace
             .as_ref()
             .map(|s| s.as_str())
             .unwrap_or("");
@@ -156,7 +156,7 @@ mod test {
         assert_eq!(render.lines().last().unwrap(), "test 5");
 
         let mut cfg = ConfigAndUsers::default();
-        cfg.config.general.openmetrics_prefix = Some("pgdog.".into());
+        cfg.config.general.openmetrics_namespace = Some("pgdog.".into());
         config::set(cfg).unwrap();
 
         let render = Metric::new(TestMetric {}).to_string();

--- a/pgdog/src/stats/open_metric.rs
+++ b/pgdog/src/stats/open_metric.rs
@@ -2,6 +2,8 @@
 
 use std::ops::Deref;
 
+use crate::config::config;
+
 pub trait OpenMetric: Send + Sync {
     fn name(&self) -> String;
     /// Metric measurement.
@@ -104,6 +106,14 @@ impl Deref for Metric {
 impl std::fmt::Display for Metric {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let name = self.name();
+        let config = config();
+        let prefix = config
+            .config
+            .general
+            .openmetrics_prefix
+            .as_ref()
+            .map(|s| s.as_str())
+            .unwrap_or("");
         writeln!(f, "# TYPE {} {}", name, self.metric_type())?;
         if let Some(unit) = self.unit() {
             writeln!(f, "# UNIT {} {}", name, unit)?;
@@ -113,8 +123,43 @@ impl std::fmt::Display for Metric {
         }
 
         for measurement in self.measurements() {
-            writeln!(f, "{}", measurement.render(&name))?;
+            writeln!(f, "{}{}", prefix, measurement.render(&name))?;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::config::{self, ConfigAndUsers};
+
+    use super::*;
+
+    #[test]
+    fn test_prefix() {
+        struct TestMetric;
+
+        impl OpenMetric for TestMetric {
+            fn name(&self) -> String {
+                "test".into()
+            }
+
+            fn measurements(&self) -> Vec<Measurement> {
+                vec![Measurement {
+                    labels: vec![],
+                    measurement: MeasurementType::Integer(5),
+                }]
+            }
+        }
+
+        let render = Metric::new(TestMetric {}).to_string();
+        assert_eq!(render.lines().last().unwrap(), "test 5");
+
+        let mut cfg = ConfigAndUsers::default();
+        cfg.config.general.openmetrics_prefix = Some("pgdog.".into());
+        config::set(cfg).unwrap();
+
+        let render = Metric::new(TestMetric {}).to_string();
+        assert_eq!(render.lines().last().unwrap(), "pgdog.test 5");
     }
 }


### PR DESCRIPTION
### Description

- Add `openmetrics_namespace` option to namespace metrics.
- Remove warnings.