### PR TITLE
fix: handle PortalSuspended correctly

### DIFF
--- a/pgdog/src/net/messages/execute.rs
+++ b/pgdog/src/net/messages/execute.rs
@@ -47,6 +47,18 @@ impl Execute {
         }
     }
 
+    /// Create an Execute message for a named portal with a row limit.
+    /// A limit of 0 means fetch all rows.
+    pub fn new_portal_limit(name: &str, max_rows: i32) -> Self {
+        let mut payload = Payload::named('E');
+        payload.put_string(name);
+        payload.put_i32(max_rows);
+        Self {
+            payload: payload.freeze(),
+            portal_len: name.len() + 1,
+        }
+    }
+
     pub fn portal(&self) -> &str {
         let start = 5;
         let end = start


### PR DESCRIPTION
We were incorrectly releasing server back into the pool after receiving:

```
Execute(limit=x)
Flush
```

Not entirely sure what the implication is since the connection cleanup logic kicked in by sending `Sync` and closing the transaction, but this does have a smell of something was handled incorrectly.