### PR TITLE
fix: support servers that dont allow query cancellation

### DIFF
--- a/pgdog/src/backend/error.rs
+++ b/pgdog/src/backend/error.rs
@@ -21,9 +21,6 @@ pub enum Error {
     #[error("unexpected message: {0}")]
     UnexpectedMessage(char),
 
-    #[error("server did not provide key data")]
-    NoBackendKeyData,
-
     #[error("unexpected transaction status: {0}")]
     UnexpectedTransactionStatus(char),
 

--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -298,7 +298,11 @@ impl Server {
             }
         }
 
-        let id = key_data.ok_or(Error::NoBackendKeyData)?;
+        // Some backends, e.g. RDS proxy don't support query cancellation,
+        // so they don't send BackendKeyData.
+        // Generating a random one is fine, it just won't work when we try to
+        // cancel a query with this secret.
+        let id = key_data.unwrap_or(BackendKeyData::new());
         let params: Parameters = params.into();
 
         info!(


### PR DESCRIPTION
RDS Proxy doesn't send BackendKeyData. Oh well, no query cancellation for us.