### PR TITLE
Fix: Preserve decimal/float values in INSERT and UPDATE statements

### DIFF
--- a/pgdog/src/frontend/client/query_engine/shard_key_rewrite.rs
+++ b/pgdog/src/frontend/client/query_engine/shard_key_rewrite.rs
@@ -421,6 +421,7 @@ fn apply_assignments(
 
         let new_value = match assignment.value() {
             AssignmentValue::Integer(value) => Some(value.to_string()),
+            AssignmentValue::Float(value) => Some(value.clone()),
             AssignmentValue::String(value) => Some(value.clone()),
             AssignmentValue::Boolean(value) => Some(value.to_string()),
             AssignmentValue::Null => None,

--- a/pgdog/src/frontend/router/parser/rewrite/shard_key.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/shard_key.rs
@@ -8,6 +8,7 @@ use super::super::table::OwnedTable;
 pub enum AssignmentValue {
     Parameter(i32),
     Integer(i64),
+    Float(String),
     String(String),
     Boolean(bool),
     Null,

--- a/pgdog/src/frontend/router/parser/value.rs
+++ b/pgdog/src/frontend/router/parser/value.rs
@@ -12,6 +12,7 @@ use crate::net::{messages::Vector, vector::str_to_vector};
 pub enum Value<'a> {
     String(&'a str),
     Integer(i64),
+    Float(&'a str),
     Boolean(bool),
     Null,
     Placeholder(i32),
@@ -53,13 +54,7 @@ impl<'a> From<&'a AConst> for Value<'a> {
             }
             Some(Val::Boolval(b)) => Value::Boolean(b.boolval),
             Some(Val::Ival(i)) => Value::Integer(i.ival as i64),
-            Some(Val::Fval(Float { fval })) => {
-                if let Ok(val) = fval.parse() {
-                    Value::Integer(val)
-                } else {
-                    Value::Null
-                }
-            }
+            Some(Val::Fval(Float { fval })) => Value::Float(fval.as_str()),
             _ => Value::Null,
         }
     }


### PR DESCRIPTION
This pull request improves support for decimal/float values in SQL parsing and sharding logic, especially for `INSERT` and `UPDATE` statements. It introduces a new `Float` variant to the `Value` and `AssignmentValue` enums, ensures decimals are preserved (not coerced to integers or null), and adds handling and tests for these cases. Additionally, it prevents the use of float/decimal columns as sharding keys, returning clear errors or routing to all shards when necessary.

**Decimal/Float Value Handling Improvements:**

* Added a `Float` variant to the `Value` and `AssignmentValue` enums, ensuring decimal values are preserved as strings throughout parsing and assignment (`pgdog/src/frontend/router/parser/value.rs`, `pgdog/src/frontend/router/parser/rewrite/shard_key.rs`). [[1]](diffhunk://#diff-bd5edaf0e41ddd3af4577a1e7e53af5953d62db4ef5e6531db38dccaf0c87b91R15) [[2]](diffhunk://#diff-7f25c6defa22d112850e0f942520463df6cd1d80af656ec435abcdeea3cd4f99R11)
* Updated parsing logic to map float/decimal literals to the new `Float` variant instead of attempting to parse as integers or returning null (`pgdog/src/frontend/router/parser/value.rs`).
* Modified assignment and value handling to correctly propagate and stringify float values in query rewriting and sharding logic (`pgdog/src/frontend/client/query_engine/shard_key_rewrite.rs`, `pgdog/src/frontend/router/parser/insert.rs`). [[1]](diffhunk://#diff-fabbbd1dac63eca483df4ee327365faebbcf441cb474b442c97e7db89d4bf854R424) [[2]](diffhunk://#diff-55ec6e26408c3763f93de5033481bdd1c9a202cfd351f48338a53d554c60a9d5R377) [[3]](diffhunk://#diff-314df04f8984799d59642fa3ea4027c9536ee9783f7a68ff7b01ddae3c5b80b3R323)

**Sharding Logic and Error Handling:**

* Updated sharding logic to reject float/decimal columns as sharding keys for split inserts, returning a clear error message, and to route updates with float sharding keys to all shards (`pgdog/src/frontend/router/parser/insert.rs`, `pgdog/src/frontend/router/parser/query/update.rs`). [[1]](diffhunk://#diff-55ec6e26408c3763f93de5033481bdd1c9a202cfd351f48338a53d554c60a9d5R247-R256) [[2]](diffhunk://#diff-314df04f8984799d59642fa3ea4027c9536ee9783f7a68ff7b01ddae3c5b80b3R266-R270)

**Testing and Validation:**

* Added comprehensive tests to verify that decimal values are preserved (not quoted unless originally quoted), that quoted decimals are treated as strings, and that float sharding keys are rejected or handled safely in both insert and update scenarios (`pgdog/src/frontend/router/parser/insert.rs`, `pgdog/src/frontend/router/parser/query/update.rs`). [[1]](diffhunk://#diff-55ec6e26408c3763f93de5033481bdd1c9a202cfd351f48338a53d554c60a9d5R892-R1074) [[2]](diffhunk://#diff-314df04f8984799d59642fa3ea4027c9536ee9783f7a68ff7b01ddae3c5b80b3R385-R470)