### PR TITLE
Add pg_dump to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN source ~/.cargo/env && \
 FROM ubuntu:latest
 ENV RUST_LOG=info
 RUN apt update && \
-    apt install -y ca-certificates && \
+    apt install -y ca-certificates postgresql-client && \
     update-ca-certificates
 
 COPY --from=builder /build/target/release/pgdog /usr/local/bin/pgdog


### PR DESCRIPTION
### Description

- Add `pg_dump` and other Postgres client tools to Docker image. `pg_dump` is required for the `schema-sync` command.