### PR TITLE
Limit AST query cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1617,9 +1617,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0281c2e25e62316a5c9d98f2d2e9e95a37841afdaf4383c177dbb5c1dfab0568"
+checksum = "86ea4e65087ff52f3862caff188d489f1fab49a0cb09e01b2e3f1a617b10aaed"
 dependencies = [
  "hashbrown",
 ]
@@ -2067,7 +2067,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "indexmap",
- "lru 0.15.0",
+ "lru 0.16.0",
  "md5",
  "once_cell",
  "parking_lot",

--- a/integration/pgdog.toml
+++ b/integration/pgdog.toml
@@ -11,6 +11,7 @@ read_write_strategy = "aggressive"
 openmetrics_port = 9090
 openmetrics_namespace = "pgdog_"
 prepared_statements_limit = 500
+query_cache_limit = 500
 
 # ------------------------------------------------------------------------------
 # ----- Database :: pgdog ------------------------------------------------------

--- a/pgdog/Cargo.toml
+++ b/pgdog/Cargo.toml
@@ -56,7 +56,7 @@ hyper-util = { version = "0.1", features = ["full"] }
 socket2 = "0.5.9"
 sha1 = "0.10"
 indexmap = "2.9"
-lru = "0.15"
+lru = "0.16"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = "0.6"

--- a/pgdog/src/backend/databases.rs
+++ b/pgdog/src/backend/databases.rs
@@ -11,6 +11,7 @@ use parking_lot::{Mutex, RawMutex};
 use tracing::{debug, info, warn};
 
 use crate::config::PoolerMode;
+use crate::frontend::router::parser::Cache;
 use crate::frontend::router::sharding::Mapping;
 use crate::frontend::PreparedStatements;
 use crate::{
@@ -68,6 +69,9 @@ pub fn reconnect() {
 pub fn init() {
     let config = config();
     replace_databases(from_config(&config), false);
+
+    // Resize query cache
+    Cache::resize(config.config.general.query_cache_limit);
 }
 
 /// Shutdown all databases.
@@ -87,6 +91,9 @@ pub fn reload() -> Result<(), Error> {
     PreparedStatements::global()
         .lock()
         .close_unused(new_config.config.general.prepared_statements_limit);
+
+    // Resize query cache
+    Cache::resize(new_config.config.general.query_cache_limit);
 
     Ok(())
 }

--- a/pgdog/src/config/mod.rs
+++ b/pgdog/src/config/mod.rs
@@ -361,6 +361,8 @@ pub struct General {
     /// Limit on the number of prepared statements in the server cache.
     #[serde(default = "General::prepared_statements_limit")]
     pub prepared_statements_limit: usize,
+    #[serde(default = "General::query_cache_limit")]
+    pub query_cache_limit: usize,
     /// Automatically add connection pools for user/database pairs we don't have.
     #[serde(default)]
     pub passthrough_auth: PassthoughAuth,
@@ -484,6 +486,7 @@ impl Default for General {
             openmetrics_namespace: None,
             prepared_statements: PreparedStatements::default(),
             prepared_statements_limit: Self::prepared_statements_limit(),
+            query_cache_limit: Self::query_cache_limit(),
             passthrough_auth: PassthoughAuth::default(),
             connect_timeout: Self::default_connect_timeout(),
             connect_attempt_delay: Self::default_connect_attempt_delay(),
@@ -598,6 +601,10 @@ impl General {
     }
 
     fn prepared_statements_limit() -> usize {
+        usize::MAX
+    }
+
+    fn query_cache_limit() -> usize {
         usize::MAX
     }
 

--- a/pgdog/src/frontend/router/parser/cache.rs
+++ b/pgdog/src/frontend/router/parser/cache.rs
@@ -111,6 +111,7 @@ impl Cache {
             });
             if let Some(ast) = ast {
                 guard.stats.hits += 1;
+                guard.queries.promote(query);
                 return Ok(ast);
             }
         }

--- a/pgdog/src/frontend/router/parser/cache.rs
+++ b/pgdog/src/frontend/router/parser/cache.rs
@@ -2,17 +2,19 @@
 //!
 //! Shared between all clients and databases.
 
+use lru::LruCache;
 use once_cell::sync::Lazy;
 use pg_query::*;
-use std::{collections::HashMap, time::Duration};
+use std::time::Duration;
 
 use parking_lot::Mutex;
 use std::sync::Arc;
+use tracing::debug;
 
 use super::{Error, Route};
 use crate::frontend::buffer::BufferedQuery;
 
-static CACHE: Lazy<Cache> = Lazy::new(Cache::default);
+static CACHE: Lazy<Cache> = Lazy::new(Cache::new);
 
 /// AST cache statistics.
 #[derive(Default, Debug, Copy, Clone)]
@@ -57,19 +59,43 @@ impl CachedAst {
     }
 }
 
-#[derive(Default, Debug)]
+#[derive(Debug)]
 struct Inner {
-    queries: HashMap<String, CachedAst>,
+    queries: LruCache<String, CachedAst>,
     stats: Stats,
 }
 
 /// AST cache.
-#[derive(Default, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct Cache {
     inner: Arc<Mutex<Inner>>,
 }
 
 impl Cache {
+    fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(Inner {
+                queries: LruCache::unbounded(),
+                stats: Stats::default(),
+            })),
+        }
+    }
+
+    /// Resize to capacity.
+    ///
+    /// Minimum capacity is 1.
+    pub fn resize(capacity: usize) {
+        let capacity = if capacity == 0 { 1 } else { capacity };
+
+        CACHE
+            .inner
+            .lock()
+            .queries
+            .resize(capacity.try_into().unwrap());
+
+        debug!("ast cache size set to {}", capacity);
+    }
+
     /// Parse a statement by either getting it from cache
     /// or using pg_query parser.
     ///
@@ -94,7 +120,7 @@ impl Cache {
         let ast = entry.ast.clone();
 
         let mut guard = self.inner.lock();
-        guard.queries.insert(query.to_owned(), entry);
+        guard.queries.put(query.to_owned(), entry);
         guard.stats.misses += 1;
 
         Ok(ast)
@@ -161,7 +187,7 @@ impl Cache {
             entry.direct += 1;
         }
 
-        guard.queries.insert(query.to_string(), entry);
+        guard.queries.put(query.to_string(), entry);
 
         Ok(())
     }
@@ -176,7 +202,7 @@ impl Cache {
     }
 
     /// Get a copy of all queries stored in the cache.
-    pub fn queries() -> HashMap<String, CachedAst> {
+    pub fn queries() -> LruCache<String, CachedAst> {
         Self::get().inner.lock().queries.clone()
     }
 
@@ -185,7 +211,6 @@ impl Cache {
         let cache = Self::get();
         let mut guard = cache.inner.lock();
         guard.queries.clear();
-        guard.queries.shrink_to_fit();
         guard.stats.hits = 0;
         guard.stats.misses = 0;
     }


### PR DESCRIPTION
### Description

Add limit to AST cache in query router. This was causing a memory leak on deployments  with high query cardinality.