### PR TITLE
Override admin in pgdog.toml with admin in users.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2389,6 +2389,7 @@ dependencies = [
  "serde_json",
  "sha1",
  "socket2",
+ "tempfile",
  "thiserror 2.0.12",
  "tikv-jemallocator",
  "tokio",
@@ -3898,9 +3899,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.20.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
  "getrandom 0.3.3",

--- a/pgdog/Cargo.toml
+++ b/pgdog/Cargo.toml
@@ -68,3 +68,6 @@ tikv-jemallocator = "0.6"
 
 [build-dependencies]
 cc = "1"
+
+[dev-dependencies]
+tempfile = "3.23.0"

--- a/pgdog/src/backend/databases.rs
+++ b/pgdog/src/backend/databases.rs
@@ -607,6 +607,7 @@ mod tests {
                     ..Default::default()
                 },
             ],
+            ..Default::default()
         };
 
         let databases = from_config(&ConfigAndUsers {
@@ -681,6 +682,7 @@ mod tests {
                 },
                 // Note: user2 missing for dest_db - this should disable mirroring
             ],
+            ..Default::default()
         };
 
         let databases = from_config(&ConfigAndUsers {
@@ -750,6 +752,7 @@ mod tests {
                     ..Default::default()
                 },
             ],
+            ..Default::default()
         };
 
         let databases = from_config(&ConfigAndUsers {
@@ -827,6 +830,7 @@ mod tests {
                     ..Default::default()
                 },
             ],
+            ..Default::default()
         };
 
         let databases = from_config(&ConfigAndUsers {
@@ -919,6 +923,7 @@ mod tests {
                     ..Default::default()
                 },
             ],
+            ..Default::default()
         };
 
         let databases = from_config(&ConfigAndUsers {
@@ -996,6 +1001,7 @@ mod tests {
                     ..Default::default()
                 },
             ],
+            ..Default::default()
         };
 
         let databases = from_config(&ConfigAndUsers {
@@ -1046,7 +1052,10 @@ mod tests {
         }];
 
         // No users at all
-        let users = crate::config::Users { users: vec![] };
+        let users = crate::config::Users {
+            users: vec![],
+            ..Default::default()
+        };
 
         let databases = from_config(&ConfigAndUsers {
             config: config.clone(),
@@ -1073,6 +1082,7 @@ mod tests {
                 },
                 // No user for dest_db!
             ],
+            ..Default::default()
         };
 
         let databases_partial = from_config(&ConfigAndUsers {
@@ -1100,6 +1110,7 @@ mod tests {
                 },
                 // No user for source_db!
             ],
+            ..Default::default()
         };
 
         let databases_dest_only = from_config(&ConfigAndUsers {

--- a/pgdog/src/config/url.rs
+++ b/pgdog/src/config/url.rs
@@ -69,7 +69,7 @@ impl ConfigAndUsers {
             .into_iter()
             .collect::<Vec<_>>();
 
-        self.users = Users { users };
+        self.users = Users { users, admin: None };
         self.config.databases = databases;
 
         Ok(self)

--- a/pgdog/src/config/users.rs
+++ b/pgdog/src/config/users.rs
@@ -18,6 +18,7 @@ pub struct Plugin {
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 #[serde(deny_unknown_fields)]
 pub struct Users {
+    pub admin: Option<Admin>,
     /// Users and passwords.
     #[serde(default)]
     pub users: Vec<User>,


### PR DESCRIPTION
Fix #521 

### Description

This allows configuring the admin section in `users.toml`, which will override admin set in `pgdog.toml`, if any.