### PR TITLE
Add after_connected hook

### DIFF
--- a/pgdog/src/frontend/client/query_engine/hooks/mod.rs
+++ b/pgdog/src/frontend/client/query_engine/hooks/mod.rs
@@ -2,7 +2,14 @@
 #![allow(unused_variables, dead_code)]
 use super::*;
 
+#[derive(Debug)]
 pub struct QueryEngineHooks;
+
+impl Default for QueryEngineHooks {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl QueryEngineHooks {
     pub(super) fn new() -> Self {
@@ -12,6 +19,14 @@ impl QueryEngineHooks {
     pub(super) fn before_execution(
         &mut self,
         context: &mut QueryEngineContext<'_>,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
+
+    pub(super) fn after_connected(
+        &mut self,
+        context: &mut QueryEngineContext<'_>,
+        backend: &Connection,
     ) -> Result<(), Error> {
         Ok(())
     }

--- a/pgdog/src/frontend/client/query_engine/query.rs
+++ b/pgdog/src/frontend/client/query_engine/query.rs
@@ -68,6 +68,8 @@ impl QueryEngine {
             }
         }
 
+        self.hooks.after_connected(context, &self.backend)?;
+
         self.backend
             .handle_client_request(context.client_request, &mut self.router, self.streaming)
             .await?;


### PR DESCRIPTION
### Description

- Add a hook to the query engine after the query is accepted and connected to backend to execute it.