### PR TITLE
Run SHOW commands on a single shard (round robin)

### DIFF
--- a/integration/pgdog.toml
+++ b/integration/pgdog.toml
@@ -14,6 +14,7 @@ prepared_statements_limit = 500
 # dns_ttl = 15_000
 query_cache_limit = 500
 pub_sub_channel_size = 4098
+cross_shard_disabled = true
 
 # ------------------------------------------------------------------------------
 # ----- Database :: pgdog ------------------------------------------------------

--- a/integration/pgdog.toml
+++ b/integration/pgdog.toml
@@ -14,7 +14,6 @@ prepared_statements_limit = 500
 # dns_ttl = 15_000
 query_cache_limit = 500
 pub_sub_channel_size = 4098
-cross_shard_disabled = true
 
 # ------------------------------------------------------------------------------
 # ----- Database :: pgdog ------------------------------------------------------

--- a/pgdog/src/frontend/router/parser/query/mod.rs
+++ b/pgdog/src/frontend/router/parser/query/mod.rs
@@ -320,9 +320,12 @@ impl QueryParser {
     ) -> Result<Command, Error> {
         match stmt.name.as_str() {
             "pgdog.shards" => Ok(Command::Shards(context.shards)),
-            _ => Ok(Command::Query(
-                Route::write(Shard::All).set_read(context.read_only),
-            )),
+            _ => {
+                let shard = Shard::Direct(round_robin::next() % context.shards);
+                let route = Route::write(shard).set_read(context.read_only);
+                let command = Command::Query(route);
+                Ok(command)
+            }
         }
     }
 
@@ -352,3 +355,42 @@ impl QueryParser {
 
 #[cfg(test)]
 mod test;
+
+#[cfg(test)]
+mod test_show {
+    use crate::backend::Cluster;
+    use crate::frontend::router::parser::Shard;
+    use crate::frontend::router::QueryParser;
+    use crate::frontend::{Buffer, PreparedStatements, RouterContext};
+    use crate::net::messages::Query;
+    use crate::net::Parameters;
+
+    #[test]
+    fn show_runs_on_a_direct_shard_round_robin() {
+        let mut ps = PreparedStatements::default();
+        let c = Cluster::new_test();
+        let p = Parameters::default();
+        let mut parser = QueryParser::default();
+
+        // First call
+        let query = "SHOW TRANSACTION ISOLATION LEVEL";
+        let buffer = Buffer::from(vec![Query::new(query).into()]);
+        let context = RouterContext::new(&buffer, &c, &mut ps, &p, false).unwrap();
+
+        let first = parser.parse(context).unwrap().clone();
+        let first_shard = first.route().shard();
+        assert!(matches!(first_shard, Shard::Direct(_)));
+
+        // Second call
+        let query = "SHOW TRANSACTION ISOLATION LEVEL";
+        let buffer = Buffer::from(vec![Query::new(query).into()]);
+        let context = RouterContext::new(&buffer, &c, &mut ps, &p, false).unwrap();
+
+        let second = parser.parse(context).unwrap().clone();
+        let second_shard = second.route().shard();
+        assert!(matches!(second_shard, Shard::Direct(_)));
+
+        // Round robin shard routing
+        assert!(second_shard != first_shard);
+    }
+}

--- a/pgdog/src/frontend/router/parser/query/mod.rs
+++ b/pgdog/src/frontend/router/parser/query/mod.rs
@@ -323,8 +323,7 @@ impl QueryParser {
             _ => {
                 let shard = Shard::Direct(round_robin::next() % context.shards);
                 let route = Route::write(shard).set_read(context.read_only);
-                let command = Command::Query(route);
-                Ok(command)
+                Ok(Command::Query(route))
             }
         }
     }


### PR DESCRIPTION
# Changes
- SHOW commands no longer run on Shard::All 
# Tests
- I ran it locally with config set to `cross_shard_disabled = true` and 👍 .
- I added a test that show commands run on a single shard.
- My initial gut of was writing a test with the config overriden, but because Config is a singleton, feel like it would have made the tests brittle.
```rust
let mut cfg = ConfigAndUsers::default();
cfg.config.general.cross_shard_disabled = true;
config::set(cfg).expect("Failed to set config");
```
Addresses #328 by making show commands not execute on every shard.