### PR TITLE
fix: protobuf stack overflow; feat: make stack size configurable for threads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2334,8 +2334,7 @@ dependencies = [
 [[package]]
 name = "pg_query"
 version = "6.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ca6fdb8f9d32182abf17328789f87f305dd8c8ce5bf48c5aa2b5cffc94e1c04"
+source = "git+https://github.com/pgdogdev/pg_query.rs.git#85a65482cd112f9702ef895fc793e9ae3d102d7f"
 dependencies = [
  "bindgen 0.66.1",
  "cc",

--- a/pgdog-config/src/memory.rs
+++ b/pgdog-config/src/memory.rs
@@ -7,6 +7,8 @@ pub struct Memory {
     pub net_buffer: usize,
     #[serde(default = "default_message_buffer")]
     pub message_buffer: usize,
+    #[serde(default = "default_stack_size")]
+    pub stack_size: usize,
 }
 
 impl Default for Memory {
@@ -14,6 +16,7 @@ impl Default for Memory {
         Self {
             net_buffer: default_net_buffer(),
             message_buffer: default_message_buffer(),
+            stack_size: default_stack_size(),
         }
     }
 }
@@ -24,4 +27,9 @@ fn default_net_buffer() -> usize {
 
 fn default_message_buffer() -> usize {
     default_net_buffer()
+}
+
+// Default: 2MiB.
+fn default_stack_size() -> usize {
+    2 * 1024 * 1024
 }

--- a/pgdog-plugin/Cargo.toml
+++ b/pgdog-plugin/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["rlib", "cdylib"]
 libloading = "0.8"
 libc = "0.2"
 tracing = "0.1"
-pg_query = "6.1.1"
+pg_query = { git = "https://github.com/pgdogdev/pg_query.rs.git" }
 pgdog-macros = { path = "../pgdog-macros", version = "0.1.1" }
 toml = "0.9"
 

--- a/pgdog/Cargo.toml
+++ b/pgdog/Cargo.toml
@@ -43,7 +43,7 @@ base64 = "0.22"
 md5 = "0.7"
 futures = "0.3"
 csv-core = "0.1"
-pg_query = "6.1.1"
+pg_query = { git = "https://github.com/pgdogdev/pg_query.rs.git" }
 regex = "1"
 uuid = { version = "1", features = ["v4", "serde"] }
 url = "2"


### PR DESCRIPTION
Remove the recursion limit for parsing queries. I may regret this in the future, but for now, we need to parse some complex queries.

Additionally, make thread stack size configurable in case recursion limits need to be increased in our own code.