### PR TITLE
Update verify_ca implementation for rustls 0.23

### DIFF
--- a/pgdog/src/net/tls.rs
+++ b/pgdog/src/net/tls.rs
@@ -382,7 +382,9 @@ impl ServerCertVerifier for NoHostnameVerifier {
                 debug!("certificate validation successful (ignoring hostname)");
                 Ok(ServerCertVerified::assertion())
             }
-            Err(rustls::Error::InvalidCertificate(rustls::CertificateError::NotValidForNameContext { .. })) => {
+            Err(rustls::Error::InvalidCertificate(
+                rustls::CertificateError::NotValidForNameContext { .. },
+            )) => {
                 // If the only error is hostname mismatch, that's fine for Certificate mode
                 debug!("certificate validation successful (hostname mismatch ignored)");
                 Ok(ServerCertVerified::assertion())


### PR DESCRIPTION
Fixes https://github.com/pgdogdev/pgdog/issues/288 - the [NotValidForNameContext](
https://docs.rs/rustls/latest/rustls/enum.CertificateError.html#variant.NotValidForNameContext) exception is the one actually being raised since rustls 0.23
