### PR TITLE
Add auth tests & plain auth for clients

### DIFF
--- a/integration/go/go_pgx/connectivity_test.go
+++ b/integration/go/go_pgx/connectivity_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConnectivityWithoutTLS(t *testing.T) {
+	ctx := context.Background()
+	conn, err := pgx.Connect(ctx, "postgres://pgdog:pgdog@127.0.0.1:6432/pgdog?sslmode=disable")
+	assert.NoError(t, err)
+	defer conn.Close(ctx)
+
+	err = conn.Ping(ctx)
+	assert.NoError(t, err)
+}
+
+func TestConnectivityWithTLS(t *testing.T) {
+	ctx := context.Background()
+	conn, err := pgx.Connect(ctx, "postgres://pgdog:pgdog@127.0.0.1:6432/pgdog?sslmode=require")
+	assert.NoError(t, err)
+	defer conn.Close(ctx)
+
+	err = conn.Ping(ctx)
+	assert.NoError(t, err)
+}

--- a/integration/go/go_pq/go_pq_test.go
+++ b/integration/go/go_pq/go_pq_test.go
@@ -27,6 +27,24 @@ func PqConnections() []*sql.DB {
 	return []*sql.DB{normal, sharded}
 }
 
+func TestAuthenticationWithoutTLS(t *testing.T) {
+	conn, err := sql.Open("postgres", "postgres://pgdog:pgdog@127.0.0.1:6432/pgdog?sslmode=disable")
+	assert.Nil(t, err)
+	defer conn.Close()
+
+	err = conn.Ping()
+	assert.Nil(t, err)
+}
+
+func TestAuthenticationWithTLS(t *testing.T) {
+	conn, err := sql.Open("postgres", "postgres://pgdog:pgdog@127.0.0.1:6432/pgdog?sslmode=require")
+	assert.Nil(t, err)
+	defer conn.Close()
+
+	err = conn.Ping()
+	assert.Nil(t, err)
+}
+
 func TestPqCrud(t *testing.T) {
 	conns := PqConnections()
 

--- a/pgdog/src/config/auth.rs
+++ b/pgdog/src/config/auth.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::str::FromStr;
+use std::{fmt::Display, str::FromStr};
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
 #[serde(rename_all = "snake_case")]
@@ -17,6 +17,18 @@ pub enum AuthType {
     #[default]
     Scram,
     Trust,
+    Plain,
+}
+
+impl Display for AuthType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Md5 => write!(f, "md5"),
+            Self::Scram => write!(f, "scram"),
+            Self::Trust => write!(f, "trust"),
+            Self::Plain => write!(f, "plain"),
+        }
+    }
 }
 
 impl AuthType {
@@ -41,6 +53,7 @@ impl FromStr for AuthType {
             "md5" => Ok(Self::Md5),
             "scram" => Ok(Self::Scram),
             "trust" => Ok(Self::Trust),
+            "plain" => Ok(Self::Plain),
             _ => Err(format!("Invalid auth type: {}", s)),
         }
     }


### PR DESCRIPTION
### Description

- Added support for `auth_type = "plain"` for plaintext client auth.
- Added tests for go/pgx and go/pq with scram, TLS on and off #532 