### PR TITLE
fix: error handling inside pipelined requests

### DIFF
--- a/pgdog/src/backend/pool/connection/binding.rs
+++ b/pgdog/src/backend/pool/connection/binding.rs
@@ -240,6 +240,15 @@ impl Binding {
         }
     }
 
+    /// Protocol is out of sync due to an error in extended protocol.
+    pub fn out_of_sync(&self) -> bool {
+        match self {
+            Binding::Direct(Some(server)) => server.out_of_sync(),
+            Binding::MultiShard(servers, _state) => servers.iter().any(|s| s.out_of_sync()),
+            _ => false,
+        }
+    }
+
     pub(super) fn state_check(&self, state: State) -> bool {
         match self {
             Binding::Direct(Some(server)) => {

--- a/pgdog/src/backend/prepared_statements.rs
+++ b/pgdog/src/backend/prepared_statements.rs
@@ -260,6 +260,11 @@ impl PreparedStatements {
         self.state.in_copy_mode()
     }
 
+    /// The protocol is out of sync due to an error in extended protocol.
+    pub(crate) fn out_of_sync(&self) -> bool {
+        self.state.out_of_sync()
+    }
+
     fn check_prepared(&mut self, name: &str) -> Result<Option<ProtocolMessage>, Error> {
         if !self.contains(name) && !self.parses.iter().any(|s| s == name) {
             let parse = self.parse(name);

--- a/pgdog/src/backend/protocol/state.rs
+++ b/pgdog/src/backend/protocol/state.rs
@@ -225,6 +225,11 @@ impl ProtocolState {
     pub(crate) fn in_sync(&self) -> bool {
         !self.out_of_sync
     }
+
+    /// Check if the protocol is out of sync due to an error in extended protocol.
+    pub(crate) fn out_of_sync(&self) -> bool {
+        self.out_of_sync
+    }
 }
 
 #[cfg(test)]

--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -605,6 +605,11 @@ impl Server {
         self.prepared_statements.in_copy_mode()
     }
 
+    /// Protocol is out of sync due to an error in extended protocol.
+    pub fn out_of_sync(&self) -> bool {
+        self.prepared_statements.out_of_sync()
+    }
+
     /// Server is still inside a transaction.
     #[inline]
     pub fn in_transaction(&self) -> bool {

--- a/pgdog/src/frontend/client/query_engine/mod.rs
+++ b/pgdog/src/frontend/client/query_engine/mod.rs
@@ -295,4 +295,9 @@ impl QueryEngine {
     pub fn get_state(&self) -> State {
         self.stats.state
     }
+
+    /// Check if the backend protocol is out of sync due to an error in extended protocol.
+    pub fn out_of_sync(&self) -> bool {
+        self.backend.out_of_sync()
+    }
 }


### PR DESCRIPTION
We were incorrectly handling error state inside pipelined requests (we call them spliced). Now we fast-forward to Sync and restore pipeline to good state.