### PR TITLE
feat: handle SET in single-primary / only replcias configuration automatically

### DIFF
--- a/pgdog/src/backend/pool/cluster.rs
+++ b/pgdog/src/backend/pool/cluster.rs
@@ -26,6 +26,7 @@ use crate::{
         ConnectionRecovery, MultiTenant, PoolerMode, ReadWriteSplit, ReadWriteStrategy,
         ShardedTable, User,
     },
+    frontend::ClientRequest,
     net::{messages::BackendKeyData, Query},
 };
 
@@ -453,7 +454,7 @@ impl Cluster {
     }
 
     /// Use the query parser.
-    pub fn use_query_parser(&self) -> bool {
+    pub(crate) fn use_query_parser(&self, request: &ClientRequest) -> bool {
         match self.query_parser() {
             QueryParserLevel::Off => false,
             QueryParserLevel::On => true,
@@ -463,6 +464,7 @@ impl Cluster {
                     || self.dry_run()
                     || self.prepared_statements() == &PreparedStatements::Full
                     || self.pub_sub_enabled()
+                    || request.is_set()
             }
         }
     }
@@ -651,7 +653,7 @@ impl Cluster {
 mod test {
     use std::{sync::Arc, time::Duration};
 
-    use pgdog_config::{ConfigAndUsers, OmnishardedTable, ShardedSchema};
+    use pgdog_config::{ConfigAndUsers, OmnishardedTable, QueryParserLevel, ShardedSchema};
 
     use crate::{
         backend::{
@@ -660,9 +662,11 @@ mod test {
             Shard, ShardedTables,
         },
         config::{
-            DataType, Hasher, LoadBalancingStrategy, MultiTenant, ReadWriteSplit,
+            config, DataType, Hasher, LoadBalancingStrategy, MultiTenant, ReadWriteSplit,
             ReadWriteStrategy, ShardedTable,
         },
+        frontend::ClientRequest,
+        net::Query,
     };
 
     use super::{Cluster, DatabaseUser};
@@ -753,6 +757,38 @@ mod test {
         pub fn new_test_single_shard(config: &ConfigAndUsers) -> Cluster {
             let mut cluster = Self::new_test(config);
             cluster.shards.pop();
+
+            cluster
+        }
+
+        pub fn new_test_single_primary(config: &ConfigAndUsers) -> Cluster {
+            let identifier = Arc::new(DatabaseUser {
+                user: "pgdog".into(),
+                database: "pgdog".into(),
+            });
+
+            let cluster = Cluster {
+                shards: vec![Shard::new(ShardConfig {
+                    number: 0,
+                    primary: &Some(PoolConfig {
+                        address: Address::new_test(),
+                        config: Config::default(),
+                    }),
+                    replicas: &[],
+                    lb_strategy: LoadBalancingStrategy::default(),
+                    rw_split: ReadWriteSplit::default(),
+                    identifier: identifier.clone(),
+                    lsn_check_interval: Duration::default(),
+                })],
+                prepared_statements: config.config.general.prepared_statements,
+                dry_run: config.config.general.dry_run,
+                expanded_explain: config.config.general.expanded_explain,
+                query_parser: config.config.general.query_parser,
+                rewrite: config.config.rewrite.clone(),
+                two_phase_commit: config.config.general.two_phase_commit,
+                two_phase_commit_auto: config.config.general.two_phase_commit_auto.unwrap_or(false),
+                ..Default::default()
+            };
 
             cluster
         }
@@ -928,5 +964,29 @@ mod test {
         // Should wait for notification and complete within timeout
         let result = timeout(Duration::from_millis(100), cluster.wait_schema_loaded()).await;
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_use_query_parser_set() {
+        let mut cluster = Cluster::new_test(&config());
+        let req = ClientRequest::from(vec![Query::new("SET statement_timeout TO 1").into()]);
+
+        for level in [QueryParserLevel::Auto, QueryParserLevel::On] {
+            cluster.query_parser = level;
+            assert!(cluster.use_query_parser(&req));
+        }
+
+        cluster.query_parser = QueryParserLevel::Off;
+        assert!(!cluster.use_query_parser(&req));
+
+        let mut cluster = Cluster::new_test_single_primary(&config());
+
+        for level in [QueryParserLevel::Auto, QueryParserLevel::On] {
+            cluster.query_parser = level;
+            assert!(cluster.use_query_parser(&req));
+        }
+
+        cluster.query_parser = QueryParserLevel::Off;
+        assert!(!cluster.use_query_parser(&req));
     }
 }

--- a/pgdog/src/frontend/client/query_engine/rewrite.rs
+++ b/pgdog/src/frontend/client/query_engine/rewrite.rs
@@ -34,7 +34,7 @@ impl QueryEngine {
         let use_parser = self
             .backend
             .cluster()
-            .map(|cluster| cluster.use_query_parser())
+            .map(|cluster| cluster.use_query_parser(context.client_request))
             .unwrap_or(false);
 
         if !use_parser {

--- a/pgdog/src/frontend/client_request.rs
+++ b/pgdog/src/frontend/client_request.rs
@@ -129,7 +129,7 @@ impl ClientRequest {
 
     /// Quick and cheap way to find out if this
     /// request is starting a transaction.
-    pub fn is_begin(&self) -> bool {
+    pub(crate) fn is_begin(&self) -> bool {
         lazy_static! {
             static ref BEGIN: Regex = Regex::new("(?i)^BEGIN").unwrap();
         }
@@ -143,6 +143,26 @@ impl ClientRequest {
 
             if BEGIN.is_match(query) {
                 return true;
+            }
+        }
+
+        false
+    }
+
+    /// Quick and cheap way to find out if this
+    /// request contains a SET statement.
+    ///
+    /// We use this to temporaily turn on the query
+    /// parser and extract the parameter so we can
+    /// maintain application state in transaction mode.
+    pub(crate) fn is_set(&self) -> bool {
+        lazy_static! {
+            static ref SET: Regex = Regex::new("(?i)^ *SET").unwrap();
+        }
+
+        for message in &self.messages {
+            if let ProtocolMessage::Query(query) = message {
+                return SET.is_match(query.query());
             }
         }
 
@@ -560,5 +580,23 @@ mod test {
             Describe::new_statement("test").into(),
         ]);
         assert!(!req.is_complete());
+    }
+
+    #[test]
+    fn test_is_set() {
+        for query in [
+            "SET statement_timeout TO 1",
+            "   SET staement_timeout to 1",
+            "set statement_timeout to 1",
+            "   set statement_timeout to 1",
+        ] {
+            let req = ClientRequest::from(vec![Query::new(query).into()]);
+            assert!(req.is_set());
+        }
+
+        for query in ["SELECT 1", "insert into users values (1)"] {
+            let req = ClientRequest::from(vec![Query::new(query).into()]);
+            assert!(!req.is_set());
+        }
     }
 }

--- a/pgdog/src/frontend/router/context.rs
+++ b/pgdog/src/frontend/router/context.rs
@@ -35,6 +35,8 @@ pub struct RouterContext<'a> {
     pub ast: Option<Ast>,
     /// Schema.
     pub schema: Schema,
+    /// Original client request.
+    pub client_request: &'a ClientRequest,
 }
 
 impl<'a> RouterContext<'a> {
@@ -62,6 +64,7 @@ impl<'a> RouterContext<'a> {
             query,
             ast: buffer.ast.clone(),
             schema: cluster.schema(),
+            client_request: buffer,
         })
     }
 

--- a/pgdog/src/frontend/router/parser/context.rs
+++ b/pgdog/src/frontend/router/parser/context.rs
@@ -91,7 +91,9 @@ impl<'a> QueryParserContext<'a> {
     ///
     /// Shortcut to avoid the overhead if we can.
     pub(super) fn use_parser(&self) -> bool {
-        self.router_context.cluster.use_query_parser()
+        self.router_context
+            .cluster
+            .use_query_parser(&self.router_context.client_request)
     }
 
     /// Get the query we're parsing, if any.

--- a/pgdog/src/frontend/router/parser/query/test/setup.rs
+++ b/pgdog/src/frontend/router/parser/query/test/setup.rs
@@ -65,6 +65,13 @@ impl QueryParserTest {
         }
     }
 
+    pub(crate) fn new_single_primary(config: &ConfigAndUsers) -> Self {
+        let mut me = Self::new_with_config(config);
+        me.cluster = Cluster::new_test_single_primary(config);
+
+        me
+    }
+
     /// Set whether we're in a transaction.
     pub(crate) fn in_transaction(mut self, in_tx: bool) -> Self {
         self.transaction = if in_tx {

--- a/pgdog/src/frontend/router/parser/query/test/test_set.rs
+++ b/pgdog/src/frontend/router/parser/query/test/test_set.rs
@@ -1,5 +1,12 @@
 use crate::{
-    frontend::{router::parser::Shard, Command},
+    config::config,
+    frontend::{
+        router::parser::{
+            route::{OverrideReason, ShardSource},
+            Shard,
+        },
+        Command,
+    },
     net::parameter::ParameterValue,
 };
 
@@ -134,4 +141,24 @@ fn test_set_transaction_level() {
             _ => panic!("expected Command::Query for '{query}', got {command:#?}"),
         }
     }
+}
+
+#[test]
+fn test_set_single_primary() {
+    let mut test = QueryParserTest::new_single_primary(&config());
+    let command = test.execute(vec![Query::new("SET statement_timeout TO 1").into()].into());
+    assert!(matches!(command, Command::Set { .. }));
+
+    let mut config = (*config()).clone();
+    config.config.general.query_parser = pgdog_config::QueryParserLevel::Off;
+
+    let mut test = QueryParserTest::new_single_primary(&config);
+    let command = test.execute(vec![Query::new("SET statement_timeout TO 1").into()].into());
+    match command {
+        Command::Query(query) => assert_eq!(
+            query.shard_with_priority().source(),
+            &ShardSource::Override(OverrideReason::ParserDisabled)
+        ),
+        _ => panic!("expected Query, got {:?}", command),
+    };
 }


### PR DESCRIPTION
Handle `SET` statements when deployments don't typically use the query parser, e.g., single primary, just replicas, no sharding. We detect `SET` using a quick regex and turn on the parser _just_ for that statement.