### PR TITLE
fix: ProtocolOutOfSync error

### DIFF
--- a/integration/ruby/Gemfile.lock
+++ b/integration/ruby/Gemfile.lock
@@ -138,7 +138,13 @@ GEM
     parser (3.3.7.3)
       ast (~> 2.4.1)
       racc
-    pg (1.5.9)
+    pg (1.6.3)
+    pg (1.6.3-aarch64-linux)
+    pg (1.6.3-aarch64-linux-musl)
+    pg (1.6.3-arm64-darwin)
+    pg (1.6.3-x86_64-darwin)
+    pg (1.6.3-x86_64-linux)
+    pg (1.6.3-x86_64-linux-musl)
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)

--- a/integration/ruby/pg_spec.rb
+++ b/integration/ruby/pg_spec.rb
@@ -3,12 +3,21 @@
 require_relative 'rspec_helper'
 
 def connect(dbname = 'pgdog', user = 'pgdog')
-  PG.connect(dbname: dbname, user: user, password: 'pgdog', port: 6432, host: '127.0.0.1')
+  PG.connect(dbname: dbname, user: user, password: 'pgdog', port: 6432, host: '127.0.0.1', application_name: '')
 end
 
 describe 'pg' do
   after do
-    ensure_done
+    # ensure_done
+  end
+
+  it 'out of sync' do
+    conn = connect 'pgdog', 'pgdog'
+    conn.exec_params 'SELECT $1', [1]
+    conn.exec "SELECT 1"
+    conn.exec "SET lock_timeout TO sdfs"
+    conn.exec "SET statement_timeout TO '1s'"
+    conn.exec 'SELECT 1'
   end
 
   it 'simple query' do

--- a/integration/ruby/pg_spec.rb
+++ b/integration/ruby/pg_spec.rb
@@ -8,7 +8,7 @@ end
 
 describe 'pg' do
   after do
-    # ensure_done
+    ensure_done
   end
 
   it 'out of sync' do
@@ -17,7 +17,7 @@ describe 'pg' do
     conn.exec "SELECT 1"
     conn.exec "SET lock_timeout TO sdfs"
     conn.exec "SET statement_timeout TO '1s'"
-    conn.exec 'SELECT 1'
+    expect { conn.exec 'SELECT 1' }.to raise_error(/invalid value for parameter/)
   end
 
   it 'simple query' do

--- a/pgdog/src/backend/protocol/state.rs
+++ b/pgdog/src/backend/protocol/state.rs
@@ -67,6 +67,14 @@ impl MemoryUsage for ExecutionItem {
     }
 }
 
+impl ExecutionItem {
+    fn extended(&self) -> bool {
+        match self {
+            Self::Code(code) | Self::Ignore(code) => code.extended(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct ProtocolState {
     queue: VecDeque<ExecutionItem>,
@@ -146,6 +154,18 @@ impl ProtocolState {
         match code {
             ExecutionCode::Untracked => return Ok(Action::Forward),
             ExecutionCode::Error => {
+                if !self.extended {
+                    // A simple-query error only aborts the current simple query.
+                    // Keep any later pipelined simple query RFQs queued.
+                    while !self.queue.is_empty()
+                        && self.queue.front()
+                            != Some(&ExecutionItem::Code(ExecutionCode::ReadyForQuery))
+                    {
+                        self.queue.pop_front();
+                    }
+                    return Ok(Action::Forward);
+                }
+
                 // Remove everything from the execution queue.
                 // The connection is out of sync until client re-syncs it.
                 if self.extended {
@@ -166,7 +186,7 @@ impl ProtocolState {
             _ => (),
         };
         let in_queue = self.queue.pop_front().ok_or(Error::ProtocolOutOfSync)?;
-        match in_queue {
+        let action = match in_queue {
             // The queue is waiting for the server to send ReadyForQuery,
             // but it sent something else. That means the execution pipeline
             // isn't done. We are not tracking every single message, so this is expected.
@@ -188,7 +208,13 @@ impl ProtocolState {
                     Err(Error::ProtocolOutOfSync)
                 }
             }
+        }?;
+
+        if code == ExecutionCode::ReadyForQuery {
+            self.extended = self.queue.iter().any(ExecutionItem::extended);
         }
+
+        Ok(action)
     }
 
     pub(crate) fn in_copy_mode(&self) -> bool {
@@ -334,7 +360,7 @@ mod test {
         assert_eq!(state.action('C').unwrap(), Action::Forward);
         assert_eq!(state.action('Z').unwrap(), Action::Forward);
         assert!(state.is_empty());
-        assert!(state.extended);
+        assert!(!state.extended);
     }
 
     #[test]
@@ -588,6 +614,23 @@ mod test {
         // Note: The ForwardAndRemove logic in the Ignore arm (line 192-193)
         // is unreachable because Error is handled at the top of action()
         // This may be dead code or a bug in the implementation.
+    }
+
+    #[test]
+    fn test_pipelined_simple_query_error_keeps_next_query_response() {
+        let mut state = ProtocolState::default();
+        state.add('Z'); // First simple query.
+        state.add('Z'); // Second simple query.
+
+        assert_eq!(state.action('E').unwrap(), Action::Forward);
+        assert_eq!(state.len(), 2);
+        assert_eq!(state.action('Z').unwrap(), Action::Forward);
+        assert_eq!(state.len(), 1);
+
+        // The next response belongs to the second simple query.
+        assert_eq!(state.action('C').unwrap(), Action::Forward);
+        assert_eq!(state.action('Z').unwrap(), Action::Forward);
+        assert!(state.is_empty());
     }
 
     #[test]

--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -1294,6 +1294,19 @@ pub mod test {
     }
 
     #[tokio::test]
+    async fn test_execute_batch_simple_query_error_then_success() {
+        let mut server = test_server().await;
+
+        let err = server
+            .execute_batch(&[Query::new("syntax error"), Query::new("SELECT 1")])
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, Error::ExecutionError(_)));
+        assert!(server.done());
+    }
+
+    #[tokio::test]
     async fn test_set() {
         let mut server = test_server().await;
         server
@@ -1676,6 +1689,39 @@ pub mod test {
         let msg = server.read().await.unwrap();
         assert_eq!(msg.code(), 'Z');
 
+        assert!(server.done());
+    }
+
+    #[tokio::test]
+    async fn test_ooo() {
+        let mut server = test_server().await;
+        server
+            .send(
+                &vec![
+                    Parse::new_anonymous("SELECT 1").into(),
+                    Bind::new_statement("").into(),
+                    Execute::new().into(),
+                    Sync.into(),
+                ]
+                .into(),
+            )
+            .await
+            .unwrap();
+
+        for c in ['1', '2', 'D', 'C', 'Z'] {
+            let msg = server.read().await.unwrap();
+            assert_eq!(msg.code(), c);
+        }
+
+        let err = server
+            .execute_batch(&[
+                "SET statement_timeout TO null".into(),
+                "SET statement_timeout TO '1s'".into(),
+            ])
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, Error::ExecutionError(_)));
         assert!(server.done());
     }
 

--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -1693,7 +1693,7 @@ pub mod test {
     }
 
     #[tokio::test]
-    async fn test_ooo() {
+    async fn test_out_of_sync_regression() {
         let mut server = test_server().await;
         server
             .send(


### PR DESCRIPTION
This was caused by the following conditions:

1. `query_parser = "on"`, so `SET` statements are intercepted
2. `ruby-pg` driver initialized with `application_name: ''` so it wouldn't run `SET application_name TO x`
3. A query executed via extended protocol
4. A bad parameter set manually via `SET`, e.g. `SET lock_timeout to sdf`
5. Any query executed afterwards

This was caused by us not resetting extended protocol state in our protocol state machine and allowing invalid `SET` statements to be executed in a batch.