### PR TITLE
add configurable log format and level

### DIFF
--- a/.schema/pgdog.schema.json
+++ b/.schema/pgdog.schema.json
@@ -62,6 +62,8 @@
         "load_schema": "auto",
         "log_connections": true,
         "log_disconnections": true,
+        "log_format": "text",
+        "log_level": "info",
         "lsn_check_delay": 9223372036854775807,
         "lsn_check_interval": 5000,
         "lsn_check_timeout": 5000,
@@ -769,6 +771,16 @@
           "type": "boolean",
           "default": true
         },
+        "log_format": {
+          "description": "Format to use for PgDog application logs.\n\n_Default:_ `text`\n\nhttps://docs.pgdog.dev/configuration/pgdog.toml/general/#log_format",
+          "$ref": "#/$defs/LogFormat",
+          "default": "text"
+        },
+        "log_level": {
+          "description": "Log filter directives using the same syntax as the `RUST_LOG` environment variable.\n\n_Default:_ `info`\n\nhttps://docs.pgdog.dev/configuration/pgdog.toml/general/#log_level",
+          "type": "string",
+          "default": "info"
+        },
         "lsn_check_delay": {
           "description": "For how long to delay checking for replication delay.\n\nhttps://docs.pgdog.dev/configuration/pgdog.toml/general/#lsn_check_delay",
           "type": "integer",
@@ -1087,6 +1099,21 @@
           "description": "Load only when sharding is configured (default).",
           "type": "string",
           "const": "auto"
+        }
+      ]
+    },
+    "LogFormat": {
+      "description": "Format to use for PgDog application logs.",
+      "oneOf": [
+        {
+          "description": "Human-readable text logs (default).",
+          "type": "string",
+          "const": "text"
+        },
+        {
+          "description": "Structured JSON logs suitable for ECS/Datadog ingestion.",
+          "type": "string",
+          "const": "json"
         }
       ]
     },

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5016,6 +5016,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5025,12 +5035,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/example.pgdog.toml
+++ b/example.pgdog.toml
@@ -131,6 +131,18 @@ openmetrics_port = 9090
 #
 # Default: none
 openmetrics_namespace = "pgdog_"
+# Log output format.
+#
+# Default: text
+#
+# Available options:
+# - text
+# - json
+log_format = "text"
+# Log filter directives using the same syntax as RUST_LOG.
+#
+# Default: info
+log_level = "info"
 # Configure levels of support for prepared statements.
 #
 # Default: enabled

--- a/pgdog-config/src/general.rs
+++ b/pgdog-config/src/general.rs
@@ -1,8 +1,10 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::env;
+use std::fmt;
 use std::net::Ipv4Addr;
 use std::path::PathBuf;
+use std::str::FromStr;
 use std::time::Duration;
 
 use crate::pooling::ConnectionRecovery;
@@ -15,6 +17,38 @@ use super::auth::{AuthType, PassthoughAuth};
 use super::database::{LoadBalancingStrategy, ReadWriteSplit, ReadWriteStrategy};
 use super::networking::TlsVerifyMode;
 use super::pooling::{PoolerMode, PreparedStatements};
+
+/// Format to use for PgDog application logs.
+#[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq, Hash, Default, JsonSchema)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub enum LogFormat {
+    /// Human-readable text logs (default).
+    #[default]
+    Text,
+    /// Structured JSON logs suitable for ECS/Datadog ingestion.
+    Json,
+}
+
+impl fmt::Display for LogFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Text => f.write_str("text"),
+            Self::Json => f.write_str("json"),
+        }
+    }
+}
+
+impl FromStr for LogFormat {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "text" => Ok(Self::Text),
+            "json" => Ok(Self::Json),
+            _ => Err(()),
+        }
+    }
+}
 
 /// General settings are relevant to the operations of the pooler itself, or apply to all database pools.
 ///
@@ -407,6 +441,22 @@ pub struct General {
     #[serde(default)]
     pub pub_sub_channel_size: usize,
 
+    /// Format to use for PgDog application logs.
+    ///
+    /// _Default:_ `text`
+    ///
+    /// https://docs.pgdog.dev/configuration/pgdog.toml/general/#log_format
+    #[serde(default = "General::log_format")]
+    pub log_format: LogFormat,
+
+    /// Log filter directives using the same syntax as the `RUST_LOG` environment variable.
+    ///
+    /// _Default:_ `info`
+    ///
+    /// https://docs.pgdog.dev/configuration/pgdog.toml/general/#log_level
+    #[serde(default = "General::log_level")]
+    pub log_level: String,
+
     /// If enabled, log every time a user creates a new connection to PgDog.
     ///
     /// _Default:_ `true`
@@ -642,6 +692,8 @@ impl Default for General {
             cross_shard_disabled: Self::cross_shard_disabled(),
             dns_ttl: Self::default_dns_ttl(),
             pub_sub_channel_size: Self::pub_sub_channel_size(),
+            log_format: Self::log_format(),
+            log_level: Self::log_level(),
             log_connections: Self::log_connections(),
             log_disconnections: Self::log_disconnections(),
             two_phase_commit: bool::default(),
@@ -1003,6 +1055,14 @@ impl General {
         Self::env_or_default("PGDOG_QUERY_CACHE_LIMIT", 50_000)
     }
 
+    pub fn log_format() -> LogFormat {
+        Self::env_enum_or_default("PGDOG_LOG_FORMAT")
+    }
+
+    pub fn log_level() -> String {
+        env::var("RUST_LOG").unwrap_or_else(|_| "info".to_string())
+    }
+
     pub fn log_connections() -> bool {
         Self::env_bool_or_default("PGDOG_LOG_CONNECTIONS", true)
     }
@@ -1362,6 +1422,21 @@ mod tests {
         assert_eq!(General::cross_shard_disabled(), false);
         assert_eq!(General::log_connections(), true);
         assert_eq!(General::log_disconnections(), true);
+    }
+
+    #[test]
+    fn test_env_log_settings() {
+        env::set_var("PGDOG_LOG_FORMAT", "json");
+        env::set_var("RUST_LOG", "pgdog=debug,info");
+
+        assert_eq!(General::log_format(), LogFormat::Json);
+        assert_eq!(General::log_level(), "pgdog=debug,info");
+
+        env::remove_var("PGDOG_LOG_FORMAT");
+        env::remove_var("RUST_LOG");
+
+        assert_eq!(General::log_format(), LogFormat::Text);
+        assert_eq!(General::log_level(), "info");
     }
 
     #[test]

--- a/pgdog-config/src/lib.rs
+++ b/pgdog-config/src/lib.rs
@@ -24,7 +24,7 @@ pub use database::{
     Database, EnumeratedDatabase, LoadBalancingStrategy, ReadWriteSplit, ReadWriteStrategy, Role,
 };
 pub use error::Error;
-pub use general::General;
+pub use general::{General, LogFormat};
 pub use memory::*;
 pub use networking::{MultiTenant, Tcp, TlsVerifyMode};
 pub use overrides::Overrides;

--- a/pgdog/Cargo.toml
+++ b/pgdog/Cargo.toml
@@ -20,7 +20,7 @@ tui = ["ratatui"]
 pin-project = "1"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter", "std"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "std"] }
 parking_lot = "0.12"
 thiserror = "2"
 bytes = "1"

--- a/pgdog/src/config/general.rs
+++ b/pgdog/src/config/general.rs
@@ -1,1 +1,1 @@
-pub use pgdog_config::general::General;
+pub use pgdog_config::general::{General, LogFormat};

--- a/pgdog/src/config/mod.rs
+++ b/pgdog/src/config/mod.rs
@@ -18,7 +18,7 @@ pub mod users;
 pub use core::{Config, ConfigAndUsers};
 pub use database::{Database, Role};
 pub use error::Error;
-pub use general::General;
+pub use general::{General, LogFormat};
 pub use memory::*;
 pub use networking::{MultiTenant, Tcp, TlsVerifyMode};
 pub use overrides::Overrides;

--- a/pgdog/src/lib.rs
+++ b/pgdog/src/lib.rs
@@ -19,6 +19,7 @@ pub mod tui;
 pub mod unique_id;
 pub mod util;
 
+use pgdog_config::{General, LogFormat};
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
@@ -41,19 +42,56 @@ static GLOBAL: &stats_alloc::StatsAlloc<System> = &stats_alloc::INSTRUMENTED_SYS
 /// Using try_init and ignoring errors to allow
 /// for use in tests (setting up multiple times).
 pub fn logger() {
-    let format = fmt::layer()
-        .with_ansi(std::io::stderr().is_terminal())
-        .with_writer(std::io::stderr)
-        .with_file(false);
-    #[cfg(not(debug_assertions))]
-    let format = format.with_target(false);
+    init_logger(None);
+}
 
-    let filter = EnvFilter::builder()
-        .with_default_directive(LevelFilter::INFO.into())
-        .from_env_lossy();
+/// Setup the logger using PgDog configuration.
+pub fn logger_with_config(general: &General) {
+    init_logger(Some(general));
+}
 
-    let _ = tracing_subscriber::registry()
-        .with(format)
-        .with(filter)
-        .try_init();
+fn init_logger(general: Option<&General>) {
+    let filter = match general {
+        Some(general) => EnvFilter::builder()
+            .with_default_directive(LevelFilter::INFO.into())
+            .parse_lossy(general.log_level.as_str()),
+        None => EnvFilter::builder()
+            .with_default_directive(LevelFilter::INFO.into())
+            .from_env_lossy(),
+    };
+
+    match general
+        .map(|general| general.log_format)
+        .unwrap_or_default()
+    {
+        LogFormat::Text => {
+            let format = fmt::layer()
+                .with_ansi(std::io::stderr().is_terminal())
+                .with_writer(std::io::stderr)
+                .with_file(false);
+            #[cfg(not(debug_assertions))]
+            let format = format.with_target(false);
+
+            let _ = tracing_subscriber::registry()
+                .with(format)
+                .with(filter)
+                .try_init();
+        }
+        LogFormat::Json => {
+            let format = fmt::layer()
+                .json()
+                .with_ansi(false)
+                .with_writer(std::io::stderr)
+                .with_file(false)
+                .with_current_span(false)
+                .with_span_list(false);
+            #[cfg(not(debug_assertions))]
+            let format = format.with_target(false);
+
+            let _ = tracing_subscriber::registry()
+                .with(format)
+                .with(filter)
+                .try_init();
+        }
+    }
 }

--- a/pgdog/src/main.rs
+++ b/pgdog/src/main.rs
@@ -1,5 +1,9 @@
 //! pgDog, modern PostgreSQL proxy, pooler and query router.
 
+use std::fs::read_to_string;
+use std::path::Path;
+use std::process::exit;
+
 use clap::Parser;
 use pgdog::backend::databases;
 use pgdog::backend::pool::dns_cache::DnsCache;
@@ -11,31 +15,18 @@ use pgdog::plugin;
 use pgdog::stats;
 use pgdog::util::pgdog_version;
 use pgdog::{healthcheck, net};
+use serde::Deserialize;
 use tokio::runtime::Builder;
 use tracing::{error, info};
 
-use std::process::exit;
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = cli::Cli::parse();
-
-    pgdog::logger();
-
+    let command = args.command.clone();
     let mut overrides = pgdog::config::Overrides::default();
 
-    match args.command {
+    match command.as_ref() {
         Some(Commands::Fingerprint { query, path }) => {
-            pgdog::cli::fingerprint(query, path)?;
-            exit(0);
-        }
-
-        Some(Commands::Configcheck) => {
-            if let Err(e) = config::load(&args.config, &args.users) {
-                error!("{}", e);
-                exit(1);
-            }
-
-            info!("✅ config valid");
+            pgdog::cli::fingerprint(query.clone(), path.clone())?;
             exit(0);
         }
 
@@ -45,17 +36,34 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             session_mode,
         }) => {
             overrides = pgdog::config::Overrides {
-                min_pool_size,
-                session_mode,
-                default_pool_size: pool_size,
+                min_pool_size: *min_pool_size,
+                session_mode: *session_mode,
+                default_pool_size: *pool_size,
             };
         }
 
         _ => (),
     }
 
+    bootstrap_logger(&args.config);
+
+    let config = match config::load(&args.config, &args.users) {
+        Ok(config) => config,
+        Err(err) => {
+            if matches!(command.as_ref(), Some(Commands::Configcheck)) {
+                error!("{}", err);
+                exit(1);
+            }
+            return Err(Box::new(err));
+        }
+    };
+
+    if matches!(command.as_ref(), Some(Commands::Configcheck)) {
+        info!("✅ config valid");
+        exit(0);
+    }
+
     info!("🐕 PgDog {}", pgdog_version());
-    let config = config::load(&args.config, &args.users)?;
 
     // Get databases from environment or from --database-url args.
     let config = if let Some(database_urls) = args.database_url {
@@ -191,4 +199,34 @@ async fn pgdog(command: Option<Commands>) -> Result<(), Box<dyn std::error::Erro
     plugin::shutdown();
 
     Ok(())
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct BootstrapLoggingConfig {
+    #[serde(default)]
+    general: BootstrapLoggingGeneral,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct BootstrapLoggingGeneral {
+    log_format: Option<pgdog::config::LogFormat>,
+    log_level: Option<String>,
+}
+
+fn bootstrap_logger(config_path: &Path) {
+    let mut general = pgdog::config::General::default();
+
+    if let Ok(config) = read_to_string(config_path) {
+        if let Ok(bootstrap) = toml::from_str::<BootstrapLoggingConfig>(&config) {
+            if let Some(log_format) = bootstrap.general.log_format {
+                general.log_format = log_format;
+            }
+
+            if let Some(log_level) = bootstrap.general.log_level {
+                general.log_level = log_level;
+            }
+        }
+    }
+
+    pgdog::logger_with_config(&general);
 }


### PR DESCRIPTION
Related to #815 

Adds configurable logging output via `general.log_format` and `general.log_level`.

- add `log_format` with `text` and `json` modes
- add `log_level` using `RUST_LOG` compatible filter syntax
- initialize logging from config during startup
- update `example.pgdog.toml` and generated JSON schema
