### PR TITLE
Pause clients, not mirrors for maintenance mode

### DIFF
--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -11,6 +11,7 @@ use tracing::{debug, enabled, error, info, trace, Level as LogLevel};
 
 use super::{ClientRequest, Comms, Error, PreparedStatements};
 use crate::auth::{md5, scram::Server};
+use crate::backend::maintenance_mode;
 use crate::backend::{
     databases,
     pool::{Connection, Request},
@@ -375,7 +376,17 @@ impl Client {
 
     /// Handle client messages.
     async fn client_messages(&mut self, query_engine: &mut QueryEngine) -> Result<(), Error> {
-        // If client sent multiple requests, split them up and execute indivdiually.
+        // Check maintenance mode.
+        if !self.in_transaction() && !self.admin {
+            if let Some(waiter) = maintenance_mode::waiter() {
+                let state = query_engine.get_state();
+                query_engine.set_state(State::Waiting);
+                waiter.await;
+                query_engine.set_state(state);
+            }
+        }
+
+        // If client sent multiple requests, split them up and execute individually.
         let spliced = self.client_request.splice()?;
         if spliced.is_empty() {
             let mut context = QueryEngineContext::new(self);

--- a/pgdog/src/frontend/comms.rs
+++ b/pgdog/src/frontend/comms.rs
@@ -14,6 +14,7 @@ use tokio_util::task::TaskTracker;
 
 use crate::net::messages::BackendKeyData;
 use crate::net::Parameters;
+use crate::state::State;
 
 use super::{ConnectedClient, Stats};
 
@@ -129,6 +130,16 @@ impl Comms {
             let mut guard = self.global.clients.lock();
             if let Some(entry) = guard.get_mut(id) {
                 entry.stats = stats;
+            }
+        }
+    }
+
+    /// Override client state.
+    pub fn set_state(&self, state: State) {
+        if let Some(ref id) = self.id {
+            let mut guard = self.global.clients.lock();
+            if let Some(entry) = guard.get_mut(id) {
+                entry.stats.state = state;
             }
         }
     }

--- a/pgdog/src/frontend/comms.rs
+++ b/pgdog/src/frontend/comms.rs
@@ -134,16 +134,6 @@ impl Comms {
         }
     }
 
-    /// Override client state.
-    pub fn set_state(&self, state: State) {
-        if let Some(ref id) = self.id {
-            let mut guard = self.global.clients.lock();
-            if let Some(entry) = guard.get_mut(id) {
-                entry.stats.state = state;
-            }
-        }
-    }
-
     /// Notify clients pgDog is shutting down.
     pub fn shutdown(&self) {
         self.global.offline.store(true, Ordering::Relaxed);

--- a/pgdog/src/frontend/comms.rs
+++ b/pgdog/src/frontend/comms.rs
@@ -14,7 +14,6 @@ use tokio_util::task::TaskTracker;
 
 use crate::net::messages::BackendKeyData;
 use crate::net::Parameters;
-use crate::state::State;
 
 use super::{ConnectedClient, Stats};
 


### PR DESCRIPTION
### Description

- Pause clients only, not mirrors, when enabling maintenance mode.