### PR TITLE
Test solution for the feature request #473

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1901,7 +1901,7 @@ version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
 dependencies = [
- "nix",
+ "nix 0.29.0",
  "winapi",
 ]
 
@@ -2037,6 +2037,18 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -2351,7 +2363,7 @@ dependencies = [
 
 [[package]]
 name = "pgdog"
-version = "0.1.7"
+version = "0.1.700"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2370,8 +2382,10 @@ dependencies = [
  "hyper-util",
  "indexmap",
  "lazy_static",
+ "libc",
  "lru 0.16.0",
  "md5",
+ "nix 0.30.1",
  "once_cell",
  "parking_lot",
  "pg_query",
@@ -3948,7 +3962,7 @@ dependencies = [
  "libc",
  "log",
  "memmem",
- "nix",
+ "nix 0.29.0",
  "num-derive",
  "num-traits",
  "ordered-float",

--- a/pgdog/Cargo.toml
+++ b/pgdog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgdog"
-version = "0.1.7"
+version = "0.1.700"
 edition = "2021"
 description = "Modern PostgreSQL proxy, pooler and load balancer."
 authors = ["Lev Kokotov <lev.kokotov@gmail.com>"]
@@ -23,6 +23,8 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "std"] }
 parking_lot = "0.12"
 thiserror = "2"
+libc = "0.2"
+nix = {version = "0.30.1", features = ["process"]}
 bytes = "1"
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }

--- a/pgdog/src/frontend/listener.rs
+++ b/pgdog/src/frontend/listener.rs
@@ -1,9 +1,4 @@
 //! Connection listener. Handles all client connections.
-use std::io::ErrorKind;
-use std::net::SocketAddr;
-use std::sync::Arc;
-use std::ffi::CString;
-use std::env::current_exe;
 use crate::backend::databases::{databases, reload, shutdown};
 use crate::config::config;
 use crate::frontend::client::query_engine::two_pc::Manager;
@@ -13,12 +8,17 @@ use crate::net::{self, tls::acceptor};
 use crate::net::{tweak, Stream};
 use crate::sighup::Sighup;
 use crate::sigusr::Sigusr;
+use nix::unistd::execv;
+use std::env::current_exe;
+use std::ffi::CString;
+use std::io::ErrorKind;
+use std::net::SocketAddr;
+use std::sync::Arc;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::signal::ctrl_c;
 use tokio::sync::Notify;
 use tokio::time::timeout;
 use tokio::{select, spawn};
-use nix::unistd::execv;
 use tracing::{error, info, warn};
 
 use super::{
@@ -40,7 +40,7 @@ impl Listener {
             addr: addr.to_string(),
             shutdown: Arc::new(Notify::new()),
             // path to executable
-            // environment 
+            // environment
             // command-line parameters
         }
     }
@@ -87,7 +87,7 @@ impl Listener {
                     self.start_shutdown();
                 }
 
-                _ = sigusr.listen() => 
+                _ = sigusr.listen() =>
                 {
                     info!("Hot-patching signal received");
                     match current_exe()
@@ -117,7 +117,7 @@ impl Listener {
         }
 
         Ok(())
-    }    
+    }
     /// Shutdown this listener.
     pub fn shutdown(&self) {
         self.shutdown.notify_one();
@@ -133,7 +133,7 @@ impl Listener {
             shutdown();
         });
     }
-    
+
     async fn execute_shutdown(&self) {
         let shutdown_timeout = config().config.general.shutdown_timeout();
 

--- a/pgdog/src/lib.rs
+++ b/pgdog/src/lib.rs
@@ -12,6 +12,7 @@ pub mod healthcheck;
 pub mod net;
 pub mod plugin;
 pub mod sighup;
+pub mod sigusr;
 pub mod state;
 pub mod stats;
 #[cfg(feature = "tui")]

--- a/pgdog/src/sigusr.rs
+++ b/pgdog/src/sigusr.rs
@@ -1,0 +1,33 @@
+#[cfg(target_family = "unix")]
+use tokio::signal::unix::*;
+
+pub struct Sigusr {
+    #[cfg(target_family = "unix")]
+    sig: Signal,
+}
+
+impl Sigusr {
+    #[cfg(target_family = "unix")]
+    pub(crate) fn new() -> std::io::Result<Self> {
+        let sig = signal(SignalKind::user_defined1())?;
+        Ok(Self { sig })
+    }
+
+    #[cfg(not(target_family = "unix"))]
+    pub(crate) fn new() -> std::io::Result<Self> {
+        Self {}
+    }
+
+    pub(crate) async fn listen(&mut self) {
+        #[cfg(target_family = "unix")]
+        self.sig.recv().await;
+
+        #[cfg(not(target_family = "unix"))]
+        loop {
+            use std::time::Duration;
+            use tokio::time::sleep;
+
+            sleep(Duration::MAX).await;
+        }
+    }
+}


### PR DESCRIPTION
Allows hot patching the new executable file into the same process using "execv" command

How to use:

0. run pgdog 
1. run _ps | grep "pgdog"_ (or pgrep) to find its process id (PID)
2. run _kill -USR1 <PID>_ will send the signal to signal listener in pgdog
3. watch the new executable starting up while keeping the current process id
3. _ps | grep "pgdog"_ or _pgrep "pgdog"_ to confirm. 

Repeat as many times as needed. You can use "cargo build" to create a new executable instance and hot-load it at any time into the same process.