### PR TITLE
Disable prepared statements in session mode

### DIFF
--- a/pgdog/CLAUDE.md
+++ b/pgdog/CLAUDE.md
@@ -13,3 +13,7 @@ Use standard Rust code style. Use `cargo fmt` to reformat code automatically aft
 
 - Prefer to run individual tests with `cargo nextest run <name of the test here>`. This is much faster.
 - A local PostgreSQL server is required for some tests to pass. Set it up and create a database called "pgdog". Create a user called "pgdog" with password "pgdog".
+
+# About the project
+
+PgDog is a connection pooler for Postgres that can shard databases. It implements the Postgres network protocol and uses pg_query to parse SQL queries. It aims to be 100% compatible with Postgres, without clients knowing they are talking to a proxy.

--- a/pgdog/src/config/mod.rs
+++ b/pgdog/src/config/mod.rs
@@ -149,7 +149,12 @@ impl ConfigAndUsers {
 
     /// Prepared statements are enabled.
     pub fn prepared_statements(&self) -> bool {
-        self.config.general.prepared_statements.enabled()
+        // Disable prepared statements automatically in session mode
+        if self.config.general.pooler_mode == PoolerMode::Session {
+            false
+        } else {
+            self.config.general.prepared_statements.enabled()
+        }
     }
 
     pub fn pub_sub_enabled(&self) -> bool {
@@ -1407,6 +1412,40 @@ column = "tenant_id"
         assert_eq!(config.tcp.time().unwrap(), Duration::from_millis(1000));
         assert_eq!(config.tcp.retries().unwrap(), 5);
         assert_eq!(config.multi_tenant.unwrap().column, "tenant_id");
+    }
+
+    #[test]
+    fn test_prepared_statements_disabled_in_session_mode() {
+        let mut config = ConfigAndUsers::default();
+
+        // Test transaction mode (default) - prepared statements should be enabled
+        config.config.general.pooler_mode = PoolerMode::Transaction;
+        config.config.general.prepared_statements = PreparedStatements::Extended;
+        assert!(
+            config.prepared_statements(),
+            "Prepared statements should be enabled in transaction mode"
+        );
+
+        // Test session mode - prepared statements should be disabled
+        config.config.general.pooler_mode = PoolerMode::Session;
+        config.config.general.prepared_statements = PreparedStatements::Extended;
+        assert!(
+            !config.prepared_statements(),
+            "Prepared statements should be disabled in session mode"
+        );
+
+        // Test session mode with full prepared statements - should still be disabled
+        config.config.general.pooler_mode = PoolerMode::Session;
+        config.config.general.prepared_statements = PreparedStatements::Full;
+        assert!(
+            !config.prepared_statements(),
+            "Prepared statements should be disabled in session mode even when set to Full"
+        );
+
+        // Test transaction mode with disabled prepared statements - should remain disabled
+        config.config.general.pooler_mode = PoolerMode::Transaction;
+        config.config.general.prepared_statements = PreparedStatements::Disabled;
+        assert!(!config.prepared_statements(), "Prepared statements should remain disabled when explicitly set to Disabled in transaction mode");
     }
 }
 

--- a/pgdog/src/config/mod.rs
+++ b/pgdog/src/config/mod.rs
@@ -157,6 +157,11 @@ impl ConfigAndUsers {
         }
     }
 
+    /// Prepared statements are in "full" mode (used for query parser decision).
+    pub fn prepared_statements_full(&self) -> bool {
+        self.config.general.prepared_statements.full()
+    }
+
     pub fn pub_sub_enabled(&self) -> bool {
         self.config.general.pub_sub_channel_size > 0
     }
@@ -396,7 +401,7 @@ pub struct General {
     pub openmetrics_namespace: Option<String>,
     /// Prepared statatements support.
     #[serde(default)]
-    pub prepared_statements: PreparedStatements,
+    prepared_statements: PreparedStatements,
     /// Limit on the number of prepared statements in the server cache.
     #[serde(default = "General::prepared_statements_limit")]
     pub prepared_statements_limit: usize,

--- a/pgdog/src/frontend/router/parser/context.rs
+++ b/pgdog/src/frontend/router/parser/context.rs
@@ -49,7 +49,7 @@ impl<'a> QueryParserContext<'a> {
             shards: router_context.cluster.shards().len(),
             sharding_schema: router_context.cluster.sharding_schema(),
             rw_strategy: router_context.cluster.read_write_strategy(),
-            full_prepared_statements: config.config.general.prepared_statements.full(),
+            full_prepared_statements: config.prepared_statements_full(),
             router_needed: router_context.cluster.router_needed(),
             pub_sub_enabled: config.config.general.pub_sub_enabled(),
             multi_tenant: router_context.cluster.multi_tenant(),


### PR DESCRIPTION
### Description

Disable prepared statements globally if pooler mode is set to session _globally_. We don't have a prepared statements configuration on a user/database level. (TODO: probably should add it) #295 