### PR TITLE
Disable LB host banning when no alternative targets available

### DIFF
--- a/pgdog/src/backend/databases.rs
+++ b/pgdog/src/backend/databases.rs
@@ -370,19 +370,20 @@ pub(crate) fn new_pool(
     if let Some(shards) = shards {
         let mut shard_configs = vec![];
         for user_databases in shards {
+            let has_single_replica = user_databases.len() == 1;
             let primary = user_databases
                 .iter()
                 .find(|d| d.role == Role::Primary)
                 .map(|primary| PoolConfig {
                     address: Address::new(primary, user),
-                    config: Config::new(general, primary, user),
+                    config: Config::new(general, primary, user, has_single_replica),
                 });
             let replicas = user_databases
                 .iter()
                 .filter(|d| d.role == Role::Replica)
                 .map(|replica| PoolConfig {
                     address: Address::new(replica, user),
-                    config: Config::new(general, replica, user),
+                    config: Config::new(general, replica, user, has_single_replica),
                 })
                 .collect::<Vec<_>>();
 

--- a/pgdog/src/backend/pool/config.rs
+++ b/pgdog/src/backend/pool/config.rs
@@ -139,7 +139,7 @@ impl Config {
     }
 
     /// Create from database/user configuration.
-    pub fn new(general: &General, database: &Database, user: &User) -> Self {
+    pub fn new(general: &General, database: &Database, user: &User, is_only_replica: bool) -> Self {
         Config {
             min: database
                 .min_pool_size
@@ -182,6 +182,7 @@ impl Config {
                 .read_only
                 .unwrap_or(user.read_only.unwrap_or_default()),
             prepared_statements_limit: general.prepared_statements_limit,
+            bannable: !is_only_replica,
             ..Default::default()
         }
     }


### PR DESCRIPTION
### Description

- Disable banning when database cluster has only one database, e.g., a primary or a replica. Banning produces confusing errors when load balancer isn't actually used.