### PR TITLE
Fix rollbacks with query parser disabled

### DIFF
--- a/pgdog/src/backend/pool/connection/binding.rs
+++ b/pgdog/src/backend/pool/connection/binding.rs
@@ -395,4 +395,20 @@ impl Binding {
             _ => false,
         }
     }
+
+    /// Number of connected shards.
+    pub fn shards(&self) -> Result<usize, Error> {
+        Ok(match self {
+            Binding::Admin(_) => 1,
+            Binding::Direct(Some(_)) => 1,
+            Binding::MultiShard(ref servers, _) => {
+                if servers.is_empty() {
+                    return Err(Error::NotConnected);
+                } else {
+                    servers.len()
+                }
+            }
+            _ => return Err(Error::NotConnected),
+        })
+    }
 }

--- a/pgdog/src/frontend/client/query_engine/query.rs
+++ b/pgdog/src/frontend/client/query_engine/query.rs
@@ -284,7 +284,13 @@ impl QueryEngine {
         context: &mut QueryEngineContext<'_>,
         route: &Route,
     ) -> Result<bool, Error> {
-        if context.in_error()
+        let shards = if let Ok(shards) = self.backend.shards() {
+            shards
+        } else {
+            return Ok(true);
+        };
+        if shards > 1 // This check only matters for cross-shard queries
+            && context.in_error()
             && !context.rollback
             && context.client_request.executable()
             && !route.rollback_savepoint()


### PR DESCRIPTION
### Description

Don't run transaction error check when we don't need to, i.e. when not using cross-shard transactions and especially when we can't detect that the client is sending a rollback (parser disabled).

#545 