### PR TITLE
feat: weighted load balancing

### DIFF
--- a/.schema/pgdog.schema.json
+++ b/.schema/pgdog.schema.json
@@ -370,6 +370,14 @@
           "format": "uint64",
           "minimum": 0
         },
+        "lb_weight": {
+          "description": "Used for weighted load balancing.",
+          "type": "integer",
+          "format": "uint8",
+          "default": 255,
+          "maximum": 255,
+          "minimum": 0
+        },
         "min_pool_size": {
           "description": "Overrides the `min_pool_size` setting. The connection pool will maintain at minimum this many connections.\n\nhttps://docs.pgdog.dev/configuration/pgdog.toml/databases/#min_pool_size",
           "type": [
@@ -1054,6 +1062,11 @@
           "description": "Route to the replica with the fewest active connections.",
           "type": "string",
           "const": "least_active_connections"
+        },
+        {
+          "description": "Weighted round-robin, distributing requests proportionally to configured weights.",
+          "type": "string",
+          "const": "weighted_round_robin"
         }
       ]
     },

--- a/pgdog-config/src/database.rs
+++ b/pgdog-config/src/database.rs
@@ -48,6 +48,8 @@ pub enum LoadBalancingStrategy {
     RoundRobin,
     /// Route to the replica with the fewest active connections.
     LeastActiveConnections,
+    /// Weighted round-robin, distributing requests proportionally to configured weights.
+    WeightedRoundRobin,
 }
 
 impl FromStr for LoadBalancingStrategy {
@@ -58,6 +60,7 @@ impl FromStr for LoadBalancingStrategy {
             "random" => Ok(Self::Random),
             "roundrobin" => Ok(Self::RoundRobin),
             "leastactiveconnections" => Ok(Self::LeastActiveConnections),
+            "weightedroundrobin" => Ok(Self::WeightedRoundRobin),
             _ => Err(format!("Invalid load balancing strategy: {}", s)),
         }
     }
@@ -184,6 +187,9 @@ pub struct Database {
     /// Used for resharding only; this database will not serve regular traffic.
     #[serde(default)]
     pub resharding_only: bool,
+    /// Used for weighted load balancing.
+    #[serde(default = "Database::lb_weight")]
+    pub lb_weight: u8,
 }
 
 impl Database {
@@ -194,6 +200,10 @@ impl Database {
 
     fn port() -> u16 {
         5432
+    }
+
+    fn lb_weight() -> u8 {
+        255
     }
 }
 

--- a/pgdog-stats/src/pool.rs
+++ b/pgdog-stats/src/pool.rs
@@ -327,6 +327,8 @@ pub struct Config {
     pub role_detection: bool,
     /// Used for resharding only.
     pub resharding_only: bool,
+    /// LB weight.
+    pub lb_weight: u8,
 }
 
 impl Default for Config {
@@ -363,6 +365,7 @@ impl Default for Config {
             lsn_check_delay: Duration::from_millis(5_000),
             role_detection: false,
             resharding_only: false,
+            lb_weight: 255,
         }
     }
 }

--- a/pgdog/src/backend/pool/config.rs
+++ b/pgdog/src/backend/pool/config.rs
@@ -144,6 +144,7 @@ impl Config {
                 lsn_check_delay: Duration::from_millis(general.lsn_check_delay),
                 role_detection: database.role == Role::Auto,
                 resharding_only: database.resharding_only,
+                lb_weight: database.lb_weight,
                 ..Default::default()
             },
         }

--- a/pgdog/src/backend/pool/lb/mod.rs
+++ b/pgdog/src/backend/pool/lb/mod.rs
@@ -2,7 +2,7 @@
 
 use std::{
     sync::{
-        atomic::{AtomicBool, AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicI64, AtomicUsize, Ordering},
         Arc,
     },
     time::{Duration, SystemTime},
@@ -38,6 +38,8 @@ pub struct Target {
     pub ban: Ban,
     replica: Arc<AtomicBool>,
     pub health: TargetHealth,
+    /// Smooth weighted round-robin current weight tracker.
+    current_weight: Arc<AtomicI64>,
 }
 
 impl Target {
@@ -48,6 +50,7 @@ impl Target {
             replica: Arc::new(AtomicBool::new(role == Role::Replica)),
             health: pool.inner().health.clone(),
             pool,
+            current_weight: Arc::new(AtomicI64::new(0)),
         }
     }
 
@@ -302,6 +305,33 @@ impl LoadBalancer {
             }
             LeastActiveConnections => {
                 candidates.sort_by_cached_key(|target| target.pool.lock().checked_out());
+            }
+            WeightedRoundRobin => {
+                let total_weight: i64 = candidates
+                    .iter()
+                    .map(|target| target.pool.config().lb_weight as i64)
+                    .sum();
+
+                if total_weight > 0 {
+                    for target in &candidates {
+                        target
+                            .current_weight
+                            .fetch_add(target.pool.config().lb_weight as i64, Ordering::Relaxed);
+                    }
+
+                    let max_idx = candidates
+                        .iter()
+                        .enumerate()
+                        .max_by_key(|(_, t)| t.current_weight.load(Ordering::Relaxed))
+                        .map(|(idx, _)| idx)
+                        .unwrap_or_default();
+
+                    candidates[max_idx]
+                        .current_weight
+                        .fetch_sub(total_weight, Ordering::Relaxed);
+
+                    candidates.swap(0, max_idx);
+                }
             }
         }
 

--- a/pgdog/src/backend/pool/lb/test.rs
+++ b/pgdog/src/backend/pool/lb/test.rs
@@ -1083,6 +1083,153 @@ async fn test_monitor_unbans_all_when_second_target_becomes_unhealthy_after_firs
     replicas.shutdown();
 }
 
+fn create_test_pool_config_weighted(host: &str, port: u16, lb_weight: u8) -> PoolConfig {
+    PoolConfig {
+        address: Address {
+            host: host.into(),
+            port,
+            user: "pgdog".into(),
+            password: "pgdog".into(),
+            database_name: "pgdog".into(),
+            ..Default::default()
+        },
+        config: Config {
+            inner: pgdog_stats::Config {
+                max: 1,
+                checkout_timeout: Duration::from_millis(1000),
+                ban_timeout: Duration::from_millis(100),
+                lb_weight,
+                ..Config::default().inner
+            },
+        },
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn test_weighted_round_robin_smooth_distribution() {
+    let pool_config1 = create_test_pool_config_weighted("127.0.0.1", 5432, 5);
+    let pool_config2 = create_test_pool_config_weighted("localhost", 5432, 1);
+
+    let lb = LoadBalancer::new(
+        &None,
+        &[pool_config1, pool_config2],
+        LoadBalancingStrategy::WeightedRoundRobin,
+        ReadWriteSplit::IncludePrimary,
+    );
+    lb.launch();
+
+    let request = Request::default();
+
+    let pool_a = lb.targets[0].pool.id();
+    let pool_b = lb.targets[1].pool.id();
+
+    // With weights [5, 1], over 6 rounds the sequence should be: A, A, B, A, A, A
+    // (B appears at position 3 due to max_by_key last-wins tie-breaking)
+    let mut sequence = Vec::new();
+    for _ in 0..6 {
+        let conn = lb.get(&request).await.unwrap();
+        sequence.push(conn.pool.id());
+    }
+
+    assert_eq!(
+        sequence,
+        vec![pool_a, pool_a, pool_b, pool_a, pool_a, pool_a],
+    );
+
+    lb.shutdown();
+}
+
+#[tokio::test]
+async fn test_weighted_round_robin_equal_weights() {
+    let pool_config1 = create_test_pool_config_weighted("127.0.0.1", 5432, 1);
+    let pool_config2 = create_test_pool_config_weighted("localhost", 5432, 1);
+
+    let lb = LoadBalancer::new(
+        &None,
+        &[pool_config1, pool_config2],
+        LoadBalancingStrategy::WeightedRoundRobin,
+        ReadWriteSplit::IncludePrimary,
+    );
+    lb.launch();
+
+    let request = Request::default();
+
+    let pool_a = lb.targets[0].pool.id();
+    let pool_b = lb.targets[1].pool.id();
+
+    // With equal weights, should alternate: B, A, B, A
+    // (max_by_key picks the last element on tie, so B goes first)
+    let mut sequence = Vec::new();
+    for _ in 0..4 {
+        let conn = lb.get(&request).await.unwrap();
+        sequence.push(conn.pool.id());
+    }
+
+    assert_eq!(sequence, vec![pool_b, pool_a, pool_b, pool_a]);
+
+    lb.shutdown();
+}
+
+#[tokio::test]
+async fn test_weighted_round_robin_zero_weight_never_selected() {
+    let pool_config1 = create_test_pool_config_weighted("127.0.0.1", 5432, 0);
+    let pool_config2 = create_test_pool_config_weighted("localhost", 5432, 10);
+
+    let lb = LoadBalancer::new(
+        &None,
+        &[pool_config1, pool_config2],
+        LoadBalancingStrategy::WeightedRoundRobin,
+        ReadWriteSplit::IncludePrimary,
+    );
+    lb.launch();
+
+    let request = Request::default();
+
+    let expected_id = lb.targets[1].pool.id();
+    for _ in 0..20 {
+        let conn = lb.get(&request).await.unwrap();
+        assert_eq!(
+            conn.pool.id(),
+            expected_id,
+            "Pool with weight 0 should never be selected first"
+        );
+    }
+
+    lb.shutdown();
+}
+
+#[tokio::test]
+async fn test_weighted_round_robin_proportional_distribution() {
+    let pool_config1 = create_test_pool_config_weighted("127.0.0.1", 5432, 3);
+    let pool_config2 = create_test_pool_config_weighted("localhost", 5432, 1);
+
+    let lb = LoadBalancer::new(
+        &None,
+        &[pool_config1, pool_config2],
+        LoadBalancingStrategy::WeightedRoundRobin,
+        ReadWriteSplit::IncludePrimary,
+    );
+    lb.launch();
+
+    let request = Request::default();
+
+    let pool_a = lb.targets[0].pool.id();
+
+    // Over 40 rounds (10 full cycles of total_weight=4), A should get exactly 30
+    let mut a_count = 0;
+    for _ in 0..40 {
+        let conn = lb.get(&request).await.unwrap();
+        if conn.pool.id() == pool_a {
+            a_count += 1;
+        }
+    }
+
+    assert_eq!(a_count, 30, "Pool A (weight 3) should get 3/4 of requests");
+
+    lb.shutdown();
+}
+
 #[tokio::test]
 async fn test_least_active_connections_prefers_pool_with_fewer_checked_out() {
     let pool_config1 = create_test_pool_config("127.0.0.1", 5432);


### PR DESCRIPTION
fix #575 

### How it works

Using weighted round robin. Each database host can specify the `lb_weight`, like so:

```toml
[general]
load_balancing_strategy = "weighted_round_robin"

[[databases]]
name = "prod"
host = "10.0.0.1"
lb_weight = 50

[[databases]]
name = "prod"
host = "10.0.0.1"
role = "replica"
lb_weight = 75
```

The `lb_weight` can be between 0 and 255. The default value is 255, so if not specified, it'll work like regular round robin. Only the relative weights matter, not total. For example, if you want a 80/20 split, you can do this:

```toml
[[databases]]
# [...]
lb_weight = 4

[[databases]]
# [...]
lb_weight = 1
```

