### PR TITLE
Fix pg_dump clean typo

### DIFF
--- a/pgdog/src/backend/schema/sync/pg_dump.rs
+++ b/pgdog/src/backend/schema/sync/pg_dump.rs
@@ -153,7 +153,7 @@ impl PgDumpCommand {
 
         Ok(PgDumpOutput {
             stmts,
-            original,
+            original: cleaned,
             table: self.table.clone(),
             schema: self.schema.clone(),
         })


### PR DESCRIPTION
### Description

Passed the wrong source text to pg_dump's output handler.