### PR TITLE
Manual ban/unban

### DIFF
--- a/integration/pgdog.toml
+++ b/integration/pgdog.toml
@@ -29,6 +29,20 @@ database_name = "shard_1"
 shard = 1
 
 [[databases]]
+name = "pgdog_sharded"
+host = "127.0.0.1"
+database_name = "shard_0"
+shard = 0
+role = "replica"
+
+[[databases]]
+name = "pgdog_sharded"
+host = "127.0.0.1"
+database_name = "shard_1"
+shard = 1
+role = "replica"
+
+[[databases]]
 name = "failover"
 host = "127.0.0.1"
 port = 5435

--- a/integration/python/globals.py
+++ b/integration/python/globals.py
@@ -16,7 +16,6 @@ def no_out_of_sync():
     cur.execute("SHOW POOLS;")
     pools = cur.fetchall()
     for pool in pools:
-        print(pools)
         assert pool[-2] == 0
 
 

--- a/integration/rust/tests/integration/ban.rs
+++ b/integration/rust/tests/integration/ban.rs
@@ -1,0 +1,80 @@
+use rust::setup::{admin_sqlx, connections_sqlx};
+use sqlx::Executor;
+use sqlx::Row;
+
+async fn ban_unban(database: &str, ban: bool, replica: bool) {
+    let admin = admin_sqlx().await;
+
+    let pools = admin.fetch_all("SHOW POOLS").await.unwrap();
+    let id = pools
+        .iter()
+        .find(|p| {
+            p.get::<String, &str>("database") == database
+                && p.get::<String, &str>("user") == "pgdog"
+                && p.get::<String, &str>("role") == if replica { "replica" } else { "primary" }
+        })
+        .map(|p| p.get::<i64, &str>("id"))
+        .unwrap();
+
+    if !ban {
+        admin
+            .execute(format!("UNBAN {}", id).as_str())
+            .await
+            .unwrap();
+    } else {
+        admin.execute(format!("BAN {}", id).as_str()).await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn test_ban_unban() {
+    let conns = connections_sqlx().await;
+
+    for (pool, database) in conns
+        .clone()
+        .into_iter()
+        .zip(["pgdog", "pgdog_sharded"].into_iter())
+    {
+        for replica in [true, false] {
+            for _ in 0..25 {
+                pool.execute("SELECT 1").await.unwrap();
+            }
+
+            ban_unban(database, true, replica).await;
+
+            for _ in 0..25 {
+                pool.execute("SELECT 1").await.unwrap();
+            }
+
+            ban_unban(database, false, replica).await;
+
+            for _ in 0..25 {
+                pool.execute("SELECT 1").await.unwrap();
+            }
+        }
+    }
+
+    for (pool, database) in conns
+        .into_iter()
+        .zip(["pgdog", "pgdog_sharded"].into_iter())
+    {
+        for _ in 0..25 {
+            pool.execute("SELECT 1").await.unwrap();
+        }
+
+        ban_unban(database, true, false).await;
+
+        for _ in 0..25 {
+            let err = pool.execute("CREATE TABLE test (id BIGINT)").await;
+            assert!(err.err().unwrap().to_string().contains("pool is banned"));
+        }
+
+        ban_unban(database, false, false).await;
+
+        let mut t = pool.begin().await.unwrap();
+        t.execute("CREATE TABLE test_ban_unban (id BIGINT)")
+            .await
+            .unwrap();
+        t.rollback().await.unwrap();
+    }
+}

--- a/integration/rust/tests/integration/mod.rs
+++ b/integration/rust/tests/integration/mod.rs
@@ -1,4 +1,5 @@
 pub mod auth;
+pub mod ban;
 pub mod fake_transactions;
 pub mod reload;
 pub mod syntax_error;

--- a/pgdog/src/admin/ban.rs
+++ b/pgdog/src/admin/ban.rs
@@ -1,0 +1,63 @@
+use super::prelude::*;
+use crate::backend::{databases::databases, pool};
+
+#[derive(Default)]
+pub struct Ban {
+    id: Option<u64>,
+    unban: bool,
+}
+
+#[async_trait]
+impl Command for Ban {
+    fn name(&self) -> String {
+        if self.unban {
+            "UNBAN".into()
+        } else {
+            "BAN".into()
+        }
+    }
+
+    fn parse(sql: &str) -> Result<Self, Error> {
+        let parts = sql.split(" ").collect::<Vec<_>>();
+
+        match parts[..] {
+            ["ban"] => Ok(Self::default()),
+            ["unban"] => Ok(Self {
+                unban: true,
+                ..Default::default()
+            }),
+            ["ban", id] => Ok(Self {
+                id: Some(id.parse()?),
+                ..Default::default()
+            }),
+
+            ["unban", id] => Ok(Self {
+                id: Some(id.parse()?),
+                unban: true,
+            }),
+
+            _ => Err(Error::Syntax),
+        }
+    }
+
+    async fn execute(&self) -> Result<Vec<Message>, Error> {
+        for (_, database) in databases().all() {
+            for shard in database.shards() {
+                for pool in shard.pools() {
+                    if let Some(id) = self.id {
+                        if id != pool.id() {
+                            continue;
+                        }
+                    }
+
+                    if self.unban {
+                        pool.unban();
+                    } else {
+                        pool.ban(pool::Error::ManualBan);
+                    }
+                }
+            }
+        }
+        Ok(vec![])
+    }
+}

--- a/pgdog/src/admin/mod.rs
+++ b/pgdog/src/admin/mod.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 use crate::net::messages::Message;
 
 pub mod backend;
+pub mod ban;
 pub mod error;
 pub mod parser;
 pub mod pause;

--- a/pgdog/src/admin/parser.rs
+++ b/pgdog/src/admin/parser.rs
@@ -1,7 +1,7 @@
 //! Admin command parser.
 
 use super::{
-    pause::Pause, prelude::Message, reconnect::Reconnect, reload::Reload,
+    ban::Ban, pause::Pause, prelude::Message, reconnect::Reconnect, reload::Reload,
     reset_query_cache::ResetQueryCache, set::Set, setup_schema::SetupSchema,
     show_clients::ShowClients, show_config::ShowConfig, show_lists::ShowLists,
     show_peers::ShowPeers, show_pools::ShowPools, show_prepared_statements::ShowPreparedStatements,
@@ -30,6 +30,7 @@ pub enum ParseResult {
     ShowLists(ShowLists),
     ShowPrepared(ShowPreparedStatements),
     Set(Set),
+    Ban(Ban),
 }
 
 impl ParseResult {
@@ -55,6 +56,7 @@ impl ParseResult {
             ShowLists(show_lists) => show_lists.execute().await,
             ShowPrepared(cmd) => cmd.execute().await,
             Set(set) => set.execute().await,
+            Ban(ban) => ban.execute().await,
         }
     }
 
@@ -80,6 +82,7 @@ impl ParseResult {
             ShowLists(show_lists) => show_lists.name(),
             ShowPrepared(show) => show.name(),
             Set(set) => set.name(),
+            Ban(ban) => ban.name(),
         }
     }
 }
@@ -98,6 +101,7 @@ impl Parser {
             "shutdown" => ParseResult::Shutdown(Shutdown::parse(&sql)?),
             "reconnect" => ParseResult::Reconnect(Reconnect::parse(&sql)?),
             "reload" => ParseResult::Reload(Reload::parse(&sql)?),
+            "ban" | "unban" => ParseResult::Ban(Ban::parse(&sql)?),
             "show" => match iter.next().ok_or(Error::Syntax)?.trim() {
                 "clients" => ParseResult::ShowClients(ShowClients::parse(&sql)?),
                 "pools" => ParseResult::ShowPools(ShowPools::parse(&sql)?),

--- a/pgdog/src/admin/show_pools.rs
+++ b/pgdog/src/admin/show_pools.rs
@@ -20,6 +20,7 @@ impl Command for ShowPools {
 
     async fn execute(&self) -> Result<Vec<Message>, Error> {
         let rd = RowDescription::new(&[
+            Field::bigint("id"),
             Field::text("database"),
             Field::text("user"),
             Field::text("addr"),
@@ -48,7 +49,8 @@ impl Command for ShowPools {
                     let state = pool.state();
                     let maxwait = state.maxwait.as_secs() as i64;
                     let maxwait_us = state.maxwait.subsec_micros() as i64;
-                    row.add(user.database.as_str())
+                    row.add(pool.id() as i64)
+                        .add(user.database.as_str())
                         .add(user.user.as_str())
                         .add(pool.addr().host.as_str())
                         .add(pool.addr().port as i64)

--- a/pgdog/src/backend/error.rs
+++ b/pgdog/src/backend/error.rs
@@ -99,6 +99,7 @@ impl Error {
             // These are recoverable errors.
             Error::Pool(PoolError::CheckoutTimeout) => true,
             Error::Pool(PoolError::AllReplicasDown) => true,
+            Error::Pool(PoolError::Banned) => true,
             _ => false,
         }
     }

--- a/pgdog/src/backend/pool/inner.rs
+++ b/pgdog/src/backend/pool/inner.rs
@@ -395,6 +395,14 @@ impl Inner {
         unbanned
     }
 
+    pub fn unban(&mut self) -> bool {
+        if let Some(_) = self.ban.take() {
+            true
+        } else {
+            false
+        }
+    }
+
     #[inline(always)]
     pub fn banned(&self) -> bool {
         self.ban.is_some()

--- a/pgdog/src/backend/pool/pool_impl.rs
+++ b/pgdog/src/backend/pool/pool_impl.rs
@@ -264,11 +264,17 @@ impl Pool {
         }
     }
 
-    /// Unban this pool from serving traffic.
-    pub fn unban(&self) {
+    /// Unban this pool from serving traffic, unless manually banned.
+    pub fn maybe_unban(&self) {
         let unbanned = self.lock().maybe_unban();
         if unbanned {
-            info!("pool unbanned manually [{}]", self.addr());
+            info!("pool unbanned [{}]", self.addr());
+        }
+    }
+
+    pub fn unban(&self) {
+        if self.lock().unban() {
+            info!("pool unbanned [{}]", self.addr());
         }
     }
 

--- a/pgdog/src/backend/pool/replicas.rs
+++ b/pgdog/src/backend/pool/replicas.rs
@@ -154,7 +154,9 @@ impl Replicas {
 
             // All replicas are banned, unban everyone.
             if banned == candidates.len() && !unbanned {
-                candidates.iter().for_each(|candidate| candidate.unban());
+                candidates
+                    .iter()
+                    .for_each(|candidate| candidate.maybe_unban());
                 unbanned = true;
             } else {
                 break;

--- a/pgdog/src/backend/pool/test/mod.rs
+++ b/pgdog/src/backend/pool/test/mod.rs
@@ -166,7 +166,7 @@ async fn test_pause() {
     pool.get(&Request::default())
         .await
         .expect_err("checkout timeout");
-    pool.unban();
+    pool.maybe_unban();
     drop(hold);
     // Make sure we're not blocked still.
     drop(pool.get(&Request::default()).await.unwrap());

--- a/pgdog/src/backend/pool/test/replica.rs
+++ b/pgdog/src/backend/pool/test/replica.rs
@@ -51,7 +51,7 @@ async fn test_replicas() {
             task.await.unwrap();
         }
 
-        replicas.pools[pool].unban();
+        replicas.pools[pool].maybe_unban();
     }
 
     replicas.pools[0].ban(Error::CheckoutTimeout);

--- a/pgdog/src/backend/prepared_statements.rs
+++ b/pgdog/src/backend/prepared_statements.rs
@@ -103,8 +103,11 @@ impl PreparedStatements {
                     }
 
                     self.describes.push_back(describe.statement().to_string());
-                } else {
+                } else if describe.is_portal() {
                     self.state.add(ExecutionCode::DescriptionOrNothing);
+                } else if describe.is_statement() {
+                    self.state.add(ExecutionCode::DescriptionOrNothing); // t
+                    self.state.add(ExecutionCode::DescriptionOrNothing); // T
                 }
             }
 

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -431,8 +431,11 @@ impl Client {
                 }
                 Err(err) => {
                     if err.no_server() {
-                        error!("connection pool is down [{}]", self.addr);
-                        self.stream.error(ErrorResponse::connection()).await?;
+                        error!("{} [{}]", err, self.addr);
+                        self.stream.error(ErrorResponse::from_err(&err)).await?;
+                        // TODO: should this be wrapped in a method?
+                        inner.disconnect();
+                        inner.reset_router();
                         return Ok(false);
                     } else {
                         return Err(err.into());


### PR DESCRIPTION
### Description
- Don't disconnect client if pool is banned. Let them  run the query again on a different pool.
- Add admin ban/unban commands to ban specific pools (or all of them).
- Show pool id in `SHOW POOLS`.
- Fix suspected out of sync in #134. 