### PR TITLE
Implement text array format

### DIFF
--- a/integration/sql/cases/921_integer_array_roundtrip_case.sql
+++ b/integration/sql/cases/921_integer_array_roundtrip_case.sql
@@ -1,0 +1,5 @@
+-- description: INTEGER[] arrays round-trip through PgDog
+-- tags: standard
+-- transactional: true
+
+SELECT id, sample_int_array FROM sql_regression_samples ORDER BY id;

--- a/integration/sql/cases/921_integer_array_roundtrip_setup.sql
+++ b/integration/sql/cases/921_integer_array_roundtrip_setup.sql
@@ -1,0 +1,10 @@
+DROP TABLE IF EXISTS sql_regression_samples;
+CREATE TABLE sql_regression_samples (
+    id BIGINT PRIMARY KEY,
+    sample_int_array INTEGER[]
+);
+INSERT INTO sql_regression_samples (id, sample_int_array) VALUES (1, '{1,2,3}');
+INSERT INTO sql_regression_samples (id, sample_int_array) VALUES (2, '{-1,0,2147483647}');
+INSERT INTO sql_regression_samples (id, sample_int_array) VALUES (3, '{}');
+INSERT INTO sql_regression_samples (id, sample_int_array) VALUES (4, '{NULL,1,NULL}');
+INSERT INTO sql_regression_samples (id, sample_int_array) VALUES (5, NULL);

--- a/integration/sql/cases/921_integer_array_roundtrip_teardown.sql
+++ b/integration/sql/cases/921_integer_array_roundtrip_teardown.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS sql_regression_samples;

--- a/integration/sql/cases/922_text_array_roundtrip_case.sql
+++ b/integration/sql/cases/922_text_array_roundtrip_case.sql
@@ -1,0 +1,5 @@
+-- description: TEXT[] arrays round-trip including quoting edge cases
+-- tags: standard
+-- transactional: true
+
+SELECT id, sample_text_array FROM sql_regression_samples ORDER BY id;

--- a/integration/sql/cases/922_text_array_roundtrip_setup.sql
+++ b/integration/sql/cases/922_text_array_roundtrip_setup.sql
@@ -1,0 +1,12 @@
+DROP TABLE IF EXISTS sql_regression_samples;
+CREATE TABLE sql_regression_samples (
+    id BIGINT PRIMARY KEY,
+    sample_text_array TEXT[]
+);
+INSERT INTO sql_regression_samples (id, sample_text_array) VALUES (1, '{"hello","world"}');
+INSERT INTO sql_regression_samples (id, sample_text_array) VALUES (2, '{"has,comma","has\"quote"}');
+INSERT INTO sql_regression_samples (id, sample_text_array) VALUES (3, '{"has\\backslash","has space"}');
+INSERT INTO sql_regression_samples (id, sample_text_array) VALUES (4, '{"","NULL"}');
+INSERT INTO sql_regression_samples (id, sample_text_array) VALUES (5, '{NULL,"actual value",NULL}');
+INSERT INTO sql_regression_samples (id, sample_text_array) VALUES (6, '{}');
+INSERT INTO sql_regression_samples (id, sample_text_array) VALUES (7, NULL);

--- a/integration/sql/cases/922_text_array_roundtrip_teardown.sql
+++ b/integration/sql/cases/922_text_array_roundtrip_teardown.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS sql_regression_samples;

--- a/integration/sql/cases/923_bigint_array_roundtrip_case.sql
+++ b/integration/sql/cases/923_bigint_array_roundtrip_case.sql
@@ -1,0 +1,5 @@
+-- description: BIGINT[] arrays round-trip through PgDog
+-- tags: standard
+-- transactional: true
+
+SELECT id, sample_bigint_array FROM sql_regression_samples ORDER BY id;

--- a/integration/sql/cases/923_bigint_array_roundtrip_setup.sql
+++ b/integration/sql/cases/923_bigint_array_roundtrip_setup.sql
@@ -1,0 +1,9 @@
+DROP TABLE IF EXISTS sql_regression_samples;
+CREATE TABLE sql_regression_samples (
+    id BIGINT PRIMARY KEY,
+    sample_bigint_array BIGINT[]
+);
+INSERT INTO sql_regression_samples (id, sample_bigint_array) VALUES (1, '{1,2,3}');
+INSERT INTO sql_regression_samples (id, sample_bigint_array) VALUES (2, '{-9223372036854775808,0,9223372036854775807}');
+INSERT INTO sql_regression_samples (id, sample_bigint_array) VALUES (3, '{}');
+INSERT INTO sql_regression_samples (id, sample_bigint_array) VALUES (4, NULL);

--- a/integration/sql/cases/923_bigint_array_roundtrip_teardown.sql
+++ b/integration/sql/cases/923_bigint_array_roundtrip_teardown.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS sql_regression_samples;

--- a/integration/sql/cases/924_boolean_array_roundtrip_case.sql
+++ b/integration/sql/cases/924_boolean_array_roundtrip_case.sql
@@ -1,0 +1,5 @@
+-- description: BOOLEAN[] arrays round-trip through PgDog
+-- tags: standard
+-- transactional: true
+
+SELECT id, sample_bool_array FROM sql_regression_samples ORDER BY id;

--- a/integration/sql/cases/924_boolean_array_roundtrip_setup.sql
+++ b/integration/sql/cases/924_boolean_array_roundtrip_setup.sql
@@ -1,0 +1,9 @@
+DROP TABLE IF EXISTS sql_regression_samples;
+CREATE TABLE sql_regression_samples (
+    id BIGINT PRIMARY KEY,
+    sample_bool_array BOOLEAN[]
+);
+INSERT INTO sql_regression_samples (id, sample_bool_array) VALUES (1, '{t,f,t}');
+INSERT INTO sql_regression_samples (id, sample_bool_array) VALUES (2, '{NULL,t,NULL}');
+INSERT INTO sql_regression_samples (id, sample_bool_array) VALUES (3, '{}');
+INSERT INTO sql_regression_samples (id, sample_bool_array) VALUES (4, NULL);

--- a/integration/sql/cases/924_boolean_array_roundtrip_teardown.sql
+++ b/integration/sql/cases/924_boolean_array_roundtrip_teardown.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS sql_regression_samples;

--- a/integration/sql/cases/925_float_array_roundtrip_case.sql
+++ b/integration/sql/cases/925_float_array_roundtrip_case.sql
@@ -1,0 +1,5 @@
+-- description: REAL[] and DOUBLE PRECISION[] arrays round-trip including NaN/Infinity
+-- tags: standard
+-- transactional: true
+
+SELECT id, sample_real_array, sample_dp_array FROM sql_regression_samples ORDER BY id;

--- a/integration/sql/cases/925_float_array_roundtrip_setup.sql
+++ b/integration/sql/cases/925_float_array_roundtrip_setup.sql
@@ -1,0 +1,11 @@
+DROP TABLE IF EXISTS sql_regression_samples;
+CREATE TABLE sql_regression_samples (
+    id BIGINT PRIMARY KEY,
+    sample_real_array REAL[],
+    sample_dp_array DOUBLE PRECISION[]
+);
+INSERT INTO sql_regression_samples (id, sample_real_array, sample_dp_array) VALUES (1, '{1.5,2.5,3.5}', '{1.5,2.5,3.5}');
+INSERT INTO sql_regression_samples (id, sample_real_array, sample_dp_array) VALUES (2, '{NaN,Infinity,-Infinity}', '{NaN,Infinity,-Infinity}');
+INSERT INTO sql_regression_samples (id, sample_real_array, sample_dp_array) VALUES (3, '{NULL,0}', '{NULL,0}');
+INSERT INTO sql_regression_samples (id, sample_real_array, sample_dp_array) VALUES (4, '{}', '{}');
+INSERT INTO sql_regression_samples (id, sample_real_array, sample_dp_array) VALUES (5, NULL, NULL);

--- a/integration/sql/cases/925_float_array_roundtrip_teardown.sql
+++ b/integration/sql/cases/925_float_array_roundtrip_teardown.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS sql_regression_samples;

--- a/integration/sql/cases/926_array_whitespace_roundtrip_case.sql
+++ b/integration/sql/cases/926_array_whitespace_roundtrip_case.sql
@@ -1,0 +1,5 @@
+-- description: Array literals with whitespace round-trip after PostgreSQL normalization
+-- tags: standard
+-- transactional: true
+
+SELECT id, sample_int_array, sample_text_array FROM sql_regression_samples ORDER BY id;

--- a/integration/sql/cases/926_array_whitespace_roundtrip_setup.sql
+++ b/integration/sql/cases/926_array_whitespace_roundtrip_setup.sql
@@ -1,0 +1,16 @@
+DROP TABLE IF EXISTS sql_regression_samples;
+CREATE TABLE sql_regression_samples (
+    id BIGINT PRIMARY KEY,
+    sample_int_array INTEGER[],
+    sample_text_array TEXT[]
+);
+-- Whitespace around elements (PostgreSQL normalizes on input)
+INSERT INTO sql_regression_samples (id, sample_int_array, sample_text_array) VALUES (1, '{ 1 , 2 , 3 }', '{ hello , world }');
+-- Leading/trailing whitespace on the literal
+INSERT INTO sql_regression_samples (id, sample_int_array, sample_text_array) VALUES (2, ' {4,5,6} ', ' {foo,bar} ');
+-- Whitespace around NULL
+INSERT INTO sql_regression_samples (id, sample_int_array, sample_text_array) VALUES (3, '{ NULL , 1 }', '{ NULL , a }');
+-- Whitespace with empty array
+INSERT INTO sql_regression_samples (id, sample_int_array, sample_text_array) VALUES (4, ' {} ', ' {} ');
+-- Whitespace with quoted elements (spaces inside quotes are preserved)
+INSERT INTO sql_regression_samples (id, sample_int_array, sample_text_array) VALUES (5, '{1,2}', '{ "has space" , plain }');

--- a/integration/sql/cases/926_array_whitespace_roundtrip_teardown.sql
+++ b/integration/sql/cases/926_array_whitespace_roundtrip_teardown.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS sql_regression_samples;

--- a/integration/sql/cases/927_array_escape_roundtrip_case.sql
+++ b/integration/sql/cases/927_array_escape_roundtrip_case.sql
@@ -1,0 +1,5 @@
+-- description: Array text literals with unquoted backslash escapes round-trip correctly
+-- tags: standard
+-- transactional: true
+
+SELECT id, sample_text_array FROM sql_regression_samples ORDER BY id;

--- a/integration/sql/cases/927_array_escape_roundtrip_setup.sql
+++ b/integration/sql/cases/927_array_escape_roundtrip_setup.sql
@@ -1,0 +1,15 @@
+DROP TABLE IF EXISTS sql_regression_samples;
+CREATE TABLE sql_regression_samples (
+    id BIGINT PRIMARY KEY,
+    sample_text_array TEXT[]
+);
+-- Unquoted backslash escape: \, means literal comma (one element)
+INSERT INTO sql_regression_samples (id, sample_text_array) VALUES (1, E'{a\\,b}');
+-- Unquoted backslash escape: \\ means literal backslash
+INSERT INTO sql_regression_samples (id, sample_text_array) VALUES (2, E'{a\\\\b}');
+-- Unquoted backslash escape: \} means literal brace
+INSERT INTO sql_regression_samples (id, sample_text_array) VALUES (3, E'{a\\}b}');
+-- Mixed quoted and unquoted escapes
+INSERT INTO sql_regression_samples (id, sample_text_array) VALUES (4, E'{"quoted\\\\bslash",unquoted}');
+-- Multiple escape sequences
+INSERT INTO sql_regression_samples (id, sample_text_array) VALUES (5, E'{a\\,b\\,c}');

--- a/integration/sql/cases/927_array_escape_roundtrip_teardown.sql
+++ b/integration/sql/cases/927_array_escape_roundtrip_teardown.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS sql_regression_samples;

--- a/integration/sql/cases/928_array_expression_roundtrip_case.sql
+++ b/integration/sql/cases/928_array_expression_roundtrip_case.sql
@@ -1,0 +1,14 @@
+-- description: Array constructor expressions and casts round-trip through PgDog
+-- tags: standard
+-- transactional: true
+
+SELECT
+    ARRAY[1,2,3] AS int_array,
+    ARRAY['hello','world'] AS text_array,
+    ARRAY[true,false,NULL::boolean] AS bool_array,
+    ARRAY[1.5,2.5]::real[] AS real_array,
+    ARRAY[]::integer[] AS empty_int,
+    ARRAY[NULL,1,NULL]::integer[] AS nulls_int,
+    ARRAY['has,comma','has"quote','has\back'] AS special_text
+FROM sql_regression_samples
+WHERE id = 1;

--- a/integration/sql/cases/928_array_expression_roundtrip_setup.sql
+++ b/integration/sql/cases/928_array_expression_roundtrip_setup.sql
@@ -1,0 +1,5 @@
+DROP TABLE IF EXISTS sql_regression_samples;
+CREATE TABLE sql_regression_samples (
+    id BIGINT PRIMARY KEY
+);
+INSERT INTO sql_regression_samples (id) VALUES (1);

--- a/integration/sql/cases/928_array_expression_roundtrip_teardown.sql
+++ b/integration/sql/cases/928_array_expression_roundtrip_teardown.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS sql_regression_samples;

--- a/integration/sql/cases/929_integer_array_binary_roundtrip_case.sql
+++ b/integration/sql/cases/929_integer_array_binary_roundtrip_case.sql
@@ -1,0 +1,6 @@
+-- description: Integer and text arrays round-trip through PgDog in binary format
+-- tags: standard
+-- transactional: true
+-- only-targets: postgres_standard_binary pgdog_standard_binary pgdog_sharded_binary
+
+SELECT id, sample_int_array, sample_text_array FROM sql_regression_samples ORDER BY id;

--- a/integration/sql/cases/929_integer_array_binary_roundtrip_setup.sql
+++ b/integration/sql/cases/929_integer_array_binary_roundtrip_setup.sql
@@ -1,0 +1,11 @@
+DROP TABLE IF EXISTS sql_regression_samples;
+CREATE TABLE sql_regression_samples (
+    id BIGINT PRIMARY KEY,
+    sample_int_array INTEGER[],
+    sample_text_array TEXT[]
+);
+INSERT INTO sql_regression_samples (id, sample_int_array, sample_text_array) VALUES (1, '{1,2,3}', '{"hello","world"}');
+INSERT INTO sql_regression_samples (id, sample_int_array, sample_text_array) VALUES (2, '{-1,0,2147483647}', '{"has,comma","has space"}');
+INSERT INTO sql_regression_samples (id, sample_int_array, sample_text_array) VALUES (3, '{}', '{}');
+INSERT INTO sql_regression_samples (id, sample_int_array, sample_text_array) VALUES (4, '{NULL,1,NULL}', '{NULL,"value",NULL}');
+INSERT INTO sql_regression_samples (id, sample_int_array, sample_text_array) VALUES (5, NULL, NULL);

--- a/integration/sql/cases/929_integer_array_binary_roundtrip_teardown.sql
+++ b/integration/sql/cases/929_integer_array_binary_roundtrip_teardown.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS sql_regression_samples;

--- a/integration/sql/cases/930_multidim_array_group_by_case.sql
+++ b/integration/sql/cases/930_multidim_array_group_by_case.sql
@@ -1,0 +1,11 @@
+-- description: Multidimensional arrays survive GROUP BY round-trips through PgDog
+-- tags: standard sharded
+-- transactional: true
+
+SELECT
+    MIN(id) AS first_id,
+    sample_matrix,
+    COUNT(*) AS occurrences
+FROM sql_regression_samples
+GROUP BY sample_matrix
+ORDER BY first_id;

--- a/integration/sql/cases/930_multidim_array_group_by_setup.sql
+++ b/integration/sql/cases/930_multidim_array_group_by_setup.sql
@@ -1,0 +1,11 @@
+DROP TABLE IF EXISTS sql_regression_samples;
+CREATE TABLE sql_regression_samples (
+    id BIGINT PRIMARY KEY,
+    sample_matrix INTEGER[][]
+);
+
+INSERT INTO sql_regression_samples (id, sample_matrix) VALUES (1, '{{1,2},{3,4}}');
+INSERT INTO sql_regression_samples (id, sample_matrix) VALUES (2, '{{1,2},{3,4}}');
+INSERT INTO sql_regression_samples (id, sample_matrix) VALUES (3, '{{5,6},{7,8}}');
+INSERT INTO sql_regression_samples (id, sample_matrix) VALUES (4, '{{5,6},{7,8}}');
+INSERT INTO sql_regression_samples (id, sample_matrix) VALUES (5, '{{1,2},{3,5}}');

--- a/integration/sql/cases/930_multidim_array_group_by_teardown.sql
+++ b/integration/sql/cases/930_multidim_array_group_by_teardown.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS sql_regression_samples;

--- a/integration/sql/cases/931_interval_array_group_by_case.sql
+++ b/integration/sql/cases/931_interval_array_group_by_case.sql
@@ -1,0 +1,11 @@
+-- description: Interval arrays survive binary and sharded GROUP BY round-trips through PgDog
+-- tags: standard sharded
+-- transactional: true
+
+SELECT
+    MIN(id) AS first_id,
+    sample_interval_array,
+    COUNT(*) AS occurrences
+FROM sql_regression_samples
+GROUP BY sample_interval_array
+ORDER BY first_id;

--- a/integration/sql/cases/931_interval_array_group_by_setup.sql
+++ b/integration/sql/cases/931_interval_array_group_by_setup.sql
@@ -1,0 +1,13 @@
+DROP TABLE IF EXISTS sql_regression_samples;
+CREATE TABLE sql_regression_samples (
+    id BIGINT PRIMARY KEY,
+    sample_interval_array INTERVAL[]
+);
+
+INSERT INTO sql_regression_samples (id, sample_interval_array) VALUES (1, ARRAY[INTERVAL '00:00:00.006']);
+INSERT INTO sql_regression_samples (id, sample_interval_array) VALUES (2, ARRAY[INTERVAL '00:00:00.006']);
+INSERT INTO sql_regression_samples (id, sample_interval_array) VALUES (3, ARRAY[INTERVAL '1 year 2 months 3 days 04:05:06.7']);
+INSERT INTO sql_regression_samples (id, sample_interval_array) VALUES (4, ARRAY[INTERVAL '1 year 2 months 3 days 04:05:06.7']);
+INSERT INTO sql_regression_samples (id, sample_interval_array) VALUES (5, ARRAY[NULL::INTERVAL, INTERVAL '00:15:30.25']);
+INSERT INTO sql_regression_samples (id, sample_interval_array) VALUES (6, ARRAY[NULL::INTERVAL, INTERVAL '00:15:30.25']);
+INSERT INTO sql_regression_samples (id, sample_interval_array) VALUES (7, ARRAY[]::INTERVAL[]);

--- a/integration/sql/cases/931_interval_array_group_by_teardown.sql
+++ b/integration/sql/cases/931_interval_array_group_by_teardown.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS sql_regression_samples;

--- a/integration/sql/cases/932_interval_array_postgres_style_group_by_case.sql
+++ b/integration/sql/cases/932_interval_array_postgres_style_group_by_case.sql
@@ -1,0 +1,14 @@
+-- description: Interval arrays grouped under postgres intervalstyle preserve PostgreSQL text output
+-- tags: standard sharded
+-- transactional: true
+-- only-targets: postgres_standard_text pgdog_standard_text pgdog_sharded_text
+
+SET intervalstyle TO postgres;
+
+SELECT
+    MIN(id) AS first_id,
+    sample_interval_array,
+    COUNT(*) AS occurrences
+FROM sql_regression_samples
+GROUP BY sample_interval_array
+ORDER BY first_id;

--- a/integration/sql/cases/932_interval_array_postgres_style_group_by_setup.sql
+++ b/integration/sql/cases/932_interval_array_postgres_style_group_by_setup.sql
@@ -1,0 +1,13 @@
+DROP TABLE IF EXISTS sql_regression_samples;
+CREATE TABLE sql_regression_samples (
+    id BIGINT PRIMARY KEY,
+    sample_interval_array INTERVAL[]
+);
+
+INSERT INTO sql_regression_samples (id, sample_interval_array) VALUES (1, ARRAY[INTERVAL '1 year 2 months 1 day 04:05:06.7']);
+INSERT INTO sql_regression_samples (id, sample_interval_array) VALUES (2, ARRAY[INTERVAL '1 year 2 months 1 day 04:05:06.7']);
+INSERT INTO sql_regression_samples (id, sample_interval_array) VALUES (3, ARRAY[INTERVAL '00:00:00.006']);
+INSERT INTO sql_regression_samples (id, sample_interval_array) VALUES (4, ARRAY[INTERVAL '00:00:00.006']);
+INSERT INTO sql_regression_samples (id, sample_interval_array) VALUES (5, ARRAY[NULL::INTERVAL, INTERVAL '00:15:30.25']);
+INSERT INTO sql_regression_samples (id, sample_interval_array) VALUES (6, ARRAY[NULL::INTERVAL, INTERVAL '00:15:30.25']);
+INSERT INTO sql_regression_samples (id, sample_interval_array) VALUES (7, ARRAY[]::INTERVAL[]);

--- a/integration/sql/cases/932_interval_array_postgres_style_group_by_teardown.sql
+++ b/integration/sql/cases/932_interval_array_postgres_style_group_by_teardown.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS sql_regression_samples;

--- a/integration/sql/lib.py
+++ b/integration/sql/lib.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import re
 from collections import OrderedDict
 from dataclasses import dataclass
@@ -9,6 +10,19 @@ from typing import Dict, Iterable, List, Sequence, Tuple
 import psycopg
 import psycopg.rows
 import sqlparse
+
+
+def _values_equal(a, b) -> bool:
+    """Equality that treats NaN == NaN so float arrays with NaN compare stably."""
+    if isinstance(a, float) and isinstance(b, float):
+        if math.isnan(a) and math.isnan(b):
+            return True
+        return a == b
+    if isinstance(a, (list, tuple)) and isinstance(b, (list, tuple)):
+        if len(a) != len(b):
+            return False
+        return all(_values_equal(x, y) for x, y in zip(a, b))
+    return a == b
 
 
 @dataclass(frozen=True)
@@ -427,7 +441,7 @@ def _assert_pair_equal(
             raise AssertionError(
                 f"{context}: column type mismatch -> {baseline_stmt.type_names} vs {candidate_stmt.type_names}"
             )
-        if tuple(baseline_stmt.rows) != tuple(candidate_stmt.rows):
+        if not _values_equal(tuple(baseline_stmt.rows), tuple(candidate_stmt.rows)):
             raise AssertionError(
                 f"{context}: row payload mismatch\n"
                 f"baseline={baseline_stmt.rows}\n"

--- a/pgdog-postgres-types/src/array.rs
+++ b/pgdog-postgres-types/src/array.rs
@@ -1,72 +1,873 @@
-use bytes::{Buf, Bytes};
+use std::cmp::Ordering;
 
-use super::{Error, Format, FromDataType};
+use bytes::{Buf, BufMut, Bytes, BytesMut};
 
-#[derive(Debug, Clone, Ord, PartialOrd, PartialEq, Eq)]
+use super::{Error, Format};
+use crate::{DataType, Datum};
+
+#[derive(Debug, Clone)]
 pub struct Array {
-    payload: Vec<Bytes>,
-    oid: i32,
-    flags: i32,
+    elements: Vec<Option<Datum>>,
+    element_oid: i32,
     dim: Dimension,
 }
 
-#[derive(Debug, Clone, Ord, PartialOrd, PartialEq, Eq, Default)]
+impl PartialEq for Array {
+    fn eq(&self, other: &Self) -> bool {
+        self.elements == other.elements
+            && self.element_oid == other.element_oid
+            && self.dim == other.dim
+    }
+}
+
+impl Eq for Array {}
+
+impl PartialOrd for Array {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Array {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.elements
+            .cmp(&other.elements)
+            .then(self.element_oid.cmp(&other.element_oid))
+            .then(self.dim.cmp(&other.dim))
+    }
+}
+
+impl std::hash::Hash for Array {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.elements.hash(state);
+        self.element_oid.hash(state);
+        self.dim.hash(state);
+    }
+}
+
+#[derive(Debug, Clone, Hash, Ord, PartialOrd, PartialEq, Eq)]
 struct Dimension {
     size: i32,
     lower_bound: i32,
 }
 
-impl FromDataType for Array {
-    fn decode(bytes: &[u8], encoding: Format) -> Result<Self, Error> {
-        match encoding {
-            Format::Text => todo!(),
-            Format::Binary => {
-                let mut bytes = Bytes::copy_from_slice(bytes);
-                // Header: dims(4) + flags(4) + oid(4) + dim_size(4) + lower_bound(4) = 20 bytes minimum
-                if bytes.remaining() < 20 {
-                    return Err(Error::UnexpectedPayload);
+impl Default for Dimension {
+    fn default() -> Self {
+        Self {
+            size: 0,
+            lower_bound: 1,
+        }
+    }
+}
+
+impl Array {
+    /// Decode an array with a known element type OID.
+    ///
+    /// For binary format, the element OID is also present in the wire header
+    /// and is validated against the provided `element_oid`.
+    /// For text format, the element OID must be supplied by the caller
+    /// (typically from the column's RowDescription).
+    pub fn decode_typed(bytes: &[u8], format: Format, element_oid: i32) -> Result<Self, Error> {
+        match format {
+            Format::Text => {
+                let input = std::str::from_utf8(bytes)?;
+                decode_text(input, element_oid)
+            }
+            Format::Binary => decode_binary(bytes, element_oid),
+        }
+    }
+
+    /// Encode the array to the specified wire format.
+    ///
+    /// Cross-format encoding works because elements are stored as typed
+    /// Datum values that can be encoded to any format.
+    pub fn encode(&self, format: Format) -> Result<Bytes, Error> {
+        match format {
+            Format::Text => self.encode_text(),
+            Format::Binary => self.encode_binary(),
+        }
+    }
+
+    fn encode_text(&self) -> Result<Bytes, Error> {
+        let mut result = String::new();
+        if self.dim.lower_bound != 1 {
+            use std::fmt::Write;
+            let ub = self
+            .dim
+            .lower_bound
+            .checked_add(self.dim.size)
+            .and_then(|v| v.checked_sub(1))
+            .ok_or(Error::UnexpectedPayload)?;
+            write!(result, "[{}:{}]=", self.dim.lower_bound, ub).unwrap();
+        }
+        result.push('{');
+        for (i, element) in self.elements.iter().enumerate() {
+            if i > 0 {
+                result.push(',');
+            }
+            match element {
+                None => result.push_str("NULL"),
+                Some(datum) => {
+                    let encoded = datum.encode(Format::Text)?;
+                    let text = std::str::from_utf8(&encoded)?;
+                    if needs_quoting(text) {
+                        result.push('"');
+                        for ch in text.chars() {
+                            match ch {
+                                '"' => result.push_str("\\\""),
+                                '\\' => result.push_str("\\\\"),
+                                _ => result.push(ch),
+                            }
+                        }
+                        result.push('"');
+                    } else {
+                        result.push_str(text);
+                    }
                 }
-                let dims = bytes.get_i32() as usize;
-                if dims > 1 {
-                    return Err(Error::ArrayDimensions(dims));
+            }
+        }
+        result.push('}');
+        Ok(Bytes::from(result))
+    }
+
+    fn encode_binary(&self) -> Result<Bytes, Error> {
+        let mut buf = BytesMut::with_capacity(12 + 8 + self.elements.len() * 8);
+        // Use ndims=0 only for truly empty arrays with default bounds.
+        // Non-default bounds need ndims=1 + size=0 to preserve the bounds.
+        let has_dim = !self.elements.is_empty() || self.dim.lower_bound != 1;
+        let dims = if has_dim { 1i32 } else { 0 };
+        let has_nulls = self.elements.iter().any(|e| e.is_none());
+        buf.put_i32(dims);
+        buf.put_i32(if has_nulls { 1 } else { 0 });
+        buf.put_i32(self.element_oid);
+        if dims > 0 {
+            buf.put_i32(self.dim.size);
+            buf.put_i32(self.dim.lower_bound);
+        }
+        for element in &self.elements {
+            match element {
+                None => buf.put_i32(-1),
+                Some(datum) => {
+                    let encoded = datum.encode(Format::Binary)?;
+                    buf.put_i32(encoded.len() as i32);
+                    buf.extend_from_slice(&encoded);
                 }
-                let flags = bytes.get_i32();
-                let oid = bytes.get_i32();
+            }
+        }
+        Ok(buf.freeze())
+    }
+}
 
-                let dim = Dimension {
-                    size: bytes.get_i32(),
-                    lower_bound: bytes.get_i32(),
-                };
+fn needs_quoting(s: &str) -> bool {
+    s.is_empty()
+        || s.eq_ignore_ascii_case("null")
+        || s.bytes()
+            .any(|b| matches!(b, b',' | b'{' | b'}' | b'"' | b'\\') || b.is_ascii_whitespace())
+}
 
-                let mut payload = vec![];
+fn decode_text(input: &str, element_oid: i32) -> Result<Array, Error> {
+    let input = input.trim();
+    let element_type = DataType::from_oid(element_oid);
+    let mut chars = input.chars().peekable();
 
-                while bytes.has_remaining() {
-                    if bytes.remaining() < 4 {
+    // Parse optional bounds prefix: [lower:upper]=
+    let (lower_bound, expected_count) = if chars.peek() == Some(&'[') {
+        chars.next();
+        let mut lb_str = String::new();
+        while let Some(&ch) = chars.peek() {
+            if ch == ':' {
+                break;
+            }
+            lb_str.push(ch);
+            chars.next();
+        }
+        chars.next(); // skip ':'
+        let mut ub_str = String::new();
+        while let Some(&ch) = chars.peek() {
+            if ch == ']' {
+                break;
+            }
+            ub_str.push(ch);
+            chars.next();
+        }
+        chars.next(); // skip ']'
+        chars.next(); // skip '='
+        let lb = lb_str
+            .parse::<i32>()
+            .map_err(|_| Error::UnexpectedPayload)?;
+        let ub = ub_str
+            .parse::<i32>()
+            .map_err(|_| Error::UnexpectedPayload)?;
+        let expected = ub
+            .checked_sub(lb)
+            .and_then(|d| d.checked_add(1))
+            .ok_or(Error::UnexpectedPayload)?;
+        (lb, Some(expected))
+    } else {
+        (1, None)
+    };
+
+    if chars.next() != Some('{') {
+        return Err(Error::UnexpectedPayload);
+    }
+
+    while chars.peek().is_some_and(|c| c.is_ascii_whitespace()) {
+        chars.next();
+    }
+
+    // Empty array
+    if chars.peek() == Some(&'}') {
+        chars.next();
+        if chars.next().is_some() {
+            return Err(Error::UnexpectedPayload);
+        }
+        if let Some(expected) = expected_count
+            && expected != 0
+        {
+            return Err(Error::UnexpectedPayload);
+        }
+        return Ok(Array {
+            elements: vec![],
+            element_oid,
+            dim: Dimension {
+                size: 0,
+                lower_bound,
+            },
+        });
+    }
+
+    let mut elements = Vec::new();
+
+    loop {
+        while chars.peek().is_some_and(|c| c.is_ascii_whitespace()) {
+            chars.next();
+        }
+
+        match chars.peek() {
+            Some(&'"') => {
+                chars.next();
+                let mut elem = String::new();
+                loop {
+                    match chars.next() {
+                        Some('\\') => {
+                            if let Some(escaped) = chars.next() {
+                                elem.push(escaped);
+                            }
+                        }
+                        Some('"') => break,
+                        Some(ch) => elem.push(ch),
+                        None => return Err(Error::UnexpectedPayload),
+                    }
+                }
+                let datum = Datum::new(elem.as_bytes(), element_type, Format::Text, false)?;
+                elements.push(Some(datum));
+            }
+            Some(_) => {
+                let mut elem = String::new();
+                let mut has_escapes = false;
+                while let Some(&ch) = chars.peek() {
+                    if ch == ',' || ch == '}' {
+                        break;
+                    }
+                    if ch == '{' {
+                        return Err(Error::ArrayDimensions(2));
+                    }
+                    if ch == '\\' {
+                        chars.next();
+                        match chars.next() {
+                            Some(escaped) => elem.push(escaped),
+                            None => return Err(Error::UnexpectedPayload),
+                        }
+                        has_escapes = true;
+                    } else {
+                        elem.push(ch);
+                        chars.next();
+                    }
+                }
+
+                if has_escapes {
+                    if elem.is_empty() {
                         return Err(Error::UnexpectedPayload);
                     }
-                    let len = bytes.get_i32();
-                    if len < 0 {
-                        payload.push(Bytes::new())
+                    let datum = Datum::new(elem.as_bytes(), element_type, Format::Text, false)?;
+                    elements.push(Some(datum));
+                } else {
+                    let trimmed = elem.trim_end_matches(|c: char| c.is_ascii_whitespace());
+                    if trimmed.is_empty() {
+                        return Err(Error::UnexpectedPayload);
+                    }
+                    if trimmed.eq_ignore_ascii_case("NULL") {
+                        elements.push(None);
                     } else {
-                        if bytes.remaining() < len as usize {
-                            return Err(Error::UnexpectedPayload);
-                        }
-                        let element = bytes.split_to(len as usize);
-                        payload.push(element);
+                        let datum =
+                            Datum::new(trimmed.as_bytes(), element_type, Format::Text, false)?;
+                        elements.push(Some(datum));
                     }
                 }
+            }
+            None => return Err(Error::UnexpectedPayload),
+        }
 
-                Ok(Self {
-                    payload,
-                    oid,
-                    flags,
-                    dim,
-                })
+        while chars.peek().is_some_and(|c| c.is_ascii_whitespace()) {
+            chars.next();
+        }
+
+        match chars.peek() {
+            Some(&',') => {
+                chars.next();
+            }
+            Some(&'}') => break,
+            _ => return Err(Error::UnexpectedPayload),
+        }
+    }
+
+    chars.next(); // consume '}'
+    if chars.next().is_some() {
+        return Err(Error::UnexpectedPayload);
+    }
+
+    let size = elements.len() as i32;
+
+    if let Some(expected) = expected_count
+        && size != expected
+    {
+        return Err(Error::UnexpectedPayload);
+    }
+
+    Ok(Array {
+        elements,
+        element_oid,
+        dim: Dimension { size, lower_bound },
+    })
+}
+
+fn decode_binary(bytes: &[u8], expected_element_oid: i32) -> Result<Array, Error> {
+    let mut bytes = Bytes::copy_from_slice(bytes);
+
+    if bytes.remaining() < 12 {
+        return Err(Error::UnexpectedPayload);
+    }
+    let dims = bytes.get_i32() as usize;
+    if dims > 1 {
+        return Err(Error::ArrayDimensions(dims));
+    }
+    let _flags = bytes.get_i32();
+    let wire_oid = bytes.get_i32();
+
+    // Validate wire OID matches the caller-supplied OID
+    let element_oid = if expected_element_oid != 0 {
+        if wire_oid != expected_element_oid {
+            return Err(Error::UnexpectedPayload);
+        }
+        expected_element_oid
+    } else {
+        wire_oid
+    };
+    let element_type = DataType::from_oid(element_oid);
+
+    let dim = if dims == 0 {
+        if bytes.has_remaining() {
+            return Err(Error::UnexpectedPayload);
+        }
+        Dimension::default()
+    } else {
+        if bytes.remaining() < 8 {
+            return Err(Error::UnexpectedPayload);
+        }
+        let size = bytes.get_i32();
+        if size < 0 {
+            return Err(Error::UnexpectedPayload);
+        }
+        let lower_bound = bytes.get_i32();
+        lower_bound
+            .checked_add(size)
+            .ok_or(Error::UnexpectedPayload)?;
+        Dimension { size, lower_bound }
+    };
+
+    let mut elements = vec![];
+
+    while bytes.has_remaining() {
+        if bytes.remaining() < 4 {
+            return Err(Error::UnexpectedPayload);
+        }
+        let len = bytes.get_i32();
+        if len == -1 {
+            elements.push(None);
+        } else if len < 0 {
+            return Err(Error::UnexpectedPayload);
+        } else {
+            if bytes.remaining() < len as usize {
+                return Err(Error::UnexpectedPayload);
+            }
+            let element_bytes = bytes.split_to(len as usize);
+            let datum = Datum::new(&element_bytes, element_type, Format::Binary, false)?;
+            elements.push(Some(datum));
+        }
+    }
+
+    if elements.len() != dim.size as usize {
+        return Err(Error::UnexpectedPayload);
+    }
+
+    Ok(Array {
+        elements,
+        element_oid,
+        dim,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ToDataRowColumn;
+
+    // ── Text decode ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_text_decode_table() {
+        let cases: Vec<(&str, &str, i32, Vec<Option<&str>>, i32)> = vec![
+            ("empty", "{}", 23, vec![], 1),
+            ("single int", "{1}", 23, vec![Some("1")], 1),
+            (
+                "three ints",
+                "{1,2,3}",
+                23,
+                vec![Some("1"), Some("2"), Some("3")],
+                1,
+            ),
+            ("negative int", "{-1}", 23, vec![Some("-1")], 1),
+            ("single NULL", "{NULL}", 23, vec![None], 1),
+            ("NULL mixed case", "{null}", 23, vec![None], 1),
+            (
+                "NULL start",
+                "{NULL,1,2}",
+                23,
+                vec![None, Some("1"), Some("2")],
+                1,
+            ),
+            ("all NULLs", "{NULL,NULL}", 23, vec![None, None], 1),
+            (
+                "text elements",
+                "{hello,world}",
+                25,
+                vec![Some("hello"), Some("world")],
+                1,
+            ),
+            ("quoted comma", r#"{"a,b"}"#, 25, vec![Some("a,b")], 1),
+            ("quoted quote", r#"{"a\"b"}"#, 25, vec![Some("a\"b")], 1),
+            ("quoted backslash", r#"{"a\\b"}"#, 25, vec![Some("a\\b")], 1),
+            ("empty string", r#"{""}"#, 25, vec![Some("")], 1),
+            (
+                "quoted NULL literal",
+                r#"{"NULL"}"#,
+                25,
+                vec![Some("NULL")],
+                1,
+            ),
+            (
+                "whitespace around",
+                "{ 1 , 2 }",
+                23,
+                vec![Some("1"), Some("2")],
+                1,
+            ),
+            ("escaped comma", r#"{a\,b}"#, 25, vec![Some("a,b")], 1),
+            (
+                "escaped trailing space",
+                r#"{a\ }"#,
+                25,
+                vec![Some("a ")],
+                1,
+            ),
+            (
+                "escaped null literal",
+                r#"{\N\U\L\L}"#,
+                25,
+                vec![Some("NULL")],
+                1,
+            ),
+            (
+                "custom lower bound",
+                "[0:2]={1,2,3}",
+                23,
+                vec![Some("1"), Some("2"), Some("3")],
+                0,
+            ),
+        ];
+
+        for (name, input, oid, expected_elements, expected_lb) in cases {
+            let array = Array::decode_typed(input.as_bytes(), Format::Text, oid).expect(name);
+            assert_eq!(array.dim.lower_bound, expected_lb, "lower_bound: {name}");
+            assert_eq!(
+                array.elements.len(),
+                expected_elements.len(),
+                "count: {name}"
+            );
+            for (i, (got, want)) in array
+                .elements
+                .iter()
+                .zip(expected_elements.iter())
+                .enumerate()
+            {
+                match (got, want) {
+                    (None, None) => {}
+                    (Some(datum), Some(expected)) => {
+                        let encoded = datum.encode(Format::Text).expect(name);
+                        assert_eq!(
+                            std::str::from_utf8(&encoded).unwrap(),
+                            *expected,
+                            "element {i}: {name}"
+                        );
+                    }
+                    _ => panic!("element {i} mismatch: {name}: got {got:?} want {want:?}"),
+                }
             }
         }
     }
 
-    fn encode(&self, _encoding: Format) -> Result<Bytes, Error> {
-        todo!()
+    // ── Text roundtrip ───────────────────────────────────────────────
+
+    #[test]
+    fn test_text_roundtrip() {
+        let cases: Vec<(&str, i32)> = vec![
+            ("{}", 23),
+            ("{1,2,3}", 23),
+            ("{NULL,1,2}", 23),
+            ("{hello,world}", 25),
+            (r#"{"a,b"}"#, 25),
+            (r#"{"a\"b"}"#, 25),
+            (r#"{"a\\b"}"#, 25),
+            (r#"{""}"#, 25),
+            (r#"{"",NULL}"#, 25),
+            (r#"{"NULL"}"#, 25),
+            ("{t,f}", 16),
+            ("[0:2]={1,2,3}", 23),
+        ];
+
+        for (input, oid) in cases {
+            let decoded = Array::decode_typed(input.as_bytes(), Format::Text, oid).expect(input);
+            let encoded = decoded.encode(Format::Text).expect(input);
+            assert_eq!(
+                std::str::from_utf8(&encoded).unwrap(),
+                input,
+                "roundtrip: {input}"
+            );
+        }
+    }
+
+    // ── Cross-format encode ──────────────────────────────────────────
+
+    #[test]
+    fn test_text_to_binary_roundtrip() {
+        // Decode from text, encode to binary, decode back from binary, encode to text
+        let input = "{1,2,3}";
+        let text_decoded = Array::decode_typed(input.as_bytes(), Format::Text, 23).unwrap();
+
+        let binary = text_decoded.encode(Format::Binary).unwrap();
+        let binary_decoded = Array::decode_typed(&binary, Format::Binary, 23).unwrap();
+
+        let text_again = binary_decoded.encode(Format::Text).unwrap();
+        assert_eq!(std::str::from_utf8(&text_again).unwrap(), input);
+    }
+
+    #[test]
+    fn test_cross_format_with_nulls() {
+        let input = "{NULL,42,NULL}";
+        let decoded = Array::decode_typed(input.as_bytes(), Format::Text, 23).unwrap();
+
+        let binary = decoded.encode(Format::Binary).unwrap();
+        let from_binary = Array::decode_typed(&binary, Format::Binary, 23).unwrap();
+
+        let text = from_binary.encode(Format::Text).unwrap();
+        assert_eq!(std::str::from_utf8(&text).unwrap(), input);
+    }
+
+    #[test]
+    fn test_binary_to_text() {
+        // Build a proper binary int4[] and verify it text-encodes correctly
+        let decoded = Array::decode_typed(b"{10,20,30}", Format::Text, 23).unwrap();
+        let binary = decoded.encode(Format::Binary).unwrap();
+        let from_binary = Array::decode_typed(&binary, Format::Binary, 23).unwrap();
+        let text = from_binary.encode(Format::Text).unwrap();
+        assert_eq!(std::str::from_utf8(&text).unwrap(), "{10,20,30}");
+    }
+
+    // ── Binary roundtrip ─────────────────────────────────────────────
+
+    #[test]
+    fn test_binary_encode_roundtrip() {
+        let cases: Vec<(&str, &str, i32)> = vec![
+            ("empty", "{}", 23),
+            ("single int", "{1}", 23),
+            ("three ints", "{1,2,3}", 23),
+            ("with NULL", "{NULL,1,NULL}", 23),
+            ("text elems", "{hello,world}", 25),
+            ("booleans", "{t,f}", 16),
+        ];
+
+        for (name, text_input, oid) in cases {
+            let original =
+                Array::decode_typed(text_input.as_bytes(), Format::Text, oid).expect(name);
+            let binary = original.encode(Format::Binary).expect(name);
+            let decoded = Array::decode_typed(&binary, Format::Binary, oid).expect(name);
+            let text = decoded.encode(Format::Text).expect(name);
+            assert_eq!(
+                std::str::from_utf8(&text).unwrap(),
+                text_input,
+                "binary roundtrip: {name}"
+            );
+        }
+    }
+
+    // ── Rejection / validation ───────────────────────────────────────
+
+    #[test]
+    fn test_text_decode_rejects_malformed() {
+        let bad: Vec<(&str, &str)> = vec![
+            ("{1}junk", "trailing garbage"),
+            ("{{1,2},{3,4}}", "nested"),
+            ("", "empty string"),
+            ("1,2,3", "missing braces"),
+            ("{1,,2}", "double comma"),
+            ("{1,2,}", "trailing comma"),
+            ("{,}", "comma only"),
+        ];
+
+        for (input, desc) in bad {
+            let result = Array::decode_typed(input.as_bytes(), Format::Text, 23);
+            assert!(result.is_err(), "should reject {desc}: {input}");
+        }
+    }
+
+    #[test]
+    fn test_text_decode_validates_bounds() {
+        assert!(Array::decode_typed(b"[5:7]={1}", Format::Text, 23).is_err());
+        assert!(Array::decode_typed(b"[0:2]={1,2}", Format::Text, 23).is_err());
+        assert!(Array::decode_typed(b"[5:7]={}", Format::Text, 23).is_err());
+        assert!(Array::decode_typed(b"[0:0]={1}", Format::Text, 23).is_ok());
+        // Overflow
+        assert!(Array::decode_typed(b"[2147483647:0]={1}", Format::Text, 23).is_err());
+    }
+
+    #[test]
+    fn test_binary_decode_validates_element_count() {
+        // Declares 3 elements but only contains 2
+        #[rustfmt::skip]
+        let short: &[u8] = &[
+            0,0,0,1,  0,0,0,0,  0,0,0,23,
+            0,0,0,3,  0,0,0,1,
+            0,0,0,4, 0,0,0,1,
+            0,0,0,4, 0,0,0,2,
+        ];
+        assert!(Array::decode_typed(short, Format::Binary, 23).is_err());
+
+        // Negative dim.size
+        #[rustfmt::skip]
+        let neg: &[u8] = &[
+            0,0,0,1,  0,0,0,0,  0,0,0,23,
+            255,255,255,255,  0,0,0,1,
+        ];
+        assert!(Array::decode_typed(neg, Format::Binary, 23).is_err());
+
+        // len=-2 (only -1 is valid NULL)
+        #[rustfmt::skip]
+        let bad_len: &[u8] = &[
+            0,0,0,1,  0,0,0,0,  0,0,0,23,
+            0,0,0,1,  0,0,0,1,
+            255,255,255,254,
+        ];
+        assert!(Array::decode_typed(bad_len, Format::Binary, 23).is_err());
+    }
+
+    #[test]
+    fn test_binary_empty_array_wire_format() {
+        let decoded = Array::decode_typed(b"{}", Format::Text, 23).unwrap();
+        let encoded = decoded.encode(Format::Binary).unwrap();
+        assert_eq!(encoded.len(), 12);
+
+        let pg_empty: &[u8] = &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 23];
+        let decoded = Array::decode_typed(pg_empty, Format::Binary, 23).unwrap();
+        assert!(decoded.elements.is_empty());
+        assert_eq!(decoded.element_oid, 23);
+    }
+
+    #[test]
+    fn test_empty_array_with_explicit_bounds_roundtrips() {
+        let input = b"[0:-1]={}";
+        let decoded = Array::decode_typed(input, Format::Text, 23).unwrap();
+
+        let text = decoded.encode(Format::Text).unwrap();
+        assert_eq!(
+            &text[..],
+            input,
+            "text encoding should preserve explicit empty-array bounds"
+        );
+
+        let binary = decoded.encode(Format::Binary).unwrap();
+        let from_binary = Array::decode_typed(&binary, Format::Binary, 23).unwrap();
+        let text_from_binary = from_binary.encode(Format::Text).unwrap();
+        assert_eq!(
+            &text_from_binary[..],
+            input,
+            "binary encoding should preserve explicit empty-array bounds"
+        );
+    }
+
+    #[test]
+    fn test_binary_ndims_zero_rejects_trailing_data() {
+        let bad: &[u8] = &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 23, 0, 0, 0, 1, 1];
+        assert!(Array::decode_typed(bad, Format::Binary, 23).is_err());
+    }
+
+    // ── Equality ─────────────────────────────────────────────────────
+
+    #[test]
+    fn test_equality_across_formats() {
+        let text = Array::decode_typed(b"{1,2,3}", Format::Text, 23).unwrap();
+        let binary = text.encode(Format::Binary).unwrap();
+        let from_binary = Array::decode_typed(&binary, Format::Binary, 23).unwrap();
+        assert_eq!(text, from_binary);
+    }
+
+    // ── Datum integration ────────────────────────────────────────────
+
+    #[test]
+    fn test_datum_array_roundtrip() {
+        let datum = Datum::new(b"{1,2,3}", DataType::Array(23), Format::Text, false).unwrap();
+        match &datum {
+            Datum::Array(arr) => {
+                assert_eq!(arr.elements.len(), 3);
+            }
+            other => panic!("expected Datum::Array, got {other:?}"),
+        }
+
+        // Encode to binary
+        let binary = datum.encode(Format::Binary).unwrap();
+        let datum2 = Datum::new(&binary, DataType::Array(23), Format::Binary, false).unwrap();
+        let text = datum2.encode(Format::Text).unwrap();
+        assert_eq!(std::str::from_utf8(&text).unwrap(), "{1,2,3}");
+    }
+
+    #[test]
+    fn test_smallint_array_datum_roundtrip() {
+        let input = b"{1,-2,32767}";
+        let datum = Datum::new(input, DataType::Array(21), Format::Text, false).unwrap();
+        let encoded = datum.encode(Format::Text).unwrap();
+        assert_eq!(&encoded[..], input);
+    }
+
+    #[test]
+    fn test_oid_array_datum_roundtrip() {
+        let input = b"{1,2500000000}";
+        let datum = Datum::new(input, DataType::Array(26), Format::Text, false).unwrap();
+        let encoded = datum.encode(Format::Text).unwrap();
+        assert_eq!(&encoded[..], input);
+    }
+
+    #[test]
+    fn test_interval_array_datum_roundtrip() {
+        let input = br#"{"1 years 0 mons 0 days 0:0:0.0"}"#;
+        let datum = Datum::new(input, DataType::Array(1186), Format::Text, false).unwrap();
+        let encoded = datum.encode(Format::Text).unwrap();
+        assert_eq!(&encoded[..], input);
+    }
+
+    #[test]
+    fn test_interval_array_binary_roundtrip() {
+        let input = br#"{"1 years 2 mons 3 days 4:5:6.006"}"#;
+        let datum = Datum::new(input, DataType::Array(1186), Format::Text, false).unwrap();
+
+        let binary = datum.encode(Format::Binary).unwrap();
+        let decoded = Datum::new(&binary, DataType::Array(1186), Format::Binary, false).unwrap();
+        let text = decoded.encode(Format::Text).unwrap();
+
+        assert_eq!(
+            &text[..],
+            input,
+            "interval[] should support text->binary->text roundtrip"
+        );
+    }
+
+    #[test]
+    fn test_smallint_array_to_data_row_column_preserves_value() {
+        let datum = Datum::new(b"{1,2}", DataType::Array(21), Format::Text, false).unwrap();
+        let data = datum.to_data_row_column();
+        assert!(
+            !data.is_null(),
+            "array serialization should not silently become NULL"
+        );
+        assert_eq!(&data.data[..], b"{1,2}");
+    }
+
+    #[test]
+    fn test_unknown_element_type_does_not_panic() {
+        // Element OID 99999 is unknown — elements become Datum::Unknown
+        // to_data_row_column must not panic
+        let datum = Datum::new(
+            b"{hello,world}",
+            DataType::Array(99999),
+            Format::Text,
+            false,
+        )
+        .unwrap();
+        let data = datum.to_data_row_column();
+        assert!(!data.is_null());
+    }
+
+    #[test]
+    fn test_binary_decode_rejects_mismatched_element_oid() {
+        #[rustfmt::skip]
+        let payload: &[u8] = &[
+            0,0,0,1,  // ndims
+            0,0,0,0,  // flags
+            0,0,4,19, // varchar element OID (1043)
+            0,0,0,1,  // dim size
+            0,0,0,1,  // lower bound
+            0,0,0,5,  // element len
+            b'h', b'e', b'l', b'l', b'o',
+        ];
+
+        assert!(
+            Array::decode_typed(payload, Format::Binary, 25).is_err(),
+            "binary array decode should reject mismatched wire element OIDs"
+        );
+    }
+
+    #[test]
+    fn test_text_array_special_chars_binary_roundtrip() {
+        let cases: Vec<&str> = vec![
+            r#"{"hello world"}"#,
+            r#"{"a,b","c\"d"}"#,
+            r#"{"a\\b"}"#,
+            r#"{"",NULL,"not null"}"#,
+        ];
+        for input in cases {
+            let decoded = Array::decode_typed(input.as_bytes(), Format::Text, 25).unwrap();
+            let binary = decoded.encode(Format::Binary).unwrap();
+            let from_binary = Array::decode_typed(&binary, Format::Binary, 25).unwrap();
+            let text = from_binary.encode(Format::Text).unwrap();
+            assert_eq!(
+                std::str::from_utf8(&text).unwrap(),
+                input,
+                "special char roundtrip: {input}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_binary_decode_rejects_overflowing_bounds() {
+        #[rustfmt::skip]
+        let payload: &[u8] = &[
+            0,0,0,1,                // ndims=1
+            0,0,0,0,                // flags=0
+            0,0,0,23,               // element OID = int4
+            0,0,3,232,              // size=1000
+            0x7F,0xFF,0xFF,0xFF,    // lower_bound=i32::MAX
+        ];
+        assert!(
+            Array::decode_typed(payload, Format::Binary, 23).is_err(),
+            "should reject lower_bound + size overflow"
+        );
     }
 }

--- a/pgdog-postgres-types/src/array.rs
+++ b/pgdog-postgres-types/src/array.rs
@@ -92,12 +92,17 @@ impl Array {
         let mut result = String::new();
         if self.dim.lower_bound != 1 {
             use std::fmt::Write;
-            let ub = self
-            .dim
-            .lower_bound
-            .checked_add(self.dim.size)
-            .and_then(|v| v.checked_sub(1))
-            .ok_or(Error::UnexpectedPayload)?;
+            let ub = if self.dim.size == 0 {
+                self.dim
+                    .lower_bound
+                    .checked_sub(1)
+                    .ok_or(Error::UnexpectedPayload)?
+            } else {
+                self.dim
+                    .lower_bound
+                    .checked_add(self.dim.size - 1)
+                    .ok_or(Error::UnexpectedPayload)?
+            };
             write!(result, "[{}:{}]=", self.dim.lower_bound, ub).unwrap();
         }
         result.push('{');
@@ -379,9 +384,11 @@ fn decode_binary(bytes: &[u8], expected_element_oid: i32) -> Result<Array, Error
             return Err(Error::UnexpectedPayload);
         }
         let lower_bound = bytes.get_i32();
-        lower_bound
-            .checked_add(size)
-            .ok_or(Error::UnexpectedPayload)?;
+        if size > 0 {
+            lower_bound
+                .checked_add(size - 1)
+                .ok_or(Error::UnexpectedPayload)?;
+        }
         Dimension { size, lower_bound }
     };
 
@@ -767,7 +774,7 @@ mod tests {
 
     #[test]
     fn test_interval_array_datum_roundtrip() {
-        let input = br#"{"1 years 0 mons 0 days 0:0:0.0"}"#;
+        let input = br#"{"1 year 0 mons 0 days 00:00:00.0"}"#;
         let datum = Datum::new(input, DataType::Array(1186), Format::Text, false).unwrap();
         let encoded = datum.encode(Format::Text).unwrap();
         assert_eq!(&encoded[..], input);
@@ -775,7 +782,7 @@ mod tests {
 
     #[test]
     fn test_interval_array_binary_roundtrip() {
-        let input = br#"{"1 years 2 mons 3 days 4:5:6.006"}"#;
+        let input = br#"{"1 year 2 mons 3 days 04:05:06.006"}"#;
         let datum = Datum::new(input, DataType::Array(1186), Format::Text, false).unwrap();
 
         let binary = datum.encode(Format::Binary).unwrap();
@@ -869,5 +876,24 @@ mod tests {
             Array::decode_typed(payload, Format::Binary, 23).is_err(),
             "should reject lower_bound + size overflow"
         );
+    }
+
+    #[test]
+    fn test_binary_decode_accepts_max_singleton_lower_bound() {
+        #[rustfmt::skip]
+        let payload: &[u8] = &[
+            0,0,0,1,                // ndims=1
+            0,0,0,0,                // flags=0
+            0,0,0,23,               // element OID = int4
+            0,0,0,1,                // size=1
+            0x7F,0xFF,0xFF,0xFF,    // lower_bound=i32::MAX
+            0,0,0,4,                // element len
+            0,0,0,1,                // element value
+        ];
+
+        let decoded = Array::decode_typed(payload, Format::Binary, 23)
+            .expect("size=1 at i32::MAX lower bound is a valid array");
+        let text = decoded.encode(Format::Text).unwrap();
+        assert_eq!(&text[..], b"[2147483647:2147483647]={1}");
     }
 }

--- a/pgdog-postgres-types/src/datum.rs
+++ b/pgdog-postgres-types/src/datum.rs
@@ -5,8 +5,8 @@ use pgdog_vector::{Float, Vector};
 use uuid::Uuid;
 
 use crate::{
-    Data, Double, Error, Format, FromDataType, Interval, Numeric, Timestamp, TimestampTz,
-    ToDataRowColumn,
+    Array, Data, Double, Error, Format, FromDataType, Interval, Numeric, Oid, Timestamp,
+    TimestampTz, ToDataRowColumn,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -35,6 +35,10 @@ pub enum Datum {
     Double(Double),
     /// Vector
     Vector(Vector),
+    /// OID.
+    Oid(Oid),
+    /// Array.
+    Array(Array),
     /// We don't know.
     Unknown(Bytes),
     /// NULL.
@@ -74,6 +78,8 @@ impl std::hash::Hash for Datum {
                 }
             }
             Vector(v) => v.hash(state),
+            Oid(v) => v.hash(state),
+            Array(v) => v.hash(state),
             Unknown(v) => v.hash(state),
             Null => {}
             Boolean(v) => v.hash(state),
@@ -103,6 +109,8 @@ impl Ord for Datum {
             (Float(a), Float(b)) => a.cmp(b),
             (Double(a), Double(b)) => a.cmp(b),
             (Vector(a), Vector(b)) => a.cmp(b),
+            (Oid(a), Oid(b)) => a.cmp(b),
+            (Array(a), Array(b)) => a.cmp(b),
             (Unknown(a), Unknown(b)) => a.cmp(b),
             (Boolean(a), Boolean(b)) => a.cmp(b),
             (Null, Null) => std::cmp::Ordering::Equal,
@@ -122,9 +130,11 @@ impl Ord for Datum {
                         Datum::Float(_) => 9,
                         Datum::Double(_) => 10,
                         Datum::Vector(_) => 11,
-                        Datum::Unknown(_) => 12,
-                        Datum::Null => 13,
-                        Datum::Boolean(_) => 14,
+                        Datum::Oid(_) => 12,
+                        Datum::Array(_) => 13,
+                        Datum::Unknown(_) => 14,
+                        Datum::Null => 15,
+                        Datum::Boolean(_) => 16,
                     }
                 }
                 variant_index(self).cmp(&variant_index(other))
@@ -150,6 +160,11 @@ impl ToDataRowColumn for Datum {
             Float(val) => val.to_data_row_column(),
             Double(val) => val.to_data_row_column(),
             Vector(vector) => vector.to_data_row_column(),
+            Oid(oid) => oid.to_data_row_column(),
+            Array(array) => array
+                .encode(Format::Text)
+                .expect("array text encode should succeed for any decoded array")
+                .into(),
             Unknown(bytes) => bytes.clone().into(),
             Null => Data::null(),
             Boolean(val) => val.to_data_row_column(),
@@ -201,7 +216,15 @@ impl Datum {
             DataType::Timestamp => Ok(Datum::Timestamp(Timestamp::decode(bytes, encoding)?)),
             DataType::TimestampTz => Ok(Datum::TimestampTz(TimestampTz::decode(bytes, encoding)?)),
             DataType::Vector => Ok(Datum::Vector(Vector::decode(bytes, encoding)?)),
+            DataType::SmallInt => Ok(Datum::SmallInt(i16::decode(bytes, encoding)?)),
+            DataType::Oid => Ok(Datum::Oid(Oid::decode(bytes, encoding)?)),
             DataType::Bool => Ok(Datum::Boolean(bool::decode(bytes, encoding)?)),
+            DataType::Array(element_oid) => match Array::decode_typed(bytes, encoding, element_oid)
+            {
+                Ok(array) => Ok(Datum::Array(array)),
+                Err(Error::ArrayDimensions(_)) => Ok(Datum::Unknown(Bytes::copy_from_slice(bytes))),
+                Err(err) => Err(err),
+            },
             _ => Ok(Datum::Unknown(Bytes::copy_from_slice(bytes))),
         }
     }
@@ -222,8 +245,13 @@ impl Datum {
             Datum::Numeric(n) => n.encode(format),
             Datum::Timestamp(t) => t.encode(format),
             Datum::TimestampTz(tz) => tz.encode(format),
+            Datum::SmallInt(i) => i.encode(format),
+            Datum::Interval(i) => i.encode(format),
+            Datum::Vector(v) => v.encode(format),
+            Datum::Oid(o) => o.encode(format),
+            Datum::Array(a) => a.encode(format),
             Datum::Null => Ok(Bytes::new()),
-            _ => Err(Error::UnsupportedDataTypeForEncoding),
+            Datum::Unknown(bytes) => Ok(bytes.clone()),
         }
     }
 }
@@ -245,5 +273,87 @@ pub enum DataType {
     Numeric,
     Other(i32),
     Uuid,
+    Oid,
     Vector,
+    /// Array type, carrying the element type OID.
+    Array(i32),
+}
+
+impl DataType {
+    /// Map a PostgreSQL type OID to a DataType.
+    pub fn from_oid(oid: i32) -> Self {
+        match oid {
+            16 => DataType::Bool,
+            20 => DataType::Bigint,
+            21 => DataType::SmallInt,
+            23 => DataType::Integer,
+            25 => DataType::Text,
+            26 => DataType::Oid,
+            700 => DataType::Real,
+            701 => DataType::DoublePrecision,
+            1043 => DataType::Text, // varchar
+            1114 => DataType::Timestamp,
+            1184 => DataType::TimestampTz,
+            1186 => DataType::Interval,
+            1700 => DataType::Numeric,
+            2950 => DataType::Uuid,
+            // Array OIDs → Array(element_oid)
+            1000 => DataType::Array(16),   // bool[]
+            1005 => DataType::Array(21),   // int2[]
+            1007 => DataType::Array(23),   // int4[]
+            1009 => DataType::Array(25),   // text[]
+            1015 => DataType::Array(1043), // varchar[]
+            1016 => DataType::Array(20),   // int8[]
+            1021 => DataType::Array(700),  // float4[]
+            1022 => DataType::Array(701),  // float8[]
+            1028 => DataType::Array(26),   // oid[]
+            1115 => DataType::Array(1114), // timestamp[]
+            1185 => DataType::Array(1184), // timestamptz[]
+            1187 => DataType::Array(1186), // interval[]
+            1231 => DataType::Array(1700), // numeric[]
+            2951 => DataType::Array(2950), // uuid[]
+            _ => DataType::Other(oid),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::{BufMut, BytesMut};
+
+    #[test]
+    fn test_multidimensional_text_array_falls_back_to_unknown() {
+        let input = b"{{1,2},{3,4}}";
+        let datum = Datum::new(input, DataType::Array(23), Format::Text, false).unwrap();
+
+        assert!(matches!(datum, Datum::Unknown(_)));
+        assert_eq!(
+            datum.encode(Format::Text).unwrap(),
+            Bytes::from_static(input)
+        );
+    }
+
+    #[test]
+    fn test_multidimensional_binary_array_falls_back_to_unknown() {
+        let mut buf = BytesMut::new();
+        buf.put_i32(2);
+        buf.put_i32(0);
+        buf.put_i32(23);
+        buf.put_i32(2);
+        buf.put_i32(1);
+        buf.put_i32(2);
+        buf.put_i32(1);
+
+        for value in [1_i32, 2, 3, 4] {
+            buf.put_i32(4);
+            buf.put_i32(value);
+        }
+
+        let input = buf.freeze();
+        let datum = Datum::new(&input, DataType::Array(23), Format::Binary, false).unwrap();
+
+        assert!(matches!(datum, Datum::Unknown(_)));
+        assert_eq!(datum.encode(Format::Binary).unwrap(), input);
+    }
 }

--- a/pgdog-postgres-types/src/error.rs
+++ b/pgdog-postgres-types/src/error.rs
@@ -9,9 +9,6 @@ pub enum Error {
     #[error("unexpected payload")]
     UnexpectedPayload,
 
-    #[error("data type not supported for encoding")]
-    UnsupportedDataTypeForEncoding,
-
     #[error("not text encoding")]
     NotTextEncoding,
 

--- a/pgdog-postgres-types/src/interval.rs
+++ b/pgdog-postgres-types/src/interval.rs
@@ -83,12 +83,7 @@ fn format_fractional_micros(micros: i32) -> String {
     while digits.ends_with('0') {
         digits.pop();
     }
-
-    if micros < 0 {
-        format!("-{digits}")
-    } else {
-        digits
-    }
+    digits
 }
 
 impl FromDataType for Interval {
@@ -134,9 +129,9 @@ impl FromDataType for Interval {
 
                     if let Some(format) = format {
                         match format {
-                            "years" => result.years = bigint(value)?,
-                            "mons" => result.months = int32(value)?,
-                            "days" => result.days = int32(value)?,
+                            "year" | "years" => result.years = bigint(value)?,
+                            "mon" | "mons" => result.months = int32(value)?,
+                            "day" | "days" => result.days = int32(value)?,
                             _ => (),
                         }
                     } else {
@@ -173,19 +168,45 @@ impl FromDataType for Interval {
 
     fn encode(&self, encoding: Format) -> Result<Bytes, Error> {
         match encoding {
-            Format::Text => Ok(Bytes::copy_from_slice(
-                format!(
-                    "{} years {} mons {} days {}:{}:{}.{}",
-                    self.years,
-                    self.months,
-                    self.days,
-                    self.hours,
-                    self.minutes,
-                    self.seconds,
-                    format_fractional_micros(self.micros)
-                )
-                .as_bytes(),
-            )),
+            Format::Text => {
+                let years_label = if self.years == 1 { "year" } else { "years" };
+                let days_label = if self.days == 1 { "day" } else { "days" };
+
+                // Collapse time fields into a signed total so a negative fractional
+                // component produces a single leading `-` on the time portion rather
+                // than an unparseable `0:0:0.-5`.
+                let total_micros: i64 = self
+                    .hours
+                    .saturating_mul(3_600_000_000)
+                    .saturating_add(self.minutes.saturating_mul(60_000_000))
+                    .saturating_add(self.seconds.saturating_mul(1_000_000))
+                    .saturating_add(self.micros as i64);
+                let negative = total_micros < 0;
+                let abs_total = total_micros.unsigned_abs();
+                let total_secs = (abs_total / 1_000_000) as i64;
+                let remaining_micros = (abs_total % 1_000_000) as i32;
+                let hours = total_secs / 3600;
+                let minutes = (total_secs % 3600) / 60;
+                let seconds = total_secs % 60;
+                let sign = if negative { "-" } else { "" };
+
+                Ok(Bytes::copy_from_slice(
+                    format!(
+                        "{} {} {} mons {} {} {}{:02}:{:02}:{:02}.{}",
+                        self.years,
+                        years_label,
+                        self.months,
+                        self.days,
+                        days_label,
+                        sign,
+                        hours,
+                        minutes,
+                        seconds,
+                        format_fractional_micros(remaining_micros)
+                    )
+                    .as_bytes(),
+                ))
+            }
             Format::Binary => {
                 let mut buf = BytesMut::with_capacity(16);
                 let microseconds = self.hours * 3_600_000_000
@@ -245,8 +266,13 @@ mod test {
     #[test]
     fn test_interval_binary_roundtrip_preserves_fractional_seconds() {
         let cases = [
-            ("00:00:00.006", 0, 6_000, "0 years 0 mons 0 days 0:0:0.006"),
-            ("00:00:06.7", 6, 700_000, "0 years 0 mons 0 days 0:0:6.7"),
+            (
+                "00:00:00.006",
+                0,
+                6_000,
+                "0 years 0 mons 0 days 00:00:00.006",
+            ),
+            ("00:00:06.7", 6, 700_000, "0 years 0 mons 0 days 00:00:06.7"),
         ];
 
         for (input, expected_seconds, expected_micros, expected_text) in cases {
@@ -302,5 +328,40 @@ mod test {
         assert!(parse_fractional_micros("1234567").is_err());
         assert!(parse_fractional_micros("").is_err());
         assert!(parse_fractional_micros("12a4").is_err());
+    }
+
+    #[test]
+    fn test_interval_decode_postgres_style_singular_units_and_padding() {
+        let s = "1 year 2 mons 1 day 04:05:06.7";
+        let interval = Interval::decode(s.as_bytes(), Format::Text).unwrap();
+
+        assert_eq!(interval.years, 1);
+        assert_eq!(interval.months, 2);
+        assert_eq!(interval.days, 1);
+        assert_eq!(interval.hours, 4);
+        assert_eq!(interval.minutes, 5);
+        assert_eq!(interval.seconds, 6);
+        assert_eq!(interval.micros, 700_000);
+
+        let encoded = interval.encode(Format::Text).unwrap();
+        assert_eq!(&encoded[..], s.as_bytes());
+    }
+
+    #[test]
+    fn test_negative_fractional_interval_binary_text_output_is_self_parseable() {
+        let original = Interval {
+            micros: -500_000,
+            ..Default::default()
+        };
+
+        let binary = original.encode(Format::Binary).unwrap();
+        let decoded = Interval::decode(&binary, Format::Binary).unwrap();
+        let text = decoded.encode(Format::Text).unwrap();
+
+        assert!(
+            Interval::decode(&text, Format::Text).is_ok(),
+            "binary->text interval output should remain parseable: {}",
+            std::str::from_utf8(&text).unwrap()
+        );
     }
 }

--- a/pgdog-postgres-types/src/interval.rs
+++ b/pgdog-postgres-types/src/interval.rs
@@ -3,17 +3,17 @@ use std::{num::ParseIntError, ops::Add};
 use crate::Data;
 
 use super::*;
-use bytes::Bytes;
+use bytes::{Buf, BufMut, Bytes, BytesMut};
 
 #[derive(Eq, PartialEq, Ord, PartialOrd, Default, Debug, Clone, Hash)]
 pub struct Interval {
     years: i64,
-    months: i8,
-    days: i8,
-    hours: i8,
-    minutes: i8,
-    seconds: i8,
-    millis: i16,
+    months: i32,
+    days: i32,
+    hours: i64,
+    minutes: i64,
+    seconds: i64,
+    micros: i32,
 }
 
 impl Add for Interval {
@@ -22,13 +22,13 @@ impl Add for Interval {
     fn add(self, rhs: Self) -> Self::Output {
         // Postgres will figure it out.
         Self {
-            years: self.years + rhs.years,
-            months: self.months + rhs.months,
-            days: self.days + rhs.days,
-            hours: self.hours + rhs.hours,
-            minutes: self.minutes + rhs.minutes,
-            seconds: self.seconds + rhs.seconds,
-            millis: self.millis + rhs.millis,
+            years: self.years.saturating_add(rhs.years),
+            months: self.months.saturating_add(rhs.months),
+            days: self.days.saturating_add(rhs.days),
+            hours: self.hours.saturating_add(rhs.hours),
+            minutes: self.minutes.saturating_add(rhs.minutes),
+            seconds: self.seconds.saturating_add(rhs.seconds),
+            micros: self.micros.saturating_add(rhs.micros),
         }
     }
 }
@@ -63,13 +63,67 @@ macro_rules! parser {
 }
 
 parser!(bigint, i64);
-parser!(tinyint, i8);
-parser!(smallint, i16);
+parser!(int32, i32);
+
+fn parse_fractional_micros(s: &str) -> Result<i32, Error> {
+    if s.is_empty() || s.len() > 6 || !s.bytes().all(|b| b.is_ascii_digit()) {
+        return Err(Error::UnexpectedPayload);
+    }
+
+    let micros = s.parse::<i32>()?;
+    Ok(micros * 10_i32.pow(6 - s.len() as u32))
+}
+
+fn format_fractional_micros(micros: i32) -> String {
+    if micros == 0 {
+        return "0".into();
+    }
+
+    let mut digits = format!("{:06}", micros.abs());
+    while digits.ends_with('0') {
+        digits.pop();
+    }
+
+    if micros < 0 {
+        format!("-{digits}")
+    } else {
+        digits
+    }
+}
 
 impl FromDataType for Interval {
     fn decode(bytes: &[u8], encoding: Format) -> Result<Self, Error> {
         match encoding {
-            Format::Binary => Err(Error::NotTextEncoding),
+            Format::Binary => {
+                // PostgreSQL binary interval: microseconds(i64) + days(i32) + months(i32) = 16 bytes
+                if bytes.len() != 16 {
+                    return Err(Error::WrongSizeBinary(bytes.len()));
+                }
+                let mut buf = bytes;
+                let microseconds = buf.get_i64();
+                let days = buf.get_i32();
+                let total_months = buf.get_i32();
+
+                let years = (total_months / 12) as i64;
+                let months = total_months % 12;
+
+                let total_secs = microseconds / 1_000_000;
+                let remaining_micros = microseconds % 1_000_000;
+                let hours = total_secs / 3600;
+                let minutes = (total_secs % 3600) / 60;
+                let seconds = total_secs % 60;
+                let micros = remaining_micros as i32;
+
+                Ok(Self {
+                    years,
+                    months,
+                    days,
+                    hours,
+                    minutes,
+                    seconds,
+                    micros,
+                })
+            }
 
             Format::Text => {
                 let mut result = Interval::default();
@@ -81,19 +135,19 @@ impl FromDataType for Interval {
                     if let Some(format) = format {
                         match format {
                             "years" => result.years = bigint(value)?,
-                            "mons" => result.months = tinyint(value)?,
-                            "days" => result.days = tinyint(value)?,
+                            "mons" => result.months = int32(value)?,
+                            "days" => result.days = int32(value)?,
                             _ => (),
                         }
                     } else {
                         let mut value = value.split(":");
                         let hours = value.next();
                         if let Some(hours) = hours {
-                            result.hours = tinyint(hours)?;
+                            result.hours = bigint(hours)?;
                         }
                         let minutes = value.next();
                         if let Some(minutes) = minutes {
-                            result.minutes = tinyint(minutes)?;
+                            result.minutes = bigint(minutes)?;
                         }
                         let seconds = value.next();
                         if let Some(seconds) = seconds {
@@ -102,11 +156,11 @@ impl FromDataType for Interval {
                             let millis = parts.next();
 
                             if let Some(seconds) = seconds {
-                                result.seconds = tinyint(seconds)?;
+                                result.seconds = bigint(seconds)?;
                             }
 
                             if let Some(millis) = millis {
-                                result.millis = smallint(millis)?;
+                                result.micros = parse_fractional_micros(millis)?;
                             }
                         }
                     }
@@ -128,11 +182,22 @@ impl FromDataType for Interval {
                     self.hours,
                     self.minutes,
                     self.seconds,
-                    self.millis
+                    format_fractional_micros(self.micros)
                 )
                 .as_bytes(),
             )),
-            Format::Binary => Err(Error::NotTextEncoding),
+            Format::Binary => {
+                let mut buf = BytesMut::with_capacity(16);
+                let microseconds = self.hours * 3_600_000_000
+                    + self.minutes * 60_000_000
+                    + self.seconds * 1_000_000
+                    + self.micros as i64;
+                let total_months = self.years as i32 * 12 + self.months;
+                buf.put_i64(microseconds);
+                buf.put_i32(self.days);
+                buf.put_i32(total_months);
+                Ok(buf.freeze())
+            }
         }
     }
 }
@@ -150,7 +215,7 @@ mod test {
         };
         let two = Interval {
             years: 1,
-            millis: 500,
+            micros: 500_000,
             ..Default::default()
         };
 
@@ -167,7 +232,7 @@ mod test {
         assert_eq!(interval.hours, 16);
         assert_eq!(interval.minutes, 48);
         assert_eq!(interval.seconds, 0);
-        assert_eq!(interval.millis, 6);
+        assert_eq!(interval.micros, 6_000);
 
         let s = "00:46:12".as_bytes();
         let interval = Interval::decode(s, Format::Text).unwrap();
@@ -175,5 +240,67 @@ mod test {
         assert_eq!(interval.minutes, 46);
         assert_eq!(interval.seconds, 12);
         assert_eq!(interval.years, 0);
+    }
+
+    #[test]
+    fn test_interval_binary_roundtrip_preserves_fractional_seconds() {
+        let cases = [
+            ("00:00:00.006", 0, 6_000, "0 years 0 mons 0 days 0:0:0.006"),
+            ("00:00:06.7", 6, 700_000, "0 years 0 mons 0 days 0:0:6.7"),
+        ];
+
+        for (input, expected_seconds, expected_micros, expected_text) in cases {
+            let original = Interval::decode(input.as_bytes(), Format::Text).unwrap();
+            let binary = original.encode(Format::Binary).unwrap();
+            let decoded = Interval::decode(&binary, Format::Binary).unwrap();
+
+            assert_eq!(decoded.seconds, expected_seconds, "seconds for {input}");
+            assert_eq!(decoded.micros, expected_micros, "micros for {input}");
+            assert_eq!(
+                decoded.encode(Format::Text).unwrap(),
+                Bytes::from(expected_text)
+            );
+        }
+    }
+
+    #[test]
+    fn test_interval_large_values_text_roundtrip() {
+        let s = "0 years 0 mons 200 days 500:30:45.0";
+        let interval = Interval::decode(s.as_bytes(), Format::Text).unwrap();
+        assert_eq!(interval.days, 200);
+        assert_eq!(interval.hours, 500);
+        assert_eq!(interval.minutes, 30);
+        assert_eq!(interval.seconds, 45);
+        let encoded = interval.encode(Format::Text).unwrap();
+        assert_eq!(&encoded[..], s.as_bytes());
+    }
+
+    #[test]
+    fn test_interval_large_values_binary_roundtrip() {
+        let original = Interval {
+            years: 0,
+            months: 0,
+            days: 200,
+            hours: 500,
+            minutes: 30,
+            seconds: 45,
+            micros: 0,
+        };
+        let binary = original.encode(Format::Binary).unwrap();
+        let decoded = Interval::decode(&binary, Format::Binary).unwrap();
+        assert_eq!(decoded.days, 200);
+        assert_eq!(decoded.hours, 500);
+        assert_eq!(decoded.minutes, 30);
+        assert_eq!(decoded.seconds, 45);
+    }
+
+    #[test]
+    fn test_parse_fractional_micros_edge_cases() {
+        assert_eq!(parse_fractional_micros("5").unwrap(), 500_000);
+        assert_eq!(parse_fractional_micros("123456").unwrap(), 123_456);
+        assert_eq!(parse_fractional_micros("000000").unwrap(), 0);
+        assert!(parse_fractional_micros("1234567").is_err());
+        assert!(parse_fractional_micros("").is_err());
+        assert!(parse_fractional_micros("12a4").is_err());
     }
 }

--- a/pgdog-postgres-types/src/lib.rs
+++ b/pgdog-postgres-types/src/lib.rs
@@ -12,6 +12,7 @@ pub mod interface;
 pub mod interval;
 pub mod numeric;
 pub mod oid;
+pub mod smallint;
 pub mod text;
 pub mod timestamp;
 pub mod timestamptz;

--- a/pgdog-postgres-types/src/smallint.rs
+++ b/pgdog-postgres-types/src/smallint.rs
@@ -1,0 +1,25 @@
+use super::*;
+use bytes::{Buf, Bytes};
+
+impl FromDataType for i16 {
+    fn decode(bytes: &[u8], encoding: Format) -> Result<Self, Error> {
+        match encoding {
+            Format::Binary => {
+                let bytes: [u8; 2] = bytes.try_into()?;
+                Ok(bytes.as_slice().get_i16())
+            }
+
+            Format::Text => {
+                let s = String::decode(bytes, Format::Text)?;
+                Ok(s.parse()?)
+            }
+        }
+    }
+
+    fn encode(&self, encoding: Format) -> Result<Bytes, Error> {
+        match encoding {
+            Format::Text => Ok(Bytes::copy_from_slice(self.to_string().as_bytes())),
+            Format::Binary => Ok(Bytes::copy_from_slice(&self.to_be_bytes())),
+        }
+    }
+}

--- a/pgdog/src/backend/pool/connection/aggregate.rs
+++ b/pgdog/src/backend/pool/connection/aggregate.rs
@@ -770,6 +770,18 @@ mod test {
         }
     }
 
+    fn interval_array_field(name: &str) -> Field {
+        Field {
+            name: name.into(),
+            table_oid: 0,
+            column: 0,
+            type_oid: 1187,
+            type_size: -1,
+            type_modifier: -1,
+            format: 0,
+        }
+    }
+
     #[test]
     fn aggregate_count_with_int_typecast() {
         // Regression test for https://github.com/pgdogdev/pgdog/issues/861
@@ -1368,5 +1380,54 @@ mod test {
             groups,
             vec![("{{1,2},{3,4}}".into(), 2), ("{{5,6},{7,8}}".into(), 1),]
         );
+    }
+
+    #[test]
+    fn aggregate_group_by_interval_arrays_preserves_postgres_text_output() {
+        let stmt = pg_query::parse("SELECT sample_interval_array, COUNT(*) FROM samples GROUP BY 1")
+            .unwrap()
+            .protobuf
+            .stmts
+            .first()
+            .cloned()
+            .unwrap();
+        let aggregate = match stmt.stmt.unwrap().node.unwrap() {
+            pg_query::NodeEnum::SelectStmt(stmt) => Aggregate::parse(&stmt),
+            _ => panic!("expected select stmt"),
+        };
+
+        let rd = RowDescription::new(&[
+            interval_array_field("sample_interval_array"),
+            Field::bigint("count"),
+        ]);
+        let decoder = Decoder::from(&rd);
+
+        let input = Bytes::from_static(br#"{"1 year 2 mons 1 day 04:05:06.7"}"#);
+
+        let mut rows = VecDeque::new();
+        let mut shard0 = DataRow::new();
+        shard0.add(input.clone()).add(1_i64);
+        rows.push_back(shard0);
+
+        let mut shard1 = DataRow::new();
+        shard1.add(input.clone()).add(1_i64);
+        rows.push_back(shard1);
+
+        let mut result = Aggregates::new(
+            &rows,
+            &decoder,
+            &aggregate,
+            &AggregateRewritePlan::default(),
+        )
+        .aggregate()
+        .unwrap();
+
+        assert_eq!(result.len(), 1);
+        let row = result.pop_front().unwrap();
+        let intervals = row.get::<String>(0, Format::Text).unwrap();
+        let count = row.get::<i64>(1, Format::Text).unwrap();
+
+        assert_eq!(intervals, r#"{"1 year 2 mons 1 day 04:05:06.7"}"#);
+        assert_eq!(count, 2);
     }
 }

--- a/pgdog/src/backend/pool/connection/aggregate.rs
+++ b/pgdog/src/backend/pool/connection/aggregate.rs
@@ -1384,13 +1384,14 @@ mod test {
 
     #[test]
     fn aggregate_group_by_interval_arrays_preserves_postgres_text_output() {
-        let stmt = pg_query::parse("SELECT sample_interval_array, COUNT(*) FROM samples GROUP BY 1")
-            .unwrap()
-            .protobuf
-            .stmts
-            .first()
-            .cloned()
-            .unwrap();
+        let stmt =
+            pg_query::parse("SELECT sample_interval_array, COUNT(*) FROM samples GROUP BY 1")
+                .unwrap()
+                .protobuf
+                .stmts
+                .first()
+                .cloned()
+                .unwrap();
         let aggregate = match stmt.stmt.unwrap().node.unwrap() {
             pg_query::NodeEnum::SelectStmt(stmt) => Aggregate::parse(&stmt),
             _ => panic!("expected select stmt"),

--- a/pgdog/src/backend/pool/connection/aggregate.rs
+++ b/pgdog/src/backend/pool/connection/aggregate.rs
@@ -713,6 +713,7 @@ mod test {
         messages::{Field, Format, RowDescription},
         Decoder,
     };
+    use bytes::Bytes;
     use std::collections::VecDeque;
 
     #[test]
@@ -752,6 +753,18 @@ mod test {
             column: 0,
             type_oid: 23, // PostgreSQL OID for int4/integer
             type_size: 4,
+            type_modifier: -1,
+            format: 0,
+        }
+    }
+
+    fn integer_array_field(name: &str) -> Field {
+        Field {
+            name: name.into(),
+            table_oid: 0,
+            column: 0,
+            type_oid: 1007,
+            type_size: -1,
             type_modifier: -1,
             format: 0,
         }
@@ -1299,5 +1312,61 @@ mod test {
         groups.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
         assert_eq!(groups[0], (10.0, 12));
         assert_eq!(groups[1], (20.0, 4));
+    }
+
+    #[test]
+    fn aggregate_group_by_multidimensional_arrays_uses_raw_bytes() {
+        let stmt = pg_query::parse("SELECT matrix, COUNT(*) FROM samples GROUP BY 1")
+            .unwrap()
+            .protobuf
+            .stmts
+            .first()
+            .cloned()
+            .unwrap();
+        let aggregate = match stmt.stmt.unwrap().node.unwrap() {
+            pg_query::NodeEnum::SelectStmt(stmt) => Aggregate::parse(&stmt),
+            _ => panic!("expected select stmt"),
+        };
+
+        let rd = RowDescription::new(&[integer_array_field("matrix"), Field::bigint("count")]);
+        let decoder = Decoder::from(&rd);
+
+        let mut rows = VecDeque::new();
+
+        let mut shard0 = DataRow::new();
+        shard0.add(Bytes::from_static(b"{{1,2},{3,4}}")).add(1_i64);
+        rows.push_back(shard0);
+
+        let mut shard1 = DataRow::new();
+        shard1.add(Bytes::from_static(b"{{1,2},{3,4}}")).add(1_i64);
+        rows.push_back(shard1);
+
+        let mut shard2 = DataRow::new();
+        shard2.add(Bytes::from_static(b"{{5,6},{7,8}}")).add(1_i64);
+        rows.push_back(shard2);
+
+        let mut result = Aggregates::new(
+            &rows,
+            &decoder,
+            &aggregate,
+            &AggregateRewritePlan::default(),
+        )
+        .aggregate()
+        .unwrap();
+
+        let mut groups: Vec<(String, i64)> = result
+            .drain(..)
+            .map(|row| {
+                let matrix = row.get::<String>(0, Format::Text).unwrap();
+                let count = row.get::<i64>(1, Format::Text).unwrap();
+                (matrix, count)
+            })
+            .collect();
+        groups.sort();
+
+        assert_eq!(
+            groups,
+            vec![("{{1,2},{3,4}}".into(), 2), ("{{5,6},{7,8}}".into(), 1),]
+        );
     }
 }

--- a/pgdog/src/net/messages/data_row.rs
+++ b/pgdog/src/net/messages/data_row.rs
@@ -247,6 +247,7 @@ impl From<DataRow> for Lsn {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::net::{Decoder, Field};
 
     #[test]
     fn test_insert() {
@@ -297,5 +298,27 @@ mod test {
         assert_eq!(dr.len(), 2);
         assert_eq!(dr.get::<String>(0, Format::Text).unwrap(), "a");
         assert_eq!(dr.get::<String>(1, Format::Text).unwrap(), "c");
+    }
+
+    #[test]
+    fn test_array_field_should_not_decode_as_unknown() {
+        let rd = RowDescription::new(&[Field {
+            name: "ints".into(),
+            table_oid: 0,
+            column: 0,
+            type_oid: 1007, // int4[]
+            type_size: -1,
+            type_modifier: -1,
+            format: 0,
+        }]);
+        let decoder = Decoder::from(&rd);
+
+        let row = DataRow::from_columns(vec![Bytes::from_static(b"{1,2,3}")]);
+        let column = row.get_column(0, &decoder).unwrap().unwrap();
+
+        assert!(
+            !matches!(column.value, Datum::Unknown(_)),
+            "array columns should participate in typed decoding"
+        );
     }
 }

--- a/pgdog/src/net/messages/row_description.rs
+++ b/pgdog/src/net/messages/row_description.rs
@@ -174,22 +174,7 @@ impl Field {
     /// Get the column data type.
     #[inline]
     pub fn data_type(&self) -> DataType {
-        match self.type_oid {
-            16 => DataType::Bool,
-            20 => DataType::Bigint,
-            23 => DataType::Integer,
-            21 => DataType::SmallInt,
-            25 => DataType::Text,
-            700 => DataType::Real,
-            701 => DataType::DoublePrecision,
-            1043 => DataType::Text,
-            1114 => DataType::Timestamp,
-            1184 => DataType::TimestampTz,
-            1186 => DataType::Interval,
-            1700 => DataType::Numeric,
-            2950 => DataType::Uuid,
-            _ => DataType::Other(self.type_oid),
-        }
+        DataType::from_oid(self.type_oid)
     }
 
     #[inline]


### PR DESCRIPTION
This adds roundtrip support for text and binary arrays containing a few sub-data-type formats, reusing the parser for other data types recursively inside the array parser. Has some SQL tests, tried to keep it relatively self-contained