### PR TITLE
SHOW INSTANCE_ID

### DIFF
--- a/pgdog/src/admin/mod.rs
+++ b/pgdog/src/admin/mod.rs
@@ -20,6 +20,7 @@ pub mod set;
 pub mod setup_schema;
 pub mod show_clients;
 pub mod show_config;
+pub mod show_instance_id;
 pub mod show_lists;
 pub mod show_mirrors;
 pub mod show_peers;

--- a/pgdog/src/admin/parser.rs
+++ b/pgdog/src/admin/parser.rs
@@ -4,10 +4,10 @@ use super::{
     ban::Ban, maintenance_mode::MaintenanceMode, pause::Pause, prelude::Message, probe::Probe,
     reconnect::Reconnect, reload::Reload, reset_query_cache::ResetQueryCache, set::Set,
     setup_schema::SetupSchema, show_clients::ShowClients, show_config::ShowConfig,
-    show_lists::ShowLists, show_mirrors::ShowMirrors, show_peers::ShowPeers, show_pools::ShowPools,
-    show_prepared_statements::ShowPreparedStatements, show_query_cache::ShowQueryCache,
-    show_servers::ShowServers, show_stats::ShowStats, show_version::ShowVersion,
-    shutdown::Shutdown, Command, Error,
+    show_instance_id::ShowInstanceId, show_lists::ShowLists, show_mirrors::ShowMirrors,
+    show_peers::ShowPeers, show_pools::ShowPools, show_prepared_statements::ShowPreparedStatements,
+    show_query_cache::ShowQueryCache, show_servers::ShowServers, show_stats::ShowStats,
+    show_version::ShowVersion, shutdown::Shutdown, Command, Error,
 };
 
 use tracing::debug;
@@ -27,6 +27,7 @@ pub enum ParseResult {
     ShowStats(ShowStats),
     ShowMirrors(ShowMirrors),
     ShowVersion(ShowVersion),
+    ShowInstanceId(ShowInstanceId),
     SetupSchema(SetupSchema),
     Shutdown(Shutdown),
     ShowLists(ShowLists),
@@ -56,6 +57,7 @@ impl ParseResult {
             ShowStats(show_stats) => show_stats.execute().await,
             ShowMirrors(show_mirrors) => show_mirrors.execute().await,
             ShowVersion(show_version) => show_version.execute().await,
+            ShowInstanceId(show_instance_id) => show_instance_id.execute().await,
             SetupSchema(setup_schema) => setup_schema.execute().await,
             Shutdown(shutdown) => shutdown.execute().await,
             ShowLists(show_lists) => show_lists.execute().await,
@@ -85,6 +87,7 @@ impl ParseResult {
             ShowStats(show_stats) => show_stats.name(),
             ShowMirrors(show_mirrors) => show_mirrors.name(),
             ShowVersion(show_version) => show_version.name(),
+            ShowInstanceId(show_instance_id) => show_instance_id.name(),
             SetupSchema(setup_schema) => setup_schema.name(),
             Shutdown(shutdown) => shutdown.name(),
             ShowLists(show_lists) => show_lists.name(),
@@ -122,6 +125,7 @@ impl Parser {
                 "stats" => ParseResult::ShowStats(ShowStats::parse(&sql)?),
                 "mirrors" => ParseResult::ShowMirrors(ShowMirrors::parse(&sql)?),
                 "version" => ParseResult::ShowVersion(ShowVersion::parse(&sql)?),
+                "instance_id" => ParseResult::ShowInstanceId(ShowInstanceId::parse(&sql)?),
                 "lists" => ParseResult::ShowLists(ShowLists::parse(&sql)?),
                 "prepared" => ParseResult::ShowPrepared(ShowPreparedStatements::parse(&sql)?),
                 command => {

--- a/pgdog/src/admin/show_instance_id.rs
+++ b/pgdog/src/admin/show_instance_id.rs
@@ -1,0 +1,56 @@
+use super::{
+    prelude::{DataRow, Field, Protocol, RowDescription},
+    *,
+};
+use crate::util::instance_id;
+
+pub struct ShowInstanceId;
+
+#[async_trait]
+impl Command for ShowInstanceId {
+    fn name(&self) -> String {
+        "SHOW INSTANCE_ID".into()
+    }
+
+    fn parse(_: &str) -> Result<Self, Error> {
+        Ok(Self)
+    }
+
+    async fn execute(&self) -> Result<Vec<Message>, Error> {
+        let mut dr = DataRow::new();
+        dr.add(instance_id());
+
+        Ok(vec![
+            RowDescription::new(&[Field::text("instance_id")]).message()?,
+            dr.message()?,
+        ])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse() {
+        assert!(ShowInstanceId::parse("show instance_id").is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_execute() {
+        let cmd = ShowInstanceId;
+        let result = cmd.execute().await.unwrap();
+        assert_eq!(result.len(), 2);
+
+        // Verify first message is RowDescription
+        assert_eq!(result[0].code(), 'T');
+        // Verify second message is DataRow
+        assert_eq!(result[1].code(), 'D');
+    }
+
+    #[test]
+    fn test_name() {
+        let cmd = ShowInstanceId;
+        assert_eq!(cmd.name(), "SHOW INSTANCE_ID");
+    }
+}


### PR DESCRIPTION
random generated 8 character string for the life of the instance, lazy init, admin db exposure

closes #417 

Notes: Thought about making this configurable, maybe we want an INSTANCE_NAME or equivalent too, but this I think is more useful tactically for seeing when e.g. the process respawns, so I kept it as is.