### PR TITLE
Add required tools via mise.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,7 @@ Contributions are welcome. If you see a bug, feel free to submit a PR with a fix
 
 ## Necessary crates - cargo install <name>
 
+(if you use mise, these can be installed with `mise install`)
 - cargo-nextest
 - cargo-watch
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,3 @@
+[tools]
+"cargo:cargo-nextest" = "latest"
+"cargo:cargo-watch" = "latest"


### PR DESCRIPTION
Obviously this doesn't require people to use mise, but this provides a simple installation for people that do, and we can hardcode the versions of dev tools that pgdog relies on in case that's needed later.

Obviously a totally optional one, but I set it up locally so figured I'd upstream.