### PR TITLE
fix: confusing tls connection indicator

### DIFF
--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -250,7 +250,7 @@ impl Server {
             addr,
             auth_type,
             connect_reason,
-            if stream.is_tls() { "🔓" } else { "" },
+            if stream.is_tls() { "🔒" } else { "" },
         );
 
         let mut server = Server {

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -294,7 +294,7 @@ impl Client {
                 } else {
                     auth_type.to_string()
                 },
-                if stream.is_tls() { "🔓" } else { "" }
+                if stream.is_tls() { "🔒" } else { "" }
             );
         }
 


### PR DESCRIPTION
Currently, the log uses `🔓` to indicate a TLS connection, which is confusing.
Since the lock in this icon is open, it appears inconsistent with the expression of security.

To convey security, using a locked lock icon `🔒` seems more appropriate. One piece of evidence is that the code in https://github.com/pgdogdev/pgdog/blob/9afa9f6e126a7ac802aaf0a3d233d5d6221456cf/pgdog/src/net/tls.rs#L127 uses `🔓` to indicate TLS is disabled.


Regarding whether to use `🔓` as an indicator for non-TLS connections, I welcome further input.