### PR TITLE
Recompute the parameters hash when the params are cleared

### DIFF
--- a/pgdog/src/net/parameter.rs
+++ b/pgdog/src/net/parameter.rs
@@ -201,6 +201,12 @@ impl Parameters {
         result
     }
 
+    /// Recompute hash when params are cleared.
+    pub fn clear(&mut self) {
+        self.params.clear();
+        self.hash = Self::compute_hash(&self.params);
+    }
+
     /// Get parameter.
     pub fn get(&self, name: &str) -> Option<&ParameterValue> {
         if let Some(param) = self.transaction_local_params.get(name) {


### PR DESCRIPTION
I ran into a bug, where the `application_name` in the postgres connection parameters was not being correctly set on the server after the first connection.

I tested with a local postgres container. Here is my `pgdog.toml`:
```
[general]
host = "127.0.0.1"
port = 6432
pooler_mode = "session"

# Primary Database
[[databases]]
host = "127.0.0.1"
name = "primary"
port = 5433
database_name = "intempus"
user = "intempus"
password = "intempus"
pool_size = 1
min_pool_size = 1
```
I could reproduce the problem by starting pgdog and then connecting with psql, running a query to print the `application_name` in the postgres DB:
```
$ psql "host=127.0.0.1 port=6432 dbname=primary application_name=test1" -c "SELECT application_name,query from pg_stat_activity;"
 application_name |                        query                         
------------------+------------------------------------------------------
 test1               | SELECT application_name,query from pg_stat_activity;

$ psql "host=127.0.0.1 port=6432 dbname=primary application_name=test1" -c "SELECT application_name,query from pg_stat_activity;"
 application_name |                        query                         
------------------+------------------------------------------------------
 PgDog            | SELECT application_name,query from pg_stat_activity;

$ psql "host=127.0.0.1 port=6432 dbname=primary application_name=test1" -c "SELECT application_name,query from pg_stat_activity;"
 application_name |                        query                         
------------------+------------------------------------------------------
 PgDog            | SELECT application_name,query from pg_stat_activity;
```

The `application_name` will always be `PgDog` after the 1st connection. If I change the `application_name` right after to something other than `test1`, it will reset and work for the 1st connection only again:

```
$ psql "host=127.0.0.1 port=6432 dbname=primary application_name=test2" -c "SELECT application_name,query from pg_stat_activity;"
 application_name |                        query                         
------------------+------------------------------------------------------
 test2               | SELECT application_name,query from pg_stat_activity;
 
$ psql "host=127.0.0.1 port=6432 dbname=primary application_name=test2" -c "SELECT application_name,query from pg_stat_activity;"
 application_name |                        query                         
------------------+------------------------------------------------------
 PgDog            | SELECT application_name,query from pg_stat_activity;

$ psql "host=127.0.0.1 port=6432 dbname=primary application_name=test2" -c "SELECT application_name,query from pg_stat_activity;"
 application_name |                        query                         
------------------+------------------------------------------------------
 PgDog            | SELECT application_name,query from pg_stat_activity;
```


I tracked down the [problem to this comparison statement in servers.rs](https://github.com/pgdogdev/pgdog/blob/main/pgdog/src/backend/server.rs#L479). The `identical` function compares if the hashes in `params` and `client_params` on the server object are the same.
On my 1st connection attempt the comparison correctly identifies that the parameters are not the same and goes into the if block. All subsequent connections never go into the if block, until the `application_name` is changed.

Here are the values for `params` and `self.client_params`:
```
# 1st call
client_params: Parameters { params: {}, transaction_params: {}, transaction_local_params: {}, hash: 0 }
params: Parameters { params: {"application_name": String("test2"), "client_encoding": String("UTF8"), "database": String("primary"), "user": String("intempus")}, transaction_params: {}, transaction_local_params: {}, hash: 6714540884140617138 }
# 2nd call
client_params: Parameters { params: {}, transaction_params: {}, transaction_local_params: {}, hash: 6714540884140617138 }
params: Parameters { params: {"application_name": String("test2"), "client_encoding": String("UTF8"), "database": String("primary"), "user": String("intempus")}, transaction_params: {}, transaction_local_params: {}, hash: 6714540884140617138 }
```

When the connection is closed and a `DISCARD ALL` query is sent, `self.client_params.clear()` [is called](https://github.com/pgdogdev/pgdog/blob/main/pgdog/src/backend/server.rs#L445), but that doesn't recompute the hash, so parameters will be cleared but the hash will stay the same value and result in wrong `identical` checks from then on.

Ensuring the hash is recomputed when the parameters are cleared fixes the issue. Let me know if it sounds good or if it should be done using a different approach :)