### PR TITLE
Connection retries

### DIFF
--- a/pgdog/src/backend/pool/ban.rs
+++ b/pgdog/src/backend/pool/ban.rs
@@ -32,6 +32,10 @@ impl Ban {
             duration > self.ban_timeout
         }
     }
+
+    pub(super) fn manual(&self) -> bool {
+        self.reason == Error::ManualBan
+    }
 }
 
 #[cfg(test)]

--- a/pgdog/src/backend/pool/config.rs
+++ b/pgdog/src/backend/pool/config.rs
@@ -19,6 +19,10 @@ pub struct Config {
     pub idle_timeout: Duration, // ms
     /// How long to wait for connections to be created.
     pub connect_timeout: Duration, // ms
+    /// How many times to attempt a connection before returning an error.
+    pub connect_attempts: u64,
+    /// How long to wait between connection attempts.
+    pub connect_attempt_delay: Duration,
     /// How long a connection can be open.
     pub max_age: Duration,
     /// Can this pool be banned from serving traffic?
@@ -152,6 +156,8 @@ impl Config {
                 .pooler_mode
                 .unwrap_or(user.pooler_mode.unwrap_or(general.pooler_mode)),
             connect_timeout: Duration::from_millis(general.connect_timeout),
+            connect_attempts: general.connect_attempts,
+            connect_attempt_delay: general.connect_attempt_delay(),
             query_timeout: Duration::from_millis(general.query_timeout),
             checkout_timeout: Duration::from_millis(general.checkout_timeout),
             idle_timeout: Duration::from_millis(
@@ -175,6 +181,8 @@ impl Default for Config {
             checkout_timeout: Duration::from_millis(5_000),
             idle_timeout: Duration::from_millis(60_000),
             connect_timeout: Duration::from_millis(5_000),
+            connect_attempts: 1,
+            connect_attempt_delay: Duration::from_millis(10),
             max_age: Duration::from_millis(24 * 3600 * 1000),
             bannable: true,
             healthcheck_timeout: Duration::from_millis(5_000),

--- a/pgdog/src/backend/pool/error.rs
+++ b/pgdog/src/backend/pool/error.rs
@@ -6,6 +6,9 @@ pub enum Error {
     #[error("checkout timeout")]
     CheckoutTimeout,
 
+    #[error("connect timeout")]
+    ConnectTimeout,
+
     #[error("replica checkout timeout")]
     ReplicaCheckoutTimeout,
 

--- a/pgdog/src/backend/pool/inner.rs
+++ b/pgdog/src/backend/pool/inner.rs
@@ -405,6 +405,7 @@ impl Inner {
     }
 
     #[inline(always)]
+    #[allow(dead_code)]
     pub fn manually_banned(&self) -> bool {
         self.ban.map(|ban| ban.manual()).unwrap_or(false)
     }

--- a/pgdog/src/backend/pool/inner.rs
+++ b/pgdog/src/backend/pool/inner.rs
@@ -403,6 +403,11 @@ impl Inner {
     pub fn banned(&self) -> bool {
         self.ban.is_some()
     }
+
+    #[inline(always)]
+    pub fn manually_banned(&self) -> bool {
+        self.ban.map(|ban| ban.manual()).unwrap_or(false)
+    }
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/pgdog/src/backend/pool/monitor.rs
+++ b/pgdog/src/backend/pool/monitor.rs
@@ -100,7 +100,6 @@ impl Monitor {
                 _ = comms.request.notified() => {
                     let (
                         should_create,
-                        connect_timeout,
                         online,
                     ) = {
                         let mut guard = self.pool.lock();
@@ -112,7 +111,6 @@ impl Monitor {
 
                         (
                             guard.should_create(),
-                            guard.config().connect_timeout,
                             guard.online,
                         )
                     };
@@ -122,7 +120,7 @@ impl Monitor {
                     }
 
                     if should_create {
-                        let ok = self.replenish(connect_timeout).await;
+                        let ok = self.replenish().await;
                         if !ok {
                             self.pool.ban(Error::ServerError);
                         }
@@ -232,29 +230,15 @@ impl Monitor {
     }
 
     /// Replenish pool with one new connection.
-    async fn replenish(&self, connect_timeout: Duration) -> bool {
-        let mut ok = false;
-        let options = self.pool.server_options();
-
-        match timeout(connect_timeout, Server::connect(self.pool.addr(), options)).await {
-            Ok(Ok(conn)) => {
-                ok = true;
-                let server = Box::new(conn);
-
-                let mut guard = self.pool.lock();
-                guard.put(server, Instant::now());
-            }
-
-            Ok(Err(err)) => {
-                error!("error connecting to server: {} [{}]", err, self.pool.addr());
-            }
-
-            Err(_) => {
-                error!("server connection timeout [{}]", self.pool.addr());
-            }
+    async fn replenish(&self) -> bool {
+        if let Ok(conn) = Self::create_connection(&self.pool).await {
+            let server = Box::new(conn);
+            let mut guard = self.pool.lock();
+            guard.put(server, Instant::now());
+            true
+        } else {
+            false
         }
-
-        ok
     }
 
     #[allow(dead_code)]
@@ -273,17 +257,15 @@ impl Monitor {
 
     /// Perform a periodic healthcheck on the pool.
     async fn healthcheck(pool: &Pool) -> Result<bool, Error> {
-        let (conn, healthcheck_timeout, connect_timeout) = {
+        let conn = {
             let mut guard = pool.lock();
-            if !guard.online || guard.banned() {
+            if !guard.online || guard.manually_banned() {
                 return Ok(false);
             }
-            (
-                guard.take(&Request::default()),
-                guard.config.healthcheck_timeout,
-                guard.config.connect_timeout,
-            )
+            guard.take(&Request::default())
         };
+
+        let healthcheck_timeout = pool.config().healthcheck_timeout;
 
         // Have an idle connection, use that for the healthcheck.
         if let Some(conn) = conn {
@@ -297,29 +279,18 @@ impl Monitor {
 
             Ok(true)
         } else {
-            // Create a new one and close it. once done.
+            // Create a new one and close it.
             info!("creating new healthcheck connection [{}]", pool.addr());
-            match timeout(
-                connect_timeout,
-                Server::connect(pool.addr(), pool.server_options()),
-            )
-            .await
-            {
-                Ok(Ok(mut server)) => {
-                    Healtcheck::mandatory(&mut server, pool, healthcheck_timeout)
-                        .healthcheck()
-                        .await?
-                }
-                Ok(Err(err)) => {
-                    error!("healthcheck error: {} [{}]", err, pool.addr());
-                }
 
-                Err(_) => {
-                    error!("healthcheck timeout [{}]", pool.addr());
-                }
-            }
+            let mut server = Self::create_connection(pool)
+                .await
+                .map_err(|_| Error::HealthcheckError)?;
 
-            Err(Error::HealthcheckError)
+            Healtcheck::mandatory(&mut server, pool, healthcheck_timeout)
+                .healthcheck()
+                .await?;
+
+            Ok(true)
         }
     }
 
@@ -341,5 +312,39 @@ impl Monitor {
                 }
             }
         }
+    }
+
+    async fn create_connection(pool: &Pool) -> Result<Server, Error> {
+        let connect_timeout = pool.config().connect_timeout;
+        let connect_attempts = pool.config().connect_attempts;
+        let connect_attempt_delay = pool.config().connect_attempt_delay;
+        let options = pool.server_options();
+
+        let mut error = Error::ServerError;
+
+        for _ in 0..connect_attempts {
+            match timeout(
+                connect_timeout,
+                Server::connect(pool.addr(), options.clone()),
+            )
+            .await
+            {
+                Ok(Ok(conn)) => return Ok(conn),
+
+                Ok(Err(err)) => {
+                    error!("error connecting to server: {} [{}]", err, pool.addr());
+                    error = Error::ServerError;
+                }
+
+                Err(_) => {
+                    error!("server connection timeout [{}]", pool.addr());
+                    error = Error::ConnectTimeout;
+                }
+            }
+
+            sleep(connect_attempt_delay).await;
+        }
+
+        Err(error)
     }
 }

--- a/pgdog/src/backend/pool/pool_impl.rs
+++ b/pgdog/src/backend/pool/pool_impl.rs
@@ -259,6 +259,7 @@ impl Pool {
     }
 
     /// Unban this pool from serving traffic, unless manually banned.
+    #[allow(dead_code)]
     pub fn maybe_unban(&self) {
         let unbanned = self.lock().maybe_unban();
         if unbanned {

--- a/pgdog/src/backend/pool/pool_impl.rs
+++ b/pgdog/src/backend/pool/pool_impl.rs
@@ -355,6 +355,12 @@ impl Pool {
         &self.inner.addr
     }
 
+    /// Get pool configuration.
+    #[inline]
+    pub fn config(&self) -> &Config {
+        &self.inner.config
+    }
+
     /// Get startup parameters for new server connections.
     pub(super) fn server_options(&self) -> ServerOptions {
         let mut params = vec![

--- a/pgdog/src/config/mod.rs
+++ b/pgdog/src/config/mod.rs
@@ -367,6 +367,13 @@ pub struct General {
     /// Server connect timeout.
     #[serde(default = "General::default_connect_timeout")]
     pub connect_timeout: u64,
+    /// Attempt connections multiple times on bad networks.
+    #[serde(default = "General::connect_attempts")]
+    pub connect_attempts: u64,
+    /// How long to wait between connection attempts.
+    #[serde(default = "General::default_connect_attempt_delay")]
+    pub connect_attempt_delay: u64,
+    /// How long to wait for a query to return the result before aborting. Dangerous: don't use unless your network is bad.
     #[serde(default = "General::default_query_timeout")]
     pub query_timeout: u64,
     /// Checkout timeout.
@@ -479,6 +486,8 @@ impl Default for General {
             prepared_statements_limit: Self::prepared_statements_limit(),
             passthrough_auth: PassthoughAuth::default(),
             connect_timeout: Self::default_connect_timeout(),
+            connect_attempt_delay: Self::default_connect_attempt_delay(),
+            connect_attempts: Self::connect_attempts(),
             query_timeout: Self::default_query_timeout(),
             checkout_timeout: Self::checkout_timeout(),
             dry_run: bool::default(),
@@ -552,6 +561,10 @@ impl General {
         Duration::from_millis(self.client_idle_timeout)
     }
 
+    pub(crate) fn connect_attempt_delay(&self) -> Duration {
+        Duration::from_millis(self.connect_attempt_delay)
+    }
+
     fn load_balancing_strategy() -> LoadBalancingStrategy {
         LoadBalancingStrategy::Random
     }
@@ -562,6 +575,14 @@ impl General {
 
     fn default_connect_timeout() -> u64 {
         5_000
+    }
+
+    fn default_connect_attempt_delay() -> u64 {
+        0
+    }
+
+    fn connect_attempts() -> u64 {
+        1
     }
 
     fn broadcast_port() -> u16 {


### PR DESCRIPTION
### Description

Add `connect_attempts` and `connect_attempt_delay` settings. The first allows to retry creating new server connections without banning a host. As long as `checkout_timeout` is longer than `connect_timeout`.