### PR TITLE
fix: RELOAD/RECONNECT broke automatic role detection temporarily

### DIFF
--- a/integration/load_balancer/pgdog.toml
+++ b/integration/load_balancer/pgdog.toml
@@ -62,8 +62,8 @@ port = 45000
 name = "postgres_auto"
 host = "localhost"
 database_name = "postgres"
-port = 45001
 role = "auto"
+port = 45001
 
 [[databases]]
 name = "postgres_auto"

--- a/integration/load_balancer/pgdog.toml
+++ b/integration/load_balancer/pgdog.toml
@@ -18,6 +18,7 @@ auth_type = "trust"
 read_write_split = "exclude_primary"
 expanded_explain = true
 lsn_check_delay = 0
+lsn_check_interval = 1_000
 
 [rewrite]
 enabled = false
@@ -48,6 +49,27 @@ role = "replica"
 name = "postgres"
 host = "localhost"
 role = "replica"
+port = 45002
+
+[[databases]]
+name = "postgres_auto"
+host = "localhost"
+database_name = "postgres"
+role = "auto"
+port = 45000
+
+[[databases]]
+name = "postgres_auto"
+host = "localhost"
+database_name = "postgres"
+port = 45001
+role = "auto"
+
+[[databases]]
+name = "postgres_auto"
+host = "localhost"
+database_name = "postgres"
+role = "auto"
 port = 45002
 
 

--- a/integration/load_balancer/pgx/reload_auto_role_test.go
+++ b/integration/load_balancer/pgx/reload_auto_role_test.go
@@ -1,0 +1,245 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+)
+
+func GetAutoPool() *pgxpool.Pool {
+	config, err := pgxpool.ParseConfig("postgres://postgres:postgres@127.0.0.1:6432/postgres_auto?sslmode=disable")
+	if err != nil {
+		panic(err)
+	}
+
+	pool, err := pgxpool.NewWithConfig(context.Background(), config)
+	if err != nil {
+		panic(err)
+	}
+
+	return pool
+}
+
+func adminExec(t *testing.T, command string) {
+	conn, err := pgx.Connect(context.Background(), "postgres://pgdog:pgdog@127.0.0.1:6432/admin?sslmode=disable")
+	if err != nil {
+		t.Logf("admin connect error: %v", err)
+		return
+	}
+	defer conn.Close(context.Background())
+
+	rows, err := conn.Query(context.Background(), command, pgx.QueryExecModeSimpleProtocol)
+	if err != nil {
+		t.Logf("%s error: %v", command, err)
+		return
+	}
+	rows.Close()
+}
+
+// TestReloadWithAutoRole validates that config reloads don't cause write
+// queries to be routed to replicas when using role = "auto".
+func TestReloadWithAutoRole(t *testing.T) {
+	pool := GetAutoPool()
+	defer pool.Close()
+
+	ctx := context.Background()
+
+	_, err := pool.Exec(ctx, `CREATE TABLE IF NOT EXISTS lb_reload_auto_test (
+		id BIGINT PRIMARY KEY,
+		data VARCHAR NOT NULL DEFAULT ''
+	)`)
+	assert.NoError(t, err)
+	defer pool.Exec(ctx, "DROP TABLE IF EXISTS lb_reload_auto_test")
+
+	// Wait for replicas to see the table.
+	time.Sleep(2 * time.Second)
+
+	duration := 10 * time.Second
+	deadline := time.Now().Add(duration)
+
+	var writeErrors atomic.Int64
+	var readErrors atomic.Int64
+	var reloads atomic.Int64
+
+	done := make(chan struct{})
+
+	// Writer goroutines: INSERT, UPDATE, DELETE
+	for w := range 5 {
+		go func(workerId int) {
+			counter := 0
+			for time.Now().Before(deadline) {
+				id := int64(workerId*100000 + counter)
+				data := fmt.Sprintf("w%d-%d", workerId, counter)
+
+				_, err := pool.Exec(ctx,
+					"INSERT INTO lb_reload_auto_test (id, data) VALUES ($1, $2) ON CONFLICT (id) DO UPDATE SET data = EXCLUDED.data",
+					id, data)
+				if err != nil {
+					t.Logf("INSERT error (worker %d): %v", workerId, err)
+					writeErrors.Add(1)
+				}
+
+				_, err = pool.Exec(ctx,
+					"UPDATE lb_reload_auto_test SET data = $2 WHERE id = $1",
+					id, data+"-updated")
+				if err != nil {
+					t.Logf("UPDATE error (worker %d): %v", workerId, err)
+					writeErrors.Add(1)
+				}
+
+				_, err = pool.Exec(ctx,
+					"DELETE FROM lb_reload_auto_test WHERE id = $1",
+					id)
+				if err != nil {
+					t.Logf("DELETE error (worker %d): %v", workerId, err)
+					writeErrors.Add(1)
+				}
+
+				counter++
+			}
+			done <- struct{}{}
+		}(w)
+	}
+
+	// Reader goroutines
+	for r := range 5 {
+		go func(readerId int) {
+			for time.Now().Before(deadline) {
+				_, err := pool.Exec(ctx, "SELECT * FROM lb_reload_auto_test LIMIT 10")
+				if err != nil {
+					t.Logf("SELECT error (reader %d): %v", readerId, err)
+					readErrors.Add(1)
+				}
+			}
+			done <- struct{}{}
+		}(r)
+	}
+
+	// Reloader goroutine: send RELOAD every 500ms
+	go func() {
+		for time.Now().Before(deadline) {
+			adminExec(t, "RELOAD")
+			reloads.Add(1)
+			time.Sleep(500 * time.Millisecond)
+		}
+		done <- struct{}{}
+	}()
+
+	// Wait for all: 5 writers + 5 readers + 1 reloader
+	for range 11 {
+		<-done
+	}
+
+	t.Logf("reloads: %d, write errors: %d, read errors: %d",
+		reloads.Load(), writeErrors.Load(), readErrors.Load())
+
+	assert.Zero(t, writeErrors.Load(), "expected no write errors from reload with auto role detection")
+	assert.Zero(t, readErrors.Load(), "expected no read errors from reload with auto role detection")
+}
+
+// TestReconnectWithAutoRole validates that RECONNECT doesn't break read/write
+// routing when using role = "auto".
+func TestReconnectWithAutoRole(t *testing.T) {
+	pool := GetAutoPool()
+	defer pool.Close()
+
+	ctx := context.Background()
+
+	_, err := pool.Exec(ctx, `CREATE TABLE IF NOT EXISTS lb_reconnect_auto_test (
+		id BIGINT PRIMARY KEY,
+		data VARCHAR NOT NULL DEFAULT ''
+	)`)
+	assert.NoError(t, err)
+	defer pool.Exec(ctx, "DROP TABLE IF EXISTS lb_reconnect_auto_test")
+
+	// Wait for replicas to see the table.
+	time.Sleep(2 * time.Second)
+
+	duration := 10 * time.Second
+	deadline := time.Now().Add(duration)
+
+	var writeErrors atomic.Int64
+	var readErrors atomic.Int64
+	var reconnects atomic.Int64
+
+	done := make(chan struct{})
+
+	// Writer goroutines: INSERT, UPDATE, DELETE
+	for w := range 5 {
+		go func(workerId int) {
+			counter := 0
+			for time.Now().Before(deadline) {
+				id := int64(workerId*100000 + counter)
+				data := fmt.Sprintf("w%d-%d", workerId, counter)
+
+				_, err := pool.Exec(ctx,
+					"INSERT INTO lb_reconnect_auto_test (id, data) VALUES ($1, $2) ON CONFLICT (id) DO UPDATE SET data = EXCLUDED.data",
+					id, data)
+				if err != nil {
+					t.Logf("INSERT error (worker %d): %v", workerId, err)
+					writeErrors.Add(1)
+				}
+
+				_, err = pool.Exec(ctx,
+					"UPDATE lb_reconnect_auto_test SET data = $2 WHERE id = $1",
+					id, data+"-updated")
+				if err != nil {
+					t.Logf("UPDATE error (worker %d): %v", workerId, err)
+					writeErrors.Add(1)
+				}
+
+				_, err = pool.Exec(ctx,
+					"DELETE FROM lb_reconnect_auto_test WHERE id = $1",
+					id)
+				if err != nil {
+					t.Logf("DELETE error (worker %d): %v", workerId, err)
+					writeErrors.Add(1)
+				}
+
+				counter++
+			}
+			done <- struct{}{}
+		}(w)
+	}
+
+	// Reader goroutines
+	for r := range 5 {
+		go func(readerId int) {
+			for time.Now().Before(deadline) {
+				_, err := pool.Exec(ctx, "SELECT * FROM lb_reconnect_auto_test LIMIT 10")
+				if err != nil {
+					t.Logf("SELECT error (reader %d): %v", readerId, err)
+					readErrors.Add(1)
+				}
+			}
+			done <- struct{}{}
+		}(r)
+	}
+
+	// Reconnect goroutine: send RECONNECT every 2s
+	go func() {
+		for time.Now().Before(deadline) {
+			adminExec(t, "RECONNECT")
+			reconnects.Add(1)
+			time.Sleep(2 * time.Second)
+		}
+		done <- struct{}{}
+	}()
+
+	// Wait for all: 5 writers + 5 readers + 1 reconnector
+	for range 11 {
+		<-done
+	}
+
+	t.Logf("reconnects: %d, write errors: %d, read errors: %d",
+		reconnects.Load(), writeErrors.Load(), readErrors.Load())
+
+	assert.Zero(t, writeErrors.Load(), "expected no write errors after RECONNECT with auto role detection")
+	assert.Zero(t, readErrors.Load(), "expected no read errors after RECONNECT with auto role detection")
+}

--- a/integration/load_balancer/pgx/show_replication_test.go
+++ b/integration/load_balancer/pgx/show_replication_test.go
@@ -34,17 +34,17 @@ func TestShowReplicationLsnStats(t *testing.T) {
 		assert.NoError(t, err)
 
 		type ReplicationRow struct {
-			ID              int64
-			Database        string
-			User            string
-			Addr            string
-			Port            int64
-			Shard           int64
-			Role            string
-			ReplicaLag      *string
-			PgLsn           *string
-			LsnAge          *string
-			PgIsInRecovery  *string
+			ID             int64
+			Database       string
+			User           string
+			Addr           string
+			Port           int64
+			Shard          int64
+			Role           string
+			ReplicaLag     *string
+			PgLsn          *string
+			LsnAge         *string
+			PgIsInRecovery *string
 		}
 
 		var results []ReplicationRow
@@ -64,11 +64,13 @@ func TestShowReplicationLsnStats(t *testing.T) {
 				&row.PgIsInRecovery,
 			)
 			assert.NoError(t, err)
-			results = append(results, row)
+			if row.Database == "postgres" {
+				results = append(results, row)
+			}
 		}
 		rows.Close()
 
-		assert.NotEmpty(t, results, "SHOW REPLICATION returned no rows")
+		assert.NotEmpty(t, results, "SHOW REPLICATION returned no rows for database 'postgres'")
 
 		// Check if any row has valid pg_lsn (non-null)
 		hasValidStats := false
@@ -123,4 +125,127 @@ func TestShowReplicationLsnStats(t *testing.T) {
 	}
 
 	t.Fatalf("LSN stats not populated after %d attempts (%dms)", maxAttempts, maxAttempts*500)
+}
+
+// TestShowReplicationAutoRoleDetection verifies that SHOW REPLICATION reports
+// the auto-detected role (primary/replica) for the postgres_auto database,
+// rather than leaving it as the configured "auto" value. The cluster has one
+// real primary on port 45000 and two replicas on ports 45001 / 45002, so once
+// the LSN monitor has populated stats, role detection must converge to exactly
+// one primary (the row whose port is 45000) and two replicas, with each row's
+// role matching its pg_is_in_recovery value.
+func TestShowReplicationAutoRoleDetection(t *testing.T) {
+	conn := GetAdminConn()
+	defer conn.Close(context.Background())
+
+	type ReplicationRow struct {
+		ID             int64
+		Database       string
+		User           string
+		Addr           string
+		Port           int64
+		Shard          int64
+		Role           string
+		ReplicaLag     *string
+		PgLsn          *string
+		LsnAge         *string
+		PgIsInRecovery *string
+	}
+
+	const expectedPrimaryPort = int64(45000)
+
+	// Wait up to 10 seconds for auto-detection to converge.
+	maxAttempts := 20
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		rows, err := conn.Query(context.Background(), "SHOW REPLICATION")
+		assert.NoError(t, err)
+
+		var results []ReplicationRow
+		for rows.Next() {
+			var row ReplicationRow
+			err := rows.Scan(
+				&row.ID,
+				&row.Database,
+				&row.User,
+				&row.Addr,
+				&row.Port,
+				&row.Shard,
+				&row.Role,
+				&row.ReplicaLag,
+				&row.PgLsn,
+				&row.LsnAge,
+				&row.PgIsInRecovery,
+			)
+			assert.NoError(t, err)
+			if row.Database == "postgres_auto" {
+				results = append(results, row)
+			}
+		}
+		rows.Close()
+
+		assert.NotEmpty(t, results,
+			"SHOW REPLICATION returned no rows for database 'postgres_auto'")
+		assert.Len(t, results, 3,
+			"expected 3 backends for postgres_auto (1 primary + 2 replicas)")
+
+		// Wait for every row to have valid LSN stats AND a resolved role
+		// (i.e., never "auto" — auto means detection hasn't run yet).
+		ready := true
+		for _, row := range results {
+			if row.PgLsn == nil || *row.PgLsn == "" {
+				ready = false
+				break
+			}
+			if row.Role == "auto" {
+				ready = false
+				break
+			}
+		}
+
+		if !ready {
+			time.Sleep(500 * time.Millisecond)
+			continue
+		}
+
+		primaryCount := 0
+		replicaCount := 0
+		for _, row := range results {
+			assert.NotNil(t, row.PgLsn, "pg_lsn should not be null")
+			assert.True(t, strings.Contains(*row.PgLsn, "/"),
+				"pg_lsn '%s' should be in LSN format", *row.PgLsn)
+			assert.NotNil(t, row.PgIsInRecovery,
+				"pg_is_in_recovery should not be null")
+
+			switch row.Role {
+			case "primary":
+				primaryCount++
+				assert.Equal(t, "f", *row.PgIsInRecovery,
+					"port %d marked primary but pg_is_in_recovery = '%s'",
+					row.Port, *row.PgIsInRecovery)
+				assert.Equal(t, expectedPrimaryPort, row.Port,
+					"auto-detected primary should be on port %d, got %d",
+					expectedPrimaryPort, row.Port)
+			case "replica":
+				replicaCount++
+				assert.Equal(t, "t", *row.PgIsInRecovery,
+					"port %d marked replica but pg_is_in_recovery = '%s'",
+					row.Port, *row.PgIsInRecovery)
+				assert.NotEqual(t, expectedPrimaryPort, row.Port,
+					"port %d is the real primary but was detected as replica",
+					row.Port)
+			default:
+				t.Fatalf("unexpected role %q for port %d", row.Role, row.Port)
+			}
+		}
+
+		assert.Equal(t, 1, primaryCount,
+			"expected exactly one auto-detected primary, got %d", primaryCount)
+		assert.Equal(t, 2, replicaCount,
+			"expected exactly two auto-detected replicas, got %d", replicaCount)
+
+		return
+	}
+
+	t.Fatalf("auto role detection did not converge after %d attempts (%dms)",
+		maxAttempts, maxAttempts*500)
 }

--- a/integration/load_balancer/users.toml
+++ b/integration/load_balancer/users.toml
@@ -2,3 +2,8 @@
 name = "postgres"
 database = "postgres"
 password = "postgres"
+
+[[users]]
+name = "postgres"
+database = "postgres_auto"
+password = "postgres"

--- a/pgdog-config/src/database.rs
+++ b/pgdog-config/src/database.rs
@@ -236,6 +236,28 @@ pub enum Role {
     Auto,
 }
 
+impl TryFrom<u8> for Role {
+    type Error = ();
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        Ok(match value {
+            0 => Role::Auto,
+            1 => Role::Primary,
+            2 => Role::Replica,
+            _ => return Err(()),
+        })
+    }
+}
+
+impl From<Role> for u8 {
+    fn from(value: Role) -> Self {
+        match value {
+            Role::Auto => 0,
+            Role::Primary => 1,
+            Role::Replica => 2,
+        }
+    }
+}
+
 impl std::fmt::Display for Role {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/pgdog/src/backend/auth/azure_workload_identity.rs
+++ b/pgdog/src/backend/auth/azure_workload_identity.rs
@@ -49,6 +49,7 @@ mod tests {
     use crate::backend::pool::Address;
     use crate::config::ServerAuth;
     use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+    use pgdog_config::Role;
     use std::env;
 
     use super::*;
@@ -92,6 +93,7 @@ mod tests {
             database_number: 0,
             server_auth: ServerAuth::AzureWorkloadIdentity,
             server_iam_region: None,
+            configured_role: Role::Auto,
         };
 
         let b64_token = token(&addr).await.unwrap();

--- a/pgdog/src/backend/auth/rds_iam.rs
+++ b/pgdog/src/backend/auth/rds_iam.rs
@@ -95,6 +95,8 @@ static TEST_TOKEN_OVERRIDE: once_cell::sync::Lazy<parking_lot::Mutex<Option<Stri
 mod tests {
     use std::env;
 
+    use pgdog_config::Role;
+
     use crate::backend::pool::Address;
     use crate::config::ServerAuth;
 
@@ -157,6 +159,7 @@ mod tests {
             database_number: 0,
             server_auth: ServerAuth::RdsIam,
             server_iam_region: Some("us-east-1".into()),
+            configured_role: Role::Auto,
         };
 
         let token = token(&addr).await.unwrap();

--- a/pgdog/src/backend/databases.rs
+++ b/pgdog/src/backend/databases.rs
@@ -52,16 +52,23 @@ pub fn databases() -> Arc<Databases> {
 pub fn replace_databases(new_databases: Databases, reload: bool) -> Result<(), Error> {
     // Order of operations is important
     // to ensure zero downtime for clients.
+    //
+    // 1. Prevent concurrent reloads.
+    let _guard = reload_notify::started();
+
+    // 2. Move connections from old databases into new ones.
     let old_databases = databases();
     let new_databases = Arc::new(new_databases);
-    reload_notify::started();
     if reload {
         // Move whatever connections we can over to new pools.
         old_databases.move_conns_to(&new_databases)?;
     }
+    // 3. Launch new databases first.
     new_databases.launch();
     DATABASES.store(new_databases);
+    // 4. Shutdown all databases.
     old_databases.shutdown();
+    // 5. Tell clients the reload is complete.
     reload_notify::done();
 
     Ok(())
@@ -71,7 +78,6 @@ pub fn replace_databases(new_databases: Databases, reload: bool) -> Result<(), E
 pub fn reconnect() -> Result<(), Error> {
     let config = config();
     let databases = from_config(&config);
-    warn!("reconnect: dropping all server connections and re-creating pools");
     replace_databases(databases, false)?;
     Ok(())
 }
@@ -82,7 +88,6 @@ pub fn reload_from_existing() -> Result<(), Error> {
     let _lock = lock();
     let config = config();
     let databases = from_config(&config);
-    info!("reloading pools from current config (connections preserved where possible)");
     replace_databases(databases, true)?;
     Ok(())
 }
@@ -122,18 +127,27 @@ pub async fn cancel_all(database: &str) -> Result<(), Error> {
 
 /// Re-create pools from config.
 pub fn reload() -> Result<(), Error> {
+    info!("reloading configuration");
+
+    // Load config from disk.
     let old_config = config();
     let new_config = load(&old_config.config_path, &old_config.users_path)?;
     let databases = from_config(&new_config);
-    info!("reloading configuration");
+
+    // Replace databases.
     replace_databases(databases, true)?;
+
+    // Reload TLS connectors.
     tls::reload()?;
+
     // Remove any unused prepared statements.
     PreparedStatements::global()
         .write()
         .close_unused(new_config.config.general.prepared_statements_limit);
-    // Resize query cache
+
+    // Resize query cache.
     Cache::resize(new_config.config.general.query_cache_limit);
+
     Ok(())
 }
 

--- a/pgdog/src/backend/databases.rs
+++ b/pgdog/src/backend/databases.rs
@@ -53,7 +53,8 @@ pub fn replace_databases(new_databases: Databases, reload: bool) -> Result<(), E
     // Order of operations is important
     // to ensure zero downtime for clients.
     //
-    // 1. Prevent concurrent reloads.
+    // 1. Prevent concurrent reloads. The guard restores the ready flag and
+    //    wakes waiters on drop, even if a step below errors out.
     let _guard = reload_notify::started();
 
     // 2. Move connections from old databases into new ones.
@@ -68,8 +69,6 @@ pub fn replace_databases(new_databases: Databases, reload: bool) -> Result<(), E
     DATABASES.store(new_databases);
     // 4. Shutdown all databases.
     old_databases.shutdown();
-    // 5. Tell clients the reload is complete.
-    reload_notify::done();
 
     Ok(())
 }

--- a/pgdog/src/backend/pool/address.rs
+++ b/pgdog/src/backend/pool/address.rs
@@ -2,6 +2,7 @@
 use std::net::{SocketAddr, ToSocketAddrs};
 
 use pgdog_config::users::PasswordKind;
+use pgdog_config::Role;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -28,6 +29,9 @@ pub struct Address {
     pub server_iam_region: Option<String>,
     /// Database number (in the config).
     pub database_number: usize,
+    /// Role given to the database at configuration time.
+    /// For automatic roles, this can change at runtime.
+    pub configured_role: Role,
 }
 
 impl From<Address> for pgdog_stats::Address {
@@ -81,6 +85,7 @@ impl Address {
             server_auth,
             server_iam_region: user.server_iam_region.clone(),
             database_number,
+            configured_role: database.role,
         }
     }
 
@@ -121,6 +126,7 @@ impl Address {
             server_auth: ServerAuth::Password,
             server_iam_region: None,
             database_number: 0,
+            configured_role: Role::Primary,
         }
     }
 }
@@ -154,6 +160,7 @@ impl TryFrom<Url> for Address {
             server_auth: ServerAuth::Password,
             server_iam_region: None,
             database_number: 0,
+            configured_role: Role::Replica,
         })
     }
 }

--- a/pgdog/src/backend/pool/address.rs
+++ b/pgdog/src/backend/pool/address.rs
@@ -115,6 +115,8 @@ impl Address {
             .ok_or(Error::DnsResolutionFailed(self.host.clone()))
     }
 
+    /// Test convention: `new_test()` represents a primary. Tests that need
+    /// a replica do `Address { configured_role: Role::Replica, ..new_test() }`.
     #[cfg(test)]
     pub fn new_test() -> Self {
         Self {
@@ -151,6 +153,9 @@ impl TryFrom<Url> for Address {
         let password = value.password().ok_or(())?.to_string();
         let database_name = value.path().replace("/", "").to_string();
 
+        // A URL says nothing about role; fall through to `Role::Auto`
+        // via the derived `Default`. The PROBE command (the only caller)
+        // never reads `configured_role` anyway.
         Ok(Self {
             host,
             port,
@@ -158,9 +163,7 @@ impl TryFrom<Url> for Address {
             user,
             database_name,
             server_auth: ServerAuth::Password,
-            server_iam_region: None,
-            database_number: 0,
-            configured_role: Role::Replica,
+            ..Default::default()
         })
     }
 }

--- a/pgdog/src/backend/pool/cluster.rs
+++ b/pgdog/src/backend/pool/cluster.rs
@@ -596,16 +596,27 @@ impl Cluster {
             spawn(async move {
                 use tokio::time::sleep;
 
-                match shard.load_schema().await {
-                    Ok(true) => schema_changed_hook(&shard.schema(), &identifier, &shard),
-                    Ok(false) => (),
-                    Err(err) => {
-                        // Retry.
-                        if shard.online() {
-                            error!("error loading schema for shard {}: {}", shard.number(), err);
-                            sleep(Duration::from_millis(100)).await;
-                        } else {
+                loop {
+                    match shard.load_schema().await {
+                        Ok(true) => {
+                            schema_changed_hook(&shard.schema(), &identifier, &shard);
                             return;
+                        }
+                        Ok(false) => return,
+                        Err(err) => {
+                            if shard.online() {
+                                error!(
+                                    "error loading schema for shard {}: {}",
+                                    shard.number(),
+                                    err
+                                );
+                                sleep(Duration::from_millis(100)).await;
+                            } else {
+                                // Cluster is shutting down: unblock any
+                                // wait_schema_loaded callers.
+                                shard.schema_not_needed();
+                                return;
+                            }
                         }
                     }
                 }

--- a/pgdog/src/backend/pool/cluster.rs
+++ b/pgdog/src/backend/pool/cluster.rs
@@ -8,7 +8,7 @@ use pgdog_config::{
 };
 use std::{
     sync::{
-        atomic::{AtomicBool, AtomicUsize, Ordering},
+        atomic::{AtomicBool, Ordering},
         Arc,
     },
     time::Duration,
@@ -681,7 +681,7 @@ mod test {
         },
         config::{
             config, DataType, Hasher, LoadBalancingStrategy, MultiTenant, ReadWriteSplit,
-            ReadWriteStrategy, ShardedTable,
+            ReadWriteStrategy, Role, ShardedTable,
         },
         frontend::ClientRequest,
         net::Query,
@@ -700,7 +700,10 @@ mod test {
                 config: Config::default(),
             });
             let replicas = &[PoolConfig {
-                address: Address::new_test(),
+                address: Address {
+                    configured_role: Role::Replica,
+                    ..Address::new_test()
+                },
                 config: Config::default(),
             }];
 
@@ -909,7 +912,28 @@ mod test {
 
     #[tokio::test]
     async fn test_launch_schema_loading_idempotent() {
-        todo!()
+        use tokio::time::{sleep, Duration};
+
+        let config = ConfigAndUsers::default();
+        let mut cluster = Cluster::new_test(&config);
+        cluster.sharded_schemas = ShardedSchemas::default();
+
+        assert!(cluster.load_schema());
+
+        // Pre-populate per-shard schemas so launch's spawned loaders become
+        // no-ops (Shard::load_schema returns Ok(false) when already initialized).
+        // This avoids touching a real database in the test.
+        for shard in &cluster.shards {
+            shard.schema_not_needed();
+        }
+
+        cluster.launch();
+        cluster.wait_schema_loaded().await;
+
+        // Second launch must be safe: per-shard OnceCell prevents any reload.
+        cluster.launch();
+        sleep(Duration::from_millis(50)).await;
+        cluster.wait_schema_loaded().await;
     }
 
     #[tokio::test]
@@ -926,12 +950,44 @@ mod test {
 
     #[tokio::test]
     async fn test_wait_schema_loaded_fast_path_when_already_loaded() {
-        todo!()
+        let config = ConfigAndUsers::default();
+        let mut cluster = Cluster::new_test(&config);
+        cluster.sharded_schemas = ShardedSchemas::default();
+
+        assert!(cluster.load_schema());
+
+        // Mark every shard's schema as already loaded.
+        for shard in &cluster.shards {
+            shard.schema_not_needed();
+        }
+
+        // Each shard's wait_schema_loaded() takes the fast path and returns
+        // immediately because schema.initialized() is true.
+        cluster.wait_schema_loaded().await;
     }
 
     #[tokio::test]
     async fn test_wait_schema_loaded_waits_for_notification() {
-        todo!()
+        use tokio::time::{timeout, Duration};
+
+        let config = ConfigAndUsers::default();
+        let mut cluster = Cluster::new_test(&config);
+        cluster.sharded_schemas = ShardedSchemas::default();
+
+        assert!(cluster.load_schema());
+
+        // Trigger schema_not_needed on each shard after a short delay so the
+        // waiter wakes up via the per-shard schema_waiter notification.
+        let shards: Vec<_> = cluster.shards.iter().cloned().collect();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            for shard in &shards {
+                shard.schema_not_needed();
+            }
+        });
+
+        let result = timeout(Duration::from_millis(200), cluster.wait_schema_loaded()).await;
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/pgdog/src/backend/pool/cluster.rs
+++ b/pgdog/src/backend/pool/cluster.rs
@@ -13,8 +13,8 @@ use std::{
     },
     time::Duration,
 };
-use tokio::{spawn, sync::Notify};
-use tracing::{error, info};
+use tokio::spawn;
+use tracing::error;
 
 use crate::{
     backend::{
@@ -46,9 +46,6 @@ pub struct PoolConfig {
 #[derive(Default, Debug)]
 struct Readiness {
     online: AtomicBool,
-    schema_loading_started: AtomicBool,
-    schemas_loaded: AtomicUsize,
-    schemas_ready: Notify,
 }
 
 /// A collection of sharded replicas and primaries
@@ -583,23 +580,26 @@ impl Cluster {
             shard.launch();
         }
 
-        // Only spawn schema loading once per cluster, even if launch() is called multiple times.
-        let already_started = self
-            .readiness
-            .schema_loading_started
-            .swap(true, Ordering::SeqCst);
+        self.readiness.online.store(true, Ordering::Relaxed);
 
-        if self.load_schema() && !already_started {
-            for shard in self.shards() {
-                let identifier = self.identifier();
-                let readiness = self.readiness.clone();
-                let shard = shard.clone();
-                let shards = self.shards.len();
+        if !self.load_schema() {
+            for shard in &self.shards {
+                shard.schema_not_needed();
+            }
+            return;
+        }
 
-                spawn(async move {
-                    use tokio::time::sleep;
+        for shard in self.shards() {
+            let identifier = self.identifier();
+            let shard = shard.clone();
 
-                    while let Err(err) = shard.update_schema().await {
+            spawn(async move {
+                use tokio::time::sleep;
+
+                match shard.load_schema().await {
+                    Ok(true) => schema_changed_hook(&shard.schema(), &identifier, &shard),
+                    Ok(false) => (),
+                    Err(err) => {
                         // Retry.
                         if shard.online() {
                             error!("error loading schema for shard {}: {}", shard.number(), err);
@@ -608,22 +608,9 @@ impl Cluster {
                             return;
                         }
                     }
-
-                    let done = readiness.schemas_loaded.fetch_add(1, Ordering::SeqCst);
-
-                    info!("loaded schema from {}/{} shards", done + 1, shards);
-
-                    schema_changed_hook(&shard.schema(), &identifier, &shard);
-
-                    // Loaded schema on all shards.
-                    if done >= shards - 1 {
-                        readiness.schemas_ready.notify_waiters();
-                    }
-                });
-            }
+                }
+            });
         }
-
-        self.readiness.online.store(true, Ordering::Relaxed);
     }
 
     /// Shutdown the connection pools.
@@ -661,22 +648,9 @@ impl Cluster {
             return;
         }
 
-        fn check_loaded(cluster: &Cluster) -> bool {
-            cluster.readiness.schemas_loaded.load(Ordering::Acquire) == cluster.shards.len()
+        for shard in &self.shards {
+            shard.wait_schema_loaded().await;
         }
-
-        // Fast path.
-        if check_loaded(self) {
-            return;
-        }
-
-        // Queue up.
-        let notified = self.readiness.schemas_ready.notified();
-        // Race condition check.
-        if check_loaded(self) {
-            return;
-        }
-        notified.await;
     }
 
     /// Execute a query on every primary in the cluster.
@@ -935,27 +909,7 @@ mod test {
 
     #[tokio::test]
     async fn test_launch_schema_loading_idempotent() {
-        use std::sync::atomic::Ordering;
-        use tokio::time::{sleep, Duration};
-
-        let config = ConfigAndUsers::default();
-        let mut cluster = Cluster::new_test(&config);
-        cluster.sharded_schemas = ShardedSchemas::default();
-
-        assert!(cluster.load_schema());
-
-        cluster.launch();
-        cluster.wait_schema_loaded().await;
-
-        let count_after_first = cluster.readiness.schemas_loaded.load(Ordering::SeqCst);
-        assert_eq!(count_after_first, cluster.shards.len());
-
-        // Second launch should not spawn additional schema loading tasks
-        cluster.launch();
-        sleep(Duration::from_millis(50)).await;
-
-        let count_after_second = cluster.readiness.schemas_loaded.load(Ordering::SeqCst);
-        assert_eq!(count_after_second, count_after_first);
+        todo!()
     }
 
     #[tokio::test]
@@ -972,50 +926,12 @@ mod test {
 
     #[tokio::test]
     async fn test_wait_schema_loaded_fast_path_when_already_loaded() {
-        use std::sync::atomic::Ordering;
-
-        let config = ConfigAndUsers::default();
-        let mut cluster = Cluster::new_test(&config);
-        cluster.sharded_schemas = ShardedSchemas::default();
-
-        assert!(cluster.load_schema());
-
-        // Simulate that all schemas have been loaded
-        cluster
-            .readiness
-            .schemas_loaded
-            .store(cluster.shards.len(), Ordering::SeqCst);
-
-        // Should return immediately via fast path
-        cluster.wait_schema_loaded().await;
+        todo!()
     }
 
     #[tokio::test]
     async fn test_wait_schema_loaded_waits_for_notification() {
-        use std::sync::atomic::Ordering;
-        use tokio::time::{timeout, Duration};
-
-        let config = ConfigAndUsers::default();
-        let mut cluster = Cluster::new_test(&config);
-        cluster.sharded_schemas = ShardedSchemas::default();
-
-        assert!(cluster.load_schema());
-
-        let readiness = cluster.readiness.clone();
-        let shards_count = cluster.shards.len();
-
-        // Spawn a task that will complete schema loading after a short delay
-        tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(10)).await;
-            readiness
-                .schemas_loaded
-                .store(shards_count, Ordering::SeqCst);
-            readiness.schemas_ready.notify_waiters();
-        });
-
-        // Should wait for notification and complete within timeout
-        let result = timeout(Duration::from_millis(100), cluster.wait_schema_loaded()).await;
-        assert!(result.is_ok());
+        todo!()
     }
 
     #[test]

--- a/pgdog/src/backend/pool/lb/mod.rs
+++ b/pgdog/src/backend/pool/lb/mod.rs
@@ -249,7 +249,11 @@ impl LoadBalancer {
                 .all(|(a, b)| a.pool.can_move_conns_to(&b.pool))
     }
 
-    /// There are no replicas.
+    /// True if the LB has any target that can serve replica reads.
+    ///
+    /// An `Auto` target counts as a potential replica until role detection
+    /// converges, so callers may briefly route reads to a target that turns
+    /// out to be the primary.
     pub fn has_replicas(&self) -> bool {
         self.targets
             .iter()
@@ -281,13 +285,20 @@ impl LoadBalancer {
         result
     }
 
+    /// Block until role detection has assigned every `Auto` target to
+    /// `Primary` or `Replica`. The wakeup is driven by `pick_primary`, so
+    /// if no primary is ever elected (e.g. LSN stats never populate),
+    /// callers will block until their `checkout_timeout` fires.
     async fn wait_roles_detected(&self) {
         if !self.roles_detected() {
             self.role_detection.notified().await;
+            // Chain the wakeup so any other waiter that arrived after us
+            // also gets released without needing another promotion event.
             self.role_detection.notify_one();
         }
     }
 
+    /// True once no target is still in the `Auto` state.
     pub fn roles_detected(&self) -> bool {
         !self
             .targets

--- a/pgdog/src/backend/pool/lb/mod.rs
+++ b/pgdog/src/backend/pool/lb/mod.rs
@@ -2,7 +2,7 @@
 
 use std::{
     sync::{
-        atomic::{AtomicBool, AtomicI64, AtomicUsize, Ordering},
+        atomic::{AtomicI64, AtomicU8, AtomicUsize, Ordering},
         Arc,
     },
     time::{Duration, SystemTime},
@@ -36,7 +36,7 @@ mod test;
 pub struct Target {
     pub pool: Pool,
     pub ban: Ban,
-    replica: Arc<AtomicBool>,
+    role: Arc<AtomicU8>,
     pub health: TargetHealth,
     /// Smooth weighted round-robin current weight tracker.
     current_weight: Arc<AtomicI64>,
@@ -47,7 +47,7 @@ impl Target {
         let ban = Ban::new(&pool);
         Self {
             ban,
-            replica: Arc::new(AtomicBool::new(role == Role::Replica)),
+            role: Arc::new(AtomicU8::new(role.into())),
             health: pool.inner().health.clone(),
             pool,
             current_weight: Arc::new(AtomicI64::new(0)),
@@ -56,17 +56,14 @@ impl Target {
 
     /// Get role.
     pub(super) fn role(&self) -> Role {
-        if self.replica.load(Ordering::Relaxed) {
-            Role::Replica
-        } else {
-            Role::Primary
-        }
+        let role = self.role.load(Ordering::Relaxed);
+        role.try_into().expect("valid role")
     }
 
     /// Set role.
     pub(super) fn set_role(&self, role: Role) -> bool {
-        let value = role == Role::Replica;
-        let old = self.replica.swap(value, Ordering::Relaxed);
+        let value = u8::from(role);
+        let old = self.role.swap(value, Ordering::Relaxed);
         value != old
     }
 }
@@ -84,6 +81,8 @@ pub struct LoadBalancer {
     pub(super) lb_strategy: LoadBalancingStrategy,
     /// Maintenance. notification.
     pub(super) maintenance: Arc<Notify>,
+    /// Role detection waiter.
+    pub(super) role_detection: Arc<Notify>,
     /// Read/write split.
     pub(super) rw_split: ReadWriteSplit,
 }
@@ -107,7 +106,7 @@ impl LoadBalancer {
 
         let mut targets: Vec<_> = addrs
             .iter()
-            .map(|config| Target::new(Pool::new(config), Role::Replica))
+            .map(|config| Target::new(Pool::new(config), config.address.configured_role))
             .collect();
 
         let primary_target = primary
@@ -124,6 +123,7 @@ impl LoadBalancer {
             round_robin: Arc::new(AtomicUsize::new(0)),
             lb_strategy,
             maintenance: Arc::new(Notify::new()),
+            role_detection: Arc::new(Notify::new()),
             rw_split,
         }
     }
@@ -187,6 +187,10 @@ impl LoadBalancer {
             }
         }
 
+        if promoted {
+            self.role_detection.notify_one();
+        }
+
         promoted
     }
 
@@ -225,6 +229,11 @@ impl LoadBalancer {
 
         for (from, to) in self.targets.iter().zip(destination.targets.iter()) {
             from.pool.move_conns_to(&to.pool)?;
+
+            // Carry over detected roles and LSN stats so the new load balancer
+            // doesn't briefly appear read-only before the role detector runs.
+            to.set_role(from.role());
+            *to.pool.inner().lsn_stats.write() = from.pool.lsn_stats();
         }
 
         Ok(())
@@ -244,7 +253,7 @@ impl LoadBalancer {
     pub fn has_replicas(&self) -> bool {
         self.targets
             .iter()
-            .any(|target| target.role() == Role::Replica)
+            .any(|target| matches!(target.role(), Role::Replica | Role::Auto))
     }
 
     /// Cancel a query if one is running.
@@ -272,6 +281,37 @@ impl LoadBalancer {
         result
     }
 
+    async fn wait_roles_detected(&self) {
+        if !self.roles_detected() {
+            self.role_detection.notified().await;
+            self.role_detection.notify_one();
+        }
+    }
+
+    pub fn roles_detected(&self) -> bool {
+        !self
+            .targets
+            .iter()
+            .any(|target| target.role() == Role::Auto)
+    }
+
+    pub(super) async fn get_primary(&self, request: &Request) -> Result<Guard, Error> {
+        match timeout(self.checkout_timeout, self.get_primary_internal(request)).await {
+            Ok(Ok(guard)) => Ok(guard),
+            Err(_) => Err(Error::CheckoutTimeout),
+            Ok(Err(err)) => Err(err.into()),
+        }
+    }
+
+    async fn get_primary_internal(&self, request: &Request) -> Result<Guard, Error> {
+        self.wait_roles_detected().await;
+        self.primary_target()
+            .ok_or(Error::NoPrimary)?
+            .pool
+            .get(request)
+            .await
+    }
+
     async fn get_internal(&self, request: &Request) -> Result<Guard, Error> {
         use LoadBalancingStrategy::*;
         use ReadWriteSplit::*;
@@ -288,11 +328,11 @@ impl LoadBalancer {
             // we read from the primary if we have no replicas
             ExcludePrimary => !candidates
                 .iter()
-                .any(|target| target.role() == Role::Replica),
+                .any(|target| matches!(target.role(), Role::Replica | Role::Auto)),
         };
 
         if !primary_reads {
-            candidates.retain(|target| target.role() == Role::Replica);
+            candidates.retain(|target| matches!(target.role(), Role::Replica | Role::Auto));
         }
 
         if candidates.is_empty() {

--- a/pgdog/src/backend/pool/lb/test.rs
+++ b/pgdog/src/backend/pool/lb/test.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use tokio::time::sleep;
 
 use crate::backend::pool::{Address, Config, Error, PoolConfig, Request};
-use crate::config::LoadBalancingStrategy;
+use crate::config::{LoadBalancingStrategy, Role};
 use pgdog_stats::ReplicaLag;
 
 use super::*;
@@ -17,6 +17,7 @@ fn create_test_pool_config(host: &str, port: u16) -> PoolConfig {
             user: "pgdog".into(),
             passwords: vec!["pgdog".into()],
             database_name: "pgdog".into(),
+            configured_role: Role::Replica,
             ..Default::default()
         },
         config: Config {
@@ -1088,6 +1089,7 @@ fn create_test_pool_config_weighted(host: &str, port: u16, lb_weight: u8) -> Poo
             user: "pgdog".into(),
             passwords: vec!["pgdog".into()],
             database_name: "pgdog".into(),
+            configured_role: Role::Replica,
             ..Default::default()
         },
         config: Config {

--- a/pgdog/src/backend/pool/shard/mod.rs
+++ b/pgdog/src/backend/pool/shard/mod.rs
@@ -364,7 +364,10 @@ mod test {
         });
 
         let replicas = &[PoolConfig {
-            address: Address::new_test(),
+            address: Address {
+                configured_role: Role::Replica,
+                ..Address::new_test()
+            },
             ..Default::default()
         }];
 

--- a/pgdog/src/backend/pool/shard/mod.rs
+++ b/pgdog/src/backend/pool/shard/mod.rs
@@ -69,11 +69,7 @@ impl Shard {
 
     /// Get connection to the primary database.
     pub async fn primary(&self, request: &Request) -> Result<Guard, Error> {
-        self.lb
-            .primary()
-            .ok_or(Error::NoPrimary)?
-            .get(request)
-            .await
+        self.lb.get_primary(request).await
     }
 
     /// Get connection to one of the replica databases, using the configured
@@ -129,7 +125,11 @@ impl Shard {
     }
 
     /// Load schema from the shard's primary.
-    pub async fn update_schema(&self) -> Result<(), crate::backend::Error> {
+    pub async fn load_schema(&self) -> Result<bool, crate::backend::Error> {
+        if self.schema.initialized() {
+            return Ok(false);
+        }
+
         let mut server = self.primary_or_replica(&Request::default()).await?;
         let schema = Schema::load(&mut server).await?;
         info!(
@@ -139,7 +139,26 @@ impl Shard {
             server.addr()
         );
         let _ = self.schema.set(schema);
-        Ok(())
+        self.schema_waiter.notify_one();
+        Ok(true)
+    }
+
+    /// Set the schema to its default value.
+    /// We don't need it for this shard.
+    pub(super) fn schema_not_needed(&self) {
+        let _ = self.schema.set(Schema::default());
+        self.schema_waiter.notify_one();
+    }
+
+    /// Wait for the shard to load the schema.
+    /// If the schema is loaded already, this returns immediately.
+    pub(super) async fn wait_schema_loaded(&self) {
+        if self.schema.initialized() {
+            return;
+        }
+        // Once the schema is loaded, ensure there is always a permit available.
+        self.schema_waiter.notified().await;
+        self.schema_waiter.notify_one();
     }
 
     /// Check that the shard LB targets are all launched.
@@ -156,7 +175,10 @@ impl Shard {
 
     /// Returns true if the shard has a primary database.
     pub fn has_primary(&self) -> bool {
-        self.lb.primary().is_some()
+        match self.lb.primary() {
+            Some(_) => true,
+            None => !self.lb.roles_detected(), // Assume there is a primary, until proven otherwise.
+        }
     }
 
     /// Returns true if the shard has any replica databases.
@@ -280,7 +302,7 @@ impl Deref for Shard {
 
 /// Shard connection pools
 /// and internal state.
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug)]
 pub struct ShardInner {
     number: usize,
     lb: LoadBalancer,
@@ -288,6 +310,7 @@ pub struct ShardInner {
     pub_sub: Arc<ArcSwap<Option<PubSubListener>>>,
     identifier: Arc<User>,
     schema: Arc<OnceCell<Schema>>,
+    schema_waiter: Notify,
     pub_sub_enabled: bool,
 }
 
@@ -317,6 +340,7 @@ impl ShardInner {
             pub_sub: Arc::new(ArcSwap::new(Arc::new(None))),
             identifier,
             schema: Arc::new(OnceCell::new()),
+            schema_waiter: Notify::new(),
             pub_sub_enabled,
         }
     }

--- a/pgdog/src/backend/pool/shard/monitor.rs
+++ b/pgdog/src/backend/pool/shard/monitor.rs
@@ -64,7 +64,11 @@ impl ShardMonitor {
 
         loop {
             select! {
-                _ = maintenance.tick() => {},
+                _ = maintenance.tick() => {
+                    if !self.shard.online() {
+                        break;
+                    }
+                },
                 _ = self.shard.comms().shutdown.notified() => {
                     break;
                 },

--- a/pgdog/src/backend/pool/shard/role_detector.rs
+++ b/pgdog/src/backend/pool/shard/role_detector.rs
@@ -46,7 +46,7 @@ mod test {
     use crate::backend::pool::lsn_monitor::LsnStats;
     use crate::backend::pool::{Address, Config, PoolConfig};
     use crate::backend::replication::publisher::Lsn;
-    use crate::config::{LoadBalancingStrategy, ReadWriteSplit};
+    use crate::config::{LoadBalancingStrategy, ReadWriteSplit, Role};
     use pgdog_stats::LsnStats as StatsLsnStats;
 
     use super::super::ShardConfig;
@@ -60,6 +60,11 @@ mod test {
                 user: "pgdog".into(),
                 passwords: vec!["pgdog".into()],
                 database_name: "pgdog".into(),
+                configured_role: if role_detection {
+                    Role::Auto
+                } else {
+                    Role::Replica
+                },
                 ..Default::default()
             },
             config: Config {

--- a/pgdog/src/backend/reload_notify.rs
+++ b/pgdog/src/backend/reload_notify.rs
@@ -22,16 +22,24 @@ pub(crate) fn ready() -> Option<Notified<'static>> {
     }
 }
 
-pub(super) fn started() -> MutexGuard<'static, ()> {
-    let guard = RELOAD_NOTIFY.running.lock();
-    RELOAD_NOTIFY.ready.store(false, Ordering::Relaxed);
-
-    guard
+/// RAII guard returned by [`started`]. Holds the reload mutex and ensures
+/// `ready` is restored (and waiters woken) on drop, even if the caller
+/// returns early or panics.
+pub(super) struct ReloadGuard {
+    _mutex: MutexGuard<'static, ()>,
 }
 
-pub(super) fn done() {
-    RELOAD_NOTIFY.ready.store(true, Ordering::Relaxed);
-    RELOAD_NOTIFY.notify.notify_waiters();
+impl Drop for ReloadGuard {
+    fn drop(&mut self) {
+        RELOAD_NOTIFY.ready.store(true, Ordering::Relaxed);
+        RELOAD_NOTIFY.notify.notify_waiters();
+    }
+}
+
+pub(super) fn started() -> ReloadGuard {
+    let mutex = RELOAD_NOTIFY.running.lock();
+    RELOAD_NOTIFY.ready.store(false, Ordering::Relaxed);
+    ReloadGuard { _mutex: mutex }
 }
 
 #[derive(Debug)]

--- a/pgdog/src/backend/reload_notify.rs
+++ b/pgdog/src/backend/reload_notify.rs
@@ -1,14 +1,19 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use once_cell::sync::Lazy;
+use parking_lot::{Mutex, MutexGuard};
 use tokio::sync::{futures::Notified, Notify};
 
 static RELOAD_NOTIFY: Lazy<ReloadNotify> = Lazy::new(|| ReloadNotify {
     notify: Notify::new(),
     ready: AtomicBool::new(true),
+    running: Mutex::new(()),
 });
 
 pub(crate) fn ready() -> Option<Notified<'static>> {
+    if RELOAD_NOTIFY.ready.load(Ordering::Relaxed) {
+        return None;
+    }
     let notified = RELOAD_NOTIFY.notify.notified();
     if RELOAD_NOTIFY.ready.load(Ordering::Relaxed) {
         None
@@ -17,8 +22,11 @@ pub(crate) fn ready() -> Option<Notified<'static>> {
     }
 }
 
-pub(super) fn started() {
+pub(super) fn started() -> MutexGuard<'static, ()> {
+    let guard = RELOAD_NOTIFY.running.lock();
     RELOAD_NOTIFY.ready.store(false, Ordering::Relaxed);
+
+    guard
 }
 
 pub(super) fn done() {
@@ -30,4 +38,5 @@ pub(super) fn done() {
 struct ReloadNotify {
     notify: Notify,
     ready: AtomicBool,
+    running: Mutex<()>,
 }


### PR DESCRIPTION
fix #927 

- fix: prevent concurrent `RELOAD`/`RECONNECT`
- fix: TOCTOU in fast/subsequent `RELOAD` commands pausing clients indefinitely (pretty unlikely but clearly possible race condition)
- fix: `RELOAD`/`RECONNECT` resets roles back to `auto` causing load balancer to send some writes to replicas