### PR TITLE
Per-statement routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ perf.data.old
 
 /pgdog.toml
 /users.toml
+
+# Ignore generated bindings
+pgdog-plugin/src/bindings.rs

--- a/pgdog-plugin-build/src/lib.rs
+++ b/pgdog-plugin-build/src/lib.rs
@@ -32,8 +32,9 @@ pub fn pg_query_version() {
     let contents: Option<toml::Value> = toml::from_str(&contents).ok();
     if let Some(contents) = contents
         && let Some(dependencies) = contents.get("dependencies")
-            && let Some(pg_query) = dependencies.get("pg_query")
-                && let Some(version) = pg_query.as_str() {
-                    println!("cargo:rustc-env=PGDOG_PGQUERY_VERSION={}", version);
-                }
+        && let Some(pg_query) = dependencies.get("pg_query")
+        && let Some(version) = pg_query.as_str()
+    {
+        println!("cargo:rustc-env=PGDOG_PGQUERY_VERSION={}", version);
+    }
 }

--- a/pgdog-plugin-build/src/lib.rs
+++ b/pgdog-plugin-build/src/lib.rs
@@ -30,13 +30,10 @@ pub fn pg_query_version() {
     }
 
     let contents: Option<toml::Value> = toml::from_str(&contents).ok();
-    if let Some(contents) = contents {
-        if let Some(dependencies) = contents.get("dependencies") {
-            if let Some(pg_query) = dependencies.get("pg_query") {
-                if let Some(version) = pg_query.as_str() {
+    if let Some(contents) = contents
+        && let Some(dependencies) = contents.get("dependencies")
+            && let Some(pg_query) = dependencies.get("pg_query")
+                && let Some(version) = pg_query.as_str() {
                     println!("cargo:rustc-env=PGDOG_PGQUERY_VERSION={}", version);
                 }
-            }
-        }
-    }
 }

--- a/pgdog/src/admin/mod.rs
+++ b/pgdog/src/admin/mod.rs
@@ -4,7 +4,6 @@ use async_trait::async_trait;
 
 use crate::net::messages::Message;
 
-pub mod backend;
 pub mod ban;
 pub mod error;
 pub mod maintenance_mode;
@@ -16,6 +15,7 @@ pub mod probe;
 pub mod reconnect;
 pub mod reload;
 pub mod reset_query_cache;
+pub mod server;
 pub mod set;
 pub mod setup_schema;
 pub mod show_clients;

--- a/pgdog/src/admin/server.rs
+++ b/pgdog/src/admin/server.rs
@@ -18,17 +18,17 @@ use super::Error;
 
 /// Admin backend.
 #[derive(Debug)]
-pub struct Backend {
+pub struct AdminServer {
     messages: VecDeque<Message>,
 }
 
-impl Default for Backend {
+impl Default for AdminServer {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl Backend {
+impl AdminServer {
     /// New admin backend handler.
     pub fn new() -> Self {
         Self {

--- a/pgdog/src/backend/pool/connection/binding.rs
+++ b/pgdog/src/backend/pool/connection/binding.rs
@@ -11,14 +11,17 @@ use super::*;
 /// The server(s) the client is connected to.
 #[derive(Debug)]
 pub enum Binding {
-    Server(Option<Guard>),
-    Admin(Backend),
+    /// Direct-to-shard transaction.
+    Direct(Option<Guard>),
+    /// Admin database connection.
+    Admin(AdminServer),
+    /// Multi-shard transaction.
     MultiShard(Vec<Guard>, Box<MultiShard>),
 }
 
 impl Default for Binding {
     fn default() -> Self {
-        Binding::Server(None)
+        Binding::Direct(None)
     }
 }
 
@@ -26,7 +29,7 @@ impl Binding {
     /// Close all connections to all servers.
     pub fn disconnect(&mut self) {
         match self {
-            Binding::Server(guard) => drop(guard.take()),
+            Binding::Direct(guard) => drop(guard.take()),
             Binding::Admin(_) => (),
             Binding::MultiShard(guards, _) => guards.clear(),
         }
@@ -36,7 +39,7 @@ impl Binding {
     /// they are probably broken and should not be re-used.
     pub fn force_close(&mut self) {
         match self {
-            Binding::Server(Some(ref mut guard)) => guard.stats_mut().state(State::ForceClose),
+            Binding::Direct(Some(ref mut guard)) => guard.stats_mut().state(State::ForceClose),
             Binding::MultiShard(ref mut guards, _) => {
                 for guard in guards {
                     guard.stats_mut().state(State::ForceClose);
@@ -51,7 +54,7 @@ impl Binding {
     /// Are we connnected to a backend?
     pub fn connected(&self) -> bool {
         match self {
-            Binding::Server(server) => server.is_some(),
+            Binding::Direct(server) => server.is_some(),
             Binding::MultiShard(servers, _) => !servers.is_empty(),
             Binding::Admin(_) => true,
         }
@@ -59,7 +62,7 @@ impl Binding {
 
     pub(super) async fn read(&mut self) -> Result<Message, Error> {
         match self {
-            Binding::Server(guard) => {
+            Binding::Direct(guard) => {
                 if let Some(guard) = guard.as_mut() {
                     guard.read().await
                 } else {
@@ -118,7 +121,7 @@ impl Binding {
         match self {
             Binding::Admin(backend) => Ok(backend.send(client_request).await?),
 
-            Binding::Server(server) => {
+            Binding::Direct(server) => {
                 if let Some(server) = server {
                     server.send(client_request).await
                 } else {
@@ -126,10 +129,27 @@ impl Binding {
                 }
             }
 
-            Binding::MultiShard(servers, _state) => {
-                for server in servers.iter_mut() {
-                    server.send(client_request).await?;
+            Binding::MultiShard(servers, state) => {
+                let mut shards_sent = servers.len();
+                for (shard, server) in servers.iter_mut().enumerate() {
+                    let send = match client_request.route().shard() {
+                        Shard::Direct(s) => {
+                            shards_sent = 1;
+                            *s == shard
+                        }
+                        Shard::Multi(shards) => {
+                            shards_sent = shards.len();
+                            shards.contains(&shard)
+                        }
+                        Shard::All => true,
+                    };
+
+                    if send {
+                        server.send(client_request).await?;
+                    }
                 }
+
+                state.update(shards_sent, client_request.route());
 
                 Ok(())
             }
@@ -170,7 +190,7 @@ impl Binding {
                 Ok(())
             }
 
-            Binding::Server(Some(ref mut server)) => {
+            Binding::Direct(Some(ref mut server)) => {
                 for row in rows {
                     server
                         .send_one(&ProtocolMessage::from(row.message()))
@@ -187,7 +207,7 @@ impl Binding {
     pub(super) fn done(&self) -> bool {
         match self {
             Binding::Admin(admin) => admin.done(),
-            Binding::Server(Some(server)) => server.done(),
+            Binding::Direct(Some(server)) => server.done(),
             Binding::MultiShard(servers, _state) => servers.iter().all(|s| s.done()),
             _ => true,
         }
@@ -196,7 +216,7 @@ impl Binding {
     pub fn has_more_messages(&self) -> bool {
         match self {
             Binding::Admin(admin) => !admin.done(),
-            Binding::Server(Some(server)) => server.has_more_messages(),
+            Binding::Direct(Some(server)) => server.has_more_messages(),
             Binding::MultiShard(servers, _state) => servers.iter().any(|s| s.has_more_messages()),
             _ => false,
         }
@@ -204,7 +224,7 @@ impl Binding {
 
     pub(super) fn state_check(&self, state: State) -> bool {
         match self {
-            Binding::Server(Some(server)) => {
+            Binding::Direct(Some(server)) => {
                 debug!(
                     "server is in \"{}\" state [{}]",
                     server.stats().state,
@@ -223,7 +243,7 @@ impl Binding {
     /// Execute a query on all servers.
     pub async fn execute(&mut self, query: &str) -> Result<(), Error> {
         match self {
-            Binding::Server(Some(ref mut server)) => {
+            Binding::Direct(Some(ref mut server)) => {
                 server.execute(query).await?;
             }
 
@@ -241,7 +261,7 @@ impl Binding {
 
     pub async fn link_client(&mut self, params: &Parameters) -> Result<usize, Error> {
         match self {
-            Binding::Server(Some(ref mut server)) => server.link_client(params).await,
+            Binding::Direct(Some(ref mut server)) => server.link_client(params).await,
             Binding::MultiShard(ref mut servers, _) => {
                 let mut max = 0;
                 for server in servers {
@@ -259,7 +279,7 @@ impl Binding {
 
     pub fn changed_params(&mut self) -> Parameters {
         match self {
-            Binding::Server(Some(ref mut server)) => server.changed_params().clone(),
+            Binding::Direct(Some(ref mut server)) => server.changed_params().clone(),
             Binding::MultiShard(ref mut servers, _) => {
                 if let Some(first) = servers.first() {
                     first.changed_params().clone()
@@ -273,7 +293,7 @@ impl Binding {
 
     pub(super) fn dirty(&mut self) {
         match self {
-            Binding::Server(Some(ref mut server)) => server.mark_dirty(true),
+            Binding::Direct(Some(ref mut server)) => server.mark_dirty(true),
             Binding::MultiShard(ref mut servers, _state) => {
                 servers.iter_mut().for_each(|s| s.mark_dirty(true))
             }
@@ -284,7 +304,7 @@ impl Binding {
     #[cfg(test)]
     pub fn is_dirty(&self) -> bool {
         match self {
-            Binding::Server(Some(ref server)) => server.dirty(),
+            Binding::Direct(Some(ref server)) => server.dirty(),
             Binding::MultiShard(ref servers, _state) => servers.iter().any(|s| s.dirty()),
             _ => false,
         }
@@ -294,7 +314,7 @@ impl Binding {
         match self {
             Binding::Admin(_) => false,
             Binding::MultiShard(ref servers, _state) => servers.iter().all(|s| s.copy_mode()),
-            Binding::Server(Some(ref server)) => server.copy_mode(),
+            Binding::Direct(Some(ref server)) => server.copy_mode(),
             _ => false,
         }
     }

--- a/pgdog/src/backend/pool/connection/buffer.rs
+++ b/pgdog/src/backend/pool/connection/buffer.rs
@@ -56,18 +56,21 @@ impl Buffer {
                     if let Some(index) = decoder.rd().field_index(name) {
                         cols.push(OrderBy::Asc(index + 1));
                     }
+                    // TODO: Error out instead of silently not sorting.
                 }
                 OrderBy::Desc(_) => cols.push(column.clone()),
                 OrderBy::DescColumn(name) => {
                     if let Some(index) = decoder.rd().field_index(name) {
                         cols.push(OrderBy::Desc(index + 1));
                     }
+                    // TODO: Error out instead of silently not sorting.
                 }
                 OrderBy::AscVectorL2(_, _) => cols.push(column.clone()),
                 OrderBy::AscVectorL2Column(name, vector) => {
                     if let Some(index) = decoder.rd().field_index(name) {
                         cols.push(OrderBy::AscVectorL2(index + 1, vector.clone()));
                     }
+                    // TODO: Error out instead of silently not sorting.
                 }
             };
         }

--- a/pgdog/src/backend/pool/test/mod.rs
+++ b/pgdog/src/backend/pool/test/mod.rs
@@ -32,6 +32,7 @@ pub fn pool() -> Pool {
             database_name: "pgdog".into(),
             user: "pgdog".into(),
             password: "pgdog".into(),
+            ..Default::default()
         },
         config,
     });
@@ -54,6 +55,7 @@ pub fn pool_with_prepared_capacity(capacity: usize) -> Pool {
             database_name: "pgdog".into(),
             user: "pgdog".into(),
             password: "pgdog".into(),
+            ..Default::default()
         },
         config,
     });

--- a/pgdog/src/backend/pool/test/replica.rs
+++ b/pgdog/src/backend/pool/test/replica.rs
@@ -12,6 +12,7 @@ fn replicas() -> Replicas {
             user: "pgdog".into(),
             password: "pgdog".into(),
             database_name: "pgdog".into(),
+            ..Default::default()
         },
         config: Config {
             max: 1,

--- a/pgdog/src/config/mod.rs
+++ b/pgdog/src/config/mod.rs
@@ -69,13 +69,9 @@ pub fn from_urls(urls: &[String]) -> Result<ConfigAndUsers, Error> {
 pub fn from_env() -> Result<ConfigAndUsers, Error> {
     let mut urls = vec![];
     let mut index = 1;
-    loop {
-        if let Ok(url) = env::var(format!("PGDOG_DATABASE_URL_{}", index)) {
-            urls.push(url);
-            index += 1;
-        } else {
-            break;
-        }
+    while let Ok(url) = env::var(format!("PGDOG_DATABASE_URL_{}", index)) {
+        urls.push(url);
+        index += 1;
     }
 
     if urls.is_empty() {

--- a/pgdog/src/frontend/client/query_engine/connect.rs
+++ b/pgdog/src/frontend/client/query_engine/connect.rs
@@ -2,7 +2,7 @@ use tokio::time::timeout;
 
 use super::*;
 
-use tracing::error;
+use tracing::{error, trace};
 
 impl QueryEngine {
     /// Connect to backend, if necessary.
@@ -75,5 +75,30 @@ impl QueryEngine {
         self.comms.stats(self.stats);
 
         Ok(connected)
+    }
+
+    /// Connect to serve a transaction.
+    pub(super) async fn connect_transaction(
+        &mut self,
+        context: &mut QueryEngineContext<'_>,
+        route: &Route,
+    ) -> Result<bool, Error> {
+        debug!("connecting to backend(s) to serve transaction");
+
+        let route = self.transaction_route(route)?;
+
+        trace!("transaction routing to {:#?}", route);
+
+        self.connect(context, &route).await
+    }
+
+    pub(super) fn transaction_route(&self, route: &Route) -> Result<Route, Error> {
+        let cluster = self.backend.cluster()?;
+
+        if cluster.shards().len() == 1 {
+            Ok(Route::write(Shard::Direct(0)).set_read(route.is_read()))
+        } else {
+            Ok(Route::write(Shard::All).set_read(route.is_read()))
+        }
     }
 }

--- a/pgdog/src/frontend/client/query_engine/route_query.rs
+++ b/pgdog/src/frontend/client/query_engine/route_query.rs
@@ -8,11 +8,6 @@ impl QueryEngine {
         &mut self,
         context: &mut QueryEngineContext<'_>,
     ) -> Result<bool, Error> {
-        // Route request if we haven't already.
-        // if self.router.routed() {
-        //     return Ok(true);
-        // }
-
         // Admin doesn't have a cluster.
         let cluster = if let Ok(cluster) = self.backend.cluster() {
             cluster

--- a/pgdog/src/frontend/client/query_engine/set.rs
+++ b/pgdog/src/frontend/client/query_engine/set.rs
@@ -15,8 +15,32 @@ impl QueryEngine {
         let bytes_sent = context
             .stream
             .send_many(&[
-                CommandComplete::from_str("SET").message()?,
-                ReadyForQuery::in_transaction(context.in_transaction()).message()?,
+                CommandComplete::from_str("SET").message()?.backend(),
+                ReadyForQuery::in_transaction(context.in_transaction())
+                    .message()?
+                    .backend(),
+            ])
+            .await?;
+
+        self.stats.sent(bytes_sent);
+
+        Ok(())
+    }
+
+    pub(crate) async fn set_route(
+        &mut self,
+        context: &mut QueryEngineContext<'_>,
+        route: Route,
+    ) -> Result<(), Error> {
+        self.set_route = Some(route);
+
+        let bytes_sent = context
+            .stream
+            .send_many(&[
+                CommandComplete::from_str("SET").message()?.backend(),
+                ReadyForQuery::in_transaction(context.in_transaction())
+                    .message()?
+                    .backend(),
             ])
             .await?;
 

--- a/pgdog/src/frontend/client/test/mod.rs
+++ b/pgdog/src/frontend/client/test/mod.rs
@@ -464,7 +464,6 @@ async fn test_transaction_state() {
     client.buffer(State::Idle).await.unwrap();
     client.client_messages(&mut engine).await.unwrap();
 
-    assert!(engine.router().routed());
     assert!(client.transaction.is_some());
     assert!(engine.router().route().is_write());
     assert!(engine.router().in_transaction());
@@ -494,10 +493,8 @@ async fn test_transaction_state() {
     .await
     .unwrap();
 
-    assert!(!engine.router().routed());
     client.buffer(State::Idle).await.unwrap();
     client.client_messages(&mut engine).await.unwrap();
-    assert!(engine.router().routed());
 
     for c in ['2', 'D', 'C', 'Z'] {
         let msg = engine.backend().read().await.unwrap();
@@ -508,7 +505,6 @@ async fn test_transaction_state() {
 
     read!(conn, ['2', 'D', 'C', 'Z']);
 
-    assert!(engine.router().routed());
     assert!(client.transaction.is_some());
     assert!(engine.router().route().is_write());
     assert!(engine.router().in_transaction());
@@ -530,7 +526,6 @@ async fn test_transaction_state() {
     read!(conn, ['C', 'Z']);
 
     assert!(client.transaction.is_none());
-    assert!(!engine.router().routed());
 }
 
 #[tokio::test]

--- a/pgdog/src/frontend/router/context.rs
+++ b/pgdog/src/frontend/router/context.rs
@@ -52,4 +52,8 @@ impl<'a> RouterContext<'a> {
     pub fn in_transaction(&self) -> bool {
         self.transaction.is_some()
     }
+
+    pub fn transaction(&self) -> &Option<TransactionType> {
+        &self.transaction
+    }
 }

--- a/pgdog/src/frontend/router/mod.rs
+++ b/pgdog/src/frontend/router/mod.rs
@@ -93,6 +93,7 @@ impl Router {
     }
 
     /// The router is configured.
+    #[cfg(test)]
     pub fn routed(&self) -> bool {
         self.routed
     }

--- a/pgdog/src/frontend/router/mod.rs
+++ b/pgdog/src/frontend/router/mod.rs
@@ -24,7 +24,6 @@ pub use sharding::{Lists, Ranges};
 pub struct Router {
     query_parser: QueryParser,
     latest_command: Command,
-    routed: bool,
 }
 
 impl Default for Router {
@@ -39,7 +38,6 @@ impl Router {
         Self {
             query_parser: QueryParser::default(),
             latest_command: Command::default(),
-            routed: false,
         }
     }
 
@@ -56,7 +54,6 @@ impl Router {
         }
 
         let command = self.query_parser.parse(context)?;
-        self.routed = !matches!(command, Command::StartTransaction { .. });
         self.latest_command = command;
         Ok(&self.latest_command)
     }
@@ -89,13 +86,6 @@ impl Router {
     pub fn reset(&mut self) {
         self.query_parser = QueryParser::default();
         self.latest_command = Command::default();
-        self.routed = false;
-    }
-
-    /// The router is configured.
-    #[cfg(test)]
-    pub fn routed(&self) -> bool {
-        self.routed
     }
 
     /// Query parser is inside a transaction.

--- a/pgdog/src/frontend/router/parser/command.rs
+++ b/pgdog/src/frontend/router/parser/command.rs
@@ -34,6 +34,7 @@ pub enum Command {
         shard: Shard,
     },
     Unlisten(String),
+    SetRoute(Route),
 }
 
 impl Command {

--- a/pgdog/src/frontend/router/parser/context.rs
+++ b/pgdog/src/frontend/router/parser/context.rs
@@ -5,6 +5,7 @@ use std::os::raw::c_void;
 use pgdog_plugin::pg_query::protobuf::ParseResult;
 use pgdog_plugin::{PdParameters, PdRouterContext, PdStatement};
 
+use crate::frontend::client::TransactionType;
 use crate::net::Bind;
 use crate::{
     backend::ShardingSchema,
@@ -66,7 +67,10 @@ impl<'a> QueryParserContext<'a> {
 
     /// Write override enabled?
     pub(super) fn write_override(&self) -> bool {
-        self.router_context.in_transaction() && self.rw_conservative()
+        matches!(
+            self.router_context.transaction(),
+            Some(TransactionType::ReadWrite)
+        ) && self.rw_conservative()
     }
 
     /// Are we using the conservative read/write separation strategy?

--- a/pgdog/src/frontend/router/parser/limit.rs
+++ b/pgdog/src/frontend/router/parser/limit.rs
@@ -6,7 +6,7 @@ use pg_query::{
 use super::Error;
 use crate::net::Bind;
 
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub struct Limit {
     pub limit: Option<usize>,
     pub offset: Option<usize>,

--- a/pgdog/src/frontend/router/parser/order_by.rs
+++ b/pgdog/src/frontend/router/parser/order_by.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 
 use crate::net::messages::Vector;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum OrderBy {
     Asc(usize),
     Desc(usize),

--- a/pgdog/src/frontend/router/parser/query/mod.rs
+++ b/pgdog/src/frontend/router/parser/query/mod.rs
@@ -134,12 +134,12 @@ impl QueryParser {
         }
 
         // e.g. Parse, Describe, Flush
-        // if !context.router_context.executable {
-        //     return Ok(Command::Query(
-        //         Route::write(Shard::Direct(round_robin::next() % context.shards))
-        //             .set_read(context.read_only),
-        //     ));
-        // }
+        if !context.router_context.executable {
+            return Ok(Command::Query(
+                Route::write(Shard::Direct(round_robin::next() % context.shards))
+                    .set_read(context.read_only),
+            ));
+        }
 
         // Parse hardcoded shard from a query comment.
         if context.router_needed {

--- a/pgdog/src/frontend/router/parser/query/set.rs
+++ b/pgdog/src/frontend/router/parser/query/set.rs
@@ -28,7 +28,7 @@ impl QueryParser {
                         ..
                     }) = node
                     {
-                        return Ok(Command::Query(
+                        return Ok(Command::SetRoute(
                             Route::write(Some(*ival as usize)).set_read(context.read_only),
                         ));
                     }
@@ -63,7 +63,7 @@ impl QueryParser {
                         } else {
                             Shard::Direct(0)
                         };
-                        return Ok(Command::Query(
+                        return Ok(Command::SetRoute(
                             Route::write(shard).set_read(context.read_only),
                         ));
                     }

--- a/pgdog/src/frontend/router/parser/query/test.rs
+++ b/pgdog/src/frontend/router/parser/query/test.rs
@@ -201,13 +201,19 @@ fn test_omni() {
 
 #[test]
 fn test_set() {
-    let route = query!(r#"SET "pgdog.shard" TO 1"#, true);
-    assert_eq!(route.shard(), &Shard::Direct(1));
+    let (command, _) = command!(r#"SET "pgdog.shard" TO 1"#, true);
+    match command {
+        Command::SetRoute(route) => assert_eq!(route.shard(), &Shard::Direct(1)),
+        _ => panic!("not a set route"),
+    }
     let (_, qp) = command!(r#"SET "pgdog.shard" TO 1"#, true);
     assert!(qp.in_transaction);
 
-    let route = query!(r#"SET "pgdog.sharding_key" TO '11'"#, true);
-    assert_eq!(route.shard(), &Shard::Direct(1));
+    let (command, _) = command!(r#"SET "pgdog.sharding_key" TO '11'"#, true);
+    match command {
+        Command::SetRoute(route) => assert_eq!(route.shard(), &Shard::Direct(1)),
+        _ => panic!("not a set route"),
+    }
     let (_, qp) = command!(r#"SET "pgdog.sharding_key" TO '11'"#, true);
     assert!(qp.in_transaction);
 
@@ -434,7 +440,7 @@ fn test_comment() {
     );
 
     match command {
-        Command::Query(query) => assert_eq!(query.shard(), &Shard::All), // Round-robin because it's only a parse
+        Command::Query(query) => assert_eq!(query.shard(), &Shard::Direct(0)), // Round-robin because it's only a parse
         _ => panic!("not a query"),
     }
 }

--- a/pgdog/src/frontend/router/parser/route.rs
+++ b/pgdog/src/frontend/router/parser/route.rs
@@ -46,7 +46,7 @@ impl From<Option<usize>> for Shard {
 
 /// Path a query should take and any transformations
 /// that should be applied along the way.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct Route {
     shard: Shard,
     read: bool,


### PR DESCRIPTION
### Description

Per-statement routing. Handles direct-to-shard queries inside cross-shard transactions.

1. `BEGIN READ ONLY`  transactions are sent to replicas.
2. `BEGIN` transactions are sent to the primary, unless `read_write_strategy = "aggressive"`, in which case the first statement inside the transaction is used for routing.
3. Each statement inside a transaction is evaluated and routed to one or more shards. This allows for cross-shard and direct-to-shard queries inside the same transaction!

Added some tests to validate.