### PR TITLE
docs(pgdog-plugin): update the README and lib docs

### DIFF
--- a/pgdog-plugin/README.md
+++ b/pgdog-plugin/README.md
@@ -1,6 +1,7 @@
 # PgDog plugins
 
-[![Documentation](https://img.shields.io/badge/documentation-blue?style=flat)](https://docsrs.pgdog.dev/pgdog_plugin/index.html)
+[![Tutorial](https://img.shields.io/badge/Tutorial-blue)](https://docs.pgdog.dev/features/plugins/)
+[![docs.rs](https://img.shields.io/docsrs/pgdog-plugin)](https://docsrs.pgdog.dev/pgdog_plugin/index.html)
 [![Latest crate](https://img.shields.io/crates/v/pgdog-plugin.svg)](https://crates.io/crates/pgdog-plugin)
 
 PgDog plugin system is based around shared libraries loaded at runtime. The plugins currently can only be
@@ -12,13 +13,13 @@ This crate implements the bridge between PgDog and plugins, making sure data typ
 Automatic checks include:
 
 - Rust compiler version check
-- `pg_query` version check
+- `pgdog-plugin` crate version check
 
 This crate should be linked at compile time against your plugins.
 
 ## Writing plugins
 
-See [documentation](https://docsrs.pgdog.dev/pgdog_plugin/index.html) for examples. Example plugins are [available in GitHub](https://github.com/pgdogdev/pgdog/tree/main/plugins) as well.
+See [crate documentation](https://docsrs.pgdog.dev/pgdog_plugin/index.html) and [pgdog tutorial](https://docs.pgdog.dev/features/plugins/) for guides and examples. Example plugins are [available in GitHub](https://github.com/pgdogdev/pgdog/tree/main/plugins) as well.
 
 ## License
 

--- a/pgdog-plugin/src/lib.rs
+++ b/pgdog-plugin/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! ```toml
 //! [lib]
-//! crate-type = ["rlib", "cdylib"]
+//! crate-type = ["cdylib"]
 //! ```
 //!
 //! ## Dependencies
@@ -26,7 +26,7 @@
 //! following 2 requirements:
 //!
 //! 1. Plugins must be compiled with the **same version of the Rust compiler** as PgDog. This is automatically checked at runtime and plugins that don't do this are not loaded.
-//! 2. Plugins must use the **same version of [`pg_query`] crate** as PgDog. This happens automatically when using `pg_query` structs re-exported by this crate.
+//! 2. Plugins must use the **same version of `pgdog-plugin` crate** as PgDog. This is automatically checked at runtime and plugins that use incompatible versions are not loaded.
 //!
 //!
 //! #### Configure dependencies
@@ -35,7 +35,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! pgdog-plugin = "0.1.6"
+//! pgdog-plugin = "0.2.0"
 //! ```
 //!
 //! # Required methods


### PR DESCRIPTION
Little update of the docs based on latest changes from https://github.com/pgdogdev/pgdog/pull/770