### PR TITLE
Ignore dealloc

### DIFF
--- a/integration/ruby/pg_spec.rb
+++ b/integration/ruby/pg_spec.rb
@@ -91,4 +91,16 @@ describe 'pg' do
       conn.exec 'SELECT 1'
     end
   end
+
+  it 'deallocate ignored' do
+    %w[pgdog pgdog_sharded].each do |db|
+      conn = connect db
+      conn.prepare 'deallocate_ignored', 'SELECT $1 AS one'
+      res = conn.exec_prepared 'deallocate_ignored', [1]
+      expect(res[0]['one']).to eq('1')
+      conn.exec 'DEALLOCATE deallocate_ignored' # Ignored
+      res = conn.exec_prepared 'deallocate_ignored', [2]
+      expect(res[0]['one']).to eq('2')
+    end
+  end
 end

--- a/pgdog/src/frontend/router/parser/command.rs
+++ b/pgdog/src/frontend/router/parser/command.rs
@@ -14,6 +14,7 @@ pub enum Command {
     PreparedStatement(Prepare),
     Rewrite(String),
     Shards(usize),
+    Deallocate,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/pgdog/src/frontend/router/parser/query.rs
+++ b/pgdog/src/frontend/router/parser/query.rs
@@ -255,8 +255,7 @@ impl QueryParser {
         let rewrite = Rewrite::new(ast.clone());
         if rewrite.needs_rewrite() {
             debug!("rewrite needed");
-            let queries = rewrite.rewrite(prepared_statements)?;
-            return Ok(Command::Rewrite(queries));
+            return rewrite.rewrite(prepared_statements);
         }
 
         if let Some(multi_tenant) = multi_tenant {
@@ -341,6 +340,9 @@ impl QueryParser {
             }
             Some(NodeEnum::VariableShowStmt(ref stmt)) => {
                 return self.show(stmt, &sharding_schema, read_only)
+            }
+            Some(NodeEnum::DeallocateStmt(_)) => {
+                return Ok(Command::Deallocate);
             }
             // COPY statements.
             Some(NodeEnum::CopyStmt(ref stmt)) => Self::copy(stmt, cluster),


### PR DESCRIPTION
### Description

Ignore `DEALLOCATE` because we're managing prepared statements.