### PR TITLE
Dont override settings when using -d

### DIFF
--- a/integration/rust/tests/integration/fake_transactions.rs
+++ b/integration/rust/tests/integration/fake_transactions.rs
@@ -1,6 +1,9 @@
+use std::time::Duration;
+
 use rust::setup::{admin_sqlx, connections_sqlx};
 use serial_test::serial;
 use sqlx::{Executor, Pool, Postgres, Row};
+use tokio::time::sleep;
 
 #[tokio::test]
 #[serial]
@@ -43,6 +46,7 @@ async fn test_fake_transactions() {
             .await
             .unwrap();
         check_client_state("idle in transaction", admin.clone()).await;
+        sleep(Duration::from_millis(10)).await;
         assert!(check_server_state("idle in transaction", admin.clone()).await);
         conn.execute("ROLLBACK").await.unwrap();
         check_client_state("idle", admin.clone()).await;

--- a/pgdog/src/config/url.rs
+++ b/pgdog/src/config/url.rs
@@ -2,7 +2,7 @@
 use std::{collections::BTreeSet, env::var};
 use url::Url;
 
-use super::{Config, ConfigAndUsers, Database, Error, User, Users};
+use super::{ConfigAndUsers, Database, Error, User, Users};
 
 fn database_name(url: &Url) -> String {
     let database = url.path().chars().skip(1).collect::<String>();
@@ -51,7 +51,7 @@ impl From<&Url> for User {
 
 impl ConfigAndUsers {
     /// Load from database URLs.
-    pub fn from_urls(urls: &[String]) -> Result<Self, Error> {
+    pub fn databases_from_urls(mut self, urls: &[String]) -> Result<Self, Error> {
         let urls = urls
             .iter()
             .map(|url| Url::parse(url))
@@ -69,14 +69,10 @@ impl ConfigAndUsers {
             .into_iter()
             .collect::<Vec<_>>();
 
-        Ok(Self {
-            users: Users { users },
-            config: Config {
-                databases,
-                ..Default::default()
-            },
-            ..Default::default()
-        })
+        self.users = Users { users };
+        self.config.databases = databases;
+
+        Ok(self)
     }
 }
 

--- a/pgdog/src/main.rs
+++ b/pgdog/src/main.rs
@@ -50,7 +50,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         None => (),
     }
 
-    info!("🐕 PgDog {}", env!("GIT_HASH"));
+    info!("🐕 PgDog v{}", env!("GIT_HASH"));
     let config = config::load(&args.config, &args.users)?;
 
     // Set database from --database-url arg.

--- a/pgdog/src/main.rs
+++ b/pgdog/src/main.rs
@@ -50,12 +50,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         None => (),
     }
 
-    info!("🐕 PgDog v{}", env!("GIT_HASH"));
+    info!("🐕 PgDog {}", env!("GIT_HASH"));
+    let config = config::load(&args.config, &args.users)?;
 
+    // Set database from --database-url arg.
     let config = if let Some(database_urls) = args.database_url {
         config::from_urls(&database_urls)?
     } else {
-        config::load(&args.config, &args.users)?
+        config
     };
 
     config::overrides(overrides);


### PR DESCRIPTION
### Description

- Don't override settings in `pgdog.toml` when using `--database-url/-d` option.