### PR TITLE
feat: add regex parser trigger to minimize parsing when not needed

### DIFF
--- a/.schema/pgdog.schema.json
+++ b/.schema/pgdog.schema.json
@@ -1390,6 +1390,11 @@
           "description": "Always disable the query parser.",
           "type": "string",
           "const": "off"
+        },
+        {
+          "description": "Control statements only.",
+          "type": "string",
+          "const": "session_control"
         }
       ]
     },

--- a/pgdog-config/src/core.rs
+++ b/pgdog-config/src/core.rs
@@ -527,7 +527,7 @@ impl Config {
                 }
                 let parser_enabled = match self.general.query_parser {
                     QueryParserLevel::On => true,
-                    QueryParserLevel::Off => false,
+                    QueryParserLevel::Off | QueryParserLevel::SessionControl => false,
                     QueryParserLevel::Auto => check.have_replicas || check.sharded,
                 };
                 if !parser_enabled {

--- a/pgdog-config/src/sharding.rs
+++ b/pgdog-config/src/sharding.rs
@@ -403,6 +403,8 @@ pub enum QueryParserLevel {
     Auto,
     /// Always disable the query parser.
     Off,
+    /// Control statements only.
+    SessionControl,
 }
 
 /// Underlying parser implementation used to analyze SQL queries.

--- a/pgdog/src/backend/pool/cluster.rs
+++ b/pgdog/src/backend/pool/cluster.rs
@@ -26,7 +26,7 @@ use crate::{
         ConnectionRecovery, MultiTenant, PoolerMode, ReadWriteSplit, ReadWriteStrategy,
         ShardedTable, User,
     },
-    frontend::ClientRequest,
+    frontend::{ClientRequest, RegexParser},
     net::{messages::BackendKeyData, Query},
 };
 
@@ -458,13 +458,14 @@ impl Cluster {
         match self.query_parser() {
             QueryParserLevel::Off => false,
             QueryParserLevel::On => true,
+            QueryParserLevel::SessionControl => RegexParser::use_parser(request),
             QueryParserLevel::Auto => {
                 self.multi_tenant().is_some()
                     || self.router_needed()
                     || self.dry_run()
                     || self.prepared_statements() == &PreparedStatements::Full
                     || self.pub_sub_enabled()
-                    || request.is_set()
+                    || RegexParser::use_parser(request)
             }
         }
     }

--- a/pgdog/src/frontend/client_request.rs
+++ b/pgdog/src/frontend/client_request.rs
@@ -149,26 +149,6 @@ impl ClientRequest {
         false
     }
 
-    /// Quick and cheap way to find out if this
-    /// request contains a SET statement.
-    ///
-    /// We use this to temporaily turn on the query
-    /// parser and extract the parameter so we can
-    /// maintain application state in transaction mode.
-    pub(crate) fn is_set(&self) -> bool {
-        lazy_static! {
-            static ref SET: Regex = Regex::new("(?i)^ *SET").unwrap();
-        }
-
-        for message in &self.messages {
-            if let ProtocolMessage::Query(query) = message {
-                return SET.is_match(query.query());
-            }
-        }
-
-        false
-    }
-
     /// If this buffer contains bound parameters, retrieve them.
     pub fn parameters(&self) -> Result<Option<&Bind>, Error> {
         for message in &self.messages {
@@ -580,23 +560,5 @@ mod test {
             Describe::new_statement("test").into(),
         ]);
         assert!(!req.is_complete());
-    }
-
-    #[test]
-    fn test_is_set() {
-        for query in [
-            "SET statement_timeout TO 1",
-            "   SET staement_timeout to 1",
-            "set statement_timeout to 1",
-            "   set statement_timeout to 1",
-        ] {
-            let req = ClientRequest::from(vec![Query::new(query).into()]);
-            assert!(req.is_set());
-        }
-
-        for query in ["SELECT 1", "insert into users values (1)"] {
-            let req = ClientRequest::from(vec![Query::new(query).into()]);
-            assert!(!req.is_set());
-        }
     }
 }

--- a/pgdog/src/frontend/mod.rs
+++ b/pgdog/src/frontend/mod.rs
@@ -12,6 +12,7 @@ pub mod logical_transaction;
 pub mod prepared_statements;
 #[cfg(debug_assertions)]
 pub mod query_logger;
+pub mod regex_parser;
 pub mod router;
 pub mod stats;
 
@@ -24,6 +25,7 @@ pub(crate) use error::Error;
 pub use prepared_statements::{PreparedStatements, Rewrite};
 #[cfg(debug_assertions)]
 pub use query_logger::QueryLogger;
+pub(crate) use regex_parser::RegexParser;
 pub use router::{Command, Router, SetParam};
 pub use router::{RouterContext, SearchPath};
 pub use stats::Stats;

--- a/pgdog/src/frontend/regex_parser.rs
+++ b/pgdog/src/frontend/regex_parser.rs
@@ -1,0 +1,89 @@
+use once_cell::sync::Lazy;
+use regex::RegexSet;
+
+use crate::{frontend::ClientRequest, net::ProtocolMessage};
+
+static CMD_RE: Lazy<RegexSet> = Lazy::new(|| {
+    RegexSet::new([
+        "(?i)^ *(RE)?SET",
+        "(?i)^ *BEGIN",
+        "(?i)^ *COMMIT",
+        "(?i)^ *ROLLBACK",
+    ])
+    .unwrap()
+});
+
+pub(crate) struct RegexParser {}
+
+impl RegexParser {
+    /// Check if we should enable the parser just for this request.
+    pub(crate) fn use_parser(request: &ClientRequest) -> bool {
+        for message in request.iter() {
+            if let ProtocolMessage::Query(query) = message {
+                return CMD_RE.is_match(query.query());
+            }
+        }
+
+        false
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::net::Query;
+
+    use super::*;
+
+    fn matches(query: &str) -> bool {
+        let req = ClientRequest::from(vec![Query::new(query).into()]);
+        RegexParser::use_parser(&req)
+    }
+
+    #[test]
+    fn test_set() {
+        assert!(matches("SET statement_timeout TO 1"));
+        assert!(matches("set statement_timeout to 1"));
+        assert!(matches("   SET statement_timeout TO 1"));
+        assert!(matches("   set statement_timeout to 1"));
+    }
+
+    #[test]
+    fn test_reset() {
+        assert!(matches("RESET statement_timeout"));
+        assert!(matches("reset statement_timeout"));
+        assert!(matches("   RESET statement_timeout"));
+        assert!(matches("RESET ALL"));
+    }
+
+    #[test]
+    fn test_begin() {
+        assert!(matches("BEGIN"));
+        assert!(matches("begin"));
+        assert!(matches("   BEGIN"));
+        assert!(matches("BEGIN WORK REPEATABLE READ"));
+        assert!(matches("BEGIN READ ONLY"));
+        assert!(matches("begin read only"));
+    }
+
+    #[test]
+    fn test_commit() {
+        assert!(matches("COMMIT"));
+        assert!(matches("commit"));
+        assert!(matches("   COMMIT"));
+    }
+
+    #[test]
+    fn test_rollback() {
+        assert!(matches("ROLLBACK"));
+        assert!(matches("rollback"));
+        assert!(matches("   ROLLBACK"));
+    }
+
+    #[test]
+    fn test_no_match() {
+        assert!(!matches("SELECT 1"));
+        assert!(!matches("INSERT INTO users VALUES (1)"));
+        assert!(!matches("UPDATE users SET name = 'foo'"));
+        assert!(!matches("DELETE FROM users"));
+    }
+}

--- a/pgdog/src/frontend/router/parser/query/test/mod.rs
+++ b/pgdog/src/frontend/router/parser/query/test/mod.rs
@@ -35,6 +35,7 @@ pub mod test_rr;
 pub mod test_schema_sharding;
 pub mod test_search_path;
 pub mod test_select;
+pub mod test_session_control;
 pub mod test_set;
 pub mod test_sharding;
 pub mod test_special;

--- a/pgdog/src/frontend/router/parser/query/test/test_session_control.rs
+++ b/pgdog/src/frontend/router/parser/query/test/test_session_control.rs
@@ -1,0 +1,91 @@
+use pgdog_config::QueryParserLevel;
+
+use crate::{config::config, frontend::Command};
+
+use super::setup::*;
+
+fn setup() -> QueryParserTest {
+    let mut config = (*config()).clone();
+    config.config.general.query_parser = QueryParserLevel::SessionControl;
+    QueryParserTest::new_single_primary(&config)
+}
+
+#[test]
+fn test_set() {
+    let mut test = setup();
+    let command = test.execute(vec![Query::new("SET statement_timeout TO 1").into()]);
+    assert!(
+        matches!(command, Command::Set { .. }),
+        "expected Command::Set, got {command:#?}",
+    );
+}
+
+#[test]
+fn test_reset() {
+    let mut test = setup();
+    let command = test.execute(vec![Query::new("RESET statement_timeout").into()]);
+    assert!(
+        matches!(command, Command::Set { .. }),
+        "expected Command::Set, got {command:#?}",
+    );
+}
+
+#[test]
+fn test_reset_all() {
+    let mut test = setup();
+    let command = test.execute(vec![Query::new("RESET ALL").into()]);
+    assert!(
+        matches!(command, Command::ResetAll),
+        "expected Command::ResetAll, got {command:#?}",
+    );
+}
+
+#[test]
+fn test_begin() {
+    let mut test = setup();
+    let command = test.execute(vec![Query::new("BEGIN").into()]);
+    assert!(
+        matches!(command, Command::StartTransaction { .. }),
+        "expected Command::StartTransaction, got {command:#?}",
+    );
+}
+
+#[test]
+fn test_commit() {
+    let mut test = setup();
+    let command = test.execute(vec![Query::new("COMMIT").into()]);
+    assert!(
+        matches!(command, Command::CommitTransaction { .. }),
+        "expected Command::CommitTransaction, got {command:#?}",
+    );
+}
+
+#[test]
+fn test_rollback() {
+    let mut test = setup();
+    let command = test.execute(vec![Query::new("ROLLBACK").into()]);
+    assert!(
+        matches!(command, Command::RollbackTransaction { .. }),
+        "expected Command::RollbackTransaction, got {command:#?}",
+    );
+}
+
+#[test]
+fn test_select_bypassed() {
+    let mut test = setup();
+    let command = test.execute(vec![Query::new("SELECT 1").into()]);
+    assert!(
+        matches!(command, Command::Query(_)),
+        "expected Command::Query (bypass), got {command:#?}",
+    );
+}
+
+#[test]
+fn test_insert_bypassed() {
+    let mut test = setup();
+    let command = test.execute(vec![Query::new("INSERT INTO users VALUES (1)").into()]);
+    assert!(
+        matches!(command, Command::Query(_)),
+        "expected Command::Query (bypass), got {command:#?}",
+    );
+}

--- a/pgdog/src/frontend/router/parser/query/test/test_set.rs
+++ b/pgdog/src/frontend/router/parser/query/test/test_set.rs
@@ -144,6 +144,27 @@ fn test_set_transaction_level() {
 }
 
 #[test]
+fn test_reset() {
+    let mut test = QueryParserTest::new();
+
+    let command = test.execute(vec![Query::new("RESET statement_timeout").into()]);
+    match &command {
+        Command::Set { params, .. } => {
+            assert_eq!(params.len(), 1);
+            assert_eq!(params[0].name, "statement_timeout");
+            assert!(params[0].reset);
+        }
+        _ => panic!("expected Command::Set, got {command:#?}"),
+    }
+
+    let command = test.execute(vec![Query::new("RESET ALL").into()]);
+    assert!(
+        matches!(command, Command::ResetAll),
+        "expected Command::ResetAll, got {command:#?}",
+    );
+}
+
+#[test]
 fn test_set_single_primary() {
     let mut test = QueryParserTest::new_single_primary(&config());
     let command = test.execute(vec![Query::new("SET statement_timeout TO 1").into()].into());


### PR DESCRIPTION
Addresses performance issues in #854.

Only parse transaction control and session control statements (`SET`, `BEGIN`, `COMMIT`, `ROLLBACK`). This is enough to do very basic load balancing and provide some session consistency, which is better than nothing. We can do this with basically no performance overhead, so it's worth doing.