### PR TITLE
feat: current settings exposed as metrics (#724)

### DIFF
--- a/pgdog/src/stats/pools.rs
+++ b/pgdog/src/stats/pools.rs
@@ -332,7 +332,7 @@ impl Pools {
                 labels: vec![],
                 measurement: general.query_cache_limit.into(),
             }],
-            help: "Maximum number of queries stored in cache".into(),
+            help: "Maximum number of queries that can be stored in the cache".into(),
             unit: None,
             metric_type: None,
         }));


### PR DESCRIPTION
This PR adds three new metrics in response to issue #724: 
- max_connections
- prepared_statements_limit
- query_cache_limit

This corresponds to the following sample pgdog.toml:
```
[general]
openmetrics_port = 9090
prepared_statements_limit = 123
query_cache_limit = 456
default_pool_size = 70

[[databases]]
name = "mydb"
host = "127.0.0.1"
port = 5432
shard = 0

```
This produces the following output when metrics are displayed. 
```
# TYPE max_connections gauge
# HELP max_connections Maximum number of server connections allowed for a pool
max_connections{user="ubuntu",database="mydb",host="127.0.0.1",port="5432",shard="0",role="primary"} 70

# TYPE prepared_statements_limit gauge
# HELP prepared_statements_limit Maximum number of prepared statements that are cached
prepared_statements_limit{user="ubuntu",database="mydb",host="127.0.0.1",port="5432",shard="0",role="primary"} 123

# TYPE query_cache_limit gauge
# HELP query_cache_limit Maximum number of queries stored in cache
query_cache_limit{user="ubuntu",database="mydb",host="127.0.0.1",port="5432",shard="0",role="primary"} 456

```