### PR TITLE
feat: change server address logging format to include user

### DIFF
--- a/pgdog/src/backend/pool/address.rs
+++ b/pgdog/src/backend/pool/address.rs
@@ -84,7 +84,11 @@ impl Address {
 
 impl std::fmt::Display for Address {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}:{}, {}", self.host, self.port, self.database_name)
+        write!(
+            f,
+            "{}@{}:{}/{}",
+            self.user, self.host, self.port, self.database_name
+        )
     }
 }
 


### PR DESCRIPTION
New format:

```
new server connection [pgdog@127.0.0.1:5438/pgdog, auth: trust]
```

Old format:

```
new server connection [localhost:5432, shard_0, pgdog, auth: trust]
```