### PR TITLE
Add --cutover flag to schema-sync

### DIFF
--- a/integration/schema_sync/dev.sh
+++ b/integration/schema_sync/dev.sh
@@ -24,6 +24,13 @@ ${PGDOG_BIN_PATH} \
     --publication pgdog \
     --data-sync-complete
 
+${PGDOG_BIN_PATH} \
+    schema-sync \
+    --from-database source \
+    --to-database destination \
+    --publication pgdog \
+    --cutover
+
 pg_dump \
     --schema-only \
     --exclude-schema pgdog \

--- a/pgdog/src/backend/schema/sync/pg_dump.rs
+++ b/pgdog/src/backend/schema/sync/pg_dump.rs
@@ -367,7 +367,7 @@ impl PgDumpOutput {
                                         sequence,
                                         sql: original,
                                     });
-                                } else {
+                                } else if state == SyncState::Cutover {
                                     let sql = sequence
                                         .setval_from_column(&column)
                                         .map_err(|_| Error::MissingEntity)?;
@@ -438,10 +438,12 @@ impl PgDumpOutput {
 
                         NodeEnum::AlterOwnerStmt(stmt) => {
                             if stmt.object_type() != ObjectType::ObjectPublication {
-                                result.push(Statement::Other {
-                                    sql: original.to_string(),
-                                    idempotent: true,
-                                });
+                                if state == SyncState::PreData {
+                                    result.push(Statement::Other {
+                                        sql: original.to_string(),
+                                        idempotent: true,
+                                    });
+                                }
                             }
                         }
 


### PR DESCRIPTION
### Description

- Add `--cutover` flag to `schema-sync` to perform steps required during traffic cutover between source and destination shards.