### PR TITLE
Preserve passthrough auth users on reload

### DIFF
--- a/integration/rust/tests/integration/auth.rs
+++ b/integration/rust/tests/integration/auth.rs
@@ -9,7 +9,7 @@ async fn test_auth() {
     let bad_password = "postgres://pgdog:skjfhjk23h4234@127.0.0.1:6432/pgdog";
 
     admin.execute("SET auth_type TO 'trust'").await.unwrap();
-    assert_auth("trust").await;
+    assert_setting_str("auth_type", "trust").await;
 
     let mut any_password = PgConnection::connect(bad_password).await.unwrap();
     any_password.execute("SELECT 1").await.unwrap();
@@ -20,24 +20,66 @@ async fn test_auth() {
     empty_password.execute("SELECT 1").await.unwrap();
 
     admin.execute("SET auth_type TO 'scram'").await.unwrap();
-    assert_auth("scram").await;
+    assert_setting_str("auth_type", "scram").await;
 
     assert!(PgConnection::connect(bad_password).await.is_err());
 }
 
-async fn assert_auth(expected: &str) {
+async fn assert_setting_str(name: &str, expected: &str) {
     let admin = admin_sqlx().await;
     let rows = admin.fetch_all("SHOW CONFIG").await.unwrap();
     let mut found = false;
     for row in rows {
-        let name: String = row.get(0);
+        let db_name: String = row.get(0);
         let value: String = row.get(1);
 
-        if name == "auth_type" {
+        if name == db_name {
             found = true;
             assert_eq!(value, expected);
         }
     }
 
     assert!(found);
+}
+
+#[tokio::test]
+async fn test_passthrough_auth() {
+    let admin = admin_sqlx().await;
+    // Make sure settings are coming from config file.
+    admin.execute("RELOAD").await.unwrap();
+
+    assert_setting_str("passthrough_auth", "disabled").await;
+
+    let no_user = PgConnection::connect("postgres://pgdog1:pgdog@127.0.0.1:6432/pgdog")
+        .await
+        .err()
+        .unwrap();
+
+    assert!(
+        no_user
+            .to_string()
+            .contains("password for user \"pgdog1\" and database \"pgdog\" is wrong")
+    );
+
+    admin
+        .execute("SET passthrough_auth TO 'enabled_plain'")
+        .await
+        .unwrap();
+
+    assert_setting_str("passthrough_auth", "enabled_plain").await;
+
+    let mut user = PgConnection::connect("postgres://pgdog1:pgdog@127.0.0.1:6432/pgdog")
+        .await
+        .unwrap();
+
+    user.execute("SELECT 1").await.unwrap();
+
+    // Survive the reload.
+    admin.execute("RELOAD").await.unwrap();
+    admin
+        .execute("SET passthrough_auth TO 'enabled_plain'")
+        .await
+        .unwrap();
+
+    user.execute("SELECT 1").await.unwrap();
 }

--- a/pgdog/src/admin/set.rs
+++ b/pgdog/src/admin/set.rs
@@ -68,6 +68,10 @@ impl Command for Set {
                 config.config.general.auth_type = Self::from_json(&self.value)?;
             }
 
+            "passthrough_auth" => {
+                config.config.general.passthrough_auth = Self::from_json(&self.value)?;
+            }
+
             "read_write_strategy" => {
                 config.config.general.read_write_strategy = Self::from_json(&self.value)?;
             }

--- a/pgdog/src/backend/pool/connection/mirror.rs
+++ b/pgdog/src/backend/pool/connection/mirror.rs
@@ -44,7 +44,7 @@ pub(crate) struct Mirror {
 
 impl Mirror {
     pub(crate) fn spawn(cluster: &Cluster) -> Result<MirrorHandler, Error> {
-        let connection = Connection::new(cluster.user(), cluster.name(), false)?;
+        let connection = Connection::new(cluster.user(), cluster.name(), false, &None)?;
 
         let mut mirror = Self {
             connection,

--- a/pgdog/src/backend/pool/connection/mod.rs
+++ b/pgdog/src/backend/pool/connection/mod.rs
@@ -279,7 +279,6 @@ impl Connection {
         match self.binding {
             Binding::Server(_) | Binding::MultiShard(_, _) | Binding::Replication(_, _) => {
                 let user = (self.user.as_str(), self.database.as_str());
-
                 // Check passthrough auth.
                 if config().config.general.passthrough_auth() && !databases().exists(user) {
                     if let Some(ref passthrough_password) = self.passthrough_password {

--- a/pgdog/src/backend/pool/connection/mod.rs
+++ b/pgdog/src/backend/pool/connection/mod.rs
@@ -7,11 +7,11 @@ use tracing::debug;
 use crate::{
     admin::backend::Backend,
     backend::{
-        databases::databases,
+        databases::{self, databases},
         reload_notify,
         replication::{Buffer, ReplicationConfig},
     },
-    config::PoolerMode,
+    config::{config, PoolerMode, User},
     frontend::{
         router::{parser::Shard, CopyRow, Route},
         Router,
@@ -42,6 +42,7 @@ use multi_shard::MultiShard;
 #[derive(Default, Debug)]
 pub struct Connection {
     user: String,
+    passthrough_password: Option<String>,
     database: String,
     binding: Binding,
     cluster: Option<Cluster>,
@@ -51,7 +52,12 @@ pub struct Connection {
 
 impl Connection {
     /// Create new server connection handler.
-    pub(crate) fn new(user: &str, database: &str, admin: bool) -> Result<Self, Error> {
+    pub(crate) fn new(
+        user: &str,
+        database: &str,
+        admin: bool,
+        passthrough_password: &Option<String>,
+    ) -> Result<Self, Error> {
         let mut conn = Self {
             binding: if admin {
                 Binding::Admin(Backend::new())
@@ -63,6 +69,7 @@ impl Connection {
             database: database.to_owned(),
             mirrors: vec![],
             locked: false,
+            passthrough_password: passthrough_password.clone(),
         };
 
         if !admin {
@@ -271,8 +278,17 @@ impl Connection {
     pub(crate) fn reload(&mut self) -> Result<(), Error> {
         match self.binding {
             Binding::Server(_) | Binding::MultiShard(_, _) | Binding::Replication(_, _) => {
-                let databases = databases();
                 let user = (self.user.as_str(), self.database.as_str());
+
+                // Check passthrough auth.
+                if config().config.general.passthrough_auth() && !databases().exists(user) {
+                    if let Some(ref passthrough_password) = self.passthrough_password {
+                        let new_user = User::new(&self.user, passthrough_password, &self.database);
+                        databases::add(new_user);
+                    }
+                }
+
+                let databases = databases();
                 let cluster = databases.cluster(user)?;
 
                 self.cluster = Some(cluster);

--- a/pgdog/src/config/convert.rs
+++ b/pgdog/src/config/convert.rs
@@ -20,4 +20,14 @@ impl User {
             ..Default::default()
         })
     }
+
+    /// New user from user, password and database.
+    pub(crate) fn new(user: &str, password: &str, database: &str) -> Self {
+        Self {
+            name: user.to_owned(),
+            database: database.to_owned(),
+            password: Some(password.to_owned()),
+            ..Default::default()
+        }
+    }
 }

--- a/pgdog/src/frontend/client/inner.rs
+++ b/pgdog/src/frontend/client/inner.rs
@@ -40,7 +40,8 @@ impl Inner {
         let user = client.params.get_required("user")?;
         let database = client.params.get_default("database", user);
 
-        let mut backend = Connection::new(user, database, client.admin)?;
+        let mut backend =
+            Connection::new(user, database, client.admin, &client.passthrough_password)?;
         let mut router = Router::new();
 
         // Configure replication mode.


### PR DESCRIPTION
### Description

- Re-create pools created with passthrough load on config reload.
- Don't create connection pools for admin connections via passthrough auth. They aren't used by clients and could log errors if the admin user doesn't exist in Postgres.