### PR TITLE
Add include_primary_if_replica_banned rw_split strategy

### DIFF
--- a/pgdog/src/backend/pool/replicas/mod.rs
+++ b/pgdog/src/backend/pool/replicas/mod.rs
@@ -178,7 +178,12 @@ impl Replicas {
 
         let mut candidates: Vec<&ReadTarget> = self.replicas.iter().collect();
 
-        let primary_reads = self.rw_split == IncludePrimary;
+        let primary_reads = match self.rw_split {
+            IncludePrimary => true,
+            IncludePrimaryIfReplicaBanned => candidates.iter().any(|target| target.ban.banned()),
+            ExcludePrimary => false,
+        };
+
         if primary_reads {
             if let Some(ref primary) = self.primary {
                 candidates.push(primary);

--- a/pgdog/src/config/database.rs
+++ b/pgdog/src/config/database.rs
@@ -51,6 +51,7 @@ pub enum ReadWriteSplit {
     #[default]
     IncludePrimary,
     ExcludePrimary,
+    IncludePrimaryIfReplicaBanned,
 }
 
 impl FromStr for ReadWriteSplit {
@@ -60,6 +61,7 @@ impl FromStr for ReadWriteSplit {
         match s.to_lowercase().replace(['_', '-'], "").as_str() {
             "includeprimary" => Ok(Self::IncludePrimary),
             "excludeprimary" => Ok(Self::ExcludePrimary),
+            "includeprimaryifreplicabanned" => Ok(Self::IncludePrimaryIfReplicaBanned),
             _ => Err(format!("Invalid read-write split: {}", s)),
         }
     }


### PR DESCRIPTION
### Description

Add a read/write spit strategy that will allow read traffic on the primary iff a replica is down and has been banned. Basically uses the primary as a failover for reads.