### PR TITLE
Refactor :: Group QueryParser processing steps logically.

### DIFF
--- a/pgdog/src/backend/pool/connection/mod.rs
+++ b/pgdog/src/backend/pool/connection/mod.rs
@@ -118,7 +118,7 @@ impl Connection {
     }
 
     /// Set the connection into replication mode.
-    pub(crate) fn replication_mode(
+    pub(crate) fn enter_replication_mode(
         &mut self,
         shard: Shard,
         replication_config: &ReplicationConfig,

--- a/pgdog/src/frontend/client/inner.rs
+++ b/pgdog/src/frontend/client/inner.rs
@@ -48,12 +48,12 @@ impl Inner {
         if client.shard.is_some() {
             let cluster = backend.cluster()?;
             if let Some(config) = cluster.replication_sharding_config() {
-                backend.replication_mode(
+                backend.enter_replication_mode(
                     client.shard.into(),
                     &config,
                     &cluster.sharding_schema(),
                 )?;
-                router.replication_mode();
+                router.enter_replication_mode();
                 debug!("logical replication sharding [{}]", client.addr);
             }
         }

--- a/pgdog/src/frontend/router/mod.rs
+++ b/pgdog/src/frontend/router/mod.rs
@@ -39,8 +39,8 @@ impl Router {
     }
 
     /// Set into replication mode.
-    pub fn replication_mode(&mut self) {
-        self.query_parser.replication_mode();
+    pub fn enter_replication_mode(&mut self) {
+        self.query_parser.enter_replication_mode();
     }
 
     /// Route a query to a shard.


### PR DESCRIPTION
# Changes
- renamed `replication_mode` to `enter_replication_mode()` given that `replication_mode()` reads like a getter, not a setter.
- Split and Grouped QueryParser methods logically to process the file in smaller mental chunks. (helps LLMs too).
- No logical changes, exact same function content, just moved.