### PR TITLE
Send ANY($1) to all shards

### DIFF
--- a/integration/go/go_pgx/sharded_test.go
+++ b/integration/go/go_pgx/sharded_test.go
@@ -42,5 +42,23 @@ func TestShardedVarchar(t *testing.T) {
 		rows.Close()
 		assert.Equal(t, 1, len)
 	}
+}
 
+func TestShardedVarcharArray(t *testing.T) {
+	conn, err := pgx.Connect(context.Background(), "postgres://pgdog:pgdog@127.0.0.1:6432/pgdog_sharded")
+	assert.NoError(t, err)
+	defer conn.Close(context.Background())
+
+	conn.Exec(context.Background(), "TRUNCATE TABLE sharded_varchar")
+	values := [7]string{"one", "two", "three", "four", "five", "six", "seven"}
+
+	for _, value := range values {
+		conn.Exec(context.Background(), "INSERT INTO sharded_varchar (id_varchar) VALUES ($1)", value)
+	}
+
+	for range 100 {
+		rows, err := conn.Query(context.Background(), "SELECT * FROM sharded_varchar WHERE id_varchar = ANY($1)", [5]string{"one", "two", "three", "four", "five"})
+		assert.NoError(t, err)
+		rows.Close()
+	}
 }

--- a/pgdog.toml
+++ b/pgdog.toml
@@ -88,6 +88,12 @@ column = "customer_id"
 database = "pgdog_sharded"
 data_type = "bigint"
 
+[[sharded_tables]]
+database = "pgdog_sharded"
+name = "sharded_varchar"
+column = "id_varchar"
+data_type = "varchar"
+
 
 #
 # ActiveRecord sends these queries

--- a/pgdog/src/frontend/router/parser/insert.rs
+++ b/pgdog/src/frontend/router/parser/insert.rs
@@ -72,6 +72,7 @@ impl<'a> Insert<'a> {
         if let Some(key) = key {
             if let Some(bind) = bind {
                 if let Ok(Some(param)) = bind.parameter(key.position) {
+                    // Arrays not supported as sharding keys at the moment.
                     let value = ShardingValue::from_param(&param, key.table.data_type)?;
                     let ctx = ContextBuilder::new(key.table)
                         .value(value)

--- a/pgdog/src/frontend/router/parser/key.rs
+++ b/pgdog/src/frontend/router/parser/key.rs
@@ -4,7 +4,7 @@
 pub enum Key {
     /// Parameter, like $1, $2, referring to a value
     /// sent in a separate Bind message.
-    Parameter(usize),
+    Parameter { pos: usize, array: bool },
     /// A constant value, e.g. "1", "2", or "'value'"
     /// which can be parsed from the query text.
     Constant(String),

--- a/pgdog/src/frontend/router/parser/key.rs
+++ b/pgdog/src/frontend/router/parser/key.rs
@@ -7,7 +7,7 @@ pub enum Key {
     Parameter { pos: usize, array: bool },
     /// A constant value, e.g. "1", "2", or "'value'"
     /// which can be parsed from the query text.
-    Constant(String),
+    Constant { value: String, array: bool },
     /// Null check on a column.
     Null,
 }

--- a/pgdog/src/frontend/router/parser/query.rs
+++ b/pgdog/src/frontend/router/parser/query.rs
@@ -586,9 +586,14 @@ impl QueryParser {
                         shards.insert(ctx.apply()?);
                     }
 
-                    Key::Parameter(param) => {
+                    Key::Parameter { pos, array } => {
+                        // Don't hash individual values yet.
+                        // The odds are high this will go to all shards anyway.
+                        if array {
+                            return Ok(HashSet::from([Shard::All]));
+                        }
                         if let Some(params) = params {
-                            if let Some(param) = params.parameter(param)? {
+                            if let Some(param) = params.parameter(pos)? {
                                 let value = ShardingValue::from_param(&param, table.data_type)?;
                                 let ctx = ContextBuilder::new(table)
                                     .value(value)

--- a/pgdog/src/frontend/router/sharding/context_builder.rs
+++ b/pgdog/src/frontend/router/sharding/context_builder.rs
@@ -9,6 +9,8 @@ pub struct ContextBuilder<'a> {
     centroids: Option<Centroids<'a>>,
     probes: usize,
     hasher: Hasher,
+    #[allow(dead_code)]
+    array: bool,
 }
 
 impl<'a> ContextBuilder<'a> {
@@ -27,6 +29,7 @@ impl<'a> ContextBuilder<'a> {
                 HasherConfig::Sha1 => Hasher::Sha1,
                 HasherConfig::Postgres => Hasher::Postgres,
             },
+            array: false,
         }
     }
 
@@ -43,6 +46,7 @@ impl<'a> ContextBuilder<'a> {
                 centroids: None,
                 operator: None,
                 hasher: Hasher::Postgres,
+                array: false,
             })
         } else if uuid.valid() {
             Ok(Self {
@@ -52,6 +56,7 @@ impl<'a> ContextBuilder<'a> {
                 centroids: None,
                 operator: None,
                 hasher: Hasher::Postgres,
+                array: false,
             })
         } else {
             Err(Error::IncompleteContext)

--- a/pgdog/src/net/error.rs
+++ b/pgdog/src/net/error.rs
@@ -75,4 +75,7 @@ pub enum Error {
 
     #[error("only simple protocols supported for rewrites")]
     OnlySimpleForRewrites,
+
+    #[error("array has {0} dimensions, only 1 is supported")]
+    ArrayDimensions(usize),
 }

--- a/pgdog/src/net/messages/data_types/array.rs
+++ b/pgdog/src/net/messages/data_types/array.rs
@@ -1,0 +1,62 @@
+use bytes::{Buf, Bytes};
+
+use super::{Error, Format, FromDataType};
+
+#[derive(Debug, Clone, Ord, PartialOrd, PartialEq, Eq)]
+pub struct Array {
+    payload: Vec<Bytes>,
+    oid: i32,
+    flags: i32,
+    dim: Dimension,
+}
+
+#[derive(Debug, Clone, Ord, PartialOrd, PartialEq, Eq, Default)]
+struct Dimension {
+    size: i32,
+    lower_bound: i32,
+}
+
+impl FromDataType for Array {
+    fn decode(bytes: &[u8], encoding: Format) -> Result<Self, Error> {
+        match encoding {
+            Format::Text => todo!(),
+            Format::Binary => {
+                let mut bytes = Bytes::copy_from_slice(bytes);
+                let dims = bytes.get_i32() as usize;
+                if dims > 1 {
+                    return Err(Error::ArrayDimensions(dims));
+                }
+                let flags = bytes.get_i32();
+                let oid = bytes.get_i32();
+
+                let dim = Dimension {
+                    size: bytes.get_i32(),
+                    lower_bound: bytes.get_i32(),
+                };
+
+                let mut payload = vec![];
+
+                while bytes.has_remaining() {
+                    let len = bytes.get_i32();
+                    if len < 0 {
+                        payload.push(Bytes::new())
+                    } else {
+                        let element = bytes.split_to(len as usize);
+                        payload.push(element);
+                    }
+                }
+
+                Ok(Self {
+                    payload,
+                    oid,
+                    flags,
+                    dim,
+                })
+            }
+        }
+    }
+
+    fn encode(&self, _encoding: Format) -> Result<Bytes, Error> {
+        todo!()
+    }
+}

--- a/pgdog/src/net/messages/data_types/mod.rs
+++ b/pgdog/src/net/messages/data_types/mod.rs
@@ -4,6 +4,7 @@ use super::{bind::Format, data_row::Data, Error, ToDataRowColumn};
 use ::uuid::Uuid;
 use bytes::Bytes;
 
+pub mod array;
 pub mod bigint;
 pub mod integer;
 pub mod interval;


### PR DESCRIPTION
### Description

If caller is using `WHERE sharding_key = ANY($1)`, send the query to all shards.

TODO: parse the `$1` parameter and hash each key. 99% of the time, this will go to all shards anyway, but it's still worth doing.