### PR TITLE
feat: add parallel copy override

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,9 @@ jobs:
           sudo -u postgres psql -c 'ALTER SYSTEM SET max_connections TO 1000;'
           sudo -u postgres psql -c 'ALTER SYSTEM SET max_prepared_transactions TO 1000;'
           sudo -u postgres psql -c 'ALTER SYSTEM SET wal_level TO logical;'
+          sudo -u postgres psql -c 'ALTER SYSTEM SET max_workers TO 64';
+          sudo -u postgres psql -c 'ALTER SYSTEM SET max_wal_senders TO 32';
+          sudo -u postgres psql -c 'ALTER SYSTEM SET max_replication_slots TO 32';
           sudo service postgresql restart
           bash integration/setup.sh
           sudo apt update && sudo apt install -y python3-virtualenv mold php-cli php-pgsql

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
           sudo -u postgres psql -c 'ALTER SYSTEM SET max_connections TO 1000;'
           sudo -u postgres psql -c 'ALTER SYSTEM SET max_prepared_transactions TO 1000;'
           sudo -u postgres psql -c 'ALTER SYSTEM SET wal_level TO logical;'
-          sudo -u postgres psql -c 'ALTER SYSTEM SET max_workers TO 64';
+          sudo -u postgres psql -c 'ALTER SYSTEM SET max_worker_processes TO 64';
           sudo -u postgres psql -c 'ALTER SYSTEM SET max_wal_senders TO 32';
           sudo -u postgres psql -c 'ALTER SYSTEM SET max_replication_slots TO 32';
           sudo service postgresql restart

--- a/.rwx/integration.yml
+++ b/.rwx/integration.yml
@@ -49,6 +49,8 @@ aliases:
         sudo -u postgres psql -c 'ALTER SYSTEM SET wal_level TO logical;'
         sudo -u postgres psql -c 'ALTER SYSTEM SET max_prepared_transactions TO 1000;'
         sudo -u postgres psql -c 'ALTER SYSTEM SET max_connections TO 1000;'
+        sudo -u postgres psql -c 'ALTER SYSTEM SET max_workers TO 64';
+        sudo -u postgres psql -c 'ALTER SYSTEM SET max_wal_senders TO 32';
         sudo service postgresql restart
         touch .pg_isready
       ready-check: |

--- a/.rwx/integration.yml
+++ b/.rwx/integration.yml
@@ -49,8 +49,9 @@ aliases:
         sudo -u postgres psql -c 'ALTER SYSTEM SET wal_level TO logical;'
         sudo -u postgres psql -c 'ALTER SYSTEM SET max_prepared_transactions TO 1000;'
         sudo -u postgres psql -c 'ALTER SYSTEM SET max_connections TO 1000;'
-        sudo -u postgres psql -c 'ALTER SYSTEM SET max_workers TO 64';
+        sudo -u postgres psql -c 'ALTER SYSTEM SET max_worker_processes TO 64';
         sudo -u postgres psql -c 'ALTER SYSTEM SET max_wal_senders TO 32';
+        sudo -u postgres psql -c 'ALTER SYSTEM SET max_replication_slots TO 32';
         sudo service postgresql restart
         touch .pg_isready
       ready-check: |

--- a/.schema/pgdog.schema.json
+++ b/.schema/pgdog.schema.json
@@ -89,6 +89,7 @@
         "read_write_strategy": "conservative",
         "reload_schema_on_ddl": true,
         "resharding_copy_format": "binary",
+        "resharding_parallel_copies": 1,
         "rollback_timeout": 5000,
         "server_lifetime": 86400000,
         "shutdown_termination_timeout": null,
@@ -938,6 +939,13 @@
           "description": "Which format to use for `COPY` statements during resharding.\n\n**Note:** Text format is required when migrating from `INTEGER` to `BIGINT` primary keys during resharding.\n\nhttps://docs.pgdog.dev/configuration/pgdog.toml/general/#resharding_copy_format",
           "$ref": "#/$defs/CopyFormat",
           "default": "binary"
+        },
+        "resharding_parallel_copies": {
+          "description": "How many parallel copies to launch, irrespective of the number of available replicas.",
+          "type": "integer",
+          "format": "uint",
+          "default": 1,
+          "minimum": 0
         },
         "rollback_timeout": {
           "description": "How long to allow for `ROLLBACK` queries to run on server connections with unfinished transactions.\n\n_Default:_ `5000`\n\nhttps://docs.pgdog.dev/configuration/pgdog.toml/general/#rollback_timeout",

--- a/integration/copy_data/pgdog.toml
+++ b/integration/copy_data/pgdog.toml
@@ -1,5 +1,6 @@
 [general]
 resharding_copy_format = "binary"
+resharding_parallel_copies = 5
 
 #
 # Source of data.

--- a/pgdog-config/src/general.rs
+++ b/pgdog-config/src/general.rs
@@ -574,6 +574,10 @@ pub struct General {
     #[serde(default)]
     pub resharding_copy_format: CopyFormat,
 
+    /// How many parallel copies to launch, irrespective of the number of available replicas.
+    #[serde(default = "General::resharding_parallel_copies")]
+    pub resharding_parallel_copies: usize,
+
     /// Automatically reload the schema cache used by PgDog to route queries upon detecting DDL statements.
     ///
     /// **Note:** This setting requires PgDog Enterprise Edition to work as expected. If using the open source edition, it will only work with single-node PgDog deployments, e.g., in local development or CI.
@@ -715,6 +719,7 @@ impl Default for General {
             system_catalogs: Self::default_system_catalogs(),
             omnisharded_sticky: bool::default(),
             resharding_copy_format: CopyFormat::default(),
+            resharding_parallel_copies: Self::resharding_parallel_copies(),
             reload_schema_on_ddl: Self::reload_schema_on_ddl(),
             load_schema: Self::load_schema(),
             cutover_replication_lag_threshold: Self::cutover_replication_lag_threshold(),
@@ -926,6 +931,10 @@ impl General {
 
     fn default_system_catalogs() -> SystemCatalogsBehavior {
         Self::env_enum_or_default("PGDOG_SYSTEM_CATALOGS")
+    }
+
+    fn resharding_parallel_copies() -> usize {
+        1
     }
 
     fn default_shutdown_termination_timeout() -> Option<u64> {

--- a/pgdog/src/backend/pool/cluster.rs
+++ b/pgdog/src/backend/pool/cluster.rs
@@ -80,6 +80,7 @@ pub struct Cluster {
     query_parser_engine: QueryParserEngine,
     reload_schema_on_ddl: bool,
     load_schema: LoadSchema,
+    resharding_parallel_copies: usize,
 }
 
 /// Sharding configuration from the cluster.
@@ -155,6 +156,7 @@ pub struct ClusterConfig<'a> {
     pub lsn_check_interval: Duration,
     pub reload_schema_on_ddl: bool,
     pub load_schema: LoadSchema,
+    pub resharding_parallel_copies: usize,
 }
 
 impl<'a> ClusterConfig<'a> {
@@ -207,6 +209,7 @@ impl<'a> ClusterConfig<'a> {
             lsn_check_interval: Duration::from_millis(general.lsn_check_interval),
             reload_schema_on_ddl: general.reload_schema_on_ddl,
             load_schema: general.load_schema,
+            resharding_parallel_copies: general.resharding_parallel_copies,
         }
     }
 }
@@ -243,6 +246,7 @@ impl Cluster {
             query_parser_engine,
             reload_schema_on_ddl,
             load_schema,
+            resharding_parallel_copies,
         } = config;
 
         let identifier = Arc::new(DatabaseUser {
@@ -291,6 +295,7 @@ impl Cluster {
             query_parser_engine,
             reload_schema_on_ddl,
             load_schema,
+            resharding_parallel_copies,
         }
     }
 
@@ -532,6 +537,12 @@ impl Cluster {
     /// for single-statement cross-shard writes.
     pub fn two_pc_auto_enabled(&self) -> bool {
         self.two_phase_commit_auto && self.two_pc_enabled()
+    }
+
+    /// How many parallel COPY commands can we
+    /// run to re-shard this cluster.
+    pub fn resharding_parallel_copies(&self) -> usize {
+        self.resharding_parallel_copies
     }
 
     /// Launch the connection pools.

--- a/pgdog/src/backend/replication/logical/publisher/parallel_sync.rs
+++ b/pgdog/src/backend/replication/logical/publisher/parallel_sync.rs
@@ -89,7 +89,9 @@ impl ParallelSyncManager {
         }
 
         Ok(Self {
-            permit: Arc::new(Semaphore::new(replicas.len())),
+            permit: Arc::new(Semaphore::new(
+                replicas.len() * dest.resharding_parallel_copies(),
+            )),
             tables,
             replicas,
             dest: dest.clone(),
@@ -99,8 +101,9 @@ impl ParallelSyncManager {
     /// Run parallel table sync and return table LSNs when everything is done.
     pub async fn run(self) -> Result<Vec<Table>, Error> {
         info!(
-            "starting parallel table copy using {} replicas",
-            self.replicas.len()
+            "starting parallel table copy using {} replicas and {} parallel copies",
+            self.replicas.len(),
+            self.permit.available_permits() / self.replicas.len(),
         );
 
         let mut replicas_iter = self.replicas.iter();

--- a/pgdog/src/backend/replication/logical/publisher/slot.rs
+++ b/pgdog/src/backend/replication/logical/publisher/slot.rs
@@ -2,6 +2,7 @@ use super::super::status::ReplicationSlot as ReplicationSlotTracker;
 use super::super::Error;
 use crate::{
     backend::{self, pool::Address, ConnectReason, Server, ServerOptions},
+    frontend::client::query_engine::two_pc::TwoPcTransactions,
     net::{
         replication::{StatusUpdate, XLogData},
         CopyData, CopyDone, DataRow, ErrorResponse, Format, FromBytes, Protocol, Query, ToBytes,
@@ -160,6 +161,16 @@ impl ReplicationSlot {
             "creating replication slot \"{}\" [{}]",
             self.name, self.address
         );
+
+        let two_pc = TwoPcTransactions::load(self.server()?).await?;
+
+        if !two_pc.is_empty() {
+            warn!(
+                "{} open two-phase transactions, this may block replication slot creation [{}]",
+                two_pc.len(),
+                self.server()?.addr()
+            );
+        }
 
         if self.kind == SlotKind::DataSync {
             self.server()?

--- a/pgdog/src/frontend/client/query_engine/two_pc/mod.rs
+++ b/pgdog/src/frontend/client/query_engine/two_pc/mod.rs
@@ -8,11 +8,13 @@ use super::Error;
 pub mod guard;
 pub mod manager;
 pub mod phase;
+pub mod server_transactions;
 pub mod transaction;
 
 pub use guard::TwoPcGuard;
 pub use manager::Manager;
 pub use phase::TwoPcPhase;
+pub(crate) use server_transactions::TwoPcTransactions;
 pub use transaction::TwoPcTransaction;
 
 #[cfg(test)]

--- a/pgdog/src/frontend/client/query_engine/two_pc/server_transactions.rs
+++ b/pgdog/src/frontend/client/query_engine/two_pc/server_transactions.rs
@@ -1,0 +1,50 @@
+use std::{ops::Deref, str::FromStr};
+
+use crate::{
+    backend::{Error, Server},
+    net::DataRow,
+};
+
+use super::TwoPcTransaction;
+
+#[derive(Debug, Clone)]
+pub enum TwoPcServerTransaction {
+    Ours(TwoPcTransaction),
+    Other { name: String },
+}
+
+pub(crate) struct TwoPcTransactions {
+    transactions: Vec<TwoPcServerTransaction>,
+}
+
+impl Deref for TwoPcTransactions {
+    type Target = Vec<TwoPcServerTransaction>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.transactions
+    }
+}
+
+impl TwoPcTransactions {
+    /// Load two phase transactions from the server.
+    pub(crate) async fn load(server: &mut Server) -> Result<Self, Error> {
+        let records: Vec<DataRow> = server.fetch_all("SELECT * FROM pg_prepared_xacts").await?;
+        let mut transactions = vec![];
+
+        for record in records {
+            let transaction = record.get_text(1).and_then(|name| {
+                if let Ok(ours) = TwoPcTransaction::from_str(&name) {
+                    Some(TwoPcServerTransaction::Ours(ours))
+                } else {
+                    Some(TwoPcServerTransaction::Other { name })
+                }
+            });
+
+            if let Some(transaction) = transaction {
+                transactions.push(transaction);
+            }
+        }
+
+        Ok(Self { transactions })
+    }
+}

--- a/pgdog/src/frontend/client/query_engine/two_pc/transaction.rs
+++ b/pgdog/src/frontend/client/query_engine/two_pc/transaction.rs
@@ -1,8 +1,10 @@
 use rand::{rng, Rng};
-use std::fmt::Display;
+use std::{fmt::Display, str::FromStr};
 
 #[derive(Debug, Clone, Copy, PartialEq, Hash, Eq)]
 pub struct TwoPcTransaction(usize);
+
+static PREFIX: &str = "__pgdog_2pc_";
 
 impl TwoPcTransaction {
     pub(crate) fn new() -> Self {
@@ -14,6 +16,33 @@ impl TwoPcTransaction {
 
 impl Display for TwoPcTransaction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "__pgdog_2pc_{}", self.0)
+        write!(f, "{PREFIX}{}", self.0)
+    }
+}
+
+impl FromStr for TwoPcTransaction {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let id = s.split(PREFIX).last().map(|id| id.parse());
+
+        if let Some(Ok(id)) = id {
+            Ok(Self(id))
+        } else {
+            Err(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_2pc_transaction_id() {
+        let transaction = TwoPcTransaction::new();
+        assert!(transaction.to_string().contains("__pgdog_2pc_"));
+        let reverse = TwoPcTransaction::from_str(transaction.to_string().as_str()).unwrap();
+        assert_eq!(reverse.0, transaction.0);
     }
 }


### PR DESCRIPTION
Add `resharding_parallel_copies` setting to `[general]` to override how many parallel `COPY` statements we run per resharding replica.

If you only have a single primary, this will run `resharding_parallel_copies` parallel `COPY` commands. If you have, say, 2 replicas, this will run `2 x resharding_parallel_copies` parallel copies.

Context: https://github.com/pgdogdev/pgdog/issues/847#issuecomment-4236983516

