### PR TITLE
[Resharding] Schema sync

### DIFF
--- a/pgdog/src/backend/pool/shard.rs
+++ b/pgdog/src/backend/pool/shard.rs
@@ -36,6 +36,7 @@ impl Shard {
         }
     }
 
+    /// Get connection to primary database.
     pub async fn primary(&self, request: &Request) -> Result<Guard, Error> {
         self.primary
             .as_ref()
@@ -44,6 +45,8 @@ impl Shard {
             .await
     }
 
+    /// Get connection to one of the replica databases, using the configured
+    /// load balancing algorithm.
     pub async fn replica(&self, request: &Request) -> Result<Guard, Error> {
         if self.replicas.is_empty() {
             self.primary
@@ -60,6 +63,15 @@ impl Shard {
             };
 
             self.replicas.get(request, primary).await
+        }
+    }
+
+    /// Get connection to primary if configured, otherwise replica.
+    pub async fn primary_or_replica(&self, request: &Request) -> Result<Guard, Error> {
+        if self.primary.is_some() {
+            self.primary(request).await
+        } else {
+            self.replica(request).await
         }
     }
 

--- a/pgdog/src/backend/replication/logical/publisher/queries.rs
+++ b/pgdog/src/backend/replication/logical/publisher/queries.rs
@@ -17,10 +17,11 @@ JOIN pg_namespace n ON n.oid = c.relnamespace
 JOIN ( SELECT (pg_get_publication_tables(VARIADIC array_agg(pubname::text))).*
        FROM pg_publication
        WHERE pubname IN ($1)) AS gpt
-    ON gpt.relid = c.oid";
+    ON gpt.relid = c.oid
+ORDER BY n.nspname, c.relname";
 
 /// Table included in a publication.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct PublicationTable {
     pub schema: String,
     pub name: String,

--- a/pgdog/src/backend/schema/mod.rs
+++ b/pgdog/src/backend/schema/mod.rs
@@ -1,6 +1,7 @@
 //! Schema operations.
 pub mod columns;
 pub mod relation;
+pub mod sync;
 
 use std::sync::Arc;
 use std::{collections::HashMap, ops::Deref};

--- a/pgdog/src/backend/schema/sync/error.rs
+++ b/pgdog/src/backend/schema/sync/error.rs
@@ -28,4 +28,7 @@ pub enum Error {
 
     #[error("parse error, stmt out of bounds")]
     StmtOutOfBounds,
+
+    #[error("cluster has no databases")]
+    NoDatabases,
 }

--- a/pgdog/src/backend/schema/sync/error.rs
+++ b/pgdog/src/backend/schema/sync/error.rs
@@ -1,0 +1,31 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("{0}")]
+    Backend(#[from] crate::backend::Error),
+
+    #[error("{0}")]
+    Replication(#[from] crate::backend::replication::Error),
+
+    #[error("{0}")]
+    Pool(#[from] crate::backend::pool::Error),
+
+    #[error("{0}")]
+    LogicalReplication(#[from] crate::backend::replication::logical::Error),
+
+    #[error("pg_dump command failed: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("{0}")]
+    Utf8(#[from] std::str::Utf8Error),
+
+    #[error("pg_dump error: {0}")]
+    PgDump(String),
+
+    #[error("{0}")]
+    Syntax(#[from] pg_query::Error),
+
+    #[error("parse error, stmt out of bounds")]
+    StmtOutOfBounds,
+}

--- a/pgdog/src/backend/schema/sync/mod.rs
+++ b/pgdog/src/backend/schema/sync/mod.rs
@@ -1,0 +1,4 @@
+pub mod error;
+pub mod pg_dump;
+
+pub use error::Error;

--- a/pgdog/src/backend/schema/sync/pg_dump.rs
+++ b/pgdog/src/backend/schema/sync/pg_dump.rs
@@ -1,0 +1,216 @@
+//! Wrapper around pg_dump.
+
+use std::str::{from_utf8, from_utf8_unchecked};
+
+use pg_query::{
+    protobuf::{ConstrType, ParseResult},
+    NodeEnum,
+};
+use tracing::warn;
+
+use super::Error;
+use crate::backend::{
+    pool::{Address, Request},
+    replication::publisher::PublicationTable,
+    Cluster,
+};
+
+use tokio::process::Command;
+
+#[derive(Debug, Clone)]
+pub struct PgDump {
+    source: Cluster,
+    publication: String,
+}
+
+impl PgDump {
+    pub async fn new(source: &Cluster, publication: &str) -> Self {
+        Self {
+            source: source.clone(),
+            publication: publication.to_string(),
+        }
+    }
+
+    pub async fn dump(&self) -> Result<(), Error> {
+        let mut comparison: Vec<PublicationTable> = vec![];
+        for (num, shard) in self.source.shards().iter().enumerate() {
+            let mut server = shard.primary_or_replica(&Request::default()).await?;
+            let tables = PublicationTable::load(&self.publication, &mut server).await?;
+            if comparison.is_empty() {
+                comparison.extend(tables);
+            } else {
+                if comparison != tables {
+                    warn!("shard {} tables are different [{}]", num, server.addr());
+                    continue;
+                }
+            }
+        }
+        todo!()
+    }
+}
+
+struct PgDumpCommand {
+    table: String,
+    schema: String,
+    address: Address,
+}
+
+impl PgDumpCommand {
+    async fn execute(&self) -> Result<PgDumpOutput, Error> {
+        let output = Command::new("pg_dump")
+            .arg("-t")
+            .arg(&self.table)
+            .arg("-n")
+            .arg(&self.schema)
+            .arg("--schema-only")
+            .arg("-h")
+            .arg(&self.address.host)
+            .arg("-p")
+            .arg(self.address.port.to_string())
+            .arg("-U")
+            .arg(&self.address.user)
+            .env("PGPASSWORD", &self.address.password)
+            .arg("-d")
+            .arg(&self.address.database_name)
+            .output()
+            .await?;
+
+        if !output.status.success() {
+            let err = from_utf8(&output.stderr)?;
+            return Err(Error::PgDump(err.to_string()));
+        }
+
+        let original = from_utf8(&output.stdout)?.to_string();
+        let stmts = pg_query::parse(&original)?.protobuf;
+
+        Ok(PgDumpOutput { stmts, original })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PgDumpOutput {
+    stmts: ParseResult,
+    original: String,
+}
+
+impl PgDumpOutput {
+    /// Get schema statements to execute before data sync,
+    /// e.g., CREATE TABLE, primary key.
+    pub fn pre_data_sync(&self) -> Result<Vec<&str>, Error> {
+        let mut result = vec![];
+
+        for stmt in &self.stmts.stmts {
+            let (_, original_start) = self
+                .original
+                .split_at_checked(stmt.stmt_location as usize)
+                .ok_or(Error::StmtOutOfBounds)?;
+            let (original, _) = original_start
+                .split_at_checked(stmt.stmt_len as usize)
+                .ok_or(Error::StmtOutOfBounds)?;
+
+            if let Some(ref node) = stmt.stmt {
+                if let Some(ref node) = node.node {
+                    match node {
+                        NodeEnum::CreateStmt(_) => {
+                            // CREATE TABLE is always good.
+                            result.push(original);
+                        }
+
+                        NodeEnum::AlterTableStmt(stmt) => {
+                            for cmd in &stmt.cmds {
+                                if let Some(ref node) = cmd.node {
+                                    if let NodeEnum::AlterTableCmd(cmd) = node {
+                                        if let Some(ref def) = cmd.def {
+                                            if let Some(ref node) = def.node {
+                                                // Only allow primary key constraints.
+                                                if let NodeEnum::Constraint(cons) = node {
+                                                    if cons.contype() == ConstrType::ConstrPrimary {
+                                                        result.push(original);
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        NodeEnum::IndexStmt(_) => {
+                            continue;
+                        }
+
+                        _ => (),
+                    }
+                }
+            }
+        }
+
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::backend::server::test::test_server;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_pg_dump_execute() {
+        let mut server = test_server().await;
+
+        let queries = vec![
+            "DROP PUBLICATION IF EXISTS test_pg_dump_execute",
+            "CREATE TABLE IF NOT EXISTS test_pg_dump_execute(id BIGINT PRIMARY KEY, email VARCHAR UNIQUE, created_at TIMESTAMPTZ)",
+            "CREATE INDEX ON test_pg_dump_execute USING btree(created_at)",
+            "CREATE TABLE IF NOT EXISTS test_pg_dump_execute_fk(fk BIGINT NOT NULL REFERENCES test_pg_dump_execute(id), meta JSONB)",
+            "CREATE PUBLICATION test_pg_dump_execute FOR TABLE test_pg_dump_execute, test_pg_dump_execute_fk"
+        ];
+
+        for query in queries {
+            server.execute(query).await.unwrap();
+        }
+
+        let output = PgDumpCommand {
+            table: "test_pg_dump_execute".into(),
+            schema: "pgdog".into(),
+            address: server.addr().clone(),
+        }
+        .execute()
+        .await
+        .unwrap();
+
+        let output = output.pre_data_sync().unwrap();
+
+        let mut dest = test_server().await;
+        dest.execute("DROP SCHEMA IF EXISTS test_pg_dump_execute_dest CASCADE")
+            .await
+            .unwrap();
+
+        dest.execute("CREATE SCHEMA test_pg_dump_execute_dest")
+            .await
+            .unwrap();
+        dest.execute("SET search_path TO test_pg_dump_execute_dest, public")
+            .await
+            .unwrap();
+
+        for stmt in output {
+            // Hack around us using the same database as destination.
+            // I know, not very elegant.
+            let stmt = stmt.replace("pgdog.", "test_pg_dump_execute_dest.");
+            dest.execute(stmt).await.unwrap();
+        }
+
+        dest.execute("SELECT * FROM test_pg_dump_execute_dest.test_pg_dump_execute")
+            .await
+            .unwrap();
+        dest.execute("DROP SCHEMA test_pg_dump_execute_dest CASCADE")
+            .await
+            .unwrap();
+
+        server
+            .execute("DROP TABLE test_pg_dump_execute CASCADE")
+            .await
+            .unwrap();
+    }
+}

--- a/pgdog/src/cli.rs
+++ b/pgdog/src/cli.rs
@@ -6,6 +6,7 @@ use thiserror::Error;
 use tokio::{select, signal::ctrl_c};
 use tracing::error;
 
+use crate::backend::schema::sync::pg_dump::PgDump;
 use crate::backend::{databases::databases, replication::logical::Publisher};
 use crate::config::{Config, Users};
 
@@ -85,6 +86,30 @@ pub enum Commands {
         /// Replicate or copy data over.
         #[arg(long, default_value = "false")]
         replicate: bool,
+    },
+
+    /// Schema synchronization between source and destination clusters.
+    SchemaSync {
+        /// Source database name.
+        #[arg(long)]
+        from_database: String,
+        /// Source user name.
+        #[arg(long)]
+        from_user: String,
+        /// Publication name.
+        #[arg(long)]
+        publication: String,
+
+        /// Destination database.
+        #[arg(long)]
+        to_database: String,
+        /// Destination user name.
+        #[arg(long)]
+        to_user: String,
+
+        /// Dry run. Print schema commands, don't actually execute them.
+        #[arg(long)]
+        dry_run: bool,
     },
 }
 
@@ -205,6 +230,40 @@ pub async fn data_sync(commands: Commands) -> Result<(), Box<dyn std::error::Err
 
             _ = ctrl_c() => (),
 
+        }
+    }
+
+    Ok(())
+}
+
+pub async fn schema_sync(commands: Commands) -> Result<(), Box<dyn std::error::Error>> {
+    let (source, _destination, publication, dry_run) = if let Commands::SchemaSync {
+        from_database,
+        from_user,
+        to_database,
+        to_user,
+        publication,
+        dry_run,
+    } = commands
+    {
+        let source = databases().cluster((from_user.as_str(), from_database.as_str()))?;
+        let dest = databases().cluster((to_user.as_str(), to_database.as_str()))?;
+
+        (source, dest, publication, dry_run)
+    } else {
+        return Ok(());
+    };
+
+    let dump = PgDump::new(&source, &publication);
+    let output = dump.dump().await?;
+
+    for output in output {
+        let queries = output.pre_data_sync()?;
+
+        if dry_run {
+            for query in queries {
+                println!("{}", query);
+            }
         }
     }
 

--- a/pgdog/src/config/mod.rs
+++ b/pgdog/src/config/mod.rs
@@ -186,20 +186,29 @@ pub struct Config {
     #[serde(default)]
     pub admin: Admin,
 
+    /// List of sharded tables.
     #[serde(default)]
     pub sharded_tables: Vec<ShardedTable>,
 
+    /// Queries routed manually to a single shard.
     #[serde(default)]
     pub manual_queries: Vec<ManualQuery>,
 
+    /// List of omnisharded tables.
     #[serde(default)]
     pub omnisharded_tables: Vec<OmnishardedTables>,
 
+    /// Explicit sharding key mappings.
     #[serde(default)]
     pub sharded_mappings: Vec<ShardedMapping>,
 
+    /// Replica lag configuration.
     #[serde(default, deserialize_with = "ReplicaLag::deserialize_optional")]
     pub replica_lag: Option<ReplicaLag>,
+
+    /// Replication config.
+    #[serde(default)]
+    pub replication: Replication,
 }
 
 impl Config {
@@ -1277,8 +1286,28 @@ impl Default for ReplicaLag {
     }
 }
 
-//--------------------------------------------------------------------------------------------------
-//----- Testing ------------------------------------------------------------------------------------
+/// Replication configuration.
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+#[serde(rename_all = "snake_case")]
+pub struct Replication {
+    /// Path to the pg_dump executable.
+    #[serde(default = "Replication::pg_dump_path")]
+    pub pg_dump_path: PathBuf,
+}
+
+impl Replication {
+    fn pg_dump_path() -> PathBuf {
+        PathBuf::from("pg_dump")
+    }
+}
+
+impl Default for Replication {
+    fn default() -> Self {
+        Self {
+            pg_dump_path: Self::pg_dump_path(),
+        }
+    }
+}
 
 #[cfg(test)]
 pub mod test {

--- a/pgdog/src/lib.rs
+++ b/pgdog/src/lib.rs
@@ -26,6 +26,7 @@ use std::io::IsTerminal;
 pub fn logger() {
     let format = fmt::layer()
         .with_ansi(std::io::stderr().is_terminal())
+        .with_writer(std::io::stderr)
         .with_file(false);
     #[cfg(not(debug_assertions))]
     let format = format.with_target(false);

--- a/pgdog/src/main.rs
+++ b/pgdog/src/main.rs
@@ -133,6 +133,11 @@ async fn pgdog(command: Option<Commands>) -> Result<(), Box<dyn std::error::Erro
                 info!("🔄 entering data sync mode");
                 cli::data_sync(command.clone()).await?;
             }
+
+            if let Commands::SchemaSync { .. } = command {
+                info!("🔄 entering schema sync mode");
+                cli::schema_sync(command.clone()).await?;
+            }
         }
     }
 


### PR DESCRIPTION
### Description

Sync schema between source and destination clusters. Uses shard 0 of the source cluster as schema source. Only the following objects are synced:

- Table columns and data types
- Primary key constraint
- Sequences

What's ignored (for now):

- Foreign keys
- Unique indexes

This is on purpose, as to accelerate data sync. Those objects will be added after sync is complete.

Continuation of #279.