### PR TITLE
[Mirroring] Buffer entire transactions & add exposure setting

### DIFF
--- a/integration/mirror/pgdog.toml
+++ b/integration/mirror/pgdog.toml
@@ -1,3 +1,6 @@
+[general]
+mirror_exposure = 0.1
+
 [[databases]]
 name = "pgdog"
 host = "127.0.0.1"

--- a/integration/mirror/pgdog.toml
+++ b/integration/mirror/pgdog.toml
@@ -1,5 +1,5 @@
 [general]
-mirror_exposure = 0.1
+mirror_exposure = 1.0
 
 [[databases]]
 name = "pgdog"

--- a/integration/mirror/pgdog.toml
+++ b/integration/mirror/pgdog.toml
@@ -1,0 +1,12 @@
+[[databases]]
+name = "pgdog"
+host = "127.0.0.1"
+
+[[databases]]
+name = "pgdog_mirror"
+host = "127.0.0.1"
+database_name = "pgdog1"
+mirror_of = "pgdog"
+
+[admin]
+password = "pgdog"

--- a/integration/mirror/users.toml
+++ b/integration/mirror/users.toml
@@ -1,0 +1,9 @@
+[[users]]
+name = "pgdog"
+password = "pgdog"
+database = "pgdog"
+
+[[users]]
+name = "pgdog"
+password = "pgdog"
+database = "pgdog_mirror"

--- a/integration/setup.sh
+++ b/integration/setup.sh
@@ -11,6 +11,7 @@ fi
 
 for user in pgdog pgdog1 pgdog2 pgdog3; do
     psql -c "CREATE USER ${user} LOGIN SUPERUSER PASSWORD 'pgdog'" || true
+    psql -c "CREATE DATABASE ${user}" || true
 done
 
 # GitHub fix

--- a/pgdog/src/backend/error.rs
+++ b/pgdog/src/backend/error.rs
@@ -101,6 +101,9 @@ pub enum Error {
 
     #[error("pub/sub channel disabled")]
     PubSubDisabled,
+
+    #[error("mirror buffer empty")]
+    MirrorBufferEmpty,
 }
 
 impl Error {

--- a/pgdog/src/backend/pool/cluster.rs
+++ b/pgdog/src/backend/pool/cluster.rs
@@ -414,6 +414,8 @@ mod test {
                         ReadWriteSplit::default(),
                     ),
                 ],
+                user: "pgdog".into(),
+                name: "pgdog".into(),
                 ..Default::default()
             }
         }

--- a/pgdog/src/backend/pool/connection/mod.rs
+++ b/pgdog/src/backend/pool/connection/mod.rs
@@ -1,6 +1,6 @@
 //! Server connection requested by a frontend.
 
-use mirror::{MirrorHandler, MirrorRequest};
+use mirror::MirrorHandler;
 use tokio::{select, time::sleep};
 use tracing::debug;
 
@@ -117,10 +117,17 @@ impl Connection {
         Ok(())
     }
 
-    /// Send traffic to mirrors.
-    pub(crate) fn mirror(&self, buffer: &crate::frontend::Buffer) {
-        for mirror in &self.mirrors {
-            let _ = mirror.tx.try_send(MirrorRequest::new(buffer));
+    /// Send client request to mirrors.
+    pub fn mirror(&mut self, buffer: &crate::frontend::Buffer) {
+        for mirror in &mut self.mirrors {
+            mirror.send(buffer);
+        }
+    }
+
+    /// Tell mirrors to flush buffered transaction.
+    pub fn mirror_flush(&mut self) {
+        for mirror in &mut self.mirrors {
+            mirror.flush();
         }
     }
 

--- a/pgdog/src/backend/pool/connection/multi_shard/mod.rs
+++ b/pgdog/src/backend/pool/connection/multi_shard/mod.rs
@@ -37,7 +37,7 @@ struct Counters {
 
 /// Multi-shard state.
 #[derive(Default, Debug)]
-pub(super) struct MultiShard {
+pub struct MultiShard {
     /// Number of shards we are connected to.
     shards: usize,
     /// Route the query is taking.

--- a/pgdog/src/config/mod.rs
+++ b/pgdog/src/config/mod.rs
@@ -418,6 +418,9 @@ pub struct General {
     /// Mirror queue size.
     #[serde(default = "General::mirror_queue")]
     pub mirror_queue: usize,
+    /// Mirror exposure
+    #[serde(default = "General::mirror_exposure")]
+    pub mirror_exposure: f32,
     #[serde(default)]
     pub auth_type: AuthType,
     /// Disable cross-shard queries.
@@ -531,6 +534,7 @@ impl Default for General {
             idle_timeout: Self::idle_timeout(),
             client_idle_timeout: Self::default_client_idle_timeout(),
             mirror_queue: Self::mirror_queue(),
+            mirror_exposure: Self::mirror_exposure(),
             auth_type: AuthType::default(),
             cross_shard_disabled: bool::default(),
             dns_ttl: None,
@@ -646,6 +650,10 @@ impl General {
 
     fn mirror_queue() -> usize {
         128
+    }
+
+    fn mirror_exposure() -> f32 {
+        1.0
     }
 
     fn prepared_statements_limit() -> usize {

--- a/pgdog/src/frontend/buffer.rs
+++ b/pgdog/src/frontend/buffer.rs
@@ -39,11 +39,6 @@ impl Buffer {
         }
     }
 
-    /// Client likely wants to communicate asynchronously.
-    pub fn is_async(&self) -> bool {
-        self.buffer.last().map(|m| m.code() == 'H').unwrap_or(false)
-    }
-
     /// The buffer is full and the client won't send any more messages
     /// until it gets a reply, or we don't want to buffer the data in memory.
     pub fn full(&self) -> bool {
@@ -71,11 +66,6 @@ impl Buffer {
     /// Number of bytes in the buffer.
     pub fn total_message_len(&self) -> usize {
         self.buffer.iter().map(|b| b.len()).sum()
-    }
-
-    /// Check if the buffer is empty.
-    pub fn is_empty(&self) -> bool {
-        self.total_message_len() == 0
     }
 
     /// If this buffer contains a query, retrieve it.
@@ -147,11 +137,6 @@ impl Buffer {
             .last()
             .map(|m| m.code() == 'd' || m.code() == 'c')
             .unwrap_or(false)
-    }
-
-    /// The client is expecting a reply now.
-    pub fn flush(&self) -> bool {
-        self.buffer.last().map(|m| m.code() == 'H').unwrap_or(false)
     }
 
     /// The client is setting state on the connection

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -630,6 +630,11 @@ impl Client {
             inner.stats.idle(self.in_transaction);
         }
 
+        // Flush mirrors.
+        if !self.in_transaction {
+            inner.backend.mirror_flush();
+        }
+
         inner.stats.sent(message.len());
 
         // Release the connection back into the pool

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -631,11 +631,11 @@ impl Client {
             // or server is telling us we are.
             self.in_transaction = message.in_transaction() || inner.start_transaction.is_some();
             inner.stats.idle(self.in_transaction);
-        }
 
-        // Flush mirrors.
-        if !self.in_transaction {
-            inner.backend.mirror_flush();
+            // Flush mirrors.
+            if !self.in_transaction {
+                inner.backend.mirror_flush();
+            }
         }
 
         inner.stats.sent(message.len());

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -576,14 +576,17 @@ impl Client {
             }
         }
 
+        // Queue up request to mirrors, if any.
+        // Do this before sending query to actual server
+        // to have accurate timings between queries.
+        inner.backend.mirror(&self.request_buffer);
+
+        // Send request to actual server.
         inner
             .handle_buffer(&self.request_buffer, self.streaming)
             .await?;
 
         self.update_stats(&mut inner);
-
-        // Send traffic to mirrors, if any.
-        inner.backend.mirror(&self.request_buffer);
 
         #[cfg(test)]
         let handle_response = false;


### PR DESCRIPTION
### Mirroring

- Buffer entire transactions to help with realism and reduce errors.
- Record timings between queries to simulate idle sessions.
- Add `mirror_exposure` setting allowing to send a percentage of traffic to the mirrors.

### Misc
- Remove dead code in `Buffer`.
- Use `Deref` for `Binding` instead of duplicating code.