### PR TITLE
feat: use scram hash in users.toml

### DIFF
--- a/.schema/users.schema.json
+++ b/.schema/users.schema.json
@@ -141,6 +141,13 @@
             "null"
           ]
         },
+        "password_hash": {
+          "description": "Passwords hash. Can be used to validate user logins without storing passwords in users.toml.\nServer authentication must use RDS IAM or some other passwordless authentication, e.g. trust.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "passwords": {
           "description": "Multiple passwords for this user, all of which will be attempted during auth to server and client.",
           "type": "array",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2844,6 +2844,7 @@ dependencies = [
  "rand 0.9.2",
  "ratatui",
  "regex",
+ "ring 0.16.20",
  "rmp-serde",
  "rust_decimal",
  "rustls-native-certs 0.8.1",
@@ -3890,7 +3891,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "scram"
 version = "0.6.0"
-source = "git+https://github.com/pgdogdev/scram.git?rev=90c511f703d2856dddd029ea062239c3132f902d#90c511f703d2856dddd029ea062239c3132f902d"
+source = "git+https://github.com/pgdogdev/scram.git?rev=2c259426941a61f30e4252b9186e5f93e42fc924#2c259426941a61f30e4252b9186e5f93e42fc924"
 dependencies = [
  "base64 0.13.1",
  "rand 0.8.5",

--- a/integration/rust/tests/integration/auth.rs
+++ b/integration/rust/tests/integration/auth.rs
@@ -301,3 +301,22 @@ async fn test_passthrough_password_change() {
 
     admin.execute("RELOAD").await.unwrap();
 }
+
+#[tokio::test]
+async fn test_scram_hashed_passthrough() {
+    let mut conn =
+        sqlx::PgConnection::connect("postgres://pgdog_hashed:pgdog@127.0.0.1:6432/pgdog")
+            .await
+            .unwrap();
+    conn.execute("SELECT 1").await.unwrap();
+
+    let conn =
+        sqlx::PgConnection::connect("postgres://pgdog_hashed:badpw@127.0.0.1:6432/pgdog").await;
+    assert!(conn.is_err());
+    assert!(
+        conn.err()
+            .unwrap()
+            .to_string()
+            .contains("password for user")
+    );
+}

--- a/integration/users.toml
+++ b/integration/users.toml
@@ -6,8 +6,9 @@ password = "pgdog"
 [[users]]
 name = "pgdog_hashed"
 database = "pgdog"
-password_hash = "SCRAM-SHA-256$4096:vX3StexTjqoOwxSBznak2w==$xCwPbcvOarL6qRsDaigEDPdUaDvdMUnZz2uptvDXud4=:aqhNv3LmJIcjFGoxf9smU/yP/gMsbniA/7eCDbTCHoY="
+password_hash = "SCRAM-SHA-256$4096:b6lksqhYfkXiN2hDMl3zfA==$9Rh0FdfjsbECkf289/WO2yHGiUBnNOOb1uNHVtOCCDE=:V7jC7GHvIr4guRsI66S3u4aXNhHWj1Pz71ymRM7bLFU="
 server_password = "pgdog" # Pointless obviously, but we can test scram hash is working as expected. pgdog -> server auth is expected to be passwordless, e.g. rds iam, trust, azure working directory, etc.
+server_user = "pgdog"
 min_pool_size = 0
 
 [[users]]

--- a/integration/users.toml
+++ b/integration/users.toml
@@ -4,6 +4,13 @@ database = "pgdog"
 password = "pgdog"
 
 [[users]]
+name = "pgdog_hashed"
+database = "pgdog"
+password_hash = "SCRAM-SHA-256$4096:vX3StexTjqoOwxSBznak2w==$xCwPbcvOarL6qRsDaigEDPdUaDvdMUnZz2uptvDXud4=:aqhNv3LmJIcjFGoxf9smU/yP/gMsbniA/7eCDbTCHoY="
+server_password = "pgdog" # Pointless obviously, but we can test scram hash is working as expected. pgdog -> server auth is expected to be passwordless, e.g. rds iam, trust, azure working directory, etc.
+min_pool_size = 0
+
+[[users]]
 name = "pgdog_session"
 database = "pgdog"
 password = "pgdog"

--- a/pgdog-config/src/core.rs
+++ b/pgdog-config/src/core.rs
@@ -62,7 +62,7 @@ impl ConfigAndUsers {
         }
 
         let mut users: Users = if let Ok(users) = read_to_string(users_path) {
-            let mut users: Users = match toml::from_str(&users) {
+            let users: Users = match toml::from_str(&users) {
                 Ok(config) => config,
                 Err(err) => {
                     let error = Error::config(&users, err);
@@ -70,7 +70,6 @@ impl ConfigAndUsers {
                     return Err(error);
                 }
             };
-            users.check(&config);
             info!("loaded \"{}\"", users_path.display());
             users
         } else {

--- a/pgdog-config/src/users.rs
+++ b/pgdog-config/src/users.rs
@@ -48,11 +48,11 @@ impl Users {
     /// Run configuration checks.
     pub fn check(&mut self, config: &Config) {
         for user in &mut self.users {
-            if user.password().is_empty() {
-                if !config.general.passthrough_auth() && user.password_hash.is_none() {
+            if user.passwords().is_empty() {
+                if !config.general.passthrough_auth() {
                     warn!(
-                        "user \"{}\" doesn't have a password and passthrough auth is disabled",
-                        user.name
+                        r#"user "{}" (database "{}") doesn't have a password and passthrough auth is disabled"#,
+                        user.name, user.database,
                     );
                 }
 
@@ -65,24 +65,36 @@ impl Users {
 
                     for database in databases {
                         if min_pool_size > 0 {
-                            warn!("user \"{}\" (database \"{}\") doesn't have a password configured, \
-                            so we can't connect to the server to maintain min_pool_size of {}; setting it to 0", user.name, database, min_pool_size);
+                            warn!(
+                                r#"user "{}" (database "{}") does not have a password configured, PgDog cannot connect to the server to maintain "min_pool_size" of {}, setting it to 0"#,
+                                user.name, database, min_pool_size
+                            );
                             user.min_pool_size = Some(0);
                         }
                     }
                 }
             }
 
+            if user.server_password.is_none()
+                && user.server_auth == ServerAuth::Password
+                && user.password_hash.is_some()
+            {
+                warn!(
+                    r#"user "{}" (database "{}") is using hash authentication but does not specify a "server_password""#,
+                    user.name, user.database
+                );
+            }
+
             if !user.database.is_empty() && !user.databases.is_empty() {
                 warn!(
-                    r#"user "{}" is configured for both "database" and "databases", defaulting to "database""#,
-                    user.name
+                    r#"user "{}" is configured for both "{}" and "{:?}", defaulting to "{}""#,
+                    user.name, user.database, user.databases, user.database,
                 );
             }
 
             if user.all_databases && (!user.databases.is_empty() || !user.database.is_empty()) {
                 warn!(
-                    r#"user "{}" is configured for "all_databases" and specific databases, defaulting to "all_databases""#,
+                    r#"user "{}" is configured for all databases and a specific database, defaulting to all databases""#,
                     user.name
                 );
             }

--- a/pgdog-config/src/users.rs
+++ b/pgdog-config/src/users.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::env;
+use std::fmt::Display;
 use std::path::PathBuf;
 use tracing::warn;
 
@@ -48,7 +49,7 @@ impl Users {
     pub fn check(&mut self, config: &Config) {
         for user in &mut self.users {
             if user.password().is_empty() {
-                if !config.general.passthrough_auth() {
+                if !config.general.passthrough_auth() && user.password_hash.is_none() {
                     warn!(
                         "user \"{}\" doesn't have a password and passthrough auth is disabled",
                         user.name
@@ -143,6 +144,31 @@ impl ServerAuth {
     }
 }
 
+/// The kind of password configured on the user.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PasswordKind {
+    Plain(String),
+    Hashed(String),
+}
+
+impl PasswordKind {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Plain(plain) => plain.as_str(),
+            Self::Hashed(hash) => hash.as_str(),
+        }
+    }
+}
+
+impl Display for PasswordKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Plain(plain) => write!(f, "{}", plain),
+            Self::Hashed(hashed) => write!(f, "{}", hashed),
+        }
+    }
+}
+
 /// User allowed to connect to pgDog.
 /// A user entry in `users.toml`, controlling which users are allowed to connect to PgDog.
 ///
@@ -174,6 +200,9 @@ pub struct User {
     /// Multiple passwords for this user, all of which will be attempted during auth to server and client.
     #[serde(default)]
     pub passwords: Vec<String>,
+    /// Passwords hash. Can be used to validate user logins without storing passwords in users.toml.
+    /// Server authentication must use RDS IAM or some other passwordless authentication, e.g. trust.
+    pub password_hash: Option<String>,
     /// Overrides [`default_pool_size`](https://docs.pgdog.dev/configuration/pgdog.toml/general/) for this user. No more than this many server connections will be open at any given time to serve requests for this connection pool.
     ///
     /// https://docs.pgdog.dev/configuration/users.toml/users/#pool_size
@@ -252,10 +281,19 @@ impl User {
         }
     }
 
-    pub fn passwords(&self) -> Vec<String> {
-        let mut passwords = self.passwords.clone();
+    pub fn passwords(&self) -> Vec<PasswordKind> {
+        let mut passwords: Vec<_> = self
+            .passwords
+            .clone()
+            .into_iter()
+            .map(|p| PasswordKind::Plain(p))
+            .collect();
         if !self.password().is_empty() {
-            passwords.push(self.password().to_string());
+            passwords.push(PasswordKind::Plain(self.password().to_string()));
+        }
+
+        if let Some(hash) = self.password_hash.clone() {
+            passwords.push(PasswordKind::Hashed(hash));
         }
 
         passwords

--- a/pgdog/Cargo.toml
+++ b/pgdog/Cargo.toml
@@ -39,7 +39,8 @@ toml = "0.8"
 pgdog-plugin.workspace = true
 tokio-util = { version = "0.7", features = ["rt"] }
 fnv = "1"
-scram = { git = "https://github.com/pgdogdev/scram.git", rev = "90c511f703d2856dddd029ea062239c3132f902d" }
+scram = { git = "https://github.com/pgdogdev/scram.git", rev = "2c259426941a61f30e4252b9186e5f93e42fc924" }
+ring = "0.16"
 base64 = "0.22"
 md5 = "0.7"
 futures = "0.3"

--- a/pgdog/src/auth/md5.rs
+++ b/pgdog/src/auth/md5.rs
@@ -4,6 +4,7 @@
 //!
 use bytes::Bytes;
 use md5::Context;
+
 use rand::Rng;
 
 use super::Error;

--- a/pgdog/src/auth/scram/mod.rs
+++ b/pgdog/src/auth/scram/mod.rs
@@ -7,3 +7,25 @@ pub mod state;
 pub use client::Client;
 pub use error::Error;
 pub use server::Server;
+
+/// Generate a `SCRAM-SHA-256$iterations:salt$StoredKey:ServerKey` hash string
+/// from a plaintext password, suitable for storage in `users.toml` or `pg_shadow`.
+pub fn generate_hash(password: &str, iterations: std::num::NonZeroU32, salt: &[u8]) -> String {
+    use base64::prelude::*;
+    use ring::digest;
+    use ring::hmac::{self, HMAC_SHA256};
+
+    let salted_password = scram::hash_password(password, iterations, salt);
+    let key = hmac::Key::new(HMAC_SHA256, &salted_password);
+    let client_key = hmac::sign(&key, b"Client Key");
+    let server_key = hmac::sign(&key, b"Server Key");
+    let stored_key = digest::digest(&digest::SHA256, client_key.as_ref());
+
+    format!(
+        "SCRAM-SHA-256${}:{}${}:{}",
+        iterations,
+        BASE64_STANDARD.encode(salt),
+        BASE64_STANDARD.encode(stored_key.as_ref()),
+        BASE64_STANDARD.encode(server_key.as_ref()),
+    )
+}

--- a/pgdog/src/auth/scram/server.rs
+++ b/pgdog/src/auth/scram/server.rs
@@ -64,7 +64,6 @@ impl AuthenticationProvider for UserPassword {
             .iter()
             .map(|password| hash_password(password, iterations, &self.salt).to_vec())
             .collect();
-        println!("hashed");
         Some(PasswordInfo::new_multi(
             hashed_passwords,
             self.iterations,
@@ -91,8 +90,6 @@ impl AuthenticationProvider for HashedPassword {
         let mut ks = keys_part.split(':');
         let stored_key = BASE64_STANDARD.decode(ks.next()?).ok()?;
         let server_key = BASE64_STANDARD.decode(ks.next()?).ok()?;
-
-        println!("stored keys");
 
         Some(PasswordInfo::from_stored_keys(
             stored_key, server_key, iterations, salt,

--- a/pgdog/src/auth/scram/server.rs
+++ b/pgdog/src/auth/scram/server.rs
@@ -4,6 +4,7 @@ use crate::frontend::Error;
 use crate::net::messages::*;
 use crate::net::Stream;
 
+use pgdog_config::users::PasswordKind;
 use scram::server::ClientFinal;
 use tracing::error;
 
@@ -39,7 +40,7 @@ pub struct UserPassword {
 /// only the first hash is used.
 #[derive(Clone)]
 pub struct HashedPassword {
-    hash: String,
+    pub(crate) hash: String,
 }
 
 enum Scram {
@@ -63,6 +64,7 @@ impl AuthenticationProvider for UserPassword {
             .iter()
             .map(|password| hash_password(password, iterations, &self.salt).to_vec())
             .collect();
+        println!("hashed");
         Some(PasswordInfo::new_multi(
             hashed_passwords,
             self.iterations,
@@ -73,45 +75,28 @@ impl AuthenticationProvider for UserPassword {
 
 impl AuthenticationProvider for HashedPassword {
     fn get_password_for(&self, _user: &str) -> Option<PasswordInfo> {
-        let mut parts = self.hash.split("$");
-        if let Some(algo) = parts.next() {
-            if algo != "SCRAM-SHA-256" {
-                return None;
-            }
-        } else {
+        let mut parts = self.hash.split('$');
+
+        if parts.next()? != "SCRAM-SHA-256" {
             return None;
         }
 
-        let (mut salt, mut iter) = (None, None);
-        if let Some(iter_salt) = parts.next() {
-            let mut split = iter_salt.split(":");
-            let maybe_iter = split.next().map(|iter| iter.parse::<u16>());
-            let maybe_salt = split.next().map(|salt| BASE64_STANDARD.decode(salt));
+        let iter_salt = parts.next()?;
+        let keys_part = parts.next()?;
 
-            if let Some(Ok(num)) = maybe_iter {
-                iter = Some(num);
-            }
+        let mut is = iter_salt.split(':');
+        let iterations: u16 = is.next()?.parse().ok()?;
+        let salt = BASE64_STANDARD.decode(is.next()?).ok()?;
 
-            if let Some(Ok(s)) = maybe_salt {
-                salt = Some(s);
-            }
-        };
+        let mut ks = keys_part.split(':');
+        let stored_key = BASE64_STANDARD.decode(ks.next()?).ok()?;
+        let server_key = BASE64_STANDARD.decode(ks.next()?).ok()?;
 
-        let hashes = parts.next().map(|hashes| hashes.split(":"));
+        println!("stored keys");
 
-        if let Some(hashes) = hashes {
-            if let Some(last) = hashes.last() {
-                if let Ok(hash) = BASE64_STANDARD.decode(last) {
-                    if let Some(iter) = iter {
-                        if let Some(salt) = salt {
-                            return Some(PasswordInfo::new(hash, iter, salt));
-                        }
-                    }
-                }
-            }
-        }
-
-        None
+        Some(PasswordInfo::from_stored_keys(
+            stored_key, server_key, iterations, salt,
+        ))
     }
 }
 
@@ -124,11 +109,22 @@ pub struct Server {
 impl Server {
     /// Create new SCRAM server. Any of the given plain text passwords will be
     /// accepted.
-    pub fn new(passwords: &[String]) -> Self {
+    pub fn new(passwords: &[PasswordKind]) -> Self {
+        let hash = passwords
+            .iter()
+            .find(|p| matches!(p, PasswordKind::Hashed(_)));
+        if let Some(hash) = hash {
+            return Self {
+                provider: Provider::Hashed(HashedPassword {
+                    hash: hash.to_string(),
+                }),
+            };
+        }
+
         let salt = rand::rng().random::<[u8; 16]>().to_vec();
         Self {
             provider: Provider::Plain(UserPassword {
-                passwords: passwords.to_vec(),
+                passwords: passwords.iter().map(|s| s.to_string()).collect(),
                 salt,
                 iterations: 4096,
             }),
@@ -138,10 +134,11 @@ impl Server {
     /// Create a new SCRAM server using a prehashed `pg_shadow` style password.
     /// Only the first hash is used; prehashed passwords cannot share salts so
     /// multi-password verification is not supported in this mode.
-    pub fn hashed(hashes: &[String]) -> Self {
-        let hash = hashes.first().cloned().unwrap_or_default();
+    pub fn hashed(hash: &str) -> Self {
         Self {
-            provider: Provider::Hashed(HashedPassword { hash }),
+            provider: Provider::Hashed(HashedPassword {
+                hash: hash.to_string(),
+            }),
         }
     }
 
@@ -216,11 +213,14 @@ impl Server {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use base64::engine::general_purpose::STANDARD;
+    use crate::auth::scram::Client;
+    use scram::AuthenticationStatus;
+
+    const SCRAM_HASH: &str = "SCRAM-SHA-256$4096:B6lJyg12n6SawAu1kD9maA==$huWaU6t+WsvcS9ZrDvocZeYtlLJ60hdP46tjszFBbW0=:706OTwYyqH5WpfNpZdgt0gxuP5ff4DPUpHYu3F3w6TY=";
 
     #[test]
     fn user_password_provider_generates_info() {
-        let server = Server::new(&["secret".to_string()]);
+        let server = Server::new(&[PasswordKind::Plain("secret".to_string())]);
         let provider = match server.provider {
             Provider::Plain(ref inner) => inner.clone(),
             _ => unreachable!(),
@@ -234,32 +234,102 @@ mod tests {
 
     #[test]
     fn hashed_password_provider_parses_scram_hash() {
-        let iterations = std::num::NonZeroU32::new(4096).unwrap();
-        let salt = b"testsalt";
-        let hash = hash_password("secret", iterations, salt);
-        let salt_b64 = STANDARD.encode(salt);
-        let hash_b64 = STANDARD.encode(hash.as_ref());
-        let scram_hash = format!("SCRAM-SHA-256${}:{salt_b64}:${hash_b64}", iterations.get());
-
-        let provider = HashedPassword { hash: scram_hash };
-
+        let provider = HashedPassword {
+            hash: SCRAM_HASH.to_string(),
+        };
         assert!(
             provider.get_password_for("user").is_some(),
             "hashed provider should produce password info"
         );
     }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
 
     #[test]
-    fn test_hashed_password() {
-        let hash = "SCRAM-SHA-256$4096:lApbvrTR0W7WOZLcVrbz0A==$O+AwRnblFCJwEezpaozQfC6iKmbJFHQ7+0WZBsR+hFU=:wWjPizZvFjc5jmIkdN/EsuLGz/9FMjOhJ7IHxZI8eqE="
-            .to_string();
-        let hashed = HashedPassword { hash };
-        let info = hashed.get_password_for("user");
-        assert!(info.is_some());
+    fn hashed_password_rejects_invalid_algo() {
+        let hash = "SCRAM-SHA-1$4096:c2FsdA==$c3RvcmVka2V5:c2VydmVya2V5".to_string();
+        let provider = HashedPassword { hash };
+        assert!(provider.get_password_for("user").is_none());
+    }
+
+    /// Drive a full SCRAM handshake between the pgdog Client and a
+    /// ScramServer<HashedPassword>, returning the authentication status.
+    fn scram_login(user: &str, password: &str, hash: &str) -> AuthenticationStatus {
+        let provider = HashedPassword {
+            hash: hash.to_string(),
+        };
+        let scram_server = ScramServer::new(provider);
+        let mut client = Client::new(user, password);
+
+        let client_first = client.first().expect("client first");
+        let server_first_state = scram_server
+            .handle_client_first(&client_first)
+            .expect("server handle client first");
+        let (server_client_final, server_first_msg) = server_first_state.server_first();
+
+        client
+            .server_first(&server_first_msg)
+            .expect("client handle server first");
+        let client_final = client.last().expect("client final");
+
+        let server_final = server_client_final
+            .handle_client_final(&client_final)
+            .expect("server handle client final");
+        let (status, server_final_msg) = server_final.server_final();
+
+        if status == AuthenticationStatus::Authenticated {
+            client
+                .server_last(&server_final_msg)
+                .expect("client verify server final");
+        }
+
+        status
+    }
+
+    #[test]
+    fn hashed_scram_accepts_correct_password() {
+        assert_eq!(
+            scram_login("user", "pgdog", SCRAM_HASH),
+            AuthenticationStatus::Authenticated,
+        );
+    }
+
+    #[test]
+    fn hashed_scram_rejects_wrong_password() {
+        assert_eq!(
+            scram_login("user", "wrong", SCRAM_HASH),
+            AuthenticationStatus::NotAuthenticated,
+        );
+    }
+
+    #[test]
+    fn hashed_scram_rejects_empty_password() {
+        assert_eq!(
+            scram_login("user", "", SCRAM_HASH),
+            AuthenticationStatus::NotAuthenticated,
+        );
+    }
+
+    #[test]
+    fn generated_hash_accepts_correct_password() {
+        let iterations = std::num::NonZeroU32::new(4096).unwrap();
+        let salt = b"pgdog_test_salt!";
+        let hash = crate::auth::scram::generate_hash("pgdog", iterations, salt);
+
+        assert!(hash.starts_with("SCRAM-SHA-256$4096:"));
+        assert_eq!(
+            scram_login("user", "pgdog", &hash),
+            AuthenticationStatus::Authenticated,
+        );
+    }
+
+    #[test]
+    fn generated_hash_rejects_wrong_password() {
+        let iterations = std::num::NonZeroU32::new(4096).unwrap();
+        let salt = b"pgdog_test_salt!";
+        let hash = crate::auth::scram::generate_hash("pgdog", iterations, salt);
+
+        assert_eq!(
+            scram_login("user", "wrong", &hash),
+            AuthenticationStatus::NotAuthenticated,
+        );
     }
 }

--- a/pgdog/src/backend/databases.rs
+++ b/pgdog/src/backend/databases.rs
@@ -9,6 +9,7 @@ use futures::future::try_join_all;
 use once_cell::sync::Lazy;
 use parking_lot::lock_api::MutexGuard;
 use parking_lot::{Mutex, RawMutex};
+use pgdog_config::users::PasswordKind;
 use tracing::{debug, error, info, warn};
 
 use crate::backend::replication::ShardedSchemas;
@@ -315,7 +316,7 @@ pub struct Databases {
 
 impl Databases {
     /// Get the database user password, if one is configured.
-    pub fn passwords(&self, user: impl ToUser) -> Option<&[String]> {
+    pub fn passwords(&self, user: impl ToUser) -> Option<&[PasswordKind]> {
         if let Some(cluster) = self.databases.get(&user.to_user()) {
             if cluster.passwords().is_empty() {
                 None

--- a/pgdog/src/backend/pool/address.rs
+++ b/pgdog/src/backend/pool/address.rs
@@ -1,6 +1,7 @@
 //! Server address.
 use std::net::{SocketAddr, ToSocketAddrs};
 
+use pgdog_config::users::PasswordKind;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -72,6 +73,10 @@ impl Address {
                 vec![password]
             } else {
                 user.passwords()
+                    .into_iter()
+                    .filter(|p| matches!(p, PasswordKind::Plain(_)))
+                    .map(|p| p.to_string())
+                    .collect()
             },
             server_auth,
             server_iam_region: user.server_iam_region.clone(),

--- a/pgdog/src/backend/pool/cluster.rs
+++ b/pgdog/src/backend/pool/cluster.rs
@@ -3,7 +3,8 @@
 use futures::future::try_join_all;
 use parking_lot::Mutex;
 use pgdog_config::{
-    LoadSchema, PreparedStatements, QueryParserEngine, QueryParserLevel, Rewrite, RewriteMode,
+    users::PasswordKind, LoadSchema, PreparedStatements, QueryParserEngine, QueryParserLevel,
+    Rewrite, RewriteMode,
 };
 use std::{
     sync::{
@@ -56,7 +57,7 @@ struct Readiness {
 pub struct Cluster {
     identifier: Arc<DatabaseUser>,
     shards: Vec<Shard>,
-    passwords: Vec<String>,
+    passwords: Vec<PasswordKind>,
     pooler_mode: PoolerMode,
     sharded_tables: ShardedTables,
     sharded_schemas: ShardedSchemas,
@@ -133,7 +134,7 @@ pub struct ClusterConfig<'a> {
     pub shards: &'a [ClusterShardConfig],
     pub lb_strategy: LoadBalancingStrategy,
     pub user: &'a str,
-    pub passwords: Vec<String>,
+    pub passwords: Vec<PasswordKind>,
     pub pooler_mode: PoolerMode,
     pub sharded_tables: ShardedTables,
     pub replication_sharding: Option<String>,
@@ -359,7 +360,7 @@ impl Cluster {
         &self.shards
     }
 
-    pub fn passwords(&self) -> &[String] {
+    pub fn passwords(&self) -> &[PasswordKind] {
         &self.passwords
     }
 

--- a/pgdog/src/backend/pool/connection/mod.rs
+++ b/pgdog/src/backend/pool/connection/mod.rs
@@ -1,6 +1,7 @@
 //! Server connection requested by a frontend.
 
 use mirror::MirrorHandler;
+use pgdog_config::users::PasswordKind;
 use tokio::{select, time::sleep};
 use tracing::debug;
 
@@ -330,12 +331,24 @@ impl Connection {
         //
         if config.config.general.passthrough_auth() && databases().passwords(user).is_none() {
             if let Some(ref cluster) = self.cluster {
-                databases::add(User {
+                let mut user = User {
                     name: self.user.clone(),
                     database: self.database.clone(),
-                    passwords: cluster.passwords().to_vec(),
                     ..Default::default()
-                })?;
+                };
+                for pass in cluster.passwords() {
+                    match pass {
+                        PasswordKind::Hashed(hashed) => {
+                            user.password_hash = Some(hashed.clone());
+                        }
+
+                        PasswordKind::Plain(plain) => {
+                            user.passwords.push(plain.clone());
+                        }
+                    }
+                }
+
+                databases::add(user)?;
             }
         }
 

--- a/pgdog/src/cli.rs
+++ b/pgdog/src/cli.rs
@@ -443,4 +443,3 @@ pub async fn route(commands: Commands) -> Result<(), Box<dyn std::error::Error>>
 
     Ok(())
 }
-

--- a/pgdog/src/cli.rs
+++ b/pgdog/src/cli.rs
@@ -51,6 +51,13 @@ pub enum Commands {
         session_mode: Option<bool>,
     },
 
+    /// Generate a SCRAM-SHA-256 hash from a plaintext password.
+    /// Output can be stored directly in users.toml.
+    Hash {
+        /// The plaintext password to hash.
+        password: String,
+    },
+
     /// Fingerprint a query.
     Fingerprint {
         #[arg(short, long)]
@@ -172,6 +179,19 @@ pub enum Commands {
         #[arg(long)]
         database: String,
     },
+}
+
+/// Generate and print a SCRAM-SHA-256 hash from a plaintext password.
+#[allow(clippy::print_stdout)]
+pub fn hash_password(password: &str) {
+    use rand::Rng;
+
+    let salt: [u8; 16] = rand::rng().random();
+    let iterations = std::num::NonZeroU32::new(4096).unwrap();
+    println!(
+        "{}",
+        crate::auth::scram::generate_hash(password, iterations, &salt)
+    );
 }
 
 /// Fingerprint some queries.
@@ -423,3 +443,4 @@ pub async fn route(commands: Commands) -> Result<(), Box<dyn std::error::Error>>
 
     Ok(())
 }
+

--- a/pgdog/src/config/auth.rs
+++ b/pgdog/src/config/auth.rs
@@ -1,1 +1,0 @@
-pub use pgdog_config::auth::*;

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -4,6 +4,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use pgdog_config::users::PasswordKind;
 use timeouts::Timeouts;
 use tokio::{select, spawn, time::timeout};
 use tracing::{debug, enabled, error, info, trace, Level as LogLevel};
@@ -173,7 +174,7 @@ impl Client {
             }
         } else {
             let passwords = if admin {
-                Some(vec![admin_password.clone()])
+                Some(vec![PasswordKind::Plain(admin_password.clone())])
             } else {
                 databases::databases()
                     .passwords((user, database))
@@ -183,7 +184,10 @@ impl Client {
             if let Some(passwords) = passwords {
                 match auth_type {
                     AuthType::Md5 => {
-                        let md5 = md5::Client::new(user, &passwords);
+                        let md5 = md5::Client::new(
+                            user,
+                            &passwords.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+                        );
                         stream.send_flush(&md5.challenge()).await?;
                         let password = Password::from_bytes(stream.read().await?.to_bytes()?)?;
                         if let Password::PasswordMessage { response } = password {

--- a/pgdog/src/main.rs
+++ b/pgdog/src/main.rs
@@ -24,6 +24,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut overrides = pgdog::config::Overrides::default();
 
     match command.as_ref() {
+        Some(Commands::Hash { ref password }) => {
+            pgdog::cli::hash_password(password);
+            exit(0);
+        }
+
         Some(Commands::Fingerprint { query, path }) => {
             pgdog::cli::fingerprint(query.clone(), path.clone())?;
             exit(0);


### PR DESCRIPTION
Allow to specify SCRAM-SHA-256 hashes in `users.toml` instead of plaintext passwords. Users can authenticate to pgdog without us having to store the password anywhere.

Server auth has to be passwordless, however, e.g. RDS IAM or trust.