### PR TITLE
Add some env vars for config

### DIFF
--- a/pgdog/src/config/error.rs
+++ b/pgdog/src/config/error.rs
@@ -22,6 +22,9 @@ pub enum Error {
 
     #[error("incomplete startup")]
     IncompleteStartup,
+
+    #[error("no database urls in environment")]
+    NoDbsInEnv,
 }
 
 impl Error {

--- a/pgdog/src/main.rs
+++ b/pgdog/src/main.rs
@@ -67,9 +67,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
     let config = config::load(&args.config, &args.users)?;
 
-    // Set database from --database-url arg.
+    // Get databases from environment or from --database-url args.
     let config = if let Some(database_urls) = args.database_url {
         config::from_urls(&database_urls)?
+    } else if let Ok(config) = config::from_env() {
+        info!(
+            "loaded {} databases from environment",
+            config.config.databases.len()
+        );
+        config
     } else {
         config
     };


### PR DESCRIPTION
### Description

- Add a few environment variables to use for configuration.

| Variable | Setting |
|-|-|
| `PGDOG_HOST` | `host` |
| `PGDOG_PORT` | `port` |
| `PGDOG_PASSTHROUGH_AUTH` | `passthrough_auth` |
| `PGDOG_DATABASE_URL_X` | `--database-url` argument. `X` starts at `1`. Supports passing multiple database URLs for multiple DBs. |
| `PGDOG_ADMIN_PASSWORD` | `admin.password` |