### PR TITLE
Add pg_dump output to trace

### DIFF
--- a/pgdog/src/backend/schema/sync/pg_dump.rs
+++ b/pgdog/src/backend/schema/sync/pg_dump.rs
@@ -6,7 +6,7 @@ use pg_query::{
     protobuf::{AlterTableType, ConstrType, ParseResult},
     NodeEnum,
 };
-use tracing::{info, warn};
+use tracing::{info, trace, warn};
 
 use super::{progress::Progress, Error};
 use crate::{
@@ -133,6 +133,7 @@ impl PgDumpCommand {
         }
 
         let original = from_utf8(&output.stdout)?.to_string();
+        trace!("{}", original);
         let stmts = pg_query::parse(&original)?.protobuf;
 
         Ok(PgDumpOutput {


### PR DESCRIPTION
### Description

Add the output of `pg_dump' to trace logging to debug any syntax errors.