### PR TITLE
docs: correct two_phase_commit_auto default to false

### DIFF
--- a/.schema/pgdog.schema.json
+++ b/.schema/pgdog.schema.json
@@ -1067,7 +1067,7 @@
           "default": false
         },
         "two_phase_commit_auto": {
-          "description": "Enable automatic conversion of single-statement write transactions to use two-phase commit.\n\n_Default:_ `true`\n\nhttps://docs.pgdog.dev/configuration/pgdog.toml/general/#two_phase_commit_auto",
+          "description": "Enable automatic conversion of single-statement write transactions to use two-phase commit.\n\n_Default:_ `false`\n\nhttps://docs.pgdog.dev/configuration/pgdog.toml/general/#two_phase_commit_auto",
           "type": [
             "boolean",
             "null"

--- a/pgdog-config/src/general.rs
+++ b/pgdog-config/src/general.rs
@@ -506,7 +506,7 @@ pub struct General {
 
     /// Enable automatic conversion of single-statement write transactions to use two-phase commit.
     ///
-    /// _Default:_ `true`
+    /// _Default:_ `false`
     ///
     /// https://docs.pgdog.dev/configuration/pgdog.toml/general/#two_phase_commit_auto
     #[serde(default)]


### PR DESCRIPTION
Docs say that `two_phase_commit_auto` defaults to true. It actually defaults to false.