### PR TITLE
feat: support pg protocol version negotiation for frontend clients using v3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,15 @@ jobs:
           sudo -u postgres createuser --superuser --login $USER
           sudo -u postgres createdb $USER
           bash integration/setup.sh || (sudo service postgresql restart && bash integration/setup.sh)
-          sudo apt update && sudo apt install -y python3-virtualenv mold php-cli php-pgsql
+          sudo apt update && sudo apt install -y python3-virtualenv mold php-cli php-pgsql curl ca-certificates
+          # Use a versioned PostgreSQL 18 client so the protocol-version smoke
+          # test does not depend on whatever libpq the runner image ships.
+          sudo install -d /usr/share/postgresql-common/pgdg
+          sudo curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
+          . /etc/os-release
+          sudo sh -c "echo 'deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $VERSION_CODENAME-pgdg main' > /etc/apt/sources.list.d/pgdg.list"
+          sudo apt update && sudo apt install -y postgresql-client-18
+          echo "PSQL_BIN=/usr/lib/postgresql/18/bin/psql" >> "$GITHUB_ENV"
           sudo gem install bundler
           sudo apt remove -y cmake
           sudo pip3 install cmake==3.31.6

--- a/integration/complex/protocol_version/run.sh
+++ b/integration/complex/protocol_version/run.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -euo pipefail
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source ${SCRIPT_DIR}/../../common.sh
+
+PSQL_BIN="${PSQL_BIN:-$(command -v psql || true)}"
+if [[ -z "${PSQL_BIN}" ]]; then
+    echo "psql not found; PostgreSQL 18+ client is required for protocol_version integration test"
+    exit 1
+fi
+
+PSQL_VERSION="$(${PSQL_BIN} --version)"
+if [[ ! "${PSQL_VERSION}" =~ [[:space:]](1[89]|[2-9][0-9])\. ]]; then
+    echo "PostgreSQL 18+ client is required for protocol_version integration test, found: ${PSQL_VERSION}"
+    exit 1
+fi
+
+PGDOG_PORT="${PGDOG_PORT:-7432}"
+OPENMETRICS_PORT="${OPENMETRICS_PORT:-19090}"
+HEALTHCHECK_PORT="${HEALTHCHECK_PORT:-18080}"
+CONFIG_DIR="$(mktemp -d "${TMPDIR:-/tmp}/pgdog-protocol-version.XXXXXX")"
+
+# Run this smoke test on a throwaway listener port so it can coexist with a
+# developer's normal PgDog / Docker setup.
+awk \
+    -v port="${PGDOG_PORT}" \
+    -v openmetrics_port="${OPENMETRICS_PORT}" \
+    -v healthcheck_port="${HEALTHCHECK_PORT}" \
+    '
+    /^\[general\]$/ { print; print "port = " port; next }
+    /^openmetrics_port = / { print "openmetrics_port = " openmetrics_port; next }
+    /^healthcheck_port = / { print "healthcheck_port = " healthcheck_port; next }
+    { print }
+    ' \
+    "${SCRIPT_DIR}/../../pgdog.toml" > "${CONFIG_DIR}/pgdog.toml"
+cp "${SCRIPT_DIR}/../../users.toml" "${CONFIG_DIR}/users.toml"
+
+cleanup() {
+    stop_pgdog >/dev/null 2>&1 || true
+    rm -rf "${CONFIG_DIR}"
+}
+trap cleanup EXIT
+
+run_pgdog "${CONFIG_DIR}"
+
+until pg_isready -h 127.0.0.1 -p "${PGDOG_PORT}" -U pgdog -d pgdog > /dev/null; do
+    sleep 1
+done
+
+run_psql_with_protocol() {
+    local protocol_version="$1"
+    local result
+
+    # This is the independent client check that complements the raw-wire Rust
+    # tests: libpq rejects the connection unless the requested protocol version
+    # can actually be negotiated.
+    result="$("${PSQL_BIN}" -X -tA "postgresql://pgdog:pgdog@127.0.0.1:${PGDOG_PORT}/pgdog?sslmode=disable&gssencmode=disable&min_protocol_version=${protocol_version}&max_protocol_version=${protocol_version}" -c 'SELECT 1')"
+    if [[ "${result}" != "1" ]]; then
+        echo "expected successful libpq ${protocol_version} query, got: ${result}"
+        exit 1
+    fi
+}
+
+run_psql_with_protocol "3.0"
+run_psql_with_protocol "3.2"
+
+echo "PASS: psql connected with min=max protocol versions 3.0 and 3.2"

--- a/integration/complex/run.sh
+++ b/integration/complex/run.sh
@@ -7,4 +7,5 @@ bash shutdown.sh
 bash passthrough_auth/run.sh
 bash cancel_query/run.sh
 bash session_listen/run.sh
+bash protocol_version/run.sh
 popd

--- a/integration/rust/src/utils.rs
+++ b/integration/rust/src/utils.rs
@@ -79,18 +79,34 @@ impl Message {
 
 /// Create a startup message.
 pub fn startup(user: &str, database: &str) -> Bytes {
+    startup_with_version(user, database, 196608, &[])
+}
+
+/// Create a startup message with a specific protocol version and extra parameters.
+pub fn startup_with_version(
+    user: &str,
+    database: &str,
+    protocol_version: i32,
+    extra_params: &[(&str, &str)],
+) -> Bytes {
     let mut payload = BytesMut::new();
-    payload.put_i32(196608);
+    payload.put_i32(protocol_version);
     payload.put_slice("user\0".as_bytes());
     payload.put_slice(user.as_bytes());
     payload.put_u8(0);
     payload.put_slice("database\0".as_bytes());
     payload.put_slice(database.as_bytes());
     payload.put_u8(0);
+    for (name, value) in extra_params {
+        payload.put_slice(name.as_bytes());
+        payload.put_u8(0);
+        payload.put_slice(value.as_bytes());
+        payload.put_u8(0);
+    }
     payload.put_u8(0);
 
     let mut bytes = BytesMut::new();
-    bytes.put_i32(payload.len() as i32);
+    bytes.put_i32(payload.len() as i32 + 4);
     bytes.put(payload);
 
     bytes.freeze()

--- a/integration/rust/tests/integration/mod.rs
+++ b/integration/rust/tests/integration/mod.rs
@@ -19,6 +19,7 @@ pub mod offset;
 pub mod partial_req;
 pub mod per_stmt_routing;
 pub mod prepared;
+pub mod protocol_version;
 pub mod reload;
 pub mod reset;
 pub mod rewrite;

--- a/integration/rust/tests/integration/protocol_version.rs
+++ b/integration/rust/tests/integration/protocol_version.rs
@@ -1,0 +1,142 @@
+use bytes::{Buf, Bytes};
+use rust::{
+    setup::admin_sqlx,
+    utils::{Message, startup_with_version},
+};
+use serial_test::serial;
+use sqlx::Executor;
+use tokio::{io::AsyncWriteExt, net::TcpStream};
+
+const PROTOCOL_3_2: i32 = 196610;
+const PROTOCOL_3_3: i32 = 196611;
+
+async fn startup_exchange(protocol_version: i32, extra_params: &[(&str, &str)]) -> Vec<Message> {
+    let mut stream = TcpStream::connect("127.0.0.1:6432").await.unwrap();
+    stream
+        .write_all(&startup_with_version(
+            "pgdog",
+            "pgdog",
+            protocol_version,
+            extra_params,
+        ))
+        .await
+        .unwrap();
+
+    let mut messages = vec![];
+    loop {
+        let message = Message::read(&mut stream).await.unwrap();
+        let done = message.code == 'Z';
+        messages.push(message);
+        if done {
+            break;
+        }
+    }
+
+    messages
+}
+
+fn backend_key_secret_len(messages: &[Message]) -> usize {
+    let key = messages
+        .iter()
+        .find(|message| message.code == 'K')
+        .expect("BackendKeyData should be present");
+    key.payload.len() - 4
+}
+
+fn parse_c_string(payload: &mut Bytes) -> String {
+    let nul = payload
+        .iter()
+        .position(|byte| *byte == 0)
+        .expect("NUL-terminated string");
+    let value = String::from_utf8(payload.split_to(nul).to_vec()).expect("valid utf-8");
+    payload.advance(1);
+    value
+}
+
+fn parse_negotiation(message: &Message) -> (i32, Vec<String>) {
+    assert_eq!(message.code, 'v');
+
+    let mut payload = message.payload.clone();
+    let version = payload.get_i32();
+    let count = payload.get_i32();
+    let mut options = Vec::with_capacity(count as usize);
+    for _ in 0..count {
+        options.push(parse_c_string(&mut payload));
+    }
+
+    (version, options)
+}
+
+#[tokio::test]
+#[serial]
+async fn test_protocol_3_2_uses_extended_backend_key_data() {
+    let admin = admin_sqlx().await;
+    admin.execute("RELOAD").await.unwrap();
+    admin.execute("SET auth_type TO 'trust'").await.unwrap();
+
+    let join = tokio::spawn(async { startup_exchange(PROTOCOL_3_2, &[]).await }).await;
+
+    admin.execute("RELOAD").await.unwrap();
+
+    let messages = join.unwrap();
+    assert!(
+        !messages.iter().any(|message| message.code == 'v'),
+        "3.2 should not need a downgrade negotiation",
+    );
+    assert!(
+        backend_key_secret_len(&messages) > 4,
+        "3.2 should return an extended cancel secret",
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_protocol_3_3_negotiates_down_to_3_2() {
+    let admin = admin_sqlx().await;
+    admin.execute("RELOAD").await.unwrap();
+    admin.execute("SET auth_type TO 'trust'").await.unwrap();
+
+    let join = tokio::spawn(async { startup_exchange(PROTOCOL_3_3, &[]).await }).await;
+
+    admin.execute("RELOAD").await.unwrap();
+
+    let messages = join.unwrap();
+    let negotiation = messages
+        .first()
+        .expect("startup exchange should return at least one message");
+    let (version, options) = parse_negotiation(negotiation);
+
+    assert_eq!(version, PROTOCOL_3_2);
+    assert!(options.is_empty());
+    assert!(
+        backend_key_secret_len(&messages) > 4,
+        "after negotiating to 3.2, the cancel secret should still be extended",
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_protocol_options_are_reported_via_negotiation() {
+    let admin = admin_sqlx().await;
+    admin.execute("RELOAD").await.unwrap();
+    admin.execute("SET auth_type TO 'trust'").await.unwrap();
+
+    let join =
+        tokio::spawn(async { startup_exchange(PROTOCOL_3_2, &[("_pq_.command_tag", "on")]).await })
+            .await;
+
+    admin.execute("RELOAD").await.unwrap();
+
+    let messages = join.unwrap();
+    let negotiation = messages
+        .first()
+        .expect("startup exchange should return at least one message");
+    let (version, options) = parse_negotiation(negotiation);
+
+    assert_eq!(version, PROTOCOL_3_2);
+    assert_eq!(options, vec!["_pq_.command_tag"]);
+    assert!(
+        backend_key_secret_len(&messages) > 4,
+        "3.2 protocol startup should still receive an extended cancel secret",
+    );
+}

--- a/pgdog/src/backend/pool/connection/multi_shard/test.rs
+++ b/pgdog/src/backend/pool/connection/multi_shard/test.rs
@@ -153,9 +153,9 @@ fn test_omni_command_complete_not_summed() {
     let route = Route::write(ShardWithPriority::new_table_omni(Shard::All));
     let mut multi_shard = MultiShard::new(vec![0, 1, 2], &route);
 
-    let backend1 = BackendKeyData { pid: 1, secret: 1 };
-    let backend2 = BackendKeyData { pid: 2, secret: 2 };
-    let backend3 = BackendKeyData { pid: 3, secret: 3 };
+    let backend1 = BackendKeyData::legacy(1, 1);
+    let backend2 = BackendKeyData::legacy(2, 2);
+    let backend3 = BackendKeyData::legacy(3, 3);
 
     // All shards report UPDATE 5
     multi_shard
@@ -195,8 +195,8 @@ fn test_omni_command_complete_uses_first_shard_row_count() {
     let route = Route::write(ShardWithPriority::new_table_omni(Shard::All));
     let mut multi_shard = MultiShard::new(vec![0, 1], &route);
 
-    let backend1 = BackendKeyData { pid: 1, secret: 1 };
-    let backend2 = BackendKeyData { pid: 2, secret: 2 };
+    let backend1 = BackendKeyData::legacy(1, 1);
+    let backend2 = BackendKeyData::legacy(2, 2);
 
     // First shard reports 7 rows
     multi_shard
@@ -230,8 +230,8 @@ fn test_omni_data_rows_only_from_first_server() {
     let route = Route::write(ShardWithPriority::new_table_omni(Shard::All));
     let mut multi_shard = MultiShard::new(vec![0, 1], &route);
 
-    let backend1 = BackendKeyData { pid: 1, secret: 1 };
-    let backend2 = BackendKeyData { pid: 2, secret: 2 };
+    let backend1 = BackendKeyData::legacy(1, 1);
+    let backend2 = BackendKeyData::legacy(2, 2);
 
     // Setup: send RowDescription from both shards
     let rd = RowDescription::new(&[Field::bigint("id")]);

--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -345,13 +345,7 @@ impl Server {
     pub async fn cancel(addr: &Address, id: &BackendKeyData) -> Result<(), Error> {
         let mut stream = TcpStream::connect(addr.addr().await?).await?;
         stream
-            .write_all(
-                &Startup::Cancel {
-                    pid: id.pid,
-                    secret: id.secret,
-                }
-                .to_bytes()?,
-            )
+            .write_all(&Startup::Cancel { id: *id }.to_bytes()?)
             .await?;
         stream.flush().await?;
 

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -23,7 +23,7 @@ use crate::frontend::client::query_engine::{QueryEngine, QueryEngineContext};
 use crate::frontend::ClientComms;
 use crate::net::messages::{
     Authentication, BackendKeyData, ErrorResponse, FromBytes, Message, Password, Protocol,
-    ReadyForQuery, ToBytes,
+    ProtocolVersion, ReadyForQuery, ToBytes,
 };
 use crate::net::{parameter::Parameters, MessageBuffer, ProtocolMessage, Stream};
 use crate::state::State;
@@ -103,10 +103,16 @@ impl Client {
         params: Parameters,
         addr: SocketAddr,
         config: Arc<ConfigAndUsers>,
+        protocol_version: ProtocolVersion,
     ) -> Result<(), Error> {
         let login_timeout = Duration::from_millis(config.config.general.client_login_timeout);
 
-        match timeout(login_timeout, Self::login(stream, params, addr, config)).await {
+        match timeout(
+            login_timeout,
+            Self::login(stream, params, addr, config, protocol_version),
+        )
+        .await
+        {
             Ok(Ok(Some(mut client))) => {
                 if client.admin {
                     // Admin clients are not waited on during shutdown.
@@ -134,6 +140,7 @@ impl Client {
         params: Parameters,
         addr: SocketAddr,
         config: Arc<ConfigAndUsers>,
+        protocol_version: ProtocolVersion,
     ) -> Result<Option<Client>, Error> {
         // Bail immediately if TLS is required but the connection isn't using it.
         if config.config.general.tls_client_required && !stream.is_tls() {
@@ -146,7 +153,7 @@ impl Client {
         let admin_password = &config.config.admin.password;
         let auth_type = &config.config.general.auth_type;
         let passthrough = config.config.general.passthrough_auth();
-        let id = BackendKeyData::new_client();
+        let id = BackendKeyData::new_client(protocol_version);
         let comms = ClientComms::new(&id);
 
         // Check if we need to ask the client for its password in plaintext

--- a/pgdog/src/frontend/client/test/mod.rs
+++ b/pgdog/src/frontend/client/test/mod.rs
@@ -21,8 +21,8 @@ use crate::{
     },
     net::{
         Bind, Close, CommandComplete, DataRow, Describe, ErrorResponse, Execute, Field, Flush,
-        Format, FromBytes, Message, Parameters, Parse, Query, ReadyForQuery, RowDescription, Sync,
-        Terminate, ToBytes,
+        Format, FromBytes, Message, Parameters, Parse, ProtocolVersion, Query, ReadyForQuery,
+        RowDescription, Sync, Terminate, ToBytes,
     },
     state::State,
 };
@@ -362,7 +362,14 @@ async fn test_client_login_timeout() {
         params.insert("user", "pgdog");
         params.insert("database", "pgdog");
 
-        Client::spawn(stream, params, addr, crate::config::config()).await
+        Client::spawn(
+            stream,
+            params,
+            addr,
+            crate::config::config(),
+            ProtocolVersion::V3_0,
+        )
+        .await
     });
 
     let conn = TcpStream::connect(&format!("127.0.0.1:{}", port))

--- a/pgdog/src/frontend/listener.rs
+++ b/pgdog/src/frontend/listener.rs
@@ -7,8 +7,7 @@ use std::sync::Arc;
 use crate::backend::databases::{databases, reload, shutdown};
 use crate::config::config;
 use crate::frontend::client::query_engine::two_pc::Manager;
-use crate::net::messages::BackendKeyData;
-use crate::net::messages::{hello::SslReply, Startup};
+use crate::net::messages::{hello::SslReply, NegotiateProtocolVersion, Startup};
 use crate::net::{self, tls::acceptor};
 use crate::net::{tweak, Stream};
 use crate::sighup::Sighup;
@@ -204,13 +203,32 @@ impl Listener {
                     stream.send_flush(&SslReply::No).await?;
                 }
 
-                Startup::Startup { params } => {
-                    Client::spawn(stream, params, addr, config).await?;
+                Startup::Startup {
+                    version,
+                    params,
+                    unrecognized_options,
+                } => {
+                    let negotiated = version
+                        .negotiated()
+                        .ok_or_else(|| net::Error::UnsupportedStartup(version.as_i32()))?;
+
+                    if negotiated != version || !unrecognized_options.is_empty() {
+                        // Send the negotiated minor version before auth so the
+                        // client can interpret later messages, including
+                        // BackendKeyData / CancelRequest, using the right shape.
+                        stream
+                            .send(&NegotiateProtocolVersion::new(
+                                negotiated,
+                                unrecognized_options,
+                            ))
+                            .await?;
+                    }
+
+                    Client::spawn(stream, params, addr, config, negotiated).await?;
                     break;
                 }
 
-                Startup::Cancel { pid, secret } => {
-                    let id = BackendKeyData { pid, secret };
+                Startup::Cancel { id } => {
                     let _ = databases().cancel(&id).await;
                     break;
                 }

--- a/pgdog/src/net/messages/backend_key.rs
+++ b/pgdog/src/net/messages/backend_key.rs
@@ -6,14 +6,97 @@ use std::sync::atomic::Ordering;
 
 use crate::net::messages::code;
 use crate::net::messages::prelude::*;
+use crate::net::messages::protocol_version::ProtocolVersion;
+use bytes::Buf;
 use once_cell::sync::Lazy;
 use rand::Rng;
 
 static COUNTER: Lazy<AtomicI32> = Lazy::new(|| AtomicI32::new(0));
+const LEGACY_SECRET_LEN: usize = std::mem::size_of::<i32>();
+const EXTENDED_SECRET_LEN: usize = 32;
+pub const MAX_SECRET_LEN: usize = 256;
 
 // This wraps around.
 fn next_counter() -> i32 {
     COUNTER.fetch_add(1, Ordering::SeqCst)
+}
+
+/// Variable-length cancel secret.
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
+pub struct SecretKey {
+    len: u16,
+    bytes: [u8; MAX_SECRET_LEN],
+}
+
+impl Default for SecretKey {
+    fn default() -> Self {
+        Self::legacy(0)
+    }
+}
+
+impl SecretKey {
+    /// Create a 3.0-compatible secret key from a 4-byte integer.
+    pub fn legacy(secret: i32) -> Self {
+        let mut bytes = [0; MAX_SECRET_LEN];
+        bytes[..LEGACY_SECRET_LEN].copy_from_slice(&secret.to_be_bytes());
+        Self {
+            len: LEGACY_SECRET_LEN as u16,
+            bytes,
+        }
+    }
+
+    /// Create a random secret key of the requested length.
+    pub fn random(len: usize) -> Self {
+        assert!(
+            (1..=MAX_SECRET_LEN).contains(&len),
+            "cancel secret must be between 1 and {MAX_SECRET_LEN} bytes"
+        );
+
+        let mut bytes = [0; MAX_SECRET_LEN];
+        rand::rng().fill(&mut bytes[..len]);
+        Self {
+            len: len as u16,
+            bytes,
+        }
+    }
+
+    /// Create a secret key from raw wire bytes.
+    pub fn from_slice(secret: &[u8]) -> Result<Self, crate::net::Error> {
+        if secret.is_empty() || secret.len() > MAX_SECRET_LEN {
+            return Err(crate::net::Error::UnexpectedPayload);
+        }
+
+        let mut bytes = [0; MAX_SECRET_LEN];
+        bytes[..secret.len()].copy_from_slice(secret);
+        Ok(Self {
+            len: secret.len() as u16,
+            bytes,
+        })
+    }
+
+    /// Secret bytes as they appear on the wire.
+    pub fn as_slice(&self) -> &[u8] {
+        &self.bytes[..self.len()]
+    }
+
+    /// Secret length in bytes.
+    pub fn len(&self) -> usize {
+        self.len as usize
+    }
+}
+
+impl Display for SecretKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.len() == LEGACY_SECRET_LEN {
+            let legacy = i32::from_be_bytes(self.as_slice().try_into().expect("4-byte secret"));
+            write!(f, "{legacy}")
+        } else {
+            for byte in self.as_slice() {
+                write!(f, "{byte:02x}")?;
+            }
+            Ok(())
+        }
+    }
 }
 
 /// BackendKeyData (B)
@@ -22,7 +105,7 @@ pub struct BackendKeyData {
     /// Process ID.
     pub pid: i32,
     /// Process secret.
-    pub secret: i32,
+    pub secret: SecretKey,
 }
 
 impl Display for BackendKeyData {
@@ -36,17 +119,33 @@ impl BackendKeyData {
     pub fn new() -> Self {
         Self {
             pid: rand::rng().random(),
-            secret: rand::rng().random(),
+            secret: SecretKey::random(LEGACY_SECRET_LEN),
         }
     }
 
     /// Create new BackendKeyData for a connected client.
     ///
     /// This counts client IDs incrementally.
-    pub fn new_client() -> Self {
+    pub fn new_client(protocol_version: ProtocolVersion) -> Self {
+        // The client must echo this secret back in CancelRequest, so its shape
+        // has to match the negotiated frontend protocol version.
+        let secret_len = if protocol_version == ProtocolVersion::V3_2 {
+            EXTENDED_SECRET_LEN
+        } else {
+            LEGACY_SECRET_LEN
+        };
+
         Self {
             pid: next_counter(),
-            secret: rand::rng().random(),
+            secret: SecretKey::random(secret_len),
+        }
+    }
+
+    /// Create legacy 3.0-compatible backend key data.
+    pub fn legacy(pid: i32, secret: i32) -> Self {
+        Self {
+            pid,
+            secret: SecretKey::legacy(secret),
         }
     }
 }
@@ -56,7 +155,7 @@ impl ToBytes for BackendKeyData {
         let mut payload = Payload::named(self.code());
 
         payload.put_i32(self.pid);
-        payload.put_i32(self.secret);
+        payload.put_slice(self.secret.as_slice());
 
         Ok(payload.freeze())
     }
@@ -66,17 +165,67 @@ impl FromBytes for BackendKeyData {
     fn from_bytes(mut bytes: Bytes) -> Result<Self, Error> {
         code!(bytes, 'K');
 
-        let _len = bytes.get_i32();
+        let len = bytes.get_i32();
+        // Protocol 3.2 extends BackendKeyData with a variable-length secret,
+        // while 3.0 keeps the legacy 4-byte payload.
+        let secret_len = usize::try_from(len)
+            .ok()
+            .and_then(|len| len.checked_sub(8))
+            .ok_or(Error::UnexpectedPayload)?;
+        if secret_len == 0 || secret_len > MAX_SECRET_LEN || bytes.remaining() != 4 + secret_len {
+            return Err(Error::UnexpectedPayload);
+        }
 
-        Ok(Self {
-            pid: bytes.get_i32(),
-            secret: bytes.get_i32(),
-        })
+        let pid = bytes.get_i32();
+        let secret = SecretKey::from_slice(&bytes.copy_to_bytes(secret_len))?;
+
+        Ok(Self { pid, secret })
     }
 }
 
 impl Protocol for BackendKeyData {
     fn code(&self) -> char {
         'K'
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BackendKeyData, ProtocolVersion, SecretKey};
+    use crate::net::messages::{FromBytes, ToBytes};
+
+    #[test]
+    fn test_backend_key_roundtrip_legacy() {
+        let key = BackendKeyData::legacy(42, 1234);
+        let roundtrip = BackendKeyData::from_bytes(key.to_bytes().unwrap()).unwrap();
+        assert_eq!(roundtrip, key);
+        assert_eq!(roundtrip.secret.len(), 4);
+    }
+
+    #[test]
+    fn test_backend_key_roundtrip_extended() {
+        let key = BackendKeyData {
+            pid: 7,
+            secret: SecretKey::random(32),
+        };
+        let roundtrip = BackendKeyData::from_bytes(key.to_bytes().unwrap()).unwrap();
+        assert_eq!(roundtrip, key);
+        assert_eq!(roundtrip.secret.len(), 32);
+    }
+
+    #[test]
+    fn test_new_client_uses_protocol_specific_secret_length() {
+        assert_eq!(
+            BackendKeyData::new_client(ProtocolVersion::V3_0)
+                .secret
+                .len(),
+            4
+        );
+        assert_eq!(
+            BackendKeyData::new_client(ProtocolVersion::V3_2)
+                .secret
+                .len(),
+            32
+        );
     }
 }

--- a/pgdog/src/net/messages/hello.rs
+++ b/pgdog/src/net/messages/hello.rs
@@ -2,6 +2,7 @@
 
 use crate::net::{
     c_string,
+    messages::{BackendKeyData, ProtocolVersion},
     parameter::{ParameterValue, Parameters},
     Error,
 };
@@ -17,22 +18,26 @@ use super::{super::Parameter, FromBytes, Payload, Protocol, ToBytes};
 /// and a server expects from a client.
 ///
 /// See: <https://www.postgresql.org/docs/current/protocol-message-formats.html>
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Startup {
     /// SSLRequest (F)
     Ssl,
     /// GSSENCRequest (F)
     GssEnc,
     /// StartupMessage (F)
-    Startup { params: Parameters },
+    Startup {
+        version: ProtocolVersion,
+        params: Parameters,
+        unrecognized_options: Vec<String>,
+    },
     /// CancelRequet (F)
-    Cancel { pid: i32, secret: i32 },
+    Cancel { id: BackendKeyData },
 }
 
 impl Startup {
     /// Read Startup message from a stream.
     pub async fn from_stream(stream: &mut (impl AsyncRead + Unpin)) -> Result<Self, Error> {
-        let _len = stream.read_i32().await?;
+        let len = stream.read_i32().await?;
         let code = stream.read_i32().await?;
 
         debug!("📡 => {}", code);
@@ -42,9 +47,34 @@ impl Startup {
             80877103 => Ok(Startup::Ssl),
             // GSSENCRequest (F)
             80877104 => Ok(Startup::GssEnc),
+            // CancelRequest (F)
+            80877102 => {
+                let pid = stream.read_i32().await?;
+                // CancelRequest secrets became variable-length in protocol 3.2.
+                let secret_len = usize::try_from(len)
+                    .ok()
+                    .and_then(|len| len.checked_sub(12))
+                    .ok_or(Error::UnexpectedPayload)?;
+                let mut secret = vec![0_u8; secret_len];
+                stream.read_exact(&mut secret).await?;
+
+                Ok(Startup::Cancel {
+                    id: BackendKeyData {
+                        pid,
+                        secret: crate::net::messages::backend_key::SecretKey::from_slice(&secret)?,
+                    },
+                })
+            }
             // StartupMessage (F)
-            196608 => {
+            code => {
+                let version =
+                    ProtocolVersion::from_i32(code).ok_or(Error::UnsupportedStartup(code))?;
+                if version.major() != 3 {
+                    return Err(Error::UnsupportedStartup(code));
+                }
+
                 let mut params = Parameters::default();
+                let mut unrecognized_options = vec![];
                 loop {
                     let name = c_string(stream).await?;
 
@@ -54,7 +84,12 @@ impl Startup {
 
                     let value = c_string(stream).await?;
 
-                    if name == "search_path" {
+                    if name.starts_with("_pq_.") {
+                        // Reserved protocol options are reported back via
+                        // NegotiateProtocolVersion rather than treated as
+                        // normal startup parameters.
+                        unrecognized_options.push(name);
+                    } else if name == "search_path" {
                         let value = search_path(&value);
                         params.insert(name, value);
                     } else if name == "options" {
@@ -84,17 +119,12 @@ impl Startup {
                     }
                 }
 
-                Ok(Startup::Startup { params })
+                Ok(Startup::Startup {
+                    version,
+                    params,
+                    unrecognized_options,
+                })
             }
-            // CancelRequest (F)
-            80877102 => {
-                let pid = stream.read_i32().await?;
-                let secret = stream.read_i32().await?;
-
-                Ok(Startup::Cancel { pid, secret })
-            }
-
-            code => Err(Error::UnsupportedStartup(code)),
         }
     }
 
@@ -104,12 +134,22 @@ impl Startup {
     pub fn parameter(&self, name: &str) -> Option<&str> {
         match self {
             Startup::Ssl | Startup::GssEnc | Startup::Cancel { .. } => None,
-            Startup::Startup { params } => params.get(name).and_then(|s| s.as_str()),
+            Startup::Startup { params, .. } => params.get(name).and_then(|s| s.as_str()),
         }
     }
 
     /// Create new startup message from config.
-    pub fn new(user: &str, database: &str, mut params: Vec<Parameter>) -> Self {
+    pub fn new(user: &str, database: &str, params: Vec<Parameter>) -> Self {
+        Self::new_with_protocol_version(ProtocolVersion::V3_0, user, database, params)
+    }
+
+    /// Create new startup message with a specific protocol version.
+    pub fn new_with_protocol_version(
+        version: ProtocolVersion,
+        user: &str,
+        database: &str,
+        mut params: Vec<Parameter>,
+    ) -> Self {
         params.extend(vec![
             Parameter {
                 name: "user".into(),
@@ -121,7 +161,9 @@ impl Startup {
             },
         ]);
         Self::Startup {
+            version,
             params: params.into(),
+            unrecognized_options: vec![],
         }
     }
 
@@ -157,17 +199,21 @@ impl super::ToBytes for Startup {
                 Ok(buf.freeze())
             }
 
-            Startup::Cancel { pid, secret } => {
+            Startup::Cancel { id } => {
                 let mut payload = Payload::new();
 
                 payload.put_i32(80877102);
-                payload.put_i32(*pid);
-                payload.put_i32(*secret);
+                payload.put_i32(id.pid);
+                payload.put_slice(id.secret.as_slice());
 
                 Ok(payload.freeze())
             }
 
-            Startup::Startup { params } => {
+            Startup::Startup {
+                version,
+                params,
+                unrecognized_options: _,
+            } => {
                 let mut params_buf = BytesMut::new();
 
                 for (name, value) in params.deref() {
@@ -182,7 +228,7 @@ impl super::ToBytes for Startup {
 
                 let mut payload = Payload::new();
 
-                payload.put_i32(196608);
+                payload.put_i32(version.as_i32());
                 payload.put(params_buf);
                 payload.put_u8(0); // Terminating null character.
 
@@ -251,7 +297,7 @@ fn search_path(value: &str) -> ParameterValue {
 
 #[cfg(test)]
 mod test {
-    use crate::net::messages::ToBytes;
+    use crate::net::messages::{BackendKeyData, ProtocolVersion, ToBytes};
 
     use super::*;
     use bytes::{Buf, BufMut, BytesMut};
@@ -278,6 +324,7 @@ mod test {
     #[tokio::test]
     async fn test_startup() {
         let startup = Startup::Startup {
+            version: ProtocolVersion::V3_0,
             params: vec![
                 Parameter {
                     name: "user".into(),
@@ -289,6 +336,7 @@ mod test {
                 },
             ]
             .into(),
+            unrecognized_options: vec![],
         };
 
         let bytes = startup.to_bytes().unwrap();
@@ -308,5 +356,78 @@ mod test {
 
         let startup = Startup::from_stream(&mut read).await.unwrap();
         assert!(matches!(startup, Startup::GssEnc));
+    }
+
+    #[tokio::test]
+    async fn test_read_startup_protocol_3_2() {
+        let (mut write, mut read) = tokio::io::duplex(128);
+        tokio::spawn(async move {
+            let startup = Startup::new_with_protocol_version(
+                ProtocolVersion::V3_2,
+                "postgres",
+                "postgres",
+                vec![],
+            );
+            write.write_all(&startup.to_bytes().unwrap()).await.unwrap();
+        });
+
+        let startup = Startup::from_stream(&mut read).await.unwrap();
+        assert!(matches!(
+            startup,
+            Startup::Startup {
+                version: ProtocolVersion::V3_2,
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_read_startup_collects_unrecognized_protocol_options() {
+        let (mut write, mut read) = tokio::io::duplex(128);
+        tokio::spawn(async move {
+            let mut payload = BytesMut::new();
+            payload.put_i32(ProtocolVersion::V3_2.as_i32());
+            payload.put_slice(b"user\0postgres\0");
+            payload.put_slice(b"_pq_.command_tag\0v2\0");
+            payload.put_u8(0);
+
+            let mut bytes = BytesMut::new();
+            bytes.put_i32(payload.len() as i32 + 4);
+            bytes.put(payload);
+            write.write_all(&bytes).await.unwrap();
+        });
+
+        let startup = Startup::from_stream(&mut read).await.unwrap();
+        let Startup::Startup {
+            version,
+            params,
+            unrecognized_options,
+        } = startup
+        else {
+            panic!("expected startup message");
+        };
+
+        assert_eq!(version, ProtocolVersion::V3_2);
+        assert_eq!(
+            params.get("user").and_then(|v| v.as_str()),
+            Some("postgres")
+        );
+        assert_eq!(unrecognized_options, vec!["_pq_.command_tag"]);
+    }
+
+    #[tokio::test]
+    async fn test_cancel_roundtrip_extended_secret() {
+        let cancel = Startup::Cancel {
+            id: BackendKeyData::new_client(ProtocolVersion::V3_2),
+        };
+        let bytes = cancel.to_bytes().unwrap();
+
+        let (mut write, mut read) = tokio::io::duplex(512);
+        tokio::spawn(async move {
+            write.write_all(&bytes).await.unwrap();
+        });
+
+        let roundtrip = Startup::from_stream(&mut read).await.unwrap();
+        assert_eq!(roundtrip, cancel);
     }
 }

--- a/pgdog/src/net/messages/mod.rs
+++ b/pgdog/src/net/messages/mod.rs
@@ -18,6 +18,7 @@ pub mod error_response;
 pub mod execute;
 pub mod flush;
 pub mod hello;
+pub mod negotiate_protocol_version;
 pub mod no_data;
 pub mod notice_response;
 pub mod notification_response;
@@ -27,6 +28,7 @@ pub mod parse;
 pub mod parse_complete;
 pub mod payload;
 pub mod prelude;
+pub mod protocol_version;
 pub mod query;
 pub mod replication;
 pub mod rfq;
@@ -53,6 +55,7 @@ pub use error_response::ErrorResponse;
 pub use execute::Execute;
 pub use flush::Flush;
 pub use hello::Startup;
+pub use negotiate_protocol_version::NegotiateProtocolVersion;
 pub use no_data::NoData;
 pub use notice_response::NoticeResponse;
 pub use notification_response::NotificationResponse;
@@ -61,6 +64,7 @@ pub use parameter_status::ParameterStatus;
 pub use parse::Parse;
 pub use parse_complete::ParseComplete;
 pub use payload::Payload;
+pub use protocol_version::ProtocolVersion;
 pub use query::Query;
 pub use rfq::{ReadyForQuery, TransactionState};
 pub use row_description::{Field, RowDescription};
@@ -161,6 +165,9 @@ impl std::fmt::Debug for Message {
                 Source::Frontend => Close::from_bytes(self.payload()).unwrap().fmt(f),
             },
             'd' => CopyData::from_bytes(self.payload()).unwrap().fmt(f),
+            'v' => NegotiateProtocolVersion::from_bytes(self.payload())
+                .unwrap()
+                .fmt(f),
             'W' => f.debug_struct("CopyBothResponse").finish(),
             'I' => f.debug_struct("EmptyQueryResponse").finish(),
             't' => ParameterDescription::from_bytes(self.payload())
@@ -300,6 +307,7 @@ from_message!(EmptyQueryResponse);
 from_message!(ErrorResponse);
 from_message!(Execute);
 from_message!(Flush);
+from_message!(NegotiateProtocolVersion);
 from_message!(NoData);
 from_message!(NoticeResponse);
 from_message!(NotificationResponse);

--- a/pgdog/src/net/messages/negotiate_protocol_version.rs
+++ b/pgdog/src/net/messages/negotiate_protocol_version.rs
@@ -1,0 +1,85 @@
+//! NegotiateProtocolVersion (B) message.
+
+use bytes::{Buf, BufMut};
+
+use crate::net::{c_string_buf, Error};
+
+use super::{code, protocol_version::ProtocolVersion, FromBytes, Payload, Protocol, ToBytes};
+
+/// NegotiateProtocolVersion (B)
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NegotiateProtocolVersion {
+    /// Protocol version chosen by the server.
+    pub version: ProtocolVersion,
+    /// Unsupported protocol option names from the startup packet.
+    pub unrecognized_options: Vec<String>,
+}
+
+impl NegotiateProtocolVersion {
+    /// Create a negotiation response.
+    pub fn new(version: ProtocolVersion, unrecognized_options: Vec<String>) -> Self {
+        Self {
+            version,
+            unrecognized_options,
+        }
+    }
+}
+
+impl ToBytes for NegotiateProtocolVersion {
+    fn to_bytes(&self) -> Result<bytes::Bytes, Error> {
+        let mut payload = Payload::named(self.code());
+        payload.put_i32(self.version.as_i32());
+        payload.put_i32(self.unrecognized_options.len() as i32);
+        for option in &self.unrecognized_options {
+            payload.put_string(option);
+        }
+
+        Ok(payload.freeze())
+    }
+}
+
+impl FromBytes for NegotiateProtocolVersion {
+    fn from_bytes(mut bytes: bytes::Bytes) -> Result<Self, Error> {
+        code!(bytes, 'v');
+
+        let _len = bytes.get_i32();
+        let version = ProtocolVersion::from_i32(bytes.get_i32()).ok_or(Error::UnexpectedPayload)?;
+        let count = bytes.get_i32();
+        if count < 0 {
+            return Err(Error::UnexpectedPayload);
+        }
+
+        let mut unrecognized_options = Vec::with_capacity(count as usize);
+        for _ in 0..count {
+            unrecognized_options.push(c_string_buf(&mut bytes));
+        }
+
+        Ok(Self {
+            version,
+            unrecognized_options,
+        })
+    }
+}
+
+impl Protocol for NegotiateProtocolVersion {
+    fn code(&self) -> char {
+        'v'
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{NegotiateProtocolVersion, ProtocolVersion};
+    use crate::net::messages::{FromBytes, ToBytes};
+
+    #[test]
+    fn test_negotiate_protocol_version_roundtrip() {
+        let message = NegotiateProtocolVersion::new(
+            ProtocolVersion::V3_2,
+            vec!["_pq_.command_tag".into(), "_pq_.other".into()],
+        );
+
+        let roundtrip = NegotiateProtocolVersion::from_bytes(message.to_bytes().unwrap()).unwrap();
+        assert_eq!(roundtrip, message);
+    }
+}

--- a/pgdog/src/net/messages/protocol_version.rs
+++ b/pgdog/src/net/messages/protocol_version.rs
@@ -1,0 +1,104 @@
+//! PostgreSQL frontend/backend protocol versions.
+
+use std::fmt::{Display, Formatter};
+
+/// PostgreSQL protocol version.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ProtocolVersion {
+    major: u16,
+    minor: u16,
+}
+
+impl ProtocolVersion {
+    /// PostgreSQL protocol 3.0.
+    pub const V3_0: Self = Self::new(3, 0);
+    /// PostgreSQL protocol 3.2.
+    pub const V3_2: Self = Self::new(3, 2);
+
+    /// Create a new protocol version.
+    pub const fn new(major: u16, minor: u16) -> Self {
+        Self { major, minor }
+    }
+
+    /// Parse a protocol version from the wire representation.
+    pub fn from_i32(raw: i32) -> Option<Self> {
+        let raw = u32::try_from(raw).ok()?;
+        let major = (raw >> 16) as u16;
+        let minor = (raw & 0xFFFF) as u16;
+
+        Some(Self::new(major, minor))
+    }
+
+    /// Encode this protocol version for the wire.
+    pub fn as_i32(self) -> i32 {
+        ((i32::from(self.major)) << 16) | i32::from(self.minor)
+    }
+
+    /// Protocol major version.
+    pub const fn major(self) -> u16 {
+        self.major
+    }
+
+    /// Protocol minor version.
+    pub const fn minor(self) -> u16 {
+        self.minor
+    }
+
+    /// Whether PgDog supports this protocol version directly.
+    pub fn is_supported(self) -> bool {
+        matches!(self, Self::V3_0 | Self::V3_2)
+    }
+
+    /// Highest supported protocol version that can satisfy this request.
+    ///
+    /// PostgreSQL minor-version negotiation is a downgrade mechanism, so a
+    /// request for 3.1 negotiates to 3.0, while 3.3 negotiates to 3.2.
+    pub fn negotiated(self) -> Option<Self> {
+        if self.major != 3 {
+            return None;
+        }
+
+        Some(match self.minor {
+            0 | 1 => Self::V3_0,
+            _ => Self::V3_2,
+        })
+    }
+}
+
+impl Display for ProtocolVersion {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}", self.major, self.minor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ProtocolVersion;
+
+    #[test]
+    fn test_protocol_version_roundtrip() {
+        let version = ProtocolVersion::V3_2;
+        assert_eq!(ProtocolVersion::from_i32(version.as_i32()), Some(version));
+    }
+
+    #[test]
+    fn test_protocol_version_negotiation() {
+        assert_eq!(
+            ProtocolVersion::V3_0.negotiated(),
+            Some(ProtocolVersion::V3_0)
+        );
+        assert_eq!(
+            ProtocolVersion::new(3, 1).negotiated(),
+            Some(ProtocolVersion::V3_0)
+        );
+        assert_eq!(
+            ProtocolVersion::V3_2.negotiated(),
+            Some(ProtocolVersion::V3_2)
+        );
+        assert_eq!(
+            ProtocolVersion::new(3, 3).negotiated(),
+            Some(ProtocolVersion::V3_2)
+        );
+        assert_eq!(ProtocolVersion::new(4, 0).negotiated(), None);
+    }
+}


### PR DESCRIPTION
This PR adds frontend-side PostgreSQL protocol 3.2 support to PgDog - addressing https://github.com/pgdogdev/pgdog/issues/578.

PgDog now accepts 3.2 startup requests, negotiates newer 3.x minor versions down with NegotiateProtocolVersion, reports unsupported _pq_.* startup options in that response, and returns cancel keys / BackendKeyData in the right shape for the negotiated protocol. Backend connections to PostgreSQL are unchanged.

**What changed**

- added protocol version parsing/negotiation and NegotiateProtocolVersion
- updated startup parsing for 3.2, 3.3+ -> 3.2, and _pq_.* option reporting
- updated BackendKeyData / CancelRequest handling for protocol-dependent secret lengths
- generated client cancel keys based on the negotiated frontend protocol version
- added unit and integration coverage for negotiation and extended cancel-key behavior
- added an independent psql 18 smoke test pinned to exact 3.0 and 3.2

**Compatibility**

3.0 clients continue to work
3.2 clients are accepted directly
newer 3.x minor versions negotiate down to 3.2
non-3.x major versions remain unsupported

**Verification**

Ran locally:

```sh
cargo fmt --all
cargo test -p pgdog --lib --no-run
cargo test -p rust --test mod --no-run
cargo test -p rust --test mod integration::protocol_version:: -- --nocapture
bash integration/complex/protocol_version/run.sh
```