### PR TITLE
Add statement mode

### DIFF
--- a/pgdog-config/src/pooling.rs
+++ b/pgdog-config/src/pooling.rs
@@ -49,6 +49,7 @@ pub enum PoolerMode {
     #[default]
     Transaction,
     Session,
+    Statement,
 }
 
 impl std::fmt::Display for PoolerMode {
@@ -56,6 +57,7 @@ impl std::fmt::Display for PoolerMode {
         match self {
             Self::Transaction => write!(f, "transaction"),
             Self::Session => write!(f, "session"),
+            Self::Statement => write!(f, "statement"),
         }
     }
 }

--- a/pgdog/src/backend/pool/connection/mod.rs
+++ b/pgdog/src/backend/pool/connection/mod.rs
@@ -402,18 +402,17 @@ impl Connection {
         self.cluster.as_ref().ok_or(Error::NotConnected)
     }
 
-    /// Transaction mode pooling.
+    /// Pooler is in session mode.
     #[inline]
-    pub(crate) fn transaction_mode(&self) -> bool {
+    pub(crate) fn session_mode(&self) -> bool {
         self.cluster()
-            .map(|c| c.pooler_mode() == PoolerMode::Transaction)
+            .map(|c| c.pooler_mode() == PoolerMode::Session)
             .unwrap_or(true)
     }
 
-    /// Pooler is in session mod
     #[inline]
-    pub(crate) fn session_mode(&self) -> bool {
-        !self.transaction_mode()
+    pub(crate) fn pooler_mode(&self) -> PoolerMode {
+        self.cluster().map(|c| c.pooler_mode()).unwrap_or_default()
     }
 
     /// This is an admin DB connection.

--- a/pgdog/src/config/mod.rs
+++ b/pgdog/src/config/mod.rs
@@ -144,6 +144,11 @@ pub fn overrides(overrides: Overrides) {
 // Test helper functions
 #[cfg(test)]
 pub fn load_test() {
+    load_test_with_pooler_mode(PoolerMode::Transaction)
+}
+
+#[cfg(test)]
+pub fn load_test_with_pooler_mode(pooler_mode: PoolerMode) {
     use crate::backend::databases::init;
 
     let mut config = ConfigAndUsers::default();
@@ -151,12 +156,14 @@ pub fn load_test() {
         name: "pgdog".into(),
         host: "127.0.0.1".into(),
         port: 5432,
+        pooler_mode: Some(pooler_mode),
         ..Default::default()
     }];
     config.users.users = vec![User {
         name: "pgdog".into(),
         database: "pgdog".into(),
         password: Some("pgdog".into()),
+        pooler_mode: Some(pooler_mode),
         ..Default::default()
     }];
 

--- a/pgdog/src/net/messages/error_response.rs
+++ b/pgdog/src/net/messages/error_response.rs
@@ -73,6 +73,16 @@ impl ErrorResponse {
         }
     }
 
+    pub fn transaction_statement_mode() -> ErrorResponse {
+        ErrorResponse {
+            severity: "ERROR".into(),
+            code: "58000".into(),
+            message: "transaction control statements are not supported in statement pooler mode"
+                .into(),
+            ..Default::default()
+        }
+    }
+
     pub fn client_idle_timeout(duration: Duration) -> ErrorResponse {
         ErrorResponse {
             severity: "FATAL".into(),


### PR DESCRIPTION
### Description

- Add `statement` pooler mode which disables transactions.
- Fix: `pooler_mode` setting on `[[databases]]` was ignored.
- Fix: format warnings in config
- Refactor: re-use `error_response` function in `QueryEngine` for sending error to client.