### PR TITLE
Deny unknown fields in users

### DIFF
--- a/pgdog/src/config/mod.rs
+++ b/pgdog/src/config/mod.rs
@@ -811,6 +811,7 @@ pub struct Plugin {
 
 /// Users and passwords.
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[serde(deny_unknown_fields)]
 pub struct Users {
     /// Users and passwords.
     #[serde(default)]


### PR DESCRIPTION
# Context
- Discovered that it was almost impossible to fail a `/users.toml` validation because these extra values just get ignored.
- This means that `pgdogdev/docs` cannot be validated.
- This is because every docs' `toml` snippet has to either pass `users.toml` validation or `pgdog.toml` validation.
- Without `#[serde(deny_unknown_fields)]`, it's very hard to fail a users verification.
- The `pgdog.toml` snippet is not labeled, so the broken `pgdog.toml` was being accepted as a `users.toml`.

```toml
[invalid_field]
always_passes = true
```

# Changes
- add `#[serde(deny_unknown_fields)]` to `config::Users`