### PR TITLE
[Checkpoint] Do Not ban pools on wrong passwords.

### DIFF
--- a/integration/pgdog.toml
+++ b/integration/pgdog.toml
@@ -14,6 +14,9 @@ prepared_statements_limit = 500
 # dns_ttl = 15_000
 query_cache_limit = 500
 
+auth_type = "scram"
+passthrough_auth = "enabled_plain"
+
 # ------------------------------------------------------------------------------
 # ----- Database :: pgdog ------------------------------------------------------
 

--- a/integration/setup.sh
+++ b/integration/setup.sh
@@ -1,61 +1,95 @@
 #!/bin/bash
 set -e
+
+echo "=== Starting setup script ==="
+
+export PGUSER=pgdog
+export PGPASSWORD=pgdog
+export PGHOST=127.0.0.1
+export PGPORT=5432
+
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+echo "SCRIPT_DIR=$SCRIPT_DIR"
+
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+echo "Detected OS: $OS"
+
 if [[ "$OS" == "darwin" ]]; then
     ARCH=arm64
 else
     ARCH=amd64
 fi
+echo "Using ARCH: $ARCH"
 
-
+echo "---- Creating users ----"
 for user in pgdog pgdog1 pgdog2 pgdog3; do
-    psql -c "CREATE USER ${user} LOGIN SUPERUSER PASSWORD 'pgdog'" || true
+    echo "Creating user $user (if not exists)"
+    psql -c "CREATE USER ${user} LOGIN SUPERUSER PASSWORD 'pgdog'" || echo "User $user already exists" -U postgres
 done
 
-# GitHub fix
+echo "---- GitHub runner fix ----"
 if [[ "$USER" == "runner" ]]; then
-    psql -c "ALTER USER runner PASSWORD 'pgdog' LOGIN;"
+    echo "Altering runner user password"
+    psql -c "ALTER USER runner PASSWORD 'pgdog' LOGIN;" -U postgres
+else
+    echo "Skipping runner fix for user $USER"
 fi
 
 export PGPASSWORD='pgdog'
 export PGHOST=127.0.0.1
 export PGPORT=5432
-#export PGUSER='pgdog'
 
+echo "---- Creating databases and granting permissions ----"
 for db in pgdog shard_0 shard_1; do
-    psql -c "CREATE DATABASE $db" || true
+    echo "Creating database $db"
+    psql -c "CREATE DATABASE $db" || echo "Database $db already exists" -U postgres
     for user in pgdog pgdog1 pgdog2 pgdog3; do
+        echo "Granting all on database $db to $user"
         psql -c "GRANT ALL ON DATABASE $db TO ${user}"
+        echo "Granting all on schema public in $db to $user"
         psql -c "GRANT ALL ON SCHEMA public TO ${user}" ${db}
     done
 done
 
+echo "---- Creating tables ----"
 for db in pgdog shard_0 shard_1; do
+    echo "Processing database $db"
     for table in sharded sharded_omni; do
-            psql -c "DROP TABLE IF EXISTS ${table}" ${db} -U pgdog
-            psql -c "CREATE TABLE IF NOT EXISTS ${table} (id BIGINT PRIMARY KEY, value TEXT)" ${db} -U pgdog
+        echo "Dropping table $table if exists"
+        psql -c "DROP TABLE IF EXISTS ${table}" ${db} -U pgdog
+        echo "Creating table $table"
+        psql -c "CREATE TABLE IF NOT EXISTS ${table} (id BIGINT PRIMARY KEY, value TEXT)" ${db} -U pgdog
     done
 
+    echo "Creating sharded_varchar"
     psql -c "CREATE TABLE IF NOT EXISTS sharded_varchar (id_varchar VARCHAR)" ${db} -U pgdog
+
+    echo "Creating sharded_uuid"
     psql -c "CREATE TABLE IF NOT EXISTS sharded_uuid (id_uuid UUID PRIMARY KEY)" -d "$db" -U pgdog
 
     for table in list range; do
+        echo "Creating sharded_$table"
         psql -c "CREATE TABLE IF NOT EXISTS sharded_${table} (id BIGINT)" ${db} -U pgdog
     done
 
+    echo "Creating sharded_list_uuid"
     psql -c "CREATE TABLE IF NOT EXISTS sharded_list_uuid (id_uuid UUID PRIMARY KEY)" -d "$db" -U pgdog
 
-    psql -f ${SCRIPT_DIR}/../pgdog/src/backend/schema/setup.sql ${db} -U ${user}
+    echo "Applying schema setup.sql to $db"
+    psql -f ${SCRIPT_DIR}/../pgdog/src/backend/schema/setup.sql ${db} -U pgdog || echo "Failed running setup.sql on $db"
 done
 
-pushd ${SCRIPT_DIR}
-
+echo "---- Downloading Toxiproxy binaries ----"
+pushd ${SCRIPT_DIR} > /dev/null
 for bin in toxiproxy-server toxiproxy-cli; do
     if [[ ! -f ${bin} ]]; then
+        echo "Downloading $bin for $OS-$ARCH"
         curl -L https://github.com/Shopify/toxiproxy/releases/download/v2.12.0/${bin}-${OS}-${ARCH} > ${bin}
         chmod +x ${bin}
+    else
+        echo "$bin already exists"
     fi
 done
+popd > /dev/null
 
-popd
+echo "=== Setup script completed ==="

--- a/pgdog/src/backend/pool/connection/mod.rs
+++ b/pgdog/src/backend/pool/connection/mod.rs
@@ -276,16 +276,28 @@ impl Connection {
 
     /// Fetch the cluster from the global database store.
     pub(crate) fn reload(&mut self) -> Result<(), Error> {
+        println!("");
+        println!("");
+        println!("");
+        println!("backend::pool::Connection::reload");
+
         match self.binding {
             Binding::Server(_) | Binding::MultiShard(_, _) | Binding::Replication(_, _) => {
                 let user = (self.user.as_str(), self.database.as_str());
                 // Check passthrough auth.
                 if config().config.general.passthrough_auth() && !databases().exists(user) {
                     if let Some(ref passthrough_password) = self.passthrough_password {
+                        println!(
+                            "backend::pool::Connection::reload ~ passthrough_password = {:?}",
+                            passthrough_password
+                        );
+
                         let new_user = User::new(&self.user, passthrough_password, &self.database);
                         databases::add(new_user);
                     }
                 }
+
+                println!("backend::pool::Connection::reload ~ New user added");
 
                 let databases = databases();
                 let cluster = databases.cluster(user)?;

--- a/pgdog/src/config/mod.rs
+++ b/pgdog/src/config/mod.rs
@@ -644,8 +644,28 @@ impl General {
     }
 
     pub fn passthrough_auth(&self) -> bool {
-        self.tls().is_some() && self.passthrough_auth == PassthoughAuth::Enabled
-            || self.passthrough_auth == PassthoughAuth::EnabledPlain
+        let tls_present = self.tls().is_some();
+        let auth_enabled_passthrough = self.passthrough_auth == PassthoughAuth::Enabled;
+        let auth_enabled_plain = self.passthrough_auth == PassthoughAuth::EnabledPlain;
+
+        println!("");
+        println!("");
+        println!("");
+        println!("");
+        println!(
+            "Config::General::passthrough ~ tls_present: {}",
+            tls_present
+        );
+        println!(
+            "Config::General::passthrough ~ auth_enabled_passthrough: {}",
+            auth_enabled_passthrough
+        );
+        println!(
+            "Config::General::passthrough ~ auth_enabled_plain: {}",
+            auth_enabled_plain
+        );
+
+        (tls_present && auth_enabled_passthrough) || auth_enabled_plain
     }
 }
 

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -102,17 +102,32 @@ impl Client {
         // Auto database.
         let exists = databases::databases().exists((user, database));
         let passthrough_password = if config.config.general.passthrough_auth() && !admin {
+            println!("");
+            println!("");
+            println!("");
+            println!("Client::spawn");
+
             let password = if auth_type.trust() {
+                println!("Client::spawn::auth_type.trust()");
+
                 // Use empty password.
                 // TODO: Postgres must be using "trust" auth
                 // or some other kind of authentication that doesn't require a password.
                 Password::new_password("")
             } else {
+                println!("Client::spawn::!auth_type.trust()");
+
                 // Get the password.
                 stream
                     .send_flush(&Authentication::ClearTextPassword)
                     .await?;
                 let password = stream.read().await?;
+
+                println!(
+                    "Client::spawn::!auth_type.trust() ~ password = {:?}",
+                    &password
+                );
+
                 Password::from_bytes(password.to_bytes()?)?
             };
 
@@ -126,6 +141,11 @@ impl Client {
         } else {
             None
         };
+
+        println!(
+            "Client::spawn ~ passthrough_password = {:?}",
+            &passthrough_password
+        );
 
         // Get server parameters and send them to the client.
         let mut conn = match Connection::new(user, database, admin, &passthrough_password) {


### PR DESCRIPTION
# Comments:
- This PR is related to the following issue. https://github.com/pgdogdev/pgdog/issues/238
- This basically adds a bunch of logs to the auth passthrough path.
- Checkpointing in git so i don't have to rewrite the logs
- I might be missing context, but i was unable to cause my pool to die by putting the wrong password.

# Screenshots
<img width="5120" height="2880" alt="screen" src="https://github.com/user-attachments/assets/e94a0a1d-71c8-496b-b557-12293466c3c7" />
