### PR TITLE
Correct log message

### DIFF
--- a/pgdog/src/backend/schema/sync/pg_dump.rs
+++ b/pgdog/src/backend/schema/sync/pg_dump.rs
@@ -83,12 +83,7 @@ impl PgDump {
             return Err(Error::PublicationNoTables(self.publication.clone()));
         }
 
-        info!(
-            "dumping schema for {} tables [{}, {}]",
-            comparison.len(),
-            addr,
-            self.source.name()
-        );
+        info!("dumping schema [{}, {}]", comparison.len(), addr,);
 
         let config = config();
         let pg_dump_path = config


### PR DESCRIPTION
### Description

Correct log message for `schema-sync` command since we're now copying entire schemas.