### PR TITLE
Do single-shard routing when no routing info available

### DIFF
--- a/pgdog/src/backend/pool/cluster.rs
+++ b/pgdog/src/backend/pool/cluster.rs
@@ -393,6 +393,13 @@ mod test {
             }
         }
 
+        pub fn new_test_single_shard() -> Cluster {
+            let mut cluster = Self::new_test();
+            cluster.shards.pop();
+
+            cluster
+        }
+
         pub fn set_read_write_strategy(&mut self, rw_strategy: ReadWriteStrategy) {
             self.rw_strategy = rw_strategy;
         }


### PR DESCRIPTION
### Description

Set shard to 0 when database isn't sharded and the client doesn't have a query in the buffer (e.g. prepared stmt close).