### PR TITLE
fix: SET TRANSACTION was captured as a session parameter

### DIFF
--- a/pgdog/src/frontend/router/parser/query/set.rs
+++ b/pgdog/src/frontend/router/parser/query/set.rs
@@ -13,15 +13,18 @@ impl QueryParser {
         stmt: &VariableSetStmt,
         context: &QueryParserContext,
     ) -> Result<Command, Error> {
+        let transaction_state = stmt.name.starts_with("TRANSACTION");
         let value = Self::parse_set_value(stmt)?;
 
         if let Some(value) = value {
-            return Ok(Command::Set {
-                name: stmt.name.to_string(),
-                value,
-                local: stmt.is_local,
-                route: Route::write(context.shards_calculator.shard()),
-            });
+            if !transaction_state {
+                return Ok(Command::Set {
+                    name: stmt.name.to_string(),
+                    value,
+                    local: stmt.is_local,
+                    route: Route::write(context.shards_calculator.shard()),
+                });
+            }
         }
 
         Ok(Command::Query(

--- a/pgdog/src/frontend/router/parser/query/test/test_set.rs
+++ b/pgdog/src/frontend/router/parser/query/test/test_set.rs
@@ -17,3 +17,23 @@ fn test_set_comment() {
         command,
     );
 }
+
+#[test]
+fn test_set_transaction_level() {
+    let mut test = QueryParserTest::new();
+
+    for query in [
+        "SET TRANSACTION SNAPSHOT '00000003-0000001B-1'",
+        "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ",
+        "set transaction isolation level repeatable read",
+        "set transaction snapshot '00000003-0000001B-1'",
+        "SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL SERIALIZABLE",
+    ] {
+        let command = test.execute(vec![Query::new(query).into()]);
+        assert!(
+            matches!(command.clone(), Command::Query(_)),
+            "{:#?}",
+            command
+        );
+    }
+}


### PR DESCRIPTION
Fixes

```
WARNING:  SET TRANSACTION can only be used in transaction blocks
```

and possibly the not in transaction warnings reported in #685