### PR TITLE
feat: log startup parameters in debug mode

### DIFF
--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -302,6 +302,11 @@ impl Client {
             );
         }
 
+        debug!(
+            "client \"{}\" startup parameters: {} [{}]",
+            user, params, addr
+        );
+
         Ok(Some(Self {
             addr,
             stream,

--- a/pgdog/src/net/parameter.rs
+++ b/pgdog/src/net/parameter.rs
@@ -155,6 +155,18 @@ pub struct Parameters {
     hash: u64,
 }
 
+impl Display for Parameters {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let output = self
+            .params
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, v))
+            .collect::<Vec<_>>()
+            .join(", ");
+        write!(f, "{}", output)
+    }
+}
+
 impl MemoryUsage for Parameters {
     #[inline]
     fn memory_usage(&self) -> usize {


### PR DESCRIPTION
```
client "pgdog" startup parameters: application_name="psql", client_encoding="UTF8", database="pgdog", pgdog.role="primary", user="pgdog" [127.0.0.1:33622]
```