### PR TITLE
Addd --version CLI flag using clap built-in macro

### DIFF
--- a/pgdog/src/cli.rs
+++ b/pgdog/src/cli.rs
@@ -6,7 +6,7 @@ use std::fs::read_to_string;
 /// pgDog is a PostgreSQL pooler, proxy, load balancer and
 /// query router.
 #[derive(Parser, Debug)]
-#[clap(version)]
+#[command(version = env!("GIT_HASH"))]
 pub struct Cli {
     /// Path to the configuration file. Default: "pgdog.toml"
     #[arg(short, long, default_value = "pgdog.toml")]

--- a/pgdog/src/cli.rs
+++ b/pgdog/src/cli.rs
@@ -6,6 +6,7 @@ use std::fs::read_to_string;
 /// pgDog is a PostgreSQL pooler, proxy, load balancer and
 /// query router.
 #[derive(Parser, Debug)]
+#[clap(version)]
 pub struct Cli {
     /// Path to the configuration file. Default: "pgdog.toml"
     #[arg(short, long, default_value = "pgdog.toml")]

--- a/pgdog/src/cli.rs
+++ b/pgdog/src/cli.rs
@@ -3,10 +3,9 @@ use std::path::PathBuf;
 use clap::{Parser, Subcommand};
 use std::fs::read_to_string;
 
-/// pgDog is a PostgreSQL pooler, proxy, load balancer and
-/// query router.
+/// PgDog is a PostgreSQL pooler, proxy, load balancer and query router.
 #[derive(Parser, Debug)]
-#[command(version = env!("GIT_HASH"))]
+#[command(name = "", version = concat!("PgDog v", env!("GIT_HASH")))]
 pub struct Cli {
     /// Path to the configuration file. Default: "pgdog.toml"
     #[arg(short, long, default_value = "pgdog.toml")]


### PR DESCRIPTION
# Changes
- Add --version flag that displays "PgDog v{GIT_HASH}"

<img width="668" alt="Screenshot 2025-07-07 at 3 40 58 PM" src="https://github.com/user-attachments/assets/8d8e4138-9fe4-4b0d-9190-6ba9222a42e3" />

Closes #250