### PR TITLE
Maintenance mode

### DIFF
--- a/pgdog/src/admin/maintenance_mode.rs
+++ b/pgdog/src/admin/maintenance_mode.rs
@@ -1,0 +1,38 @@
+//! Turn maintenance mode on/off.
+
+use crate::backend::maintenance_mode;
+
+use super::prelude::*;
+
+/// Turn maintenance mode on/off.
+#[derive(Default)]
+pub struct MaintenanceMode {
+    enable: bool,
+}
+
+#[async_trait]
+impl Command for MaintenanceMode {
+    fn parse(sql: &str) -> Result<Self, Error> {
+        let parts = sql.split(" ").collect::<Vec<_>>();
+
+        match parts[..] {
+            ["maintenance", "on"] => Ok(Self { enable: true }),
+            ["maintenance", "off"] => Ok(Self { enable: false }),
+            _ => Err(Error::Syntax),
+        }
+    }
+
+    async fn execute(&self) -> Result<Vec<Message>, Error> {
+        if self.enable {
+            maintenance_mode::start();
+        } else {
+            maintenance_mode::stop();
+        }
+
+        Ok(vec![])
+    }
+
+    fn name(&self) -> String {
+        format!("MAINTENANCE {}", if self.enable { "ON" } else { "OFF" })
+    }
+}

--- a/pgdog/src/admin/mod.rs
+++ b/pgdog/src/admin/mod.rs
@@ -7,6 +7,7 @@ use crate::net::messages::Message;
 pub mod backend;
 pub mod ban;
 pub mod error;
+pub mod maintenance_mode;
 pub mod named_row;
 pub mod parser;
 pub mod pause;

--- a/pgdog/src/admin/parser.rs
+++ b/pgdog/src/admin/parser.rs
@@ -1,12 +1,13 @@
 //! Admin command parser.
 
 use super::{
-    ban::Ban, pause::Pause, prelude::Message, probe::Probe, reconnect::Reconnect, reload::Reload,
-    reset_query_cache::ResetQueryCache, set::Set, setup_schema::SetupSchema,
-    show_clients::ShowClients, show_config::ShowConfig, show_lists::ShowLists,
-    show_peers::ShowPeers, show_pools::ShowPools, show_prepared_statements::ShowPreparedStatements,
-    show_query_cache::ShowQueryCache, show_servers::ShowServers, show_stats::ShowStats,
-    show_version::ShowVersion, shutdown::Shutdown, Command, Error,
+    ban::Ban, maintenance_mode::MaintenanceMode, pause::Pause, prelude::Message, probe::Probe,
+    reconnect::Reconnect, reload::Reload, reset_query_cache::ResetQueryCache, set::Set,
+    setup_schema::SetupSchema, show_clients::ShowClients, show_config::ShowConfig,
+    show_lists::ShowLists, show_peers::ShowPeers, show_pools::ShowPools,
+    show_prepared_statements::ShowPreparedStatements, show_query_cache::ShowQueryCache,
+    show_servers::ShowServers, show_stats::ShowStats, show_version::ShowVersion,
+    shutdown::Shutdown, Command, Error,
 };
 
 use tracing::debug;
@@ -32,6 +33,7 @@ pub enum ParseResult {
     Set(Set),
     Ban(Ban),
     Probe(Probe),
+    MaintenanceMode(MaintenanceMode),
 }
 
 impl ParseResult {
@@ -59,6 +61,7 @@ impl ParseResult {
             Set(set) => set.execute().await,
             Ban(ban) => ban.execute().await,
             Probe(probe) => probe.execute().await,
+            MaintenanceMode(maintenance_mode) => maintenance_mode.execute().await,
         }
     }
 
@@ -86,6 +89,7 @@ impl ParseResult {
             Set(set) => set.name(),
             Ban(ban) => ban.name(),
             Probe(probe) => probe.name(),
+            MaintenanceMode(maintenance_mode) => maintenance_mode.name(),
         }
     }
 }
@@ -136,6 +140,7 @@ impl Parser {
                 }
             },
             "probe" => ParseResult::Probe(Probe::parse(&sql)?),
+            "maintenance" => ParseResult::MaintenanceMode(MaintenanceMode::parse(&sql)?),
             // TODO: This is not ready yet. We have a race and
             // also the changed settings need to be propagated
             // into the pools.

--- a/pgdog/src/backend/maintenance_mode.rs
+++ b/pgdog/src/backend/maintenance_mode.rs
@@ -1,0 +1,38 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use once_cell::sync::Lazy;
+use tokio::sync::{futures::Notified, Notify};
+
+static MAINTENANCE_MODE: Lazy<MaintenanceMode> = Lazy::new(|| MaintenanceMode {
+    notify: Notify::new(),
+    on: AtomicBool::new(false),
+});
+
+pub(crate) fn waiter() -> Option<Notified<'static>> {
+    println!("mode: {}", MAINTENANCE_MODE.on.load(Ordering::Relaxed));
+    if !MAINTENANCE_MODE.on.load(Ordering::Relaxed) {
+        None
+    } else {
+        let notified = MAINTENANCE_MODE.notify.notified();
+        if !MAINTENANCE_MODE.on.load(Ordering::Relaxed) {
+            None
+        } else {
+            Some(notified)
+        }
+    }
+}
+
+pub fn start() {
+    MAINTENANCE_MODE.on.store(true, Ordering::Relaxed);
+}
+
+pub fn stop() {
+    MAINTENANCE_MODE.on.store(false, Ordering::Relaxed);
+    MAINTENANCE_MODE.notify.notify_waiters();
+}
+
+#[derive(Debug)]
+struct MaintenanceMode {
+    notify: Notify,
+    on: AtomicBool,
+}

--- a/pgdog/src/backend/mod.rs
+++ b/pgdog/src/backend/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod databases;
 pub mod error;
+pub mod maintenance_mode;
 pub mod pool;
 pub mod prepared_statements;
 pub mod protocol;

--- a/pgdog/src/backend/pool/connection/mod.rs
+++ b/pgdog/src/backend/pool/connection/mod.rs
@@ -399,6 +399,11 @@ impl Connection {
     pub(crate) fn session_mode(&self) -> bool {
         !self.transaction_mode()
     }
+
+    /// This is an admin DB connection.
+    pub fn is_admin(&self) -> bool {
+        matches!(self.binding, Binding::Admin(_))
+    }
 }
 
 impl Deref for Connection {

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -437,6 +437,10 @@ impl Client {
 
         Ok(BufferEvent::HaveRequest)
     }
+
+    pub fn in_transaction(&self) -> bool {
+        self.transaction.is_some()
+    }
 }
 
 impl Drop for Client {


### PR DESCRIPTION
### Description

- Add `MAINTENANCE` admin command that pauses all clients until turned off. This allows to perform config changes  between multiple instances of PgDog  with synchronization.