### PR TITLE
Fix connection examples to disable GSSAPI authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ docker-compose up
 It will take a few minutes to build PgDog from source and launch the containers. Once started, you can connect to PgDog with psql (or any other PostgreSQL client):
 
 ```
-PGPASSWORD=postgres psql -h 127.0.0.1 -p 6432 -U postgres
+PGPASSWORD=postgres psql -h 127.0.0.1 -p 6432 -U postgres gssencmode=disable
 ```
 
 The demo comes with 3 shards and 2 sharded tables:
@@ -188,7 +188,7 @@ cargo run --release -- -d postgres://user:pass@localhost:5432/db1 -d postgres://
 You can connect to PgDog with psql or any other PostgreSQL client:
 
 ```bash
-psql postgres://pgdog:pgdog@127.0.0.1:6432/pgdog
+psql "postgres://pgdog:pgdog@127.0.0.1:6432/pgdog?gssencmode=disable"
 ```
 
 ## &#128678; Status &#128678;


### PR DESCRIPTION
## Summary
• Updates connection examples in README.md to disable GSSAPI authentication
• Adds gssencmode=disable parameter to psql connection strings

With gssencmode enabled:

```
psql -h ********* -p 6432 -U postgres
psql: error: connection to server at "*********", port 6432 failed: server closed the connection unexpectedly
	This probably means the server terminated abnormally
	before or while processing the request.

```

With gssencmode disabled
```

PGPASSWORD=xxxx  psql -h ********* -p 6432 -U postgres gssencmode=disable

psql (14.15 (Homebrew), server 17.5 (Debian 17.5-1.pgdg120+1))
WARNING: psql major version 14, server major version 17.
         Some psql features might not work.
Type "help" for help.

postgres=# \q
```

## Test plan
- [ ] Verify connection examples work with the updated parameters
- [ ] Test that GSSAPI is properly disabled in the connection strings