### PR TITLE
feat: wait for primary to be detected

### DIFF
--- a/integration/role_detector/pgdog.toml
+++ b/integration/role_detector/pgdog.toml
@@ -2,6 +2,7 @@
 lsn_check_delay = 0
 lsn_check_interval = 5_000
 idle_timeout = 1_000
+read_write_strategy = "conservative_primary_required"
 
 [[databases]]
 name = "postgres"

--- a/pgdog-config/src/database.rs
+++ b/pgdog-config/src/database.rs
@@ -17,8 +17,21 @@ pub enum ReadWriteStrategy {
     /// Transactions are writes, standalone `SELECT` are reads (default).
     #[default]
     Conservative,
+    /// Same as conservative, except primary is required before accepting queries.
+    ConservativePrimaryRequired,
     /// Use first statement inside a transaction for determining query route.
     Aggressive,
+}
+
+impl ReadWriteStrategy {
+    pub fn is_conservative(&self) -> bool {
+        matches!(self, Self::Conservative | Self::ConservativePrimaryRequired)
+    }
+
+    /// Requires primary database before serving traffic.
+    pub fn primary_required(&self) -> bool {
+        matches!(self, Self::ConservativePrimaryRequired)
+    }
 }
 
 impl FromStr for ReadWriteStrategy {

--- a/pgdog/src/backend/pool/cluster.rs
+++ b/pgdog/src/backend/pool/cluster.rs
@@ -679,6 +679,17 @@ impl Cluster {
         notified.await;
     }
 
+    /// Wait for the cluster to be ready to serve queries.
+    pub(crate) async fn wait_ready(&self) {
+        self.wait_schema_loaded().await;
+
+        if self.read_write_strategy().primary_required() {
+            for shard in &self.shards {
+                shard.wait_primary_detected().await;
+            }
+        }
+    }
+
     /// Execute a query on every primary in the cluster.
     pub async fn execute(
         &self,

--- a/pgdog/src/backend/pool/lb/mod.rs
+++ b/pgdog/src/backend/pool/lb/mod.rs
@@ -201,6 +201,13 @@ impl LoadBalancer {
         self.targets.iter().all(|target| target.pool.lock().online)
     }
 
+    /// Load balancer has a primary database.
+    pub(crate) fn has_primary(&self) -> bool {
+        self.targets
+            .iter()
+            .any(|target| target.role() == Role::Primary)
+    }
+
     /// Get a live connection from the pool.
     pub async fn get(&self, request: &Request) -> Result<Guard, Error> {
         match timeout(self.checkout_timeout, self.get_internal(request)).await {

--- a/pgdog/src/backend/pool/shard/mod.rs
+++ b/pgdog/src/backend/pool/shard/mod.rs
@@ -262,6 +262,18 @@ impl Shard {
         }
     }
 
+    /// Wait for the first primary detection.
+    pub(super) async fn wait_primary_detected(&self) {
+        if self.lb.has_primary() {
+            return;
+        }
+        let waiter = self.role_detected.notified();
+        if self.lb.has_primary() {
+            return;
+        }
+        waiter.await
+    }
+
     /// Shutdown pub/sub listener.
     fn shutdown_pub_sub(&self) {
         if let Some(pub_sub) = self.inner.pub_sub.swap(Arc::new(None)).deref() {
@@ -280,15 +292,16 @@ impl Deref for Shard {
 
 /// Shard connection pools
 /// and internal state.
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug)]
 pub struct ShardInner {
     number: usize,
     lb: LoadBalancer,
-    comms: Arc<ShardComms>,
-    pub_sub: Arc<ArcSwap<Option<PubSubListener>>>,
+    comms: ShardComms,
+    pub_sub: ArcSwap<Option<PubSubListener>>,
     identifier: Arc<User>,
-    schema: Arc<OnceCell<Schema>>,
+    schema: OnceCell<Schema>,
     pub_sub_enabled: bool,
+    role_detected: Notify,
 }
 
 impl ShardInner {
@@ -305,19 +318,20 @@ impl ShardInner {
         } = shard;
         let primary = primary.as_ref().map(Pool::new);
         let lb = LoadBalancer::new(&primary, replicas, lb_strategy, rw_split);
-        let comms = Arc::new(ShardComms {
+        let comms = ShardComms {
             shutdown: Notify::new(),
             lsn_check_interval,
-        });
+        };
 
         Self {
             number,
             lb,
             comms,
-            pub_sub: Arc::new(ArcSwap::new(Arc::new(None))),
+            pub_sub: ArcSwap::new(Arc::new(None)),
             identifier,
-            schema: Arc::new(OnceCell::new()),
+            schema: OnceCell::new(),
             pub_sub_enabled,
+            role_detected: Notify::new(),
         }
     }
 }

--- a/pgdog/src/backend/pool/shard/monitor.rs
+++ b/pgdog/src/backend/pool/shard/monitor.rs
@@ -76,6 +76,7 @@ impl ShardMonitor {
                     self.shard.number(),
                     self.shard.identifier()
                 );
+                self.shard.role_detected.notify_waiters();
             }
 
             let pool_with_stats = self

--- a/pgdog/src/frontend/client/query_engine/route_query.rs
+++ b/pgdog/src/frontend/client/query_engine/route_query.rs
@@ -52,10 +52,10 @@ impl QueryEngine {
             if let Ok(cluster) = self.backend.cluster() {
                 timeout(
                     context.timeouts.query_timeout(&State::Active),
-                    cluster.wait_schema_loaded(),
+                    cluster.wait_ready(),
                 )
                 .await
-                .map_err(|_| Error::SchemaLoad)?;
+                .map_err(|_| Error::ClusterReady)?;
             }
             res
         } else {

--- a/pgdog/src/frontend/error.rs
+++ b/pgdog/src/frontend/error.rs
@@ -45,8 +45,8 @@ pub enum Error {
     #[error("query timeout")]
     Timeout(#[from] tokio::time::error::Elapsed),
 
-    #[error("schema load timeout")]
-    SchemaLoad,
+    #[error("cluster readiness timeout")]
+    ClusterReady,
 
     #[error("join error")]
     Join(#[from] tokio::task::JoinError),

--- a/pgdog/src/frontend/router/parser/context.rs
+++ b/pgdog/src/frontend/router/parser/context.rs
@@ -84,7 +84,7 @@ impl<'a> QueryParserContext<'a> {
 
     /// Are we using the conservative read/write separation strategy?
     pub(super) fn rw_conservative(&self) -> bool {
-        self.rw_strategy == &ReadWriteStrategy::Conservative
+        self.rw_strategy.is_conservative()
     }
 
     /// We need to parse queries using pg_query.


### PR DESCRIPTION
fix #927 

```toml
[general]
read_write_strategy = "conservative_primary_required"
```

This will pause all queries until a primary is detected by `lsn_check_interval`. This will prevent this error:

```
 cannot execute INSERT in a read-only transaction
```

since PgDog won't allow any queries through until a primary is detected, so a write won't be sent to a replica.

This is not default behavior because primary databases are optional, i.e. pgdog can proxy a set of replicas only, so a primary will never be detected.