### PR TITLE
fix: ensure config is TOML-serializable

### DIFF
--- a/pgdog-config/src/general.rs
+++ b/pgdog-config/src/general.rs
@@ -368,19 +368,22 @@ impl General {
     fn default_client_idle_timeout() -> u64 {
         Self::env_or_default(
             "PGDOG_CLIENT_IDLE_TIMEOUT",
-            Duration::MAX.as_millis() as u64,
+            crate::MAX_DURATION.as_millis() as u64,
         )
     }
 
     fn default_client_idle_in_transaction_timeout() -> u64 {
         Self::env_or_default(
             "PGDOG_CLIENT_IDLE_IN_TRANSACTION_TIMEOUT",
-            Duration::MAX.as_millis() as u64,
+            crate::MAX_DURATION.as_millis() as u64,
         )
     }
 
     fn default_query_timeout() -> u64 {
-        Self::env_or_default("PGDOG_QUERY_TIMEOUT", Duration::MAX.as_millis() as u64)
+        Self::env_or_default(
+            "PGDOG_QUERY_TIMEOUT",
+            crate::MAX_DURATION.as_millis() as u64,
+        )
     }
 
     pub fn query_timeout(&self) -> Duration {
@@ -447,7 +450,10 @@ impl General {
     }
 
     fn lsn_check_delay() -> u64 {
-        Self::env_or_default("PGDOG_LSN_CHECK_DELAY", Duration::MAX.as_millis() as u64)
+        Self::env_or_default(
+            "PGDOG_LSN_CHECK_DELAY",
+            crate::MAX_DURATION.as_millis() as u64,
+        )
     }
 
     fn read_write_strategy() -> ReadWriteStrategy {
@@ -541,7 +547,7 @@ impl General {
     }
 
     pub fn prepared_statements_limit() -> usize {
-        Self::env_or_default("PGDOG_PREPARED_STATEMENTS_LIMIT", usize::MAX)
+        Self::env_or_default("PGDOG_PREPARED_STATEMENTS_LIMIT", i64::MAX as usize)
     }
 
     pub fn query_cache_limit() -> usize {
@@ -873,7 +879,7 @@ mod tests {
 
         assert_eq!(General::broadcast_port(), General::port() + 1);
         assert_eq!(General::openmetrics_port(), None);
-        assert_eq!(General::prepared_statements_limit(), usize::MAX);
+        assert_eq!(General::prepared_statements_limit(), i64::MAX as usize);
         assert_eq!(General::query_cache_limit(), 50_000);
         assert_eq!(General::connect_attempts(), 1);
         assert_eq!(General::mirror_queue(), 128);

--- a/pgdog-config/src/lib.rs
+++ b/pgdog-config/src/lib.rs
@@ -32,3 +32,42 @@ pub use replication::*;
 pub use rewrite::{Rewrite, RewriteMode};
 pub use sharding::*;
 pub use users::{Admin, Plugin, User, Users};
+
+use std::time::Duration;
+
+// Make sure all duration fields
+// are at least TOML-serializable.
+pub const MAX_DURATION: Duration = Duration::from_millis(i64::MAX as u64);
+
+#[cfg(test)]
+mod test {
+    use std::time::Duration;
+
+    use serde::Serialize;
+
+    use crate::{ConfigAndUsers, MAX_DURATION};
+
+    #[test]
+    fn test_max_duration() {
+        assert!(MAX_DURATION > Duration::from_hours(24 * 7 * 52 * 100)); // 100 years
+        assert_eq!(MAX_DURATION.as_millis() as i64, i64::MAX);
+
+        #[derive(Serialize)]
+        struct SerTest {
+            value: u64,
+        }
+
+        let instance = SerTest {
+            value: MAX_DURATION.as_millis() as u64,
+        };
+
+        toml::to_string(&instance).unwrap();
+    }
+
+    #[test]
+    fn test_default_config_serializable() {
+        let config = ConfigAndUsers::default();
+        toml::to_string(&config.config).unwrap();
+        toml::to_string(&config.users).unwrap();
+    }
+}


### PR DESCRIPTION
Makes sure default values in the config are only as large as the largest TOML value, so it's serializable.