### PR TITLE
Adding List and Range based partitioning 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ toxi.log
 *.sqlite3
 perf.data
 perf.data.old
+/shard_test/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,6 +386,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]

--- a/pgdog/Cargo.toml
+++ b/pgdog/Cargo.toml
@@ -49,7 +49,7 @@ uuid = { version = "1", features = ["v4"] }
 url = "2"
 ratatui = { version = "0.30.0-alpha.1", optional = true }
 rmp-serde = "1"
-chrono = "0.4"
+chrono = { version = "0.4", features = ["serde"] }
 hyper = { version = "1", features = ["full"] }
 http-body-util = "0.1"
 hyper-util = { version = "0.1", features = ["full"] }

--- a/pgdog/src/backend/pool/cluster.rs
+++ b/pgdog/src/backend/pool/cluster.rs
@@ -360,6 +360,9 @@ mod test {
                         data_type: DataType::Bigint,
                         centroids_path: None,
                         centroid_probes: 1,
+                        sharding_method: None,
+                        shard_range_map: None,
+                        shard_list_map: None
                     }],
                     vec!["sharded_omni".into()],
                     false,

--- a/pgdog/src/backend/pool/cluster.rs
+++ b/pgdog/src/backend/pool/cluster.rs
@@ -362,7 +362,7 @@ mod test {
                         centroid_probes: 1,
                         sharding_method: None,
                         shard_range_map: None,
-                        shard_list_map: None
+                        shard_list_map: None,
                     }],
                     vec!["sharded_omni".into()],
                     false,

--- a/pgdog/src/config/mod.rs
+++ b/pgdog/src/config/mod.rs
@@ -4,6 +4,7 @@ pub mod convert;
 pub mod error;
 pub mod overrides;
 pub mod url;
+mod shards;
 
 use error::Error;
 pub use overrides::Overrides;
@@ -21,6 +22,7 @@ use serde::{Deserialize, Serialize};
 use tracing::info;
 use tracing::warn;
 
+pub(crate) use crate::config::shards::{ShardingMethod, ShardListMap, ShardRangeMap};
 use crate::net::messages::Vector;
 use crate::util::{human_duration_optional, random_string};
 
@@ -826,6 +828,12 @@ pub struct ShardedTable {
     /// How many centroids to probe.
     #[serde(default)]
     pub centroid_probes: usize,
+    #[serde(default)]
+    pub sharding_method: Option<ShardingMethod>,
+
+    pub shard_range_map: Option<ShardRangeMap>,
+
+    pub shard_list_map: Option<ShardListMap>
 }
 
 impl ShardedTable {
@@ -865,6 +873,10 @@ pub enum DataType {
     Bigint,
     Uuid,
     Vector,
+    // TODO: implement more types?
+    // String,
+    // DateTimeUTC
+    // Float
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Default)]
@@ -955,8 +967,8 @@ pub struct MultiTenant {
 
 #[cfg(test)]
 pub mod test {
+    
     use crate::backend::databases::init;
-
     use super::*;
 
     pub fn load_test() {
@@ -1052,4 +1064,5 @@ column = "tenant_id"
         assert_eq!(config.tcp.retries().unwrap(), 5);
         assert_eq!(config.multi_tenant.unwrap().column, "tenant_id");
     }
+
 }

--- a/pgdog/src/config/shards.rs
+++ b/pgdog/src/config/shards.rs
@@ -2,8 +2,7 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::frontend::router::parser::{Shard};
-
+use crate::frontend::router::parser::Shard;
 
 // =============================================================================
 // Serialization Helper Module
@@ -18,10 +17,7 @@ mod usize_map_keys_as_strings {
         S: Serializer,
         V: Serialize,
     {
-        let string_map: HashMap<String, &V> = map
-            .iter()
-            .map(|(k, v)| (k.to_string(), v))
-            .collect();
+        let string_map: HashMap<String, &V> = map.iter().map(|(k, v)| (k.to_string(), v)).collect();
         string_map.serialize(serializer)
     }
 

--- a/pgdog/src/config/shards.rs
+++ b/pgdog/src/config/shards.rs
@@ -198,33 +198,3 @@ impl<'de> Deserialize<'de> for ShardListMap {
         )?))
     }
 }
-
-// =============================================================================
-// Shardable Trait and Implementations
-// =============================================================================
-
-/// Trait for types that can provide sharding functionality
-pub trait Shardable {
-    /// Get the shard ID for a given value
-    fn shard(&self, value: i64) -> Shard;
-}
-
-impl Shardable for ShardRangeMap {
-    fn shard(&self, value: i64) -> Shard {
-        if self.0.is_empty() {
-            return Shard::All;
-        }
-
-        self.find_shard_key(value).unwrap_or_else(|| Shard::All)
-    }
-}
-
-impl Shardable for ShardListMap {
-    fn shard(&self, value: i64) -> Shard {
-        if self.0.is_empty() {
-            return Shard::All;
-        }
-
-        self.find_shard_key(value).unwrap_or_else(|| Shard::All)
-    }
-}

--- a/pgdog/src/config/shards.rs
+++ b/pgdog/src/config/shards.rs
@@ -1,0 +1,230 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::frontend::router::parser::{Shard};
+
+
+// =============================================================================
+// Serialization Helper Module
+// =============================================================================
+
+/// Helper module for (de)serializing maps with usize keys as strings
+mod usize_map_keys_as_strings {
+    use super::*;
+
+    pub fn serialize<S, V>(map: &HashMap<usize, V>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+        V: Serialize,
+    {
+        let string_map: HashMap<String, &V> = map
+            .iter()
+            .map(|(k, v)| (k.to_string(), v))
+            .collect();
+        string_map.serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D, V>(deserializer: D) -> Result<HashMap<usize, V>, D::Error>
+    where
+        D: Deserializer<'de>,
+        V: Deserialize<'de>,
+    {
+        let string_map = HashMap::<String, V>::deserialize(deserializer)?;
+        string_map
+            .into_iter()
+            .map(|(s, v)| {
+                s.parse::<usize>()
+                    .map(|k| (k, v))
+                    .map_err(serde::de::Error::custom)
+            })
+            .collect()
+    }
+}
+
+// =============================================================================
+// Core Sharding Types
+// =============================================================================
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ShardingMethod {
+    #[default]
+    Hash,
+    Range,
+    List,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ShardRange {
+    pub start: Option<i64>,
+    pub end: Option<i64>,
+    #[serde(default)]
+    pub no_max: bool,
+    #[serde(default)]
+    pub no_min: bool,
+}
+
+impl ShardRange {
+    /// Check if a value falls within this range
+    pub fn contains(&self, value: i64) -> bool {
+        // Check lower bound
+        if !self.no_min {
+            if let Some(start) = self.start {
+                if value < start {
+                    return false;
+                }
+            }
+        }
+
+        // Check upper bound
+        if !self.no_max {
+            if let Some(end) = self.end {
+                if value >= end {
+                    // Using >= for exclusive upper bound
+                    return false;
+                }
+            }
+        }
+
+        true
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ShardList {
+    pub values: Vec<i64>,
+}
+
+impl ShardList {
+    /// Check if a value is contained in this list
+    pub fn contains(&self, value: i64) -> bool {
+        self.values.contains(&value)
+    }
+}
+
+// =============================================================================
+// Shard Map Types
+// =============================================================================
+
+/// A map of shard IDs to their range definitions
+#[derive(Debug, Clone, PartialEq)]
+pub struct ShardRangeMap(pub HashMap<usize, ShardRange>);
+
+impl ShardRangeMap {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Find the shard key for a given value based on range containment
+    pub fn find_shard_key(&self, value: i64) -> Option<Shard> {
+        for (shard_id, range) in &self.0 {
+            if range.contains(value) {
+                return Some(Shard::Direct(*shard_id));
+            }
+        }
+        None
+    }
+}
+
+impl Default for ShardRangeMap {
+    fn default() -> Self {
+        Self(HashMap::new())
+    }
+}
+
+impl Serialize for ShardRangeMap {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        usize_map_keys_as_strings::serialize(&self.0, serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for ShardRangeMap {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(ShardRangeMap(usize_map_keys_as_strings::deserialize(
+            deserializer,
+        )?))
+    }
+}
+
+/// A map of shard IDs to their list definitions
+#[derive(Debug, Clone, PartialEq)]
+pub struct ShardListMap(pub HashMap<usize, ShardList>);
+
+impl ShardListMap {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Find the shard key for a given value based on list containment
+    pub fn find_shard_key(&self, value: i64) -> Option<Shard> {
+        for (shard_id, list) in &self.0 {
+            if list.contains(value) {
+                return Some(Shard::Direct(*shard_id));
+            }
+        }
+        None
+    }
+}
+
+impl Default for ShardListMap {
+    fn default() -> Self {
+        Self(HashMap::new())
+    }
+}
+
+impl Serialize for ShardListMap {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        usize_map_keys_as_strings::serialize(&self.0, serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for ShardListMap {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(ShardListMap(usize_map_keys_as_strings::deserialize(
+            deserializer,
+        )?))
+    }
+}
+
+// =============================================================================
+// Shardable Trait and Implementations
+// =============================================================================
+
+/// Trait for types that can provide sharding functionality
+pub trait Shardable {
+    /// Get the shard ID for a given value
+    fn shard(&self, value: i64) -> Shard;
+}
+
+impl Shardable for ShardRangeMap {
+    fn shard(&self, value: i64) -> Shard {
+        if self.0.is_empty() {
+            return Shard::All;
+        }
+
+        self.find_shard_key(value).unwrap_or_else(|| Shard::All)
+    }
+}
+
+impl Shardable for ShardListMap {
+    fn shard(&self, value: i64) -> Shard {
+        if self.0.is_empty() {
+            return Shard::All;
+        }
+
+        self.find_shard_key(value).unwrap_or_else(|| Shard::All)
+    }
+}

--- a/pgdog/src/frontend/router/sharding/context.rs
+++ b/pgdog/src/frontend/router/sharding/context.rs
@@ -1,5 +1,5 @@
-use crate::frontend::router::parser::Shard;
 use super::{Error, Operator, Value};
+use crate::frontend::router::parser::Shard;
 
 #[derive(Debug)]
 pub struct Context<'a> {
@@ -24,14 +24,14 @@ impl<'a> Context<'a> {
                     return Ok(centroids.shard(&vector, *shards, *probes));
                 }
             }
-            Operator::Ranges(srm)=> {
+            Operator::Ranges(srm) => {
                 if let Some(i) = self.value.int()? {
-                    return Ok(srm.find_shard_key(i).unwrap())
+                    return Ok(srm.find_shard_key(i).unwrap());
                 }
             }
-            Operator::Lists(slm)=> {
+            Operator::Lists(slm) => {
                 if let Some(i) = self.value.int()? {
-                    return Ok(slm.find_shard_key(i).unwrap())
+                    return Ok(slm.find_shard_key(i).unwrap());
                 }
             }
         }

--- a/pgdog/src/frontend/router/sharding/context.rs
+++ b/pgdog/src/frontend/router/sharding/context.rs
@@ -1,5 +1,4 @@
 use crate::frontend::router::parser::Shard;
-
 use super::{Error, Operator, Value};
 
 #[derive(Debug)]
@@ -16,7 +15,6 @@ impl<'a> Context<'a> {
                     return Ok(Shard::Direct(hash as usize % shards));
                 }
             }
-
             Operator::Centroids {
                 shards,
                 probes,
@@ -24,6 +22,16 @@ impl<'a> Context<'a> {
             } => {
                 if let Some(vector) = self.value.vector()? {
                     return Ok(centroids.shard(&vector, *shards, *probes));
+                }
+            }
+            Operator::Ranges(srm)=> {
+                if let Some(i) = self.value.int()? {
+                    return Ok(srm.find_shard_key(i).unwrap())
+                }
+            }
+            Operator::Lists(slm)=> {
+                if let Some(i) = self.value.int()? {
+                    return Ok(slm.find_shard_key(i).unwrap())
                 }
             }
         }

--- a/pgdog/src/frontend/router/sharding/context_builder.rs
+++ b/pgdog/src/frontend/router/sharding/context_builder.rs
@@ -1,4 +1,4 @@
-use crate::config::{DataType, ShardedTable, ShardingMethod, ShardListMap, ShardRangeMap};
+use crate::config::{DataType, ShardListMap, ShardRangeMap, ShardedTable, ShardingMethod};
 
 use super::{Centroids, Context, Data, Error, Operator, Value};
 
@@ -10,8 +10,7 @@ pub struct ContextBuilder<'a> {
     probes: usize,
     sharding_method: Option<ShardingMethod>,
     shard_range_map: Option<ShardRangeMap>,
-    shard_list_map: Option<ShardListMap>
-    
+    shard_list_map: Option<ShardListMap>,
 }
 
 impl<'a> ContextBuilder<'a> {
@@ -26,8 +25,8 @@ impl<'a> ContextBuilder<'a> {
             probes: table.centroid_probes,
             operator: None,
             value: None,
-            // added for list and range sharding 
-            // todo: add lifetimes to these to avoid cloning  
+            // added for list and range sharding
+            // todo: add lifetimes to these to avoid cloning
             sharding_method: table.sharding_method.clone(),
             shard_range_map: table.shard_range_map.clone(),
             shard_list_map: table.shard_list_map.clone(),
@@ -77,11 +76,12 @@ impl<'a> ContextBuilder<'a> {
             match method {
                 ShardingMethod::Hash => {
                     self.operator = Some(Operator::Shards(shards));
-                    return self
+                    return self;
                 }
                 ShardingMethod::Range => {
                     if self.shard_range_map.is_some() {
-                        self.operator = Some(Operator::Ranges(self.shard_range_map.clone().unwrap()))
+                        self.operator =
+                            Some(Operator::Ranges(self.shard_range_map.clone().unwrap()))
                     }
                 }
                 ShardingMethod::List => {

--- a/pgdog/src/frontend/router/sharding/error.rs
+++ b/pgdog/src/frontend/router/sharding/error.rs
@@ -25,4 +25,3 @@ pub enum Error {
     #[error("wrong integer binary size")]
     IntegerSize,
 }
-

--- a/pgdog/src/frontend/router/sharding/error.rs
+++ b/pgdog/src/frontend/router/sharding/error.rs
@@ -25,3 +25,4 @@ pub enum Error {
     #[error("wrong integer binary size")]
     IntegerSize,
 }
+

--- a/pgdog/src/frontend/router/sharding/mod.rs
+++ b/pgdog/src/frontend/router/sharding/mod.rs
@@ -17,7 +17,6 @@ pub mod tables;
 pub mod value;
 pub mod vector;
 
-
 pub use context::*;
 pub use context_builder::*;
 pub use error::Error;
@@ -27,7 +26,6 @@ pub use value::*;
 pub use vector::{Centroids, Distance};
 
 use super::parser::Shard;
-
 
 /// Hash `BIGINT`.
 pub fn bigint(id: i64) -> u64 {
@@ -81,26 +79,25 @@ pub(crate) fn shard_value(
     centroids: &Vec<Vector>,
     centroid_probes: usize,
 ) -> Shard {
-      match data_type {
-            DataType::Bigint => value
-                .parse()
-                .map(|v| bigint(v) as usize % shards)
-                .ok()
-                .map(Shard::Direct)
-                .unwrap_or(Shard::All),
-            DataType::Uuid => value
-                .parse()
-                .map(|v| uuid(v) as usize % shards)
-                .ok()
-                .map(Shard::Direct)
-                .unwrap_or(Shard::All),
-            DataType::Vector => Vector::try_from(value)
-                .ok()
-                .map(|v| Centroids::from(centroids).shard(&v, shards, centroid_probes))
-                .unwrap_or(Shard::All),
-        } 
+    match data_type {
+        DataType::Bigint => value
+            .parse()
+            .map(|v| bigint(v) as usize % shards)
+            .ok()
+            .map(Shard::Direct)
+            .unwrap_or(Shard::All),
+        DataType::Uuid => value
+            .parse()
+            .map(|v| uuid(v) as usize % shards)
+            .ok()
+            .map(Shard::Direct)
+            .unwrap_or(Shard::All),
+        DataType::Vector => Vector::try_from(value)
+            .ok()
+            .map(|v| Centroids::from(centroids).shard(&v, shards, centroid_probes))
+            .unwrap_or(Shard::All),
+    }
 }
-
 
 pub(crate) fn shard_binary(
     bytes: &[u8],

--- a/pgdog/src/frontend/router/sharding/operator.rs
+++ b/pgdog/src/frontend/router/sharding/operator.rs
@@ -1,5 +1,5 @@
-use crate::config::{ShardListMap, ShardRangeMap};
 use super::Centroids;
+use crate::config::{ShardListMap, ShardRangeMap};
 
 #[derive(Debug)]
 pub enum Operator<'a> {
@@ -11,5 +11,4 @@ pub enum Operator<'a> {
     },
     Lists(ShardListMap),
     Ranges(ShardRangeMap),
-
 }

--- a/pgdog/src/frontend/router/sharding/operator.rs
+++ b/pgdog/src/frontend/router/sharding/operator.rs
@@ -1,3 +1,4 @@
+use crate::config::{ShardListMap, ShardRangeMap};
 use super::Centroids;
 
 #[derive(Debug)]
@@ -8,4 +9,7 @@ pub enum Operator<'a> {
         probes: usize,
         centroids: Centroids<'a>,
     },
+    Lists(ShardListMap),
+    Ranges(ShardRangeMap),
+
 }

--- a/pgdog/src/frontend/router/sharding/value.rs
+++ b/pgdog/src/frontend/router/sharding/value.rs
@@ -70,7 +70,7 @@ impl<'a> Value<'a> {
             Ok(None)
         }
     }
-    
+
     pub fn int(&self) -> Result<Option<i64>, Error> {
         match self.data_type {
             DataType::Bigint => match self.data {
@@ -114,7 +114,7 @@ impl<'a> Value<'a> {
                     8 => i64::from_be_bytes(data.try_into()?) as i64,
                     _ => return Err(Error::IntegerSize),
                 }))),
-                Data::Integer(int) => Ok(Some(bigint(int))), 
+                Data::Integer(int) => Ok(Some(bigint(int))),
             },
 
             DataType::Uuid => match self.data {
@@ -122,9 +122,8 @@ impl<'a> Value<'a> {
                 Data::Binary(data) => Ok(Some(uuid(Uuid::from_bytes(data.try_into()?)))),
                 Data::Integer(_) => Ok(None),
             },
-            
+
             DataType::Vector => Ok(None),
-                        
         }
     }
 }


### PR DESCRIPTION
## Basics: 
This PR  adds the ability for PGDog to support List and Range based partitioning in addition to the existing Hash method. Conceptually, the code simply looks at the configuration to see if the partition key's value is defined within a given shard. If the key value is not found the query will be routed to `Shard::All`

## Summary of changes
- Added `pgdoc/src/config/shards.rs` with the majority of the config structs and implementation logic. 
- Updates to `pgdoc/src/config/mod.rs` for integrating into the ShardedTable struct
- Updates to `pgdoc/src/frontend/sharding/values.rs` to integrate into Routing and Operators
- Updates to `pgdoc/src/frontend/sharding/operator.rs` to integrate into Routing and Operators
- Updates to `pgdoc/src/frontend/sharding/context.rs` to integrate into Routing and Operators
- Updates to `pgdoc/src/frontend/sharding/context_builder.rs` to integrate into Routing and Operators

## Supported Datatypes
Currently only `bigint` is supported however ideally these can support floats, strings and datetimes in the future. 

## Config changes
3 fields have been added to the ShardedTables configuration. Because this defaults to hash partitioning, the configuration should be compatible with previously valid configs.  

- `sharding_method`: This controls what sharding method is used.  defaults to `hash`, other options are `list` and `range`
- `shard_list_map`: This holds the config for a map of shards (0,1 etc) to a list of values. If the partitioned column's value is in a list the query will be sent to the specified shard. It is possible for lists to overlap, in which case the first one found will be returned. 
- `shard_range_map`: This provides the ability to define ranges instead of using discrete values (as with the list). 


Example Configs: 

Range based sharding: 

```toml
[[sharded_tables]]
database = "emb"
name = "globe24"
column = "partkey"
data_type = "bigint"
sharding_method = "range"

sharding_method = "range"
shard_range_map = { "0" = { start = 0, end = 1000 }, "1" = { start = 1000, end = 2000 }, "2" = { start = 2000, no_max = true } }

```

List based sharding:
```toml
[[sharded_tables]]
database = "emb"
name = "globe24"
column = "partkey"
data_type = "bigint"
sharding_method = "list"

[sharded_tables.shard_list_map]
"0" = { values = [64, 79, 90, 101, 109, 112, 127, 147, 150, 151, 153, 156, 157, 179, 180, 182, 193, 194, 195, 196, 197, 198, 199, 200, 201, 203, 204, 205, 206, 207, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 229, 233, 234, 235, 240, 241, 242, 244, 245, 247, 251, 252, 295, 297, 298, 301, 302, 303, 306, 307, 308, 309, 310, 311, 312, 313, 314, 315, 316, 317, 318, 319, 320, 321, 323, 324, 325, 326, 327, 329, 331, 332, 333, 334, 335, 336, 338, 344, 346, 352, 353, 354, 355, 356, 357, 358, 359, 360, 361, 362, 363, 364, 365, 366, 367, 368, 370, 376, 378, 384, 385, 386, 387, 388, 389, 390, 391, 392, 393, 394, 395, 396, 397, 400, 401, 402, 403, 404, 405, 406, 407, 409, 413, 448, 449, 450, 451, 452, 453, 454, 455, 456, 457, 458, 459, 460, 461, 462, 463, 464, 466, 472, 474, 484, 485, 496, 1007, 1018] }
"1" = { values = [422, 423, 424, 425, 426, 427, 428, 429, 430, 431, 438, 439, 440, 441, 442, 443, 446, 447, 462, 463, 474, 484, 485, 487, 489, 490, 491, 493, 494, 495, 496, 498, 504, 532, 543, 565, 572, 573, 579, 582, 583, 585, 588, 589, 591, 592, 593, 594, 595, 597, 598, 599, 600, 601, 602, 603, 604, 605, 606, 607, 613, 617, 619, 624, 625, 626, 627, 628, 629, 630, 636, 637, 768, 769, 770, 771, 772, 773, 774, 775, 776, 777, 778, 779, 780, 781, 782, 783, 784, 785, 786, 787, 788, 789, 790, 791, 792, 793, 794, 795, 796, 797, 798, 799, 800, 801, 804, 805, 808, 816, 817, 820, 821, 823, 829, 831, 832, 833, 834, 835, 836, 837, 838, 839, 840, 841, 842, 843, 844, 845, 846, 847, 850, 856, 858, 864, 865, 866, 867, 868, 869, 870, 871, 872, 873, 874, 875, 876, 877, 878, 879, 880, 882, 888, 890, 917, 960, 961, 964, 965, 976] }
"2" = { values = [64, 68, 69, 71, 77, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 101, 256, 258, 259, 260, 261, 263, 264, 269, 272, 273, 274, 637, 694, 700, 701, 702, 703, 711, 713, 715, 716, 717, 718, 719, 721, 725, 726, 727, 728, 729, 730, 731, 732, 733, 734, 735, 736, 737, 738, 739, 740, 741, 742, 743, 744, 746, 747, 748, 749, 750, 751, 752, 753, 754, 755, 756, 757, 758, 759, 760, 761, 762, 763, 764, 765, 766, 767, 778, 779, 782, 783, 794, 795, 798, 799, 800, 801, 804, 805, 807, 808, 809, 810, 811, 812, 813, 814, 815, 816, 817, 818, 819, 820, 821, 822, 823, 824, 825, 826, 827, 828, 829, 830, 831, 842, 864, 866, 872, 874, 875, 878, 879, 890, 896, 897, 898, 899, 900, 901, 902, 903, 904, 905, 906, 907, 908, 909, 910, 912, 913, 914, 915, 916, 917, 918, 919, 920, 921, 922, 923, 924, 925, 926, 927, 928, 929, 930, 931, 932, 933, 936, 937, 938, 939, 940, 941, 942, 944, 945, 946, 948, 949, 951, 960, 961, 962, 963, 964, 965, 966, 967, 968, 969, 970, 971, 972, 973, 974, 975, 976, 978, 984, 986, 992, 993, 994, 995, 996, 997, 998, 999, 1000, 1001, 1003, 1004, 1005, 1006, 1007, 1008, 1010, 1016, 1018] }
```
