### PR TITLE
Check the prepared statements cache only once

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1617,9 +1617,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f8cc7106155f10bdf99a6f379688f543ad6596a415375b36a59a054ceda1198"
+checksum = "0281c2e25e62316a5c9d98f2d2e9e95a37841afdaf4383c177dbb5c1dfab0568"
 dependencies = [
  "hashbrown",
 ]
@@ -2067,7 +2067,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "indexmap",
- "lru 0.14.0",
+ "lru 0.15.0",
  "md5",
  "once_cell",
  "parking_lot",

--- a/pgdog/Cargo.toml
+++ b/pgdog/Cargo.toml
@@ -56,7 +56,7 @@ hyper-util = { version = "0.1", features = ["full"] }
 socket2 = "0.5.9"
 sha1 = "0.10"
 indexmap = "2.9"
-lru = "0.14"
+lru = "0.15"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = "0.6"

--- a/pgdog/src/backend/prepared_statements.rs
+++ b/pgdog/src/backend/prepared_statements.rs
@@ -262,12 +262,7 @@ impl PreparedStatements {
 
     /// The server has prepared this statement already.
     pub fn contains(&mut self, name: &str) -> bool {
-        if self.local_cache.contains(name) {
-            self.local_cache.promote(name);
-            true
-        } else {
-            false
-        }
+        self.local_cache.promote(name)
     }
 
     /// Indicate this statement is prepared on the connection.


### PR DESCRIPTION
### Description

Update `lru` crate to 0.15 to check the hashmap only once.