### PR TITLE
feat: max_pool_size alias for default_pool_size (and pool_size)

### DIFF
--- a/pgdog-config/src/database.rs
+++ b/pgdog-config/src/database.rs
@@ -159,6 +159,7 @@ pub struct Database {
     /// **Note:** We strongly recommend keeping this value well below the supported connections of the backend database(s) to allow connections for maintenance in high load scenarios.
     ///
     /// https://docs.pgdog.dev/configuration/pgdog.toml/databases/#pool_size
+    #[serde(alias = "max_pool_size")]
     pub pool_size: Option<usize>,
     /// Overrides the `min_pool_size` setting. The connection pool will maintain at minimum this many connections.
     ///

--- a/pgdog-config/src/general.rs
+++ b/pgdog-config/src/general.rs
@@ -94,7 +94,7 @@ pub struct General {
     /// _Default:_ `10`
     ///
     /// https://docs.pgdog.dev/configuration/pgdog.toml/general/#default_pool_size
-    #[serde(default = "General::default_pool_size")]
+    #[serde(default = "General::default_pool_size", alias = "max_pool_size")]
     pub default_pool_size: usize,
 
     /// Default minimum number of connections per database pool to keep open at all times.


### PR DESCRIPTION
Create a `default_pool_size` alias in config:

```toml
# both settings are identical
[general]
max_pool_size = 100
default_pool_size = 100
```

```toml
[[databases]]
name = "prod"
host = "10.0.0.0"
# both settings are identical
pool_size = 100
max_pool_size = 100
```