### PR TITLE
Handle Close in order it was received

### DIFF
--- a/pgdog/src/frontend/client/query_engine/incomplete_requests.rs
+++ b/pgdog/src/frontend/client/query_engine/incomplete_requests.rs
@@ -1,6 +1,6 @@
 use tokio::io::AsyncWriteExt;
 
-use crate::net::{Close, CloseComplete, FromBytes, Protocol, ReadyForQuery, ToBytes};
+use crate::net::{CloseComplete, Protocol, ReadyForQuery};
 
 use super::*;
 
@@ -31,10 +31,6 @@ impl QueryEngine {
         for msg in context.client_request.messages.iter() {
             match msg.code() {
                 'C' => {
-                    let close = Close::from_bytes(msg.to_bytes()?)?;
-                    if close.is_statement() {
-                        context.prepared_statements.close(close.name());
-                    }
                     if only_close {
                         bytes_sent += context.stream.send(&CloseComplete).await?;
                     }

--- a/pgdog/src/frontend/client/query_engine/mod.rs
+++ b/pgdog/src/frontend/client/query_engine/mod.rs
@@ -213,6 +213,7 @@ impl QueryEngine {
             self.flush_notify().await?;
         }
 
+        self.handle_close(context)?;
         self.update_stats(context);
 
         Ok(())

--- a/pgdog/src/frontend/client/query_engine/mod.rs
+++ b/pgdog/src/frontend/client/query_engine/mod.rs
@@ -213,7 +213,6 @@ impl QueryEngine {
             self.flush_notify().await?;
         }
 
-        self.handle_close(context)?;
         self.update_stats(context);
 
         Ok(())

--- a/pgdog/src/frontend/client/query_engine/mod.rs
+++ b/pgdog/src/frontend/client/query_engine/mod.rs
@@ -103,14 +103,14 @@ impl QueryEngine {
         self.stats
             .received(context.client_request.total_message_len());
 
+        // Rewrite prepared statements.
+        self.rewrite_extended(context)?;
+
         // Intercept commands we don't have to forward to a server.
         if self.intercept_incomplete(context).await? {
             self.update_stats(context);
             return Ok(());
         }
-
-        // Rewrite prepared statements.
-        self.rewrite_extended(context)?;
 
         // Route transaction to the right servers.
         if !self.route_transaction(context).await? {

--- a/pgdog/src/frontend/client/query_engine/prepared_statements.rs
+++ b/pgdog/src/frontend/client/query_engine/prepared_statements.rs
@@ -1,5 +1,3 @@
-use crate::net::{Close, FromBytes, Protocol, ToBytes};
-
 use super::*;
 
 impl QueryEngine {
@@ -13,24 +11,6 @@ impl QueryEngine {
                 context.prepared_statements.maybe_rewrite(message)?;
             }
         }
-        Ok(())
-    }
-
-    /// Remove prepared statements from local cache
-    /// that the client doesn't want anymore.
-    pub(super) fn handle_close(
-        &mut self,
-        context: &mut QueryEngineContext<'_>,
-    ) -> Result<(), Error> {
-        for message in context.client_request.iter() {
-            if message.code() == 'C' {
-                let close = Close::from_bytes(message.to_bytes()?)?;
-                if close.is_statement() {
-                    context.prepared_statements.close(close.name());
-                }
-            }
-        }
-
         Ok(())
     }
 }

--- a/pgdog/src/frontend/prepared_statements/rewrite.rs
+++ b/pgdog/src/frontend/prepared_statements/rewrite.rs
@@ -1,7 +1,7 @@
 //! Rerwrite messages if using prepared statements.
 use crate::net::{
     messages::{Bind, Describe, Parse},
-    ProtocolMessage,
+    Close, ProtocolMessage,
 };
 
 use super::{Error, PreparedStatements};
@@ -24,6 +24,7 @@ impl<'a> Rewrite<'a> {
             ProtocolMessage::Bind(ref mut bind) => Ok(self.bind(bind)?),
             ProtocolMessage::Describe(ref mut describe) => Ok(self.describe(describe)?),
             ProtocolMessage::Parse(ref mut parse) => Ok(self.parse(parse)?),
+            ProtocolMessage::Close(ref close) => Ok(self.close(close)?),
             _ => Ok(()),
         }
     }
@@ -55,6 +56,12 @@ impl<'a> Rewrite<'a> {
             }
             Ok(())
         }
+    }
+
+    /// Handle Close message.
+    fn close(&mut self, close: &Close) -> Result<(), Error> {
+        self.statements.close(close.name());
+        Ok(())
     }
 }
 

--- a/pgdog/src/net/protocol_message.rs
+++ b/pgdog/src/net/protocol_message.rs
@@ -27,7 +27,7 @@ impl ProtocolMessage {
         use ProtocolMessage::*;
         matches!(
             self,
-            Bind(_) | Parse(_) | Describe(_) | Execute(_) | Sync(_)
+            Bind(_) | Parse(_) | Describe(_) | Execute(_) | Sync(_) | Close(_)
         )
     }
 


### PR DESCRIPTION
### Description

Handle Close message in the order it was received. Clients sometimes close a prepared statement with the same name as they are preparing, in the same request. Previously, we handled Close before/after the request, which disrupted the order of operations. Now, we're handling it in the order it was sent by the client.