### PR TITLE
feat: make resharding copy format configurable

### DIFF
--- a/integration/copy_data/pgdog.toml
+++ b/integration/copy_data/pgdog.toml
@@ -1,3 +1,6 @@
+[general]
+resharding_copy_format = "binary"
+
 [[databases]]
 name = "source"
 host = "127.0.0.1"

--- a/pgdog-config/src/general.rs
+++ b/pgdog-config/src/general.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use crate::pooling::ConnectionRecovery;
-use crate::{QueryParserEngine, QueryParserLevel, SystemCatalogsBehavior};
+use crate::{CopyFormat, QueryParserEngine, QueryParserLevel, SystemCatalogsBehavior};
 
 use super::auth::{AuthType, PassthoughAuth};
 use super::database::{LoadBalancingStrategy, ReadWriteSplit, ReadWriteStrategy};
@@ -200,6 +200,9 @@ pub struct General {
     /// Omnisharded queries are sticky by default.
     #[serde(default)]
     pub omnisharded_sticky: bool,
+    /// Copy format used for resharding.
+    #[serde(default)]
+    pub resharding_copy_format: CopyFormat,
 }
 
 impl Default for General {
@@ -270,6 +273,7 @@ impl Default for General {
             unique_id_min: u64::default(),
             system_catalogs: Self::default_system_catalogs(),
             omnisharded_sticky: bool::default(),
+            resharding_copy_format: CopyFormat::default(),
         }
     }
 }

--- a/pgdog-config/src/sharding.rs
+++ b/pgdog-config/src/sharding.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::collections::{hash_map::DefaultHasher, HashSet};
+use std::fmt::Display;
 use std::hash::{Hash, Hasher as StdHasher};
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -334,5 +335,22 @@ impl FromStr for SystemCatalogsBehavior {
             "sharded" => Self::Sharded,
             _ => return Err(()),
         })
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq, Hash, Default)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub enum CopyFormat {
+    Text,
+    #[default]
+    Binary,
+}
+
+impl Display for CopyFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Binary => write!(f, "binary"),
+            Self::Text => write!(f, "text"),
+        }
     }
 }

--- a/pgdog/src/backend/replication/logical/publisher/copy.rs
+++ b/pgdog/src/backend/replication/logical/publisher/copy.rs
@@ -2,6 +2,7 @@ use crate::{
     backend::Server,
     net::{CopyData, ErrorResponse, FromBytes, Protocol, Query, ToBytes},
 };
+use pgdog_config::CopyFormat;
 use tracing::{debug, trace};
 
 use super::{
@@ -15,7 +16,7 @@ pub struct Copy {
 }
 
 impl Copy {
-    pub fn new(table: &Table) -> Self {
+    pub fn new(table: &Table, copy_format: CopyFormat) -> Self {
         let stmt = CopyStatement::new(
             &table.table,
             &table
@@ -23,6 +24,7 @@ impl Copy {
                 .iter()
                 .map(|c| c.name.clone())
                 .collect::<Vec<_>>(),
+            copy_format,
         );
 
         Self { stmt }

--- a/pgdog/src/backend/replication/logical/publisher/table.rs
+++ b/pgdog/src/backend/replication/logical/publisher/table.rs
@@ -9,6 +9,7 @@ use crate::backend::replication::publisher::progress::Progress;
 use crate::backend::replication::publisher::Lsn;
 
 use crate::backend::{Cluster, Server};
+use crate::config::config;
 use crate::net::replication::StatusUpdate;
 
 use super::super::{subscriber::CopySubscriber, Error};
@@ -186,7 +187,7 @@ impl Table {
         // Sync data using COPY.
         // Publisher uses COPY [...] TO STDOUT.
         // Subscriber uses COPY [...] FROM STDIN.
-        let copy = Copy::new(self);
+        let copy = Copy::new(self, config().config.general.resharding_copy_format);
 
         // Create new standalone connection for the copy.
         // let mut server = Server::connect(source, ServerOptions::new_replication()).await?;

--- a/pgdog/src/backend/replication/logical/subscriber/copy.rs
+++ b/pgdog/src/backend/replication/logical/subscriber/copy.rs
@@ -224,7 +224,11 @@ mod test {
             ..Default::default()
         };
 
-        let copy = CopyStatement::new(&table, &["id".into(), "value".into()]);
+        let copy = CopyStatement::new(
+            &table,
+            &["id".into(), "value".into()],
+            pgdog_config::CopyFormat::Binary,
+        );
         let cluster = Cluster::new_test(&config());
         cluster.launch();
 


### PR DESCRIPTION
Make the format we use for COPY during resharding configurable. This is helpful when data types change between source and destination, e.g. `integer` -> `bigint`.