### PR TITLE
Fix #374

### DIFF
--- a/integration/rust/tests/integration/cross_shard_disabled.rs
+++ b/integration/rust/tests/integration/cross_shard_disabled.rs
@@ -50,4 +50,10 @@ async fn test_cross_shard_disabled() {
 
     // Still works with cross-shard disabled.
     admin.fetch_all("SHOW QUERY_CACHE").await.unwrap();
+
+    // Set it back to default value.
+    admin
+        .execute("SET cross_shard_disabled TO false")
+        .await
+        .unwrap();
 }

--- a/integration/rust/tests/integration/cross_shard_disabled.rs
+++ b/integration/rust/tests/integration/cross_shard_disabled.rs
@@ -1,0 +1,53 @@
+use std::time::Duration;
+
+use rust::setup::{admin_sqlx, connections_sqlx};
+use sqlx::Executor;
+use tokio::time::sleep;
+
+#[tokio::test]
+async fn test_cross_shard_disabled() {
+    let admin = admin_sqlx().await;
+    admin
+        .execute("SET cross_shard_disabled TO false")
+        .await
+        .unwrap();
+
+    let conns = connections_sqlx().await;
+
+    for conn in &conns {
+        sqlx::query("SELECT * FROM sharded")
+            .fetch_optional(conn)
+            .await
+            .unwrap();
+    }
+
+    admin
+        .execute("SET cross_shard_disabled TO true")
+        .await
+        .unwrap();
+    sleep(Duration::from_millis(100)).await;
+
+    // Not sharded DB.
+    sqlx::query("SELECT * FROM sharded")
+        .fetch_optional(conns.get(0).unwrap())
+        .await
+        .unwrap();
+
+    // Sharded DB.
+    let err = sqlx::query("SELECT * FROM sharded")
+        .fetch_optional(conns.get(1).unwrap())
+        .await
+        .err()
+        .unwrap();
+    assert!(err.to_string().contains("cross-shard queries are disabled"));
+
+    // Query has sharding key.
+    sqlx::query("SELECT * FROM sharded WHERE id = $1")
+        .bind(1)
+        .fetch_optional(conns.get(1).unwrap())
+        .await
+        .unwrap();
+
+    // Still works with cross-shard disabled.
+    admin.fetch_all("SHOW QUERY_CACHE").await.unwrap();
+}

--- a/integration/rust/tests/integration/mod.rs
+++ b/integration/rust/tests/integration/mod.rs
@@ -1,5 +1,6 @@
 pub mod auth;
 pub mod ban;
+pub mod cross_shard_disabled;
 pub mod distinct;
 pub mod fake_transactions;
 pub mod maintenance_mode;

--- a/pgdog/src/admin/set.rs
+++ b/pgdog/src/admin/set.rs
@@ -91,6 +91,10 @@ impl Command for Set {
                     .close_unused(config.config.general.prepared_statements_limit);
             }
 
+            "cross_shard_disabled" => {
+                config.config.general.cross_shard_disabled = Self::from_json(&self.value)?;
+            }
+
             _ => return Err(Error::Syntax),
         }
 
@@ -103,7 +107,11 @@ impl Command for Set {
 
 impl Set {
     fn from_json<T: DeserializeOwned>(value: &str) -> serde_json::Result<T> {
-        serde_json::from_str::<T>(&format!(r#""{}""#, value))
+        let value = match value {
+            "true" | "false" => value.to_string(),
+            _ => format!(r#""{}""#, value),
+        };
+        serde_json::from_str::<T>(&value)
     }
 }
 

--- a/pgdog/src/config/mod.rs
+++ b/pgdog/src/config/mod.rs
@@ -70,7 +70,7 @@ pub fn from_env() -> Result<ConfigAndUsers, Error> {
     let mut urls = vec![];
     let mut index = 1;
     loop {
-        if let Ok(url) = env::var(&format!("PGDOG_DATABASE_URL_{}", index)) {
+        if let Ok(url) = env::var(format!("PGDOG_DATABASE_URL_{}", index)) {
             urls.push(url);
             index += 1;
         } else {
@@ -79,7 +79,7 @@ pub fn from_env() -> Result<ConfigAndUsers, Error> {
     }
 
     if urls.is_empty() {
-        return Err(Error::NoDbsInEnv);
+        Err(Error::NoDbsInEnv)
     } else {
         from_urls(&urls)
     }

--- a/pgdog/src/frontend/client/query_engine/context.rs
+++ b/pgdog/src/frontend/client/query_engine/context.rs
@@ -26,6 +26,8 @@ pub struct QueryEngineContext<'a> {
     pub(super) cross_shard_disabled: bool,
     /// Client memory usage.
     pub(super) memory_usage: usize,
+    /// Is the client an admin.
+    pub(super) admin: bool,
 }
 
 impl<'a> QueryEngineContext<'a> {
@@ -41,6 +43,7 @@ impl<'a> QueryEngineContext<'a> {
             timeouts: client.timeouts,
             cross_shard_disabled: client.cross_shard_disabled,
             memory_usage,
+            admin: client.admin,
         }
     }
 
@@ -55,6 +58,7 @@ impl<'a> QueryEngineContext<'a> {
             timeouts: mirror.timeouts,
             cross_shard_disabled: mirror.cross_shard_disabled,
             memory_usage: 0,
+            admin: false,
         }
     }
 

--- a/pgdog/src/frontend/client/query_engine/query.rs
+++ b/pgdog/src/frontend/client/query_engine/query.rs
@@ -18,7 +18,11 @@ impl QueryEngine {
         route: &Route,
     ) -> Result<(), Error> {
         // Check for cross-shard quries.
-        if context.cross_shard_disabled && route.is_cross_shard() {
+        if context.cross_shard_disabled
+            && route.is_cross_shard()
+            && !context.admin
+            && context.client_request.executable()
+        {
             let bytes_sent = context
                 .stream
                 .error(


### PR DESCRIPTION
### Description

Fix #374

The following bugs are fixed when `cross_shard_disabled = true`:

1. Admin queries failed with "cross-shard queries disabled" error.
2. Queries that prepared statements but didn't execute them failed with the same error, e.g. Parse, Describe, Flush sequence.