### PR TITLE
Forward FATAL errors from PostgreSQL to client

### DIFF
--- a/pgdog/src/backend/protocol/state.rs
+++ b/pgdog/src/backend/protocol/state.rs
@@ -199,6 +199,10 @@ impl ProtocolState {
         self.len() == 0
     }
 
+    pub(crate) fn clear_queue(&mut self) {
+        self.queue.clear();
+    }
+
     pub(crate) fn len(&self) -> usize {
         self.queue.len()
     }

--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -441,6 +441,9 @@ impl Server {
                 let error = ErrorResponse::from_bytes(message.to_bytes()?)?;
                 self.schema_changed = error.code == "0A000";
                 self.stats.error();
+                if matches!(error.severity.as_str(), "FATAL" | "PANIC") {
+                    self.prepared_statements.state_mut().clear_queue();
+                }
             }
             'W' => {
                 debug!("streaming replication on [{}]", self.addr());

--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -3391,4 +3391,52 @@ pub mod test {
         assert!(!server.needs_drain());
         verify_server_usable(&mut server).await;
     }
+
+    #[tokio::test]
+    async fn test_transaction_timeout_fatal_clears_queue() {
+        let mut server = test_server().await;
+
+        server
+            .send(&vec![ProtocolMessage::from(Query::new(
+                "SET transaction_timeout = '100ms'",
+            ))]
+            .into())
+            .await
+            .unwrap();
+        for c in ['C', 'Z'] {
+            assert_eq!(server.read().await.unwrap().code(), c);
+        }
+
+        server
+            .send(&vec![ProtocolMessage::from(Query::new("BEGIN"))].into())
+            .await
+            .unwrap();
+        for c in ['C', 'Z'] {
+            assert_eq!(server.read().await.unwrap().code(), c);
+        }
+
+        server
+            .send(&vec![ProtocolMessage::from(Query::new("SELECT pg_sleep(1)"))].into())
+            .await
+            .unwrap();
+
+        let msg = server.read().await.unwrap();
+        assert_eq!(msg.code(), 'T');
+
+        let msg = server.read().await.unwrap();
+        assert_eq!(msg.code(), 'E');
+
+        let error = ErrorResponse::from_bytes(msg.to_bytes().unwrap()).unwrap();
+        assert_eq!(error.severity, "FATAL");
+        assert!(
+            error.message.contains("transaction timeout"),
+            "unexpected error message: {}",
+            error.message
+        );
+
+        assert!(
+            !server.has_more_messages(),
+            "FATAL should clear the message queue"
+        );
+    }
 }

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -420,6 +420,9 @@ impl Client {
                 message = query_engine.read_backend() => {
                     let message = message?;
                     self.server_message(&mut query_engine, message).await?;
+                    if !query_engine.backend_connected() {
+                        break;
+                    }
                 }
 
                 buffer = self.buffer(client_state), if !terminating => {

--- a/pgdog/src/frontend/client/query_engine/mod.rs
+++ b/pgdog/src/frontend/client/query_engine/mod.rs
@@ -127,6 +127,11 @@ impl QueryEngine {
         self.begin_stmt.is_none() && self.backend.done()
     }
 
+    /// Backend connection is active.
+    pub fn backend_connected(&self) -> bool {
+        self.backend.connected()
+    }
+
     /// Current state.
     pub fn client_state(&self) -> State {
         self.stats.state

--- a/pgdog/src/frontend/client/query_engine/query.rs
+++ b/pgdog/src/frontend/client/query_engine/query.rs
@@ -240,6 +240,10 @@ impl QueryEngine {
             context.stream.send(&message).await?;
         }
 
+        if code == 'E' && !has_more_messages {
+            self.backend.force_close();
+        }
+
         if code == 'Z' {
             self.pending_explain = None;
         }

--- a/pgdog/src/frontend/client/query_engine/test/mod.rs
+++ b/pgdog/src/frontend/client/query_engine/test/mod.rs
@@ -9,6 +9,7 @@ use crate::{
 
 mod lock_session;
 mod omni;
+mod transaction_timeout;
 pub mod prelude;
 mod rewrite_extended;
 mod rewrite_insert_split;

--- a/pgdog/src/frontend/client/query_engine/test/transaction_timeout.rs
+++ b/pgdog/src/frontend/client/query_engine/test/transaction_timeout.rs
@@ -1,0 +1,57 @@
+use crate::net::{ErrorResponse, Parameters, Query};
+
+use super::prelude::*;
+
+#[tokio::test]
+async fn test_transaction_timeout_fatal_forwarded_to_client() {
+    let mut client = TestClient::new_basic(Parameters::default()).await;
+
+    client
+        .send_simple(Query::new("SET transaction_timeout = '100ms'"))
+        .await;
+    client.read_until('Z').await.unwrap();
+
+    client.send_simple(Query::new("BEGIN")).await;
+    client.read_until('Z').await.unwrap();
+
+    client
+        .send_simple(Query::new("SELECT pg_sleep(1)"))
+        .await;
+
+    let message = client.read().await;
+    assert_eq!(
+        message.code(),
+        'T',
+        "expected RowDescription before FATAL, got '{}'",
+        message.code()
+    );
+
+    let message = client.read().await;
+    assert_eq!(
+        message.code(),
+        'E',
+        "expected ErrorResponse, got '{}'",
+        message.code()
+    );
+
+    let error = ErrorResponse::try_from(message).unwrap();
+    assert_eq!(
+        error.severity, "FATAL",
+        "expected FATAL severity, got '{}': {}",
+        error.severity, error.message
+    );
+    assert!(
+        error.message.contains("transaction timeout"),
+        "expected transaction timeout message, got: {}",
+        error.message
+    );
+    assert!(
+        !error.message.contains("connection closed by peer"),
+        "pgdog should not mask FATAL with its own error"
+    );
+
+    assert!(
+        !client.backend_connected(),
+        "backend should be disconnected after FATAL"
+    );
+}

--- a/pgdog/src/frontend/client/test/test_client.rs
+++ b/pgdog/src/frontend/client/test/test_client.rs
@@ -10,7 +10,7 @@ use tokio::{
 
 use crate::{
     backend::databases::{reload_from_existing, shutdown},
-    config::{config, load_test_replicas, load_test_sharded, set},
+    config::{config, load_test, load_test_replicas, load_test_sharded, set},
     frontend::{
         client::query_engine::QueryEngine,
         router::{parser::Shard, sharding::ContextBuilder},
@@ -81,6 +81,12 @@ impl TestClient {
             engine: QueryEngine::from_client(&client).expect("create query engine from client"),
             client,
         }
+    }
+
+    /// New basic (non-sharded) client with parameters.
+    pub(crate) async fn new_basic(params: Parameters) -> Self {
+        load_test();
+        Self::new(params).await
     }
 
     /// New sharded client with parameters.


### PR DESCRIPTION
When PostgreSQL terminates a connection with a `FATAL` error (e.g. `transaction_timeout`, `idle_in_transaction_timeout`), PgDog was returning `ERROR: net: connection closed by peer to the client instead of the original error.

```
ActiveRecord::Base.connection.execute("SET statement_timeout = 0")
ActiveRecord::Base.connection.execute("SET transaction_timeout = '1s'")
ActiveRecord::Base.transaction do
  ActiveRecord::Base.connection.execute("SELECT pg_sleep(2)")
end

# Before:
PG::SystemError: ERROR:  net: connection closed by peer (ActiveRecord::StatementInvalid)

# After:
PQconsumeInput() FATAL:  terminating connection due to transaction timeout (PG::ConnectionBad)
```