### PR TITLE
server_lifetime setting

### DIFF
--- a/pgdog/src/admin/show_config.rs
+++ b/pgdog/src/admin/show_config.rs
@@ -58,6 +58,7 @@ fn pretty_value(name: &str, value: &serde_json::Value) -> Result<String, serde_j
         || name.contains("_interval")
         || name.contains("_delay")
         || name.contains("_time")
+        || name.contains("_lifetime")
     {
         match s.parse::<u64>() {
             Ok(v) => human_duration(Duration::from_millis(v)),

--- a/pgdog/src/backend/pool/config.rs
+++ b/pgdog/src/backend/pool/config.rs
@@ -147,6 +147,11 @@ impl Config {
             max: database
                 .pool_size
                 .unwrap_or(user.pool_size.unwrap_or(general.default_pool_size)),
+            max_age: Duration::from_millis(
+                database
+                    .server_lifetime
+                    .unwrap_or(user.server_lifetime.unwrap_or(general.server_lifetime)),
+            ),
             healthcheck_interval: Duration::from_millis(general.healthcheck_interval),
             idle_healthcheck_interval: Duration::from_millis(general.idle_healthcheck_interval),
             idle_healthcheck_delay: Duration::from_millis(general.idle_healthcheck_delay),
@@ -169,8 +174,9 @@ impl Config {
             query_timeout: Duration::from_millis(general.query_timeout),
             checkout_timeout: Duration::from_millis(general.checkout_timeout),
             idle_timeout: Duration::from_millis(
-                user.idle_timeout
-                    .unwrap_or(database.idle_timeout.unwrap_or(general.idle_timeout)),
+                database
+                    .idle_timeout
+                    .unwrap_or(user.idle_timeout.unwrap_or(general.idle_timeout)),
             ),
             read_only: database
                 .read_only

--- a/pgdog/src/config/database.rs
+++ b/pgdog/src/config/database.rs
@@ -103,6 +103,8 @@ pub struct Database {
     pub idle_timeout: Option<u64>,
     /// Read-only mode.
     pub read_only: Option<bool>,
+    /// Server lifetime.
+    pub server_lifetime: Option<u64>,
 }
 
 impl Database {

--- a/pgdog/src/config/general.rs
+++ b/pgdog/src/config/general.rs
@@ -118,6 +118,9 @@ pub struct General {
     /// Client idle timeout.
     #[serde(default = "General::default_client_idle_timeout")]
     pub client_idle_timeout: u64,
+    /// Server lifetime.
+    #[serde(default = "General::server_lifetime")]
+    pub server_lifetime: u64,
     /// Mirror queue size.
     #[serde(default = "General::mirror_queue")]
     pub mirror_queue: usize,
@@ -200,6 +203,7 @@ impl Default for General {
             log_disconnections: Self::log_disconnections(),
             two_phase_commit: bool::default(),
             two_phase_commit_auto: None,
+            server_lifetime: Self::server_lifetime(),
         }
     }
 }
@@ -454,6 +458,13 @@ impl General {
 
     pub fn log_disconnections() -> bool {
         Self::env_bool_or_default("PGDOG_LOG_DISCONNECTIONS", true)
+    }
+
+    pub fn server_lifetime() -> u64 {
+        Self::env_or_default(
+            "PGDOG_SERVER_LIFETIME",
+            Duration::from_secs(3600 * 24).as_millis() as u64,
+        )
     }
 
     fn default_passthrough_auth() -> PassthoughAuth {

--- a/pgdog/src/config/users.rs
+++ b/pgdog/src/config/users.rs
@@ -98,6 +98,8 @@ pub struct User {
     pub two_phase_commit: Option<bool>,
     /// Automatic transactions.
     pub two_phase_commit_auto: Option<bool>,
+    /// Server lifetime.
+    pub server_lifetime: Option<u64>,
 }
 
 impl User {


### PR DESCRIPTION
### Description

- Make connection max age configurable. 
- Fix `idle_timeout` user setting taking priority over database setting (it should be inverse).