### PR TITLE
Fix configcheck

### DIFF
--- a/pgdog/src/cli.rs
+++ b/pgdog/src/cli.rs
@@ -56,14 +56,7 @@ pub enum Commands {
     },
 
     /// Check configuration files for errors.
-    Configcheck {
-        /// Path to the configuration file.
-        #[arg(short, long)]
-        config: Option<PathBuf>,
-        /// Path to the users.toml file.
-        #[arg(short, long)]
-        users: Option<PathBuf>,
-    },
+    Configcheck,
 
     /// Copy data from source to destination cluster
     /// using logical replication.

--- a/pgdog/src/main.rs
+++ b/pgdog/src/main.rs
@@ -11,7 +11,7 @@ use pgdog::stats;
 use pgdog::util::pgdog_version;
 use pgdog::{healthcheck, net};
 use tokio::runtime::Builder;
-use tracing::info;
+use tracing::{error, info};
 
 use std::process::exit;
 
@@ -35,13 +35,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             exit(0);
         }
 
-        Some(Commands::Configcheck { config, users }) => {
-            if let Err(e) = pgdog::cli::config_check(config, users) {
-                eprintln!("Configuration error: {}", e);
+        Some(Commands::Configcheck) => {
+            if let Err(e) = config::load(&args.config, &args.users) {
+                error!("{}", e);
                 exit(1);
             }
 
-            println!("✅ Configuration valid");
+            info!("✅ config valid");
             exit(0);
         }
 


### PR DESCRIPTION
### Description

- Make `configcheck` use correct config arguments.

### Example

```bash
pgdpg \
  --config /path/to/pgdog.toml \
  --users /path/to/users.toml \
configcheck
```