### PR TITLE
fix: respect prepared_statements setting

### DIFF
--- a/pgdog/src/frontend/router/parser/query/mod.rs
+++ b/pgdog/src/frontend/router/parser/query/mod.rs
@@ -232,7 +232,7 @@ impl QueryParser {
         trace!("{:#?}", statement);
 
         let rewrite = Rewrite::new(statement.ast());
-        if rewrite.needs_rewrite() {
+        if context.full_prepared_statements && rewrite.needs_rewrite() {
             debug!("rewrite needed");
             return rewrite.rewrite(context.prepared_statements());
         }


### PR DESCRIPTION
#677 

Prepared statements engine was acting as if `prepared_statements = "full"` was default, and rewriting `PREPARE` and `EXECUTE` commands (incorrectly, inside transactions) even though `prepared_statements = "extended"` is actually the default.