### PR TITLE
fix: shard key updater didn't disconnect servers, causing routing confusion

### DIFF
--- a/pgdog/src/frontend/client/query_engine/multi_step/update.rs
+++ b/pgdog/src/frontend/client/query_engine/multi_step/update.rs
@@ -126,11 +126,12 @@ impl<'a> UpdateMulti<'a> {
                 return Ok(());
             }
 
-            if !context.in_transaction() && !self.engine.backend.is_multishard()
+            if !context.in_transaction() || !self.engine.backend.is_multishard()
             // Do this check at the last possible moment.
             // Just in case we change how transactions are
             // routed in the future.
             {
+                self.engine.cleanup_backend(context);
                 return Err(UpdateError::TransactionRequired.into());
             }
 


### PR DESCRIPTION
If client attempted to do a sharding key update without a transaction, PgDog would return an error and forget to disconnect backends. Subsequent query would be routed to previous route incorrectly, causing confusion.