### PR TITLE
refactor: make client_connection_recovery = drop by default

### DIFF
--- a/pgdog-config/src/general.rs
+++ b/pgdog-config/src/general.rs
@@ -614,7 +614,7 @@ impl General {
     }
 
     pub fn client_connection_recovery() -> ConnectionRecovery {
-        Self::env_enum_or_default("PGDOG_CLIENT_CONNECTION_RECOVERY")
+        Self::env_option("PGDOG_CLIENT_CONNECTION_RECOVERY").unwrap_or(ConnectionRecovery::Drop)
     }
 
     fn stats_period() -> u64 {


### PR DESCRIPTION
fix #759 

I'm going to follow up with a fix for `recover` later on, but the problem I think is we are splitting the pipelined request and feeding the rest of it into the servers even if we receive checkout timeout from the pool.

Related: #776 