### PR TITLE
Deteremine transaction type based on query. `BEGIN` vs `BEGIN READ ONLY`

### DIFF
--- a/pgdog/src/backend/pool/connection/mirror.rs
+++ b/pgdog/src/backend/pool/connection/mirror.rs
@@ -135,7 +135,7 @@ impl Mirror {
                     &self.cluster,
                     &mut self.prepared_statements,
                     &self.params,
-                    false,
+                    None,
                 ) {
                     match self.router.query(context) {
                         Ok(command) => {

--- a/pgdog/src/frontend/client/query_engine/connect.rs
+++ b/pgdog/src/frontend/client/query_engine/connect.rs
@@ -59,7 +59,7 @@ impl QueryEngine {
                     error!("{} [{:?}]", err, context.stream.peer_addr());
                     let bytes_sent = context
                         .stream
-                        .error(ErrorResponse::from_err(&err), context.in_transaction)
+                        .error(ErrorResponse::from_err(&err), context.in_transaction())
                         .await?;
                     self.stats.sent(bytes_sent);
                     self.backend.disconnect();

--- a/pgdog/src/frontend/client/query_engine/context.rs
+++ b/pgdog/src/frontend/client/query_engine/context.rs
@@ -1,5 +1,8 @@
 use crate::{
-    frontend::{client::timeouts::Timeouts, Buffer, Client, PreparedStatements},
+    frontend::{
+        client::{timeouts::Timeouts, TransactionType},
+        Buffer, Client, PreparedStatements,
+    },
     net::{Parameters, Stream},
     stats::memory::MemoryUsage,
 };
@@ -15,7 +18,7 @@ pub struct QueryEngineContext<'a> {
     /// Client's socket to send responses to.
     pub(super) stream: &'a mut Stream,
     /// Client in transaction?
-    pub(super) in_transaction: bool,
+    pub(super) transaction: Option<TransactionType>,
     /// Timeouts
     pub(super) timeouts: Timeouts,
     /// Cross shard  queries are disabled.
@@ -33,14 +36,18 @@ impl<'a> QueryEngineContext<'a> {
             params: &mut client.params,
             buffer: &mut client.request_buffer,
             stream: &mut client.stream,
-            in_transaction: client.in_transaction,
+            transaction: client.transaction,
             timeouts: client.timeouts,
             cross_shard_disabled: client.cross_shard_disabled,
             memory_usage,
         }
     }
 
+    pub fn transaction(&self) -> Option<TransactionType> {
+        self.transaction
+    }
+
     pub fn in_transaction(&self) -> bool {
-        self.in_transaction
+        self.transaction.is_some()
     }
 }

--- a/pgdog/src/frontend/client/query_engine/end_transaction.rs
+++ b/pgdog/src/frontend/client/query_engine/end_transaction.rs
@@ -13,7 +13,7 @@ impl QueryEngine {
         } else {
             CommandComplete::new_commit()
         };
-        let mut messages = if !context.in_transaction {
+        let mut messages = if !context.in_transaction() {
             vec![NoticeResponse::from(ErrorResponse::no_transaction()).message()?]
         } else {
             vec![]

--- a/pgdog/src/frontend/client/query_engine/incomplete_requests.rs
+++ b/pgdog/src/frontend/client/query_engine/incomplete_requests.rs
@@ -36,7 +36,7 @@ impl QueryEngine {
                     if only_close || only_sync && !self.backend.connected() {
                         bytes_sent += context
                             .stream
-                            .send(&ReadyForQuery::in_transaction(context.in_transaction))
+                            .send(&ReadyForQuery::in_transaction(context.in_transaction()))
                             .await?;
                     }
                 }

--- a/pgdog/src/frontend/client/query_engine/mod.rs
+++ b/pgdog/src/frontend/client/query_engine/mod.rs
@@ -164,7 +164,7 @@ impl<'a> QueryEngine {
             command => self.unknown_command(context, command.clone()).await?,
         }
 
-        if !context.in_transaction {
+        if !context.in_transaction() {
             self.backend.mirror_flush();
         }
 
@@ -177,7 +177,7 @@ impl<'a> QueryEngine {
         let state = if self.backend.has_more_messages() {
             State::Active
         } else {
-            match context.in_transaction {
+            match context.in_transaction() {
                 true => State::IdleInTransaction,
                 false => State::Idle,
             }

--- a/pgdog/src/frontend/client/query_engine/query.rs
+++ b/pgdog/src/frontend/client/query_engine/query.rs
@@ -94,10 +94,14 @@ impl QueryEngine {
             // if they sent a BEGIN statement to us already.
             // 2. We're sending non-data fetching statements to the server without starting a transacation, e.g. Parse, Describe, Sync.
             // 3. We're confusing the hell out of pretty much anyone reading this. I wrote the damn thing and I'm still confused.
-            context.in_transaction = message.in_transaction() || self.begin_stmt.is_some();
-            self.stats.idle(context.in_transaction);
+            let in_transaction = message.in_transaction() || self.begin_stmt.is_some();
+            if !in_transaction {
+                context.transaction = None;
+            }
 
-            if !context.in_transaction {
+            self.stats.idle(context.in_transaction());
+
+            if !context.in_transaction() {
                 self.stats.transaction();
             }
         }

--- a/pgdog/src/frontend/client/query_engine/route_query.rs
+++ b/pgdog/src/frontend/client/query_engine/route_query.rs
@@ -25,7 +25,7 @@ impl QueryEngine {
             cluster,
             context.prepared_statements,
             context.params,
-            context.in_transaction,
+            context.transaction,
         )?;
         match self.router.query(router_context) {
             Ok(cmd) => {
@@ -36,7 +36,7 @@ impl QueryEngine {
                     let mut bytes_sent = context.stream.send(&EmptyQueryResponse).await?;
                     bytes_sent += context
                         .stream
-                        .send_flush(&ReadyForQuery::in_transaction(context.in_transaction))
+                        .send_flush(&ReadyForQuery::in_transaction(context.in_transaction()))
                         .await?;
                     self.stats.sent(bytes_sent);
                 } else {
@@ -45,7 +45,7 @@ impl QueryEngine {
                         .stream
                         .error(
                             ErrorResponse::syntax(err.to_string().as_str()),
-                            context.in_transaction,
+                            context.in_transaction(),
                         )
                         .await?;
                     self.stats.sent(bytes_sent);

--- a/pgdog/src/frontend/client/query_engine/set.rs
+++ b/pgdog/src/frontend/client/query_engine/set.rs
@@ -16,7 +16,7 @@ impl QueryEngine {
             .stream
             .send_many(&vec![
                 CommandComplete::from_str("SET").message()?,
-                ReadyForQuery::in_transaction(context.in_transaction).message()?,
+                ReadyForQuery::in_transaction(context.in_transaction()).message()?,
             ])
             .await?;
 

--- a/pgdog/src/frontend/client/query_engine/show_shards.rs
+++ b/pgdog/src/frontend/client/query_engine/show_shards.rs
@@ -15,7 +15,7 @@ impl QueryEngine {
                 RowDescription::new(&[Field::bigint("shards")]).message()?,
                 DataRow::from_columns(vec![shards]).message()?,
                 CommandComplete::from_str("SHOW").message()?,
-                ReadyForQuery::in_transaction(context.in_transaction).message()?,
+                ReadyForQuery::in_transaction(context.in_transaction()).message()?,
             ])
             .await?;
 

--- a/pgdog/src/frontend/client/query_engine/start_transaction.rs
+++ b/pgdog/src/frontend/client/query_engine/start_transaction.rs
@@ -1,4 +1,9 @@
-use crate::net::{CommandComplete, Protocol, ReadyForQuery};
+use pg_query::protobuf::{a_const, node, Node, TransactionStmtKind};
+
+use crate::{
+    frontend::client::TransactionType,
+    net::{CommandComplete, Protocol, ReadyForQuery},
+};
 
 use super::*;
 
@@ -9,20 +14,152 @@ impl QueryEngine {
         context: &mut QueryEngineContext<'_>,
         begin: BufferedQuery,
     ) -> Result<(), Error> {
-        context.in_transaction = true;
+        context.transaction = detect_transaction_type(&begin);
 
         let bytes_sent = context
             .stream
             .send_many(&[
                 CommandComplete::new_begin().message()?.backend(),
-                ReadyForQuery::in_transaction(context.in_transaction).message()?,
+                ReadyForQuery::in_transaction(context.in_transaction()).message()?,
             ])
             .await?;
 
         self.stats.sent(bytes_sent);
         self.begin_stmt = Some(begin);
-        debug!("transaction started");
 
         Ok(())
+    }
+}
+
+#[inline]
+pub fn detect_transaction_type(buffered_query: &BufferedQuery) -> Option<TransactionType> {
+    let simple_query = match buffered_query {
+        BufferedQuery::Query(q) => q,
+        _ => return None,
+    };
+
+    let parsed = pg_query::parse(simple_query.query()).ok()?;
+    for raw_stmt in parsed.protobuf.stmts {
+        let node_enum = raw_stmt.stmt?.node?;
+        if let node::Node::TransactionStmt(txn) = node_enum {
+            if is_txn_begin_kind(txn.kind) {
+                return match read_only_flag(&txn.options) {
+                    Some(true) => Some(TransactionType::ReadOnly),
+                    Some(false) => Some(TransactionType::ReadWrite),
+                    None => Some(TransactionType::ReadWrite),
+                };
+            }
+        }
+    }
+
+    None
+}
+
+#[inline]
+fn is_txn_begin_kind(kind_i32: i32) -> bool {
+    let k = kind_i32;
+
+    let is_begin = k == TransactionStmtKind::TransStmtBegin as i32;
+    let is_start = k == TransactionStmtKind::TransStmtStart as i32;
+
+    is_begin || is_start
+}
+
+#[inline]
+fn read_only_flag(options: &[Node]) -> Option<bool> {
+    for option_node in options {
+        let node_enum = option_node.node.as_ref()?;
+        if let node::Node::DefElem(def_elem) = node_enum {
+            if def_elem.defname == "transaction_read_only" {
+                let arg_node = def_elem.arg.as_ref()?.node.as_ref()?;
+                if let node::Node::AConst(ac) = arg_node {
+                    // 1 => read-only, 0 => read-write
+                    if let Some(a_const::Val::Ival(i)) = ac.val.as_ref() {
+                        return Some(i.ival != 0);
+                    }
+                }
+            }
+        }
+    }
+
+    None
+}
+
+#[test]
+fn test_detect_transaction_type() {
+    use super::*;
+
+    use crate::frontend::client::TransactionType;
+    use crate::net::Query;
+
+    // Helper to create BufferedQuery::Query
+    fn query(q: &str) -> BufferedQuery {
+        BufferedQuery::Query(Query::new(q))
+    }
+
+    let none_queries = vec![
+        "COMMIT",
+        "ROLLBACK",
+        "SET TRANSACTION READ ONLY",
+        "SELECT 1",
+        "INSERT INTO table VALUES (1)",
+        "BEGINS",
+        "START", // not START TRANSACTION
+        "BEGIN INVALID OPTION",
+        "",
+        "INVALID",
+    ];
+
+    let read_write_queries = vec![
+        "BEGIN",
+        "BEGIN;",
+        "begin",
+        "bEgIn",
+        "BEGIN WORK",
+        "BEGIN TRANSACTION",
+        "BEGIN READ WRITE",
+        "BEGIN WORK READ WRITE",
+        "BEGIN TRANSACTION READ WRITE",
+        "START TRANSACTION",
+        "START TRANSACTION;",
+        "start transaction",
+        "START TRANSACTION READ WRITE",
+        "BEGIN ISOLATION LEVEL REPEATABLE READ READ WRITE DEFERRABLE",
+    ];
+
+    let read_only_queries = vec![
+        "BEGIN READ ONLY",
+        "BEGIN WORK READ ONLY",
+        "BEGIN TRANSACTION READ ONLY",
+        "START TRANSACTION READ ONLY",
+        "BEGIN ISOLATION LEVEL SERIALIZABLE READ ONLY",
+        "START TRANSACTION ISOLATION LEVEL READ COMMITTED READ ONLY NOT DEFERRABLE",
+    ];
+
+    for q in none_queries {
+        assert_eq!(
+            detect_transaction_type(&query(q)),
+            None,
+            "Failed for query: {}",
+            q
+        );
+    }
+
+    for q in read_write_queries {
+        assert_eq!(
+            detect_transaction_type(&query(q)),
+            Some(TransactionType::ReadWrite),
+            "Failed for query: {}",
+            q
+        );
+    }
+
+    for q in read_only_queries {
+        assert_eq!(
+            detect_transaction_type(&query(q)),
+            Some(TransactionType::ReadOnly),
+            "Failed for query: {}",
+            q
+        );
     }
 }

--- a/pgdog/src/frontend/client/query_engine/unknown_command.rs
+++ b/pgdog/src/frontend/client/query_engine/unknown_command.rs
@@ -10,7 +10,7 @@ impl QueryEngine {
             .stream
             .error(
                 ErrorResponse::syntax(&format!("unknown command: {:?}", command)),
-                context.in_transaction,
+                context.in_transaction(),
             )
             .await?;
 

--- a/pgdog/src/frontend/client/test/mod.rs
+++ b/pgdog/src/frontend/client/test/mod.rs
@@ -127,7 +127,7 @@ async fn test_test_client() {
     assert_eq!(client.request_buffer.total_message_len(), query.len());
 
     client.client_messages(&mut engine).await.unwrap();
-    assert!(!client.in_transaction);
+    assert!(client.transaction.is_none());
     assert_eq!(engine.stats().state, State::Active);
     // Buffer not cleared yet.
     assert_eq!(client.request_buffer.total_message_len(), query.len());
@@ -449,7 +449,7 @@ async fn test_transaction_state() {
     client.client_messages(&mut engine).await.unwrap();
     read!(conn, ['C', 'Z']);
 
-    assert!(client.in_transaction);
+    assert!(client.transaction.is_some());
     assert!(engine.router().route().is_write());
     assert!(engine.router().in_transaction());
 
@@ -465,7 +465,7 @@ async fn test_transaction_state() {
     client.client_messages(&mut engine).await.unwrap();
 
     assert!(engine.router().routed());
-    assert!(client.in_transaction);
+    assert!(client.transaction.is_some());
     assert!(engine.router().route().is_write());
     assert!(engine.router().in_transaction());
 
@@ -509,7 +509,7 @@ async fn test_transaction_state() {
     read!(conn, ['2', 'D', 'C', 'Z']);
 
     assert!(engine.router().routed());
-    assert!(client.in_transaction);
+    assert!(client.transaction.is_some());
     assert!(engine.router().route().is_write());
     assert!(engine.router().in_transaction());
 
@@ -529,7 +529,7 @@ async fn test_transaction_state() {
 
     read!(conn, ['C', 'Z']);
 
-    assert!(!client.in_transaction);
+    assert!(client.transaction.is_none());
     assert!(!engine.router().routed());
 }
 

--- a/pgdog/src/frontend/router/context.rs
+++ b/pgdog/src/frontend/router/context.rs
@@ -1,7 +1,7 @@
 use super::Error;
 use crate::{
     backend::Cluster,
-    frontend::{buffer::BufferedQuery, Buffer, PreparedStatements},
+    frontend::{buffer::BufferedQuery, client::TransactionType, Buffer, PreparedStatements},
     net::{Bind, Parameters},
 };
 
@@ -18,7 +18,7 @@ pub struct RouterContext<'a> {
     /// Client parameters, e.g. search_path.
     pub params: &'a Parameters,
     /// Client inside transaction,
-    pub in_transaction: bool,
+    pub transaction: Option<TransactionType>,
     /// Currently executing COPY statement.
     pub copy_mode: bool,
     /// Do we have an executable buffer?
@@ -31,7 +31,7 @@ impl<'a> RouterContext<'a> {
         cluster: &'a Cluster,
         stmt: &'a mut PreparedStatements,
         params: &'a Parameters,
-        in_transaction: bool,
+        transaction: Option<TransactionType>,
     ) -> Result<Self, Error> {
         let query = buffer.query()?;
         let bind = buffer.parameters()?;
@@ -43,9 +43,13 @@ impl<'a> RouterContext<'a> {
             params,
             prepared_statements: stmt,
             cluster,
-            in_transaction,
+            transaction,
             copy_mode,
             executable: buffer.executable(),
         })
+    }
+
+    pub fn in_transaction(&self) -> bool {
+        self.transaction.is_some()
     }
 }

--- a/pgdog/src/frontend/router/parser/context.rs
+++ b/pgdog/src/frontend/router/parser/context.rs
@@ -63,7 +63,7 @@ impl<'a> QueryParserContext<'a> {
 
     /// Write override enabled?
     pub(super) fn write_override(&self) -> bool {
-        self.router_context.in_transaction && self.rw_conservative()
+        self.router_context.in_transaction() && self.rw_conservative()
     }
 
     /// Are we using the conservative read/write separation strategy?
@@ -103,7 +103,7 @@ impl<'a> QueryParserContext<'a> {
             shards: self.shards as u64,
             has_replicas: if self.read_only { 0 } else { 1 },
             has_primary: if self.write_only { 0 } else { 1 },
-            in_transaction: if self.router_context.in_transaction {
+            in_transaction: if self.router_context.in_transaction() {
                 1
             } else {
                 0

--- a/pgdog/src/frontend/router/parser/query/explain.rs
+++ b/pgdog/src/frontend/router/parser/query/explain.rs
@@ -40,7 +40,7 @@ mod tests {
         let mut stmts = PreparedStatements::default();
         let params = Parameters::default();
 
-        let ctx = RouterContext::new(&buffer, &cluster, &mut stmts, &params, false).unwrap();
+        let ctx = RouterContext::new(&buffer, &cluster, &mut stmts, &params, None).unwrap();
 
         match QueryParser::default().parse(ctx).unwrap().clone() {
             Command::Query(route) => route,
@@ -66,7 +66,7 @@ mod tests {
         let mut stmts = PreparedStatements::default();
         let params = Parameters::default();
 
-        let ctx = RouterContext::new(&buffer, &cluster, &mut stmts, &params, false).unwrap();
+        let ctx = RouterContext::new(&buffer, &cluster, &mut stmts, &params, None).unwrap();
 
         match QueryParser::default().parse(ctx).unwrap().clone() {
             Command::Query(route) => route,

--- a/pgdog/src/frontend/router/parser/query/mod.rs
+++ b/pgdog/src/frontend/router/parser/query/mod.rs
@@ -86,7 +86,7 @@ impl QueryParser {
         let mut qp_context = QueryParserContext::new(context);
 
         let mut command = if qp_context.query().is_ok() {
-            self.in_transaction = qp_context.router_context.in_transaction;
+            self.in_transaction = qp_context.router_context.in_transaction();
             self.write_override = qp_context.write_override();
 
             self.query(&mut qp_context)?

--- a/pgdog/src/frontend/router/parser/query/show.rs
+++ b/pgdog/src/frontend/router/parser/query/show.rs
@@ -38,7 +38,7 @@ mod test_show {
         // First call
         let query = "SHOW TRANSACTION ISOLATION LEVEL";
         let buffer = Buffer::from(vec![Query::new(query).into()]);
-        let context = RouterContext::new(&buffer, &c, &mut ps, &p, false).unwrap();
+        let context = RouterContext::new(&buffer, &c, &mut ps, &p, None).unwrap();
 
         let first = parser.parse(context).unwrap().clone();
         let first_shard = first.route().shard();
@@ -47,7 +47,7 @@ mod test_show {
         // Second call
         let query = "SHOW TRANSACTION ISOLATION LEVEL";
         let buffer = Buffer::from(vec![Query::new(query).into()]);
-        let context = RouterContext::new(&buffer, &c, &mut ps, &p, false).unwrap();
+        let context = RouterContext::new(&buffer, &c, &mut ps, &p, None).unwrap();
 
         let second = parser.parse(context).unwrap().clone();
         let second_shard = second.route().shard();


### PR DESCRIPTION
## Changes

- Introduced `TransactionType` enum with `ReadOnly` and `ReadWrite` variants to classify transactions.
- Replaced `in_transaction` boolean with `transaction: Option<TransactionType>` in `Client` and `QueryEngineContext` structs for more precise state tracking.
- Updated transaction checks to infer state via `transaction.is_some()`, eliminating the need for a separate boolean.
- Added `detect_transaction_type` function in `begin.rs` to parse `BEGIN` queries (using `pg_query`) and detect options like `READ ONLY` or `READ WRITE`.
- Made minimal adjustments to tests and related code (e.g., in `execute.rs`, `parse.rs`) to maintain compatibility without breaking existing functionality.