### PR TITLE
Use parsed AST instead of double-parsing SELECT stmt

### DIFF
--- a/pgdog/src/frontend/router/parser/query/explain.rs
+++ b/pgdog/src/frontend/router/parser/query/explain.rs
@@ -3,6 +3,7 @@ use super::*;
 impl QueryParser {
     pub(super) fn explain(
         &mut self,
+        ast: &pg_query::ParseResult,
         stmt: &ExplainStmt,
         context: &mut QueryParserContext,
     ) -> Result<Command, Error> {
@@ -10,7 +11,7 @@ impl QueryParser {
         let node = query.node.as_ref().ok_or(Error::EmptyQuery)?;
 
         match node {
-            NodeEnum::SelectStmt(ref stmt) => self.select(stmt, context),
+            NodeEnum::SelectStmt(ref stmt) => self.select(ast, stmt, context),
             NodeEnum::InsertStmt(ref stmt) => Self::insert(stmt, context),
             NodeEnum::UpdateStmt(ref stmt) => Self::update(stmt, context),
             NodeEnum::DeleteStmt(ref stmt) => Self::delete(stmt, context),

--- a/pgdog/src/frontend/router/parser/query/mod.rs
+++ b/pgdog/src/frontend/router/parser/query/mod.rs
@@ -212,7 +212,7 @@ impl QueryParser {
                 return Ok(Command::Deallocate);
             }
             // SELECT statements.
-            Some(NodeEnum::SelectStmt(ref stmt)) => self.select(stmt, context),
+            Some(NodeEnum::SelectStmt(ref stmt)) => self.select(statement.ast(), stmt, context),
             // COPY statements.
             Some(NodeEnum::CopyStmt(ref stmt)) => Self::copy(stmt, context),
             // INSERT statements.
@@ -258,7 +258,7 @@ impl QueryParser {
                 return Ok(Command::Unlisten(stmt.conditionname.clone()));
             }
 
-            Some(NodeEnum::ExplainStmt(ref stmt)) => self.explain(stmt, context),
+            Some(NodeEnum::ExplainStmt(ref stmt)) => self.explain(statement.ast(), stmt, context),
 
             // VACUUM.
             Some(NodeEnum::VacuumRelation(_)) | Some(NodeEnum::VacuumStmt(_)) => {

--- a/pgdog/src/frontend/router/parser/query/select.rs
+++ b/pgdog/src/frontend/router/parser/query/select.rs
@@ -12,6 +12,7 @@ impl QueryParser {
     ///
     pub(super) fn select(
         &mut self,
+        ast: &pg_query::ParseResult,
         stmt: &SelectStmt,
         context: &mut QueryParserContext,
     ) -> Result<Command, Error> {
@@ -93,8 +94,11 @@ impl QueryParser {
         // Only rewrite if query is cross-shard.
         if query.is_cross_shard() && context.shards > 1 {
             if let Some(buffered_query) = context.router_context.query.as_ref() {
-                let rewrite =
-                    RewriteEngine::new().rewrite_select(buffered_query.query(), query.aggregate());
+                let rewrite = RewriteEngine::new().rewrite_select(
+                    ast,
+                    buffered_query.query(),
+                    query.aggregate(),
+                );
                 if !rewrite.plan.is_noop() {
                     if let BufferedQuery::Prepared(parse) = buffered_query {
                         let name = parse.name().to_owned();


### PR DESCRIPTION
### Description

- Don't parse `SELECT` statement twice when rewriting for ghost columns.