### PR TITLE
[2pc] Support vacuum & multi-stmt transactions

### DIFF
--- a/pgdog/src/frontend/client/query_engine/query.rs
+++ b/pgdog/src/frontend/client/query_engine/query.rs
@@ -209,6 +209,7 @@ impl QueryEngine {
             && route.should_2pc()
             && self.begin_stmt.is_none()
             && context.client_request.executable()
+            && !context.in_transaction()
         {
             debug!("[2pc] enabling automatic transaction");
             self.two_pc.set_auto();

--- a/pgdog/src/frontend/router/parser/query/mod.rs
+++ b/pgdog/src/frontend/router/parser/query/mod.rs
@@ -255,6 +255,11 @@ impl QueryParser {
 
             Some(NodeEnum::ExplainStmt(ref stmt)) => self.explain(stmt, context),
 
+            // VACUUM.
+            Some(NodeEnum::VacuumRelation(_)) | Some(NodeEnum::VacuumStmt(_)) => {
+                Ok(Command::Query(Route::write(None).set_maintenace()))
+            }
+
             // All others are not handled.
             // They are sent to all shards concurrently.
             _ => Ok(Command::Query(Route::write(None))),

--- a/pgdog/src/frontend/router/parser/route.rs
+++ b/pgdog/src/frontend/router/parser/route.rs
@@ -55,6 +55,7 @@ pub struct Route {
     limit: Limit,
     lock_session: bool,
     distinct: Option<DistinctBy>,
+    maintenance: bool,
 }
 
 impl Display for Route {
@@ -148,6 +149,15 @@ impl Route {
         self
     }
 
+    pub fn set_maintenace(mut self) -> Self {
+        self.maintenance = true;
+        self
+    }
+
+    pub fn is_maintenance(&self) -> bool {
+        self.maintenance
+    }
+
     pub fn set_shard_raw_mut(&mut self, shard: &Shard) {
         self.shard = shard.clone();
     }
@@ -197,6 +207,6 @@ impl Route {
     }
 
     pub fn should_2pc(&self) -> bool {
-        self.is_cross_shard() && self.is_write()
+        self.is_cross_shard() && self.is_write() && !self.is_maintenance()
     }
 }


### PR DESCRIPTION
### Description

- Don't start transaction when running `VACUUM`.
- Don't start subtransaction when a transaction is already started when using 2pc.