### PR TITLE
fix: COPY sent via extended protocol with Sync can block server re-use in transaction mode

### DIFF
--- a/pgdog/src/backend/protocol/state.rs
+++ b/pgdog/src/backend/protocol/state.rs
@@ -163,6 +163,12 @@ impl ProtocolState {
             ExecutionCode::ReadyForQuery => {
                 self.out_of_sync = false;
             }
+            ExecutionCode::Copy => {
+                // Remove any RFQ messages from the queue
+                // in case the client sent Sync during copy mode.
+                self.queue
+                    .retain(|item| item != &ExecutionItem::Code(ExecutionCode::ReadyForQuery));
+            }
             _ => (),
         };
         let in_queue = self.queue.pop_front().ok_or(Error::ProtocolOutOfSync)?;

--- a/pgdog/src/backend/protocol/state.rs
+++ b/pgdog/src/backend/protocol/state.rs
@@ -36,6 +36,10 @@ impl ExecutionCode {
     fn extended(&self) -> bool {
         matches!(self, Self::ParseComplete | Self::BindComplete)
     }
+
+    fn done(&self) -> bool {
+        matches!(self, Self::ReadyForQuery)
+    }
 }
 
 impl From<char> for ExecutionCode {
@@ -94,7 +98,7 @@ impl ProtocolState {
     ///
     pub(crate) fn add_ignore(&mut self, code: impl Into<ExecutionCode>) {
         let code = code.into();
-        self.extended = self.extended || code.extended();
+        self.extended = (self.extended || code.extended()) && !code.done();
         self.queue.push_back(ExecutionItem::Ignore(code));
     }
 
@@ -102,7 +106,7 @@ impl ProtocolState {
     /// to be returned by the server.
     pub(crate) fn add(&mut self, code: impl Into<ExecutionCode>) {
         let code = code.into();
-        self.extended = self.extended || code.extended();
+        self.extended = (self.extended || code.extended()) && !code.done();
         self.queue.push_back(ExecutionItem::Code(code))
     }
 
@@ -164,10 +168,12 @@ impl ProtocolState {
                 self.out_of_sync = false;
             }
             ExecutionCode::Copy => {
-                // Remove any RFQ messages from the queue
-                // in case the client sent Sync during copy mode.
-                self.queue
-                    .retain(|item| item != &ExecutionItem::Code(ExecutionCode::ReadyForQuery));
+                if self.extended {
+                    // Remove any RFQ messages from the queue
+                    // in case the client sent Sync during copy mode.
+                    self.queue
+                        .retain(|item| item != &ExecutionItem::Code(ExecutionCode::ReadyForQuery));
+                }
             }
             _ => (),
         };

--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -408,8 +408,9 @@ impl Server {
 
     /// Flush all pending messages making sure they are sent to the server immediately.
     pub async fn flush(&mut self) -> Result<(), Error> {
+        trace!("😳 [{}]", self.addr());
+
         if let Err(err) = self.stream().flush().await {
-            trace!("😳");
             self.stats.state(State::Error);
             Err(err.into())
         } else {
@@ -1101,7 +1102,7 @@ pub mod test {
         net::TcpListener,
     };
 
-    use crate::{config::Memory, frontend::PreparedStatements, net::*};
+    use crate::{backend::pool::Guard, config::Memory, frontend::PreparedStatements, net::*};
 
     use super::{Error, *};
 
@@ -2171,6 +2172,71 @@ pub mod test {
 
         server.execute("ROLLBACK").await.unwrap();
         assert!(server.in_sync());
+    }
+
+    #[tokio::test]
+    async fn test_copy_protocol_extended() {
+        crate::logger();
+
+        let mut server = test_server().await;
+        server.execute("BEGIN").await.unwrap();
+        server
+            .execute("CREATE TABLE test_copy_protocol_extended (id BIGINT)")
+            .await
+            .unwrap();
+
+        server
+            .send(
+                &vec![
+                    Parse::new_anonymous("COPY test_copy_protocol_extended FROM STDIN").into(),
+                    Bind::new_statement("").into(),
+                    Execute::new().into(),
+                    Sync.into(),
+                ]
+                .into(),
+            )
+            .await
+            .unwrap();
+        for c in ['1', '2', 'G'] {
+            let msg = server.read().await.unwrap();
+            assert_eq!(msg.code(), c);
+        }
+
+        server
+            .send_one(&CopyData::new("1\n".as_bytes()).into())
+            .await
+            .unwrap();
+
+        server.send_one(&CopyDone.into()).await.unwrap();
+        server.send_one(&Sync.into()).await.unwrap();
+        server.flush().await.unwrap();
+
+        for c in ['C', 'Z'] {
+            let msg = server.read().await.unwrap();
+            assert_eq!(msg.code(), c);
+        }
+
+        assert!(server.prepared_statements().done());
+
+        server
+            .send(
+                &vec![
+                    Parse::new_anonymous("ROLLBACK").into(),
+                    Bind::new_statement("").into(),
+                    Execute::new().into(),
+                    Sync.into(),
+                ]
+                .into(),
+            )
+            .await
+            .unwrap();
+
+        for c in ['1', '2', 'C', 'Z'] {
+            let msg = server.read().await.unwrap();
+            assert_eq!(msg.code(), c);
+        }
+
+        assert!(server.done());
     }
 
     #[tokio::test]

--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -1102,7 +1102,7 @@ pub mod test {
         net::TcpListener,
     };
 
-    use crate::{backend::pool::Guard, config::Memory, frontend::PreparedStatements, net::*};
+    use crate::{config::Memory, frontend::PreparedStatements, net::*};
 
     use super::{Error, *};
 
@@ -2172,6 +2172,69 @@ pub mod test {
 
         server.execute("ROLLBACK").await.unwrap();
         assert!(server.in_sync());
+    }
+
+    #[tokio::test]
+    async fn test_extended_set_back_to_normal_when_done() {
+        crate::logger();
+        let mut server = test_server().await;
+        server
+            .send(
+                &vec![
+                    Parse::new_anonymous("SET statement_timeout TO '1s'").into(),
+                    Bind::new_statement("").into(),
+                    Execute::new().into(),
+                    Sync.into(),
+                ]
+                .into(),
+            )
+            .await
+            .unwrap();
+
+        for c in ['1', '2', 'C', 'Z'] {
+            let msg = server.read().await.unwrap();
+            assert_eq!(c, msg.code());
+        }
+
+        assert!(server.done());
+
+        server
+            .send(
+                &vec![
+                    Query::new("COPY public.sharded FROM STDIN").into(),
+                    CopyDone.into(),
+                ]
+                .into(),
+            )
+            .await
+            .unwrap();
+
+        for c in ['G', 'C', 'Z'] {
+            let msg = server.read().await.unwrap();
+            assert_eq!(c, msg.code());
+        }
+
+        assert!(server.done());
+
+        server
+            .send(
+                &vec![
+                    Parse::new_anonymous("SET statement_timeout TO '1s'").into(),
+                    Bind::new_statement("").into(),
+                    Execute::new().into(),
+                    Sync.into(),
+                ]
+                .into(),
+            )
+            .await
+            .unwrap();
+
+        for c in ['1', '2', 'C', 'Z'] {
+            let msg = server.read().await.unwrap();
+            assert_eq!(c, msg.code());
+        }
+
+        assert!(server.done());
     }
 
     #[tokio::test]


### PR DESCRIPTION
The following sequence of messages can make a server be stuck in "unfinished state", blocking its re-use by other clients:

```
Parse("COPY t FROM STDIN")
Bind
Execute
Sync # This message is ignored by Postgres but not by pgdog
CopyData
[...]
CopyDone
Sync
```

The `Sync` sent after `Execute` is not necessary, but we record it and expect a `ReadyForQuery` from the server which only arrives after the second `Sync` is sent. An additional `ReadyForQuery` message remains in our internal state, and `server.done()` never returns true, causing the server to be tied to the client until it disconnects.

Related #885 