### PR TITLE
Client active status update

### DIFF
--- a/pgdog/src/frontend/client/query_engine/mod.rs
+++ b/pgdog/src/frontend/client/query_engine/mod.rs
@@ -109,11 +109,9 @@ impl QueryEngine {
 
     /// Handle client request.
     pub async fn handle(&mut self, context: &mut QueryEngineContext<'_>) -> Result<(), Error> {
-        // ensure that when we are handling a client request, it shows as active
-        self.update_stats(context);
-
         self.stats
             .received(context.client_request.total_message_len());
+        self.set_state(State::Active); // Client is active.
 
         // Rewrite prepared statements.
         self.rewrite_extended(context)?;


### PR DESCRIPTION
### Description

- fix: client doesn't set its state to `active` upon receiving request