### PR TITLE
Fix transaction type overhead

### DIFF
--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -51,9 +51,10 @@ pub struct Client {
     passthrough_password: Option<String>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum TransactionType {
     ReadOnly,
+    #[default]
     ReadWrite,
 }
 

--- a/pgdog/src/frontend/client/query_engine/mod.rs
+++ b/pgdog/src/frontend/client/query_engine/mod.rs
@@ -132,8 +132,12 @@ impl<'a> QueryEngine {
 
         match command {
             Command::Shards(shards) => self.show_shards(context, *shards).await?,
-            Command::StartTransaction(begin) => {
-                self.start_transaction(context, begin.clone()).await?
+            Command::StartTransaction {
+                query,
+                transaction_type,
+            } => {
+                self.start_transaction(context, query.clone(), *transaction_type)
+                    .await?
             }
             Command::CommitTransaction => {
                 if self.backend.connected() {

--- a/pgdog/src/frontend/client/query_engine/start_transaction.rs
+++ b/pgdog/src/frontend/client/query_engine/start_transaction.rs
@@ -1,5 +1,3 @@
-use pg_query::protobuf::{a_const, node, Node, TransactionStmtKind};
-
 use crate::{
     frontend::client::TransactionType,
     net::{CommandComplete, Protocol, ReadyForQuery},
@@ -13,8 +11,9 @@ impl QueryEngine {
         &mut self,
         context: &mut QueryEngineContext<'_>,
         begin: BufferedQuery,
+        transaction_type: TransactionType,
     ) -> Result<(), Error> {
-        context.transaction = detect_transaction_type(&begin);
+        context.transaction = Some(transaction_type);
 
         let bytes_sent = context
             .stream
@@ -28,138 +27,5 @@ impl QueryEngine {
         self.begin_stmt = Some(begin);
 
         Ok(())
-    }
-}
-
-#[inline]
-pub fn detect_transaction_type(buffered_query: &BufferedQuery) -> Option<TransactionType> {
-    let simple_query = match buffered_query {
-        BufferedQuery::Query(q) => q,
-        _ => return None,
-    };
-
-    let parsed = pg_query::parse(simple_query.query()).ok()?;
-    for raw_stmt in parsed.protobuf.stmts {
-        let node_enum = raw_stmt.stmt?.node?;
-        if let node::Node::TransactionStmt(txn) = node_enum {
-            if is_txn_begin_kind(txn.kind) {
-                return match read_only_flag(&txn.options) {
-                    Some(true) => Some(TransactionType::ReadOnly),
-                    Some(false) => Some(TransactionType::ReadWrite),
-                    None => Some(TransactionType::ReadWrite),
-                };
-            }
-        }
-    }
-
-    None
-}
-
-#[inline]
-fn is_txn_begin_kind(kind_i32: i32) -> bool {
-    let k = kind_i32;
-
-    let is_begin = k == TransactionStmtKind::TransStmtBegin as i32;
-    let is_start = k == TransactionStmtKind::TransStmtStart as i32;
-
-    is_begin || is_start
-}
-
-#[inline]
-fn read_only_flag(options: &[Node]) -> Option<bool> {
-    for option_node in options {
-        let node_enum = option_node.node.as_ref()?;
-        if let node::Node::DefElem(def_elem) = node_enum {
-            if def_elem.defname == "transaction_read_only" {
-                let arg_node = def_elem.arg.as_ref()?.node.as_ref()?;
-                if let node::Node::AConst(ac) = arg_node {
-                    // 1 => read-only, 0 => read-write
-                    if let Some(a_const::Val::Ival(i)) = ac.val.as_ref() {
-                        return Some(i.ival != 0);
-                    }
-                }
-            }
-        }
-    }
-
-    None
-}
-
-#[test]
-fn test_detect_transaction_type() {
-    use super::*;
-
-    use crate::frontend::client::TransactionType;
-    use crate::net::Query;
-
-    // Helper to create BufferedQuery::Query
-    fn query(q: &str) -> BufferedQuery {
-        BufferedQuery::Query(Query::new(q))
-    }
-
-    let none_queries = vec![
-        "COMMIT",
-        "ROLLBACK",
-        "SET TRANSACTION READ ONLY",
-        "SELECT 1",
-        "INSERT INTO table VALUES (1)",
-        "BEGINS",
-        "START", // not START TRANSACTION
-        "BEGIN INVALID OPTION",
-        "",
-        "INVALID",
-    ];
-
-    let read_write_queries = vec![
-        "BEGIN",
-        "BEGIN;",
-        "begin",
-        "bEgIn",
-        "BEGIN WORK",
-        "BEGIN TRANSACTION",
-        "BEGIN READ WRITE",
-        "BEGIN WORK READ WRITE",
-        "BEGIN TRANSACTION READ WRITE",
-        "START TRANSACTION",
-        "START TRANSACTION;",
-        "start transaction",
-        "START TRANSACTION READ WRITE",
-        "BEGIN ISOLATION LEVEL REPEATABLE READ READ WRITE DEFERRABLE",
-    ];
-
-    let read_only_queries = vec![
-        "BEGIN READ ONLY",
-        "BEGIN WORK READ ONLY",
-        "BEGIN TRANSACTION READ ONLY",
-        "START TRANSACTION READ ONLY",
-        "BEGIN ISOLATION LEVEL SERIALIZABLE READ ONLY",
-        "START TRANSACTION ISOLATION LEVEL READ COMMITTED READ ONLY NOT DEFERRABLE",
-    ];
-
-    for q in none_queries {
-        assert_eq!(
-            detect_transaction_type(&query(q)),
-            None,
-            "Failed for query: {}",
-            q
-        );
-    }
-
-    for q in read_write_queries {
-        assert_eq!(
-            detect_transaction_type(&query(q)),
-            Some(TransactionType::ReadWrite),
-            "Failed for query: {}",
-            q
-        );
-    }
-
-    for q in read_only_queries {
-        assert_eq!(
-            detect_transaction_type(&query(q)),
-            Some(TransactionType::ReadOnly),
-            "Failed for query: {}",
-            q
-        );
     }
 }

--- a/pgdog/src/frontend/router/mod.rs
+++ b/pgdog/src/frontend/router/mod.rs
@@ -56,7 +56,7 @@ impl Router {
         }
 
         let command = self.query_parser.parse(context)?;
-        self.routed = !matches!(command, Command::StartTransaction(_));
+        self.routed = !matches!(command, Command::StartTransaction { .. });
         self.latest_command = command;
         Ok(&self.latest_command)
     }

--- a/pgdog/src/frontend/router/parser/command.rs
+++ b/pgdog/src/frontend/router/parser/command.rs
@@ -1,12 +1,18 @@
 use super::*;
-use crate::{frontend::BufferedQuery, net::parameter::ParameterValue};
+use crate::{
+    frontend::{client::TransactionType, BufferedQuery},
+    net::parameter::ParameterValue,
+};
 use lazy_static::lazy_static;
 
 #[derive(Debug, Clone)]
 pub enum Command {
     Query(Route),
     Copy(Box<CopyParser>),
-    StartTransaction(BufferedQuery),
+    StartTransaction {
+        query: BufferedQuery,
+        transaction_type: TransactionType,
+    },
     CommitTransaction,
     RollbackTransaction,
     ReplicationMeta,

--- a/pgdog/src/frontend/router/parser/query/test.rs
+++ b/pgdog/src/frontend/router/parser/query/test.rs
@@ -283,7 +283,7 @@ fn test_set() {
 fn test_transaction() {
     let (command, mut qp) = command!("BEGIN");
     match command {
-        Command::StartTransaction(q) => assert_eq!(q.query(), "BEGIN"),
+        Command::StartTransaction { query: q, .. } => assert_eq!(q.query(), "BEGIN"),
         _ => panic!("not a query"),
     };
 
@@ -304,10 +304,7 @@ fn test_transaction() {
         true,
         cluster.clone()
     );
-    assert!(matches!(
-        command,
-        Command::StartTransaction(BufferedQuery::Query(_))
-    ));
+    assert!(matches!(command, Command::StartTransaction { .. }));
     assert!(qp.in_transaction);
 
     qp.in_transaction = true;
@@ -372,7 +369,7 @@ fn test_cte() {
 #[test]
 fn test_function_begin() {
     let (cmd, mut qp) = command!("BEGIN");
-    assert!(matches!(cmd, Command::StartTransaction(_)));
+    assert!(matches!(cmd, Command::StartTransaction { .. }));
     assert!(qp.in_transaction);
     let cluster = Cluster::new_test();
     let mut prep_stmts = PreparedStatements::default();

--- a/pgdog/src/frontend/router/parser/query/transaction.rs
+++ b/pgdog/src/frontend/router/parser/query/transaction.rs
@@ -1,3 +1,5 @@
+use crate::frontend::client::TransactionType;
+
 use super::*;
 
 impl QueryParser {
@@ -26,12 +28,115 @@ impl QueryParser {
                 TransactionStmtKind::TransStmtRollback => return Ok(Command::RollbackTransaction),
                 TransactionStmtKind::TransStmtBegin | TransactionStmtKind::TransStmtStart => {
                     self.in_transaction = true;
-                    return Ok(Command::StartTransaction(context.query()?.clone()));
+                    let transaction_type =
+                        Self::transaction_type(&stmt.options).unwrap_or_default();
+                    return Ok(Command::StartTransaction {
+                        query: context.query()?.clone(),
+                        transaction_type,
+                    });
                 }
                 _ => Ok(Command::Query(Route::write(None))),
             }
         } else {
             Ok(Command::Query(Route::write(None)))
+        }
+    }
+
+    #[inline]
+    fn transaction_type(options: &[Node]) -> Option<TransactionType> {
+        for option_node in options {
+            let node_enum = option_node.node.as_ref()?;
+            if let NodeEnum::DefElem(def_elem) = node_enum {
+                if def_elem.defname == "transaction_read_only" {
+                    let arg_node = def_elem.arg.as_ref()?.node.as_ref()?;
+                    if let NodeEnum::AConst(ac) = arg_node {
+                        // 1 => read-only, 0 => read-write
+                        if let Some(a_const::Val::Ival(i)) = ac.val.as_ref() {
+                            if i.ival != 0 {
+                                return Some(TransactionType::ReadOnly);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return Some(TransactionType::ReadWrite);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_detect_transaction_type() {
+        let read_write_queries = vec![
+            "BEGIN",
+            "BEGIN;",
+            "begin",
+            "bEgIn",
+            "BEGIN WORK",
+            "BEGIN TRANSACTION",
+            "BEGIN READ WRITE",
+            "BEGIN WORK READ WRITE",
+            "BEGIN TRANSACTION READ WRITE",
+            "START TRANSACTION",
+            "START TRANSACTION;",
+            "start transaction",
+            "START TRANSACTION READ WRITE",
+            "BEGIN ISOLATION LEVEL REPEATABLE READ READ WRITE DEFERRABLE",
+        ];
+
+        let read_only_queries = vec![
+            "BEGIN READ ONLY",
+            "BEGIN WORK READ ONLY",
+            "BEGIN TRANSACTION READ ONLY",
+            "START TRANSACTION READ ONLY",
+            "BEGIN ISOLATION LEVEL SERIALIZABLE READ ONLY",
+            "START TRANSACTION ISOLATION LEVEL READ COMMITTED READ ONLY NOT DEFERRABLE",
+        ];
+
+        for q in read_write_queries {
+            let binding = pg_query::parse(q).unwrap();
+            let stmt = binding
+                .protobuf
+                .stmts
+                .first()
+                .as_ref()
+                .unwrap()
+                .stmt
+                .as_ref()
+                .unwrap();
+
+            match stmt.node {
+                Some(NodeEnum::TransactionStmt(ref stmt)) => {
+                    let t = QueryParser::transaction_type(&stmt.options);
+                    assert_eq!(t, Some(TransactionType::ReadWrite));
+                }
+                _ => panic!("not a transaction"),
+            }
+        }
+
+        for q in read_only_queries {
+            let binding = pg_query::parse(q).unwrap();
+            let stmt = binding
+                .protobuf
+                .stmts
+                .first()
+                .as_ref()
+                .unwrap()
+                .stmt
+                .as_ref()
+                .unwrap();
+
+            match stmt.node {
+                Some(NodeEnum::TransactionStmt(ref stmt)) => {
+                    let t = QueryParser::transaction_type(&stmt.options);
+                    assert_eq!(t, Some(TransactionType::ReadOnly));
+                }
+                _ => panic!("not a transaction"),
+            }
         }
     }
 }


### PR DESCRIPTION
### Description

- Don't double parse transactions. We were invoking `pg_query` parser twice.