### PR TITLE
fix: correct aggregate function matching in parser

### DIFF
--- a/pgdog/src/frontend/router/parser/aggregate.rs
+++ b/pgdog/src/frontend/router/parser/aggregate.rs
@@ -85,7 +85,7 @@ impl Aggregate {
 
                             "sum" => targets.push(AggregateTarget {
                                 column: idx,
-                                function: AggregateFunction::Max,
+                                function: AggregateFunction::Sum,
                             }),
 
                             _ => {}


### PR DESCRIPTION
found this bug while working to implement `avg()`