### PR TITLE
fix: least active connections was doing the opposite

### DIFF
--- a/pgdog/src/backend/pool/lb/mod.rs
+++ b/pgdog/src/backend/pool/lb/mod.rs
@@ -285,7 +285,7 @@ impl LoadBalancer {
                 candidates = reshuffled;
             }
             LeastActiveConnections => {
-                candidates.sort_by_cached_key(|target| target.pool.lock().idle());
+                candidates.sort_by_cached_key(|target| target.pool.lock().checked_out());
             }
         }
 


### PR DESCRIPTION
<img width="92" height="92" alt="image" src="https://github.com/user-attachments/assets/f2d0e459-8181-4f2a-b2cf-03d69ec1aa91" />

The load balancer `least_active_connections` was doing the opposite: it was sending queries to most busy databases.