### PR TITLE
List and range based sharding

### DIFF
--- a/integration/go/go_pgx/sharded_test.go
+++ b/integration/go/go_pgx/sharded_test.go
@@ -62,3 +62,61 @@ func TestShardedVarcharArray(t *testing.T) {
 		rows.Close()
 	}
 }
+
+func TestShardedList(t *testing.T) {
+	conn, err := pgx.Connect(context.Background(), "postgres://pgdog:pgdog@127.0.0.1:6432/pgdog_sharded")
+	assert.NoError(t, err)
+	defer conn.Close(context.Background())
+
+	_, err = conn.Exec(context.Background(), "TRUNCATE TABLE sharded_list")
+	assert.NoError(t, err)
+
+	for i := range 20 {
+		for _, query := range [4]string{
+			"INSERT INTO sharded_list (id) VALUES ($1) RETURNING *",
+			"SELECT * FROM sharded_list WHERE id = $1",
+			"UPDATE sharded_list SET id = $1 WHERE id = $1 RETURNING *",
+			"DELETE FROM sharded_list WHERE id = $1 RETURNING *",
+		} {
+			rows, err := conn.Query(context.Background(), query, int64(i))
+			assert.NoError(t, err)
+			count := 0
+
+			for rows.Next() {
+				count += 1
+			}
+
+			rows.Close()
+			assert.Equal(t, 1, count)
+		}
+	}
+}
+
+func TestShardedRange(t *testing.T) {
+	conn, err := pgx.Connect(context.Background(), "postgres://pgdog:pgdog@127.0.0.1:6432/pgdog_sharded")
+	assert.NoError(t, err)
+	defer conn.Close(context.Background())
+
+	_, err = conn.Exec(context.Background(), "TRUNCATE TABLE sharded_range")
+	assert.NoError(t, err)
+
+	for i := range 200 {
+		for _, query := range [4]string{
+			"INSERT INTO sharded_range (id) VALUES ($1) RETURNING *",
+			"SELECT * FROM sharded_range WHERE id = $1",
+			"UPDATE sharded_range SET id = $1 WHERE id = $1 RETURNING *",
+			"DELETE FROM sharded_range WHERE id = $1 RETURNING *",
+		} {
+			rows, err := conn.Query(context.Background(), query, int64(i))
+			assert.NoError(t, err)
+			count := 0
+
+			for rows.Next() {
+				count += 1
+			}
+
+			rows.Close()
+			assert.Equal(t, 1, count)
+		}
+	}
+}

--- a/integration/pgdog.toml
+++ b/integration/pgdog.toml
@@ -91,6 +91,59 @@ name = "sharded_varchar"
 column = "id_varchar"
 data_type = "varchar"
 
+#
+# Shard by range
+#
+[[sharded_tables]]
+database = "pgdog_sharded"
+name = "sharded_range"
+column = "id"
+data_type = "bigint"
+
+[[sharded_mappings]]
+database = "pgdog_sharded"
+table = "sharded_range"
+column = "id"
+kind = "range"
+start = 0
+end = 100
+shard = 0
+
+[[sharded_mappings]]
+database = "pgdog_sharded"
+table = "sharded_range"
+column = "id"
+kind = "range"
+start = 100
+end = 200
+shard = 1
+
+
+#
+# Shard by list
+#
+[[sharded_tables]]
+database = "pgdog_sharded"
+name = "sharded_list"
+column = "id"
+data_type = "bigint"
+
+[[sharded_mappings]]
+database = "pgdog_sharded"
+table = "sharded_list"
+column = "id"
+kind = "list"
+values = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+shard = 0
+
+[[sharded_mappings]]
+database = "pgdog_sharded"
+table = "sharded_list"
+column = "id"
+kind = "list"
+values = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
+shard = 1
+
 [[omnisharded_tables]]
 database = "pgdog_sharded"
 tables = ["sharded_omni"]

--- a/integration/setup.sh
+++ b/integration/setup.sh
@@ -38,6 +38,11 @@ for db in pgdog shard_0 shard_1; do
     done
 
     psql -c "CREATE TABLE IF NOT EXISTS sharded_varchar (id_varchar VARCHAR)" ${db} -U pgdog
+
+    for table in list range; do
+        psql -c "CREATE TABLE IF NOT EXISTS sharded_${table} (id BIGINT)" ${db} -U pgdog
+    done
+
     psql -f ${SCRIPT_DIR}/../pgdog/src/backend/schema/setup.sql ${db} -U ${user}
 done
 

--- a/pgdog.toml
+++ b/pgdog.toml
@@ -85,6 +85,32 @@ column = "id"
 data_type = "bigint"
 primary = true
 
+# [[sharded_mappings]]
+# database = "pgdog_sharded"
+# table = "sharded"
+# column = "id"
+# kind = "range"
+# start = 0
+# end = 100
+# shard = 0
+
+# [[sharded_mappings]]
+# database = "pgdog_sharded"
+# table = "sharded"
+# column = "id"
+# kind = "range"
+# start = 100
+# shard = 1
+
+[[sharded_mappings]]
+database = "pgdog_sharded"
+table = "sharded"
+column = "id"
+kind = "list"
+values = [1, 2, 3, 4]
+shard = 0
+
+
 [[sharded_tables]]
 column = "customer_id"
 database = "pgdog_sharded"

--- a/pgdog.toml
+++ b/pgdog.toml
@@ -11,6 +11,7 @@ idle_healthcheck_delay = 2342343243
 read_write_strategy = "aggressive"
 prepared_statements_limit = 500
 # client_idle_timeout = 5_000
+# cross_shard_disabled = false
 
 #
 # Admin database password.
@@ -109,6 +110,14 @@ column = "id"
 kind = "list"
 values = [1, 2, 3, 4]
 shard = 0
+
+[[sharded_mappings]]
+database = "pgdog_sharded"
+table = "sharded"
+column = "id"
+kind = "list"
+values = [5, 6, 7]
+shard = 1
 
 
 [[sharded_tables]]

--- a/pgdog/src/backend/databases.rs
+++ b/pgdog/src/backend/databases.rs
@@ -11,6 +11,7 @@ use parking_lot::{Mutex, RawMutex};
 use tracing::{info, warn};
 
 use crate::config::PoolerMode;
+use crate::frontend::router::{Lists, Ranges};
 use crate::frontend::PreparedStatements;
 use crate::{
     backend::pool::PoolConfig,
@@ -364,6 +365,26 @@ pub(crate) fn new_pool(
 
             if let Some(mappings) = mappings {
                 sharded_table.mappings = mappings.to_vec();
+            }
+
+            if let Some(ranges) = Ranges::new(sharded_table) {
+                if !ranges.valid() {
+                    warn!(
+                        "sharded table name=\"{}\", column=\"{}\" has overlapping ranges",
+                        sharded_table.name.as_ref().unwrap_or(&String::from("")),
+                        sharded_table.column
+                    );
+                }
+            }
+
+            if let Some(lists) = Lists::new(sharded_table) {
+                if !lists.valid() {
+                    warn!(
+                        "sharded table name=\"{}\", column=\"{}\" has overlapping lists",
+                        sharded_table.name.as_ref().unwrap_or(&String::from("")),
+                        sharded_table.column
+                    );
+                }
             }
         }
 

--- a/pgdog/src/backend/pool/cluster.rs
+++ b/pgdog/src/backend/pool/cluster.rs
@@ -367,6 +367,7 @@ mod test {
                         centroids_path: None,
                         centroid_probes: 1,
                         hasher: Hasher::Postgres,
+                        mappings: vec![],
                     }],
                     vec!["sharded_omni".into()],
                     false,

--- a/pgdog/src/config/mod.rs
+++ b/pgdog/src/config/mod.rs
@@ -943,7 +943,7 @@ pub enum DataType {
     Varchar,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
 pub struct ShardedMapping {
     pub database: String,
@@ -966,9 +966,10 @@ pub struct ShardedMapping {
     pub shard: usize,
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Default)]
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
 pub enum ShardedMappingKind {
+    #[default]
     List,
     Range,
 }

--- a/pgdog/src/config/mod.rs
+++ b/pgdog/src/config/mod.rs
@@ -393,6 +393,9 @@ pub struct General {
     pub mirror_queue: usize,
     #[serde(default)]
     pub auth_type: AuthType,
+    /// Disable cross-shard queries.
+    #[serde(default)]
+    pub cross_shard_disabled: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
@@ -490,6 +493,7 @@ impl Default for General {
             client_idle_timeout: Self::default_client_idle_timeout(),
             mirror_queue: Self::mirror_queue(),
             auth_type: AuthType::default(),
+            cross_shard_disabled: bool::default(),
         }
     }
 }

--- a/pgdog/src/config/mod.rs
+++ b/pgdog/src/config/mod.rs
@@ -181,6 +181,8 @@ pub struct Config {
     pub manual_queries: Vec<ManualQuery>,
     #[serde(default)]
     pub omnisharded_tables: Vec<OmnishardedTables>,
+    #[serde(default)]
+    pub sharded_mappings: Vec<ShardedMapping>,
 }
 
 impl Config {
@@ -240,6 +242,34 @@ impl Config {
         }
 
         queries
+    }
+
+    /// Sharded mappings.
+    pub fn sharded_mappings(
+        &self,
+    ) -> HashMap<(String, String, Option<String>), Vec<ShardedMapping>> {
+        let mut mappings = HashMap::new();
+
+        for mapping in &self.sharded_mappings {
+            let mut mapping = mapping.clone();
+            let values = std::mem::take(&mut mapping.values);
+            for value in values {
+                match value {
+                    FlexibleType::String(s) => mapping.values_str.insert(s),
+                    FlexibleType::Integer(i) => mapping.values_integer.insert(i),
+                };
+            }
+            let entry = mappings
+                .entry((
+                    mapping.database.clone(),
+                    mapping.column.clone(),
+                    mapping.table.clone(),
+                ))
+                .or_insert_with(Vec::new);
+            entry.push(mapping);
+        }
+
+        mappings
     }
 
     pub fn check(&self) {
@@ -856,6 +886,9 @@ pub struct ShardedTable {
     /// Hasher function.
     #[serde(default)]
     pub hasher: Hasher,
+    /// Explicit routing rules.
+    #[serde(skip, default)]
+    pub mappings: Vec<ShardedMapping>,
 }
 
 impl ShardedTable {
@@ -904,6 +937,55 @@ pub enum DataType {
     Uuid,
     Vector,
     Varchar,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub struct ShardedMapping {
+    pub database: String,
+    pub column: String,
+    pub table: Option<String>,
+    pub kind: ShardedMappingKind,
+    pub start: Option<FlexibleType>,
+    pub end: Option<FlexibleType>,
+
+    // Be flexible with user inputs.
+    #[serde(default)]
+    pub values: HashSet<FlexibleType>,
+
+    // Be strict and fast when calculating the shard.
+    #[serde(skip, default)]
+    pub values_str: HashSet<String>,
+    #[serde(skip, default)]
+    pub values_integer: HashSet<i64>,
+
+    pub shard: usize,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub enum ShardedMappingKind {
+    List,
+    Range,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq, Hash)]
+#[serde(untagged)]
+pub enum FlexibleType {
+    Integer(i64),
+    String(String),
+}
+
+impl From<i64> for FlexibleType {
+    fn from(value: i64) -> Self {
+        Self::Integer(value)
+    }
+}
+
+impl From<String> for FlexibleType {
+    fn from(value: String) -> Self {
+        Self::String(value)
+    }
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Default)]

--- a/pgdog/src/frontend/router/mod.rs
+++ b/pgdog/src/frontend/router/mod.rs
@@ -16,6 +16,7 @@ pub use parser::{Command, QueryParser, Route};
 use super::Buffer;
 pub use context::RouterContext;
 pub use search_path::SearchPath;
+pub use sharding::{Lists, Ranges};
 
 /// Query router.
 #[derive(Debug)]

--- a/pgdog/src/frontend/router/parser/route.rs
+++ b/pgdog/src/frontend/router/parser/route.rs
@@ -127,6 +127,10 @@ impl Route {
         matches!(self.shard, Shard::Multi(_))
     }
 
+    pub fn is_cross_shard(&self) -> bool {
+        self.is_all_shards() || self.is_multi_shard()
+    }
+
     pub fn order_by(&self) -> &[OrderBy] {
         &self.order_by
     }

--- a/pgdog/src/frontend/router/sharding/list.rs
+++ b/pgdog/src/frontend/router/sharding/list.rs
@@ -1,0 +1,72 @@
+use std::collections::HashSet;
+
+use super::{Error, Shard, Value};
+
+use crate::config::{ShardedMappingKind, ShardedTable};
+
+#[derive(Debug)]
+pub struct Lists<'a> {
+    table: &'a ShardedTable,
+}
+
+impl<'a> Lists<'a> {
+    pub(super) fn new(table: &'a ShardedTable) -> Option<Self> {
+        if table
+            .mappings
+            .iter()
+            .any(|m| m.kind == ShardedMappingKind::List)
+        {
+            Some(Self { table })
+        } else {
+            None
+        }
+    }
+
+    pub(super) fn shard(&self, value: &Value) -> Result<Shard, Error> {
+        let integer = value.integer()?;
+        let varchar = value.varchar()?;
+
+        for mapping in self
+            .table
+            .mappings
+            .iter()
+            .filter(|m| m.kind == ShardedMappingKind::List)
+        {
+            let list = List {
+                values_str: &mapping.values_str,
+                values_integer: &mapping.values_integer,
+                shard: mapping.shard,
+            };
+
+            if let Some(integer) = &integer {
+                if list.integer(integer)? {
+                    return Ok(Shard::Direct(list.shard));
+                }
+            }
+
+            if let Some(varchar) = varchar {
+                if list.varchar(varchar)? {
+                    return Ok(Shard::Direct(list.shard));
+                }
+            }
+        }
+
+        Ok(Shard::All)
+    }
+}
+
+pub struct List<'a> {
+    values_str: &'a HashSet<String>,
+    values_integer: &'a HashSet<i64>,
+    shard: usize,
+}
+
+impl<'a> List<'a> {
+    fn integer(&self, value: &i64) -> Result<bool, Error> {
+        Ok(self.values_integer.contains(value))
+    }
+
+    fn varchar(&self, value: &str) -> Result<bool, Error> {
+        Ok(self.values_str.contains(value))
+    }
+}

--- a/pgdog/src/frontend/router/sharding/list.rs
+++ b/pgdog/src/frontend/router/sharding/list.rs
@@ -10,7 +10,7 @@ pub struct Lists<'a> {
 }
 
 impl<'a> Lists<'a> {
-    pub(super) fn new(table: &'a ShardedTable) -> Option<Self> {
+    pub fn new(table: &'a ShardedTable) -> Option<Self> {
         if table
             .mappings
             .iter()
@@ -20,6 +20,41 @@ impl<'a> Lists<'a> {
         } else {
             None
         }
+    }
+
+    pub fn valid(&self) -> bool {
+        let a = self
+            .table
+            .mappings
+            .iter()
+            .filter(|m| m.kind == ShardedMappingKind::List);
+
+        let b = a.clone();
+
+        for a in a {
+            let mut matches = 0;
+            for b in b.clone() {
+                for va in &a.values_integer {
+                    if b.values_integer.contains(va) {
+                        matches += 1;
+                        break;
+                    }
+                }
+
+                for va in &a.values_str {
+                    if b.values_str.contains(va) {
+                        matches += 1;
+                        break;
+                    }
+                }
+            }
+
+            if matches > 1 {
+                return false;
+            }
+        }
+
+        true
     }
 
     pub(super) fn shard(&self, value: &Value) -> Result<Shard, Error> {

--- a/pgdog/src/frontend/router/sharding/mod.rs
+++ b/pgdog/src/frontend/router/sharding/mod.rs
@@ -31,8 +31,8 @@ pub use value::*;
 pub use vector::{Centroids, Distance};
 
 use super::parser::Shard;
-use list::Lists;
-use range::Ranges;
+pub use list::Lists;
+pub use range::Ranges;
 
 /// Hash `BIGINT`.
 pub fn bigint(id: i64) -> u64 {

--- a/pgdog/src/frontend/router/sharding/mod.rs
+++ b/pgdog/src/frontend/router/sharding/mod.rs
@@ -12,7 +12,9 @@ pub mod context_builder;
 pub mod error;
 pub mod ffi;
 pub mod hasher;
+pub mod list;
 pub mod operator;
+pub mod range;
 pub mod tables;
 #[cfg(test)]
 pub mod test;
@@ -29,6 +31,8 @@ pub use value::*;
 pub use vector::{Centroids, Distance};
 
 use super::parser::Shard;
+use list::Lists;
+use range::Ranges;
 
 /// Hash `BIGINT`.
 pub fn bigint(id: i64) -> u64 {

--- a/pgdog/src/frontend/router/sharding/operator.rs
+++ b/pgdog/src/frontend/router/sharding/operator.rs
@@ -1,4 +1,4 @@
-use super::Centroids;
+use super::{Centroids, Lists, Ranges};
 
 #[derive(Debug)]
 pub enum Operator<'a> {
@@ -8,4 +8,6 @@ pub enum Operator<'a> {
         probes: usize,
         centroids: Centroids<'a>,
     },
+    Range(Ranges<'a>),
+    List(Lists<'a>),
 }

--- a/pgdog/src/frontend/router/sharding/range.rs
+++ b/pgdog/src/frontend/router/sharding/range.rs
@@ -1,0 +1,108 @@
+use super::{Error, Value};
+use crate::{
+    config::{FlexibleType, ShardedMapping, ShardedMappingKind, ShardedTable},
+    frontend::router::parser::Shard,
+};
+
+#[derive(Debug)]
+pub struct Ranges<'a> {
+    table: &'a ShardedTable,
+}
+
+impl<'a> Ranges<'a> {
+    pub(super) fn new(table: &'a ShardedTable) -> Option<Self> {
+        if table
+            .mappings
+            .iter()
+            .any(|m| m.kind == ShardedMappingKind::Range)
+        {
+            Some(Self { table })
+        } else {
+            None
+        }
+    }
+
+    pub(super) fn shard(&self, value: &Value) -> Result<Shard, Error> {
+        // These are quick and return None if the datatype isn't right.
+        let integer = value.integer()?;
+        let varchar = value.varchar()?;
+
+        for mapping in self
+            .table
+            .mappings
+            .iter()
+            .filter(|m| m.kind == ShardedMappingKind::Range)
+        {
+            let range = Range::new(mapping);
+            if let Some(integer) = &integer {
+                if range.integer(integer) {
+                    return Ok(Shard::Direct(range.shard));
+                }
+            }
+
+            if let Some(varchar) = &varchar {
+                if range.varchar(varchar) {
+                    return Ok(Shard::Direct(range.shard));
+                }
+            }
+        }
+
+        Ok(Shard::All)
+    }
+}
+
+#[derive(Debug)]
+pub struct Range<'a> {
+    start: &'a Option<FlexibleType>,
+    end: &'a Option<FlexibleType>,
+    shard: usize,
+}
+
+impl<'a> Range<'a> {
+    pub fn new(mapping: &'a ShardedMapping) -> Self {
+        Self {
+            start: &mapping.start,
+            end: &mapping.end,
+            shard: mapping.shard,
+        }
+    }
+
+    #[allow(dead_code)]
+    fn matches(&self, value: &Value) -> Result<bool, Error> {
+        if let Some(integer) = value.integer()? {
+            Ok(self.integer(&integer))
+        } else if let Some(varchar) = value.varchar()? {
+            Ok(self.varchar(varchar))
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn integer(&self, value: &i64) -> bool {
+        if let Some(FlexibleType::Integer(start)) = self.start {
+            if let Some(FlexibleType::Integer(end)) = self.end {
+                value >= start && value < end
+            } else {
+                value >= start
+            }
+        } else if let Some(FlexibleType::Integer(end)) = self.end {
+            value < end
+        } else {
+            false
+        }
+    }
+
+    fn varchar(&self, value: &str) -> bool {
+        if let Some(FlexibleType::String(start)) = self.start {
+            if let Some(FlexibleType::String(end)) = self.end {
+                value >= start.as_str() && value < end.as_str()
+            } else {
+                value >= start.as_str()
+            }
+        } else if let Some(FlexibleType::String(end)) = self.end {
+            value < end.as_str()
+        } else {
+            false
+        }
+    }
+}

--- a/pgdog/src/net/messages/error_response.rs
+++ b/pgdog/src/net/messages/error_response.rs
@@ -50,6 +50,18 @@ impl ErrorResponse {
         }
     }
 
+    pub fn cross_shard_disabled() -> ErrorResponse {
+        ErrorResponse {
+            severity: "ERROR".into(),
+            code: "58000".into(),
+            message: "cross-shard queries are disabled".into(),
+            detail: Some("query doesn't have a sharding key".into()),
+            context: None,
+            file: None,
+            routine: None,
+        }
+    }
+
     pub fn client_idle_timeout(duration: Duration) -> ErrorResponse {
         ErrorResponse {
             severity: "FATAL".into(),


### PR DESCRIPTION
### Description

1. Add support for range-based and list-based sharding.
2. Add setting to disable cross-shard queries.

#### Range-based sharding

```toml
[[sharded_tables]]
name = "my_table"
data_type = "bigint"
column = "id"

[[sharded_mappings]]
table = "my_table"
column = "id"
kind = "range"
start = 0
end = 100
shard = 0

[[sharded_mappings]]
table = "my_table"
column = "id"
kind = "range"
start = 100
end = 200
shard = 1
```


#### List-based sharding

```toml
[[sharded_tables]]
name = "my_table"
data_type = "bigint"
column = "id"

[[sharded_mappings]]
table = "my_table"
column = "id"
kind = "list"
values = [1, 2, 3, 4, 5]
shard = 0
```

#### Disable cross-shard queries

```toml
[general]
cross_shard_disabled = true
```