### PR TITLE
Isolate SELECT Handling in QueryParser

### DIFF
--- a/pgdog/src/frontend/router/parser/query.rs
+++ b/pgdog/src/frontend/router/parser/query.rs
@@ -302,7 +302,7 @@ impl QueryParser {
 
             // SELECT statements.
             Some(NodeEnum::SelectStmt(ref stmt)) => {
-                self.select(stmt, &ast, cluster, &mut shard, bind, &sharding_schema)
+                self.select(stmt, &ast, cluster, &shard, bind, &sharding_schema)
             }
             // COPY statements.
             Some(NodeEnum::CopyStmt(ref stmt)) => Self::copy(stmt, cluster),
@@ -342,7 +342,7 @@ impl QueryParser {
             }
 
             Some(NodeEnum::ExplainStmt(ref stmt)) => {
-                self.explain(stmt, &ast, cluster, &mut shard, bind, &sharding_schema)
+                self.explain(stmt, &ast, cluster, &shard, bind, &sharding_schema)
             }
 
             // All others are not handled.
@@ -567,7 +567,7 @@ impl QueryParser {
         stmt: &SelectStmt,
         ast: &Arc<pg_query::ParseResult>,
         cluster: &Cluster,
-        shard: &mut Shard,
+        shard: &Shard,
         bind: Option<&Bind>,
         sharding_schema: &ShardingSchema,
     ) -> Result<Command, Error> {
@@ -823,7 +823,7 @@ impl QueryParser {
         stmt: &ExplainStmt,
         ast: &Arc<pg_query::ParseResult>,
         cluster: &Cluster,
-        shard: &mut Shard,
+        shard: &Shard,
         bind: Option<&Bind>,
         sharding_schema: &ShardingSchema,
     ) -> Result<Command, Error> {


### PR DESCRIPTION
### TLDR;
- Refactored `SELECT` query logic from split between `query() ->> match ast.node {}` branch and `select()` into **ONLY**  having the logic inside `select()`.
- Propagated to `explain()` for recursive calls.

### Key Changes:
- Moved `SELECT` routing, write detection, sharding from `query()` match block to `select()`.
- Updated `select()` params: `ast`, `cluster`, `shard`, `bind`, `sharding_schema`.
- Propagated changes to `explain()` function signature (added `ast`, `cluster`, `shard`) so it can call the new `select()` for inner `SELECTs`.
- Removed the logic duplication that was inside `EXPLAIN`

### Files:
- src/frontend/router/parser/query.rs:

### Why?
Avoids duplicating `SELECT` logic in `explain()`. `explain()` recursively invokes `select()` on its inner AST query; without centralizing in `select()`, `explain()` couldn't access the full logic.

### Testing/Impact:
- Passes existing tests.
- Did not add test because the goal was to match current behavior.