### PR TITLE
Pool checkout tweak

### DIFF
--- a/integration/pub_sub/pgdog.toml
+++ b/integration/pub_sub/pgdog.toml
@@ -1,6 +1,5 @@
 [general]
 pub_sub_channel_size = 4098
-healthcheck_interval = 500
 
 [rewrite]
 enabled = false

--- a/pgdog/src/backend/pool/error.rs
+++ b/pgdog/src/backend/pool/error.rs
@@ -65,7 +65,4 @@ pub enum Error {
 
     #[error("pool is not healthy")]
     PoolUnhealthy,
-
-    #[error("connection has been closed by the database")]
-    DatabaseClosedConnection,
 }

--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -653,6 +653,7 @@ impl Server {
         debug!("running healthcheck \"{}\" [{}]", query, self.addr);
 
         self.execute(query).await?;
+
         self.stats.healthcheck();
 
         Ok(())


### PR DESCRIPTION
### Description

- Attempt to fetch another connection from the pool if a health check fails while checking out a connection
- Remove double-removal of water from connection pool, move checkout timeout logic up to pool from waiter