### PR TITLE
ci: dependabot ignore integration tests checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+version: 2
+updates:
+  # ignore integration tests security alerts
+  - package-ecosystem: composer
+    directory: /
+    schedule:
+      interval: weekly
+    exclude-paths:
+      - "/integration/**"
+      - "**/tests/**"
+  - package-ecosystem: bundler
+    directory: /
+    schedule:
+      interval: weekly
+    exclude-paths:
+      - "/integration/**"
+      - "**/tests/**"
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    exclude-paths:
+      - "/integration/**"
+      - "**/tests/**"
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    exclude-paths:
+      - "/integration/**"
+      - "**/tests/**"
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    exclude-paths:
+      - "/integration/**"
+      - "**/tests/**"


### PR DESCRIPTION
I'm not sure if it will actually disable security alerts or just disable the automatic prs with updates from dependabot.

Might see some prs started to pop-up from it