### PR TITLE
fix: don't prepare unnamed prepared statements

### DIFF
--- a/integration/js/pg_tests/test/postgres_js.js
+++ b/integration/js/pg_tests/test/postgres_js.js
@@ -561,8 +561,14 @@ describe("postgres.js unsafe stress test (50k unique statements, 5 clients)", fu
           selectParts.push(`$${paramIdx}::timestamptz AS ts_q${i}`);
           expected[`ts_q${i}`] = (val) => {
             const got = val instanceof Date ? val : new Date(val);
-            assert.ok(!isNaN(got.getTime()), `invalid timestamp at query ${i}: ${val}`);
-            assert.ok(Math.abs(got.getTime() - ts.getTime()) < 60000, `timestamp mismatch at query ${i}: expected ~${ts.toISOString()}, got ${got.toISOString()}`);
+            assert.ok(
+              !isNaN(got.getTime()),
+              `invalid timestamp at query ${i}: ${val}`,
+            );
+            assert.ok(
+              Math.abs(got.getTime() - ts.getTime()) < 60000,
+              `timestamp mismatch at query ${i}: expected ~${ts.toISOString()}, got ${got.toISOString()}`,
+            );
           };
         } else {
           const intVal = (i + k) * 7 + 1;
@@ -608,28 +614,36 @@ describe("postgres.js unsafe stress test (50k unique statements, 5 clients)", fu
           // Boolean + int parameters
           const flag = i % 2 === 0;
           const num = i % 1000;
-          return client`SELECT ${flag}::bool AS flag, ${num}::int AS num`.then((rows) => {
-            assert.strictEqual(rows[0].flag, flag);
-            assert.strictEqual(rows[0].num, num);
-          });
+          return client`SELECT ${flag}::bool AS flag, ${num}::int AS num`.then(
+            (rows) => {
+              assert.strictEqual(rows[0].flag, flag);
+              assert.strictEqual(rows[0].num, num);
+            },
+          );
         }
         case 4: {
           // Timestamp parameter
           const ts = new Date(1700000000000 + i * 1000);
           return client`SELECT ${ts}::timestamptz AS ts`.then((rows) => {
-            const got = rows[0].ts instanceof Date ? rows[0].ts : new Date(rows[0].ts);
+            const got =
+              rows[0].ts instanceof Date ? rows[0].ts : new Date(rows[0].ts);
             assert.ok(Math.abs(got.getTime() - ts.getTime()) < 60000);
           });
         }
         case 5: {
           // Many parameters (4)
-          const a = i % 100, b = i % 50, c = i % 25, d = i % 10;
-          return client`SELECT ${a}::int AS a, ${b}::int AS b, ${c}::int AS c, ${d}::int AS d`.then((rows) => {
-            assert.strictEqual(rows[0].a, a);
-            assert.strictEqual(rows[0].b, b);
-            assert.strictEqual(rows[0].c, c);
-            assert.strictEqual(rows[0].d, d);
-          });
+          const a = i % 100,
+            b = i % 50,
+            c = i % 25,
+            d = i % 10;
+          return client`SELECT ${a}::int AS a, ${b}::int AS b, ${c}::int AS c, ${d}::int AS d`.then(
+            (rows) => {
+              assert.strictEqual(rows[0].a, a);
+              assert.strictEqual(rows[0].b, b);
+              assert.strictEqual(rows[0].c, c);
+              assert.strictEqual(rows[0].d, d);
+            },
+          );
         }
       }
     }
@@ -652,29 +666,31 @@ describe("postgres.js unsafe stress test (50k unique statements, 5 clients)", fu
         if (i % 2 === 0) {
           // Even: unsafe query (unique query text each time)
           const { queryText, vals, expected } = buildQuery(i);
-          p = client
-            .unsafe(queryText, vals)
-            .then((rows) => {
-              for (const [col, val] of Object.entries(expected)) {
-                if (typeof val === "function") {
-                  val(rows[0][col]);
-                } else {
-                  assert.strictEqual(
-                    rows[0][col],
-                    val,
-                    `mismatch at query ${i}, col ${col}`,
-                  );
-                }
+          p = client.unsafe(queryText, vals).then((rows) => {
+            for (const [col, val] of Object.entries(expected)) {
+              if (typeof val === "function") {
+                val(rows[0][col]);
+              } else {
+                assert.strictEqual(
+                  rows[0][col],
+                  val,
+                  `mismatch at query ${i}, col ${col}`,
+                );
               }
-            });
+            }
+          });
         } else {
           // Odd: tagged template (reused SQL text, unnamed prepared statements)
           p = taggedQuery(client, i);
         }
 
         p = p
-          .then(() => { completed++; })
-          .catch((err) => { errors.push({ i, err: err.message }); });
+          .then(() => {
+            completed++;
+          })
+          .catch((err) => {
+            errors.push({ i, err: err.message });
+          });
 
         promises.push(p);
       }
@@ -703,8 +719,8 @@ describe("postgres.js unsafe stress test (50k unique statements, 5 clients)", fu
       .map((l) => parseInt(l.split(" ").pop(), 10))
       .reduce((a, b) => a + b, 0);
     assert.ok(
-      evictions > 0,
-      `expected prepared statement evictions, got ${evictions}`,
+      evictions === 0,
+      `expected no prepared statement evictions, got ${evictions}`,
     );
   });
 });

--- a/integration/js/pg_tests/test/postgres_js.js
+++ b/integration/js/pg_tests/test/postgres_js.js
@@ -705,7 +705,8 @@ describe("postgres.js unsafe stress test (50k unique statements, 5 clients)", fu
     );
     assert.strictEqual(completed, TOTAL_QUERIES);
 
-    // Verify backend prepared statement evictions are happening.
+    // Verify backend prepared statement evictions are not happening
+    // because prepared statements are not cached (extended_anonymous).
     const res = await fetch("http://127.0.0.1:9090");
     const metrics = await res.text();
     const evictions = metrics

--- a/pgdog-stats/src/pool.rs
+++ b/pgdog-stats/src/pool.rs
@@ -3,7 +3,7 @@ use std::{
     time::Duration,
 };
 
-use pgdog_config::{PoolerMode, pooling::ConnectionRecovery};
+use pgdog_config::{PoolerMode, PreparedStatements, pooling::ConnectionRecovery};
 use serde::{Deserialize, Serialize};
 
 use crate::{LsnStats, ReplicaLag};
@@ -329,6 +329,8 @@ pub struct Config {
     pub resharding_only: bool,
     /// LB weight.
     pub lb_weight: u8,
+    /// Prepared statements level.
+    pub prepared_statements_level: PreparedStatements,
 }
 
 impl Default for Config {
@@ -366,6 +368,7 @@ impl Default for Config {
             role_detection: false,
             resharding_only: false,
             lb_weight: 255,
+            prepared_statements_level: PreparedStatements::default(),
         }
     }
 }

--- a/pgdog/src/backend/pool/config.rs
+++ b/pgdog/src/backend/pool/config.rs
@@ -145,6 +145,7 @@ impl Config {
                 role_detection: database.role == Role::Auto,
                 resharding_only: database.resharding_only,
                 lb_weight: database.lb_weight,
+                prepared_statements_level: general.prepared_statements,
                 ..Default::default()
             },
         }

--- a/pgdog/src/backend/pool/pool_impl.rs
+++ b/pgdog/src/backend/pool/pool_impl.rs
@@ -164,6 +164,9 @@ impl Pool {
             server
                 .prepared_statements_mut()
                 .set_capacity(self.inner.config.prepared_statements_limit);
+            server
+                .prepared_statements_mut()
+                .set_prepared_statements_level(self.inner.config.prepared_statements_level);
             server.set_pooler_mode(self.inner.config.pooler_mode);
 
             match self

--- a/pgdog/src/backend/prepared_statements.rs
+++ b/pgdog/src/backend/prepared_statements.rs
@@ -293,8 +293,6 @@ impl PreparedStatements {
                 self.state.action(code)?;
             }
 
-            'Z' => {}
-
             _ => (),
         }
 
@@ -439,4 +437,385 @@ impl PreparedStatements {
 
         close
     }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::frontend::PreparedStatements as FrontendPreparedStatements;
+    use crate::net::{
+        bind::Parameter, Bind, Describe, Execute, Parse, ProtocolMessage, Query, Sync,
+    };
+    use pgdog_config::PreparedStatements as PreparedStatementsLevel;
+
+    /// Build a PreparedStatements instance configured for ExtendedAnonymous mode.
+    fn new_extended_anonymous() -> PreparedStatements {
+        let mut ps = PreparedStatements::new();
+        ps.set_prepared_statements_level(PreparedStatementsLevel::ExtendedAnonymous);
+        ps
+    }
+
+    /// Build a PreparedStatements instance configured for Extended (default) mode.
+    fn new_extended() -> PreparedStatements {
+        let mut ps = PreparedStatements::new();
+        ps.set_prepared_statements_level(PreparedStatementsLevel::Extended);
+        ps
+    }
+
+    /// Insert a prepared statement into the global cache so check_prepared can find it.
+    fn insert_global(name: &str, query: &str) -> String {
+        let parse = Parse::named(name, query);
+        let (_, rewritten_name) = FrontendPreparedStatements::global().write().insert(&parse);
+        rewritten_name
+    }
+
+    // -------------------------------------------------------
+    // Parse message tests
+    // -------------------------------------------------------
+
+    #[test]
+    fn parse_named_extended_mode_forwards() {
+        let mut ps = new_extended();
+        let parse = Parse::named("stmt1", "SELECT 1");
+        let result = ps.handle(&ProtocolMessage::Parse(parse)).unwrap();
+        assert!(matches!(result, HandleResult::Forward));
+    }
+
+    #[test]
+    fn parse_named_extended_anonymous_mode_rewrites_to_anonymous() {
+        let mut ps = new_extended_anonymous();
+        let parse = Parse::named("stmt1", "SELECT 1");
+        let result = ps.handle(&ProtocolMessage::Parse(parse)).unwrap();
+        match result {
+            HandleResult::Rewrite(ProtocolMessage::Parse(p)) => {
+                assert!(p.anonymous(), "Parse should be anonymized");
+                assert_eq!(p.query(), "SELECT 1");
+            }
+            other => panic!("expected Rewrite(Parse), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_anonymous_unchanged_in_extended_anonymous_mode() {
+        let mut ps = new_extended_anonymous();
+        let parse = Parse::new_anonymous("SELECT 1");
+        let result = ps.handle(&ProtocolMessage::Parse(parse)).unwrap();
+        assert!(matches!(result, HandleResult::Forward));
+    }
+
+    #[test]
+    fn parse_already_prepared_returns_drop_in_extended_mode() {
+        let mut ps = new_extended();
+        // Simulate the statement being already prepared on this connection.
+        ps.prepared("stmt1");
+        let parse = Parse::named("stmt1", "SELECT 1");
+        let result = ps.handle(&ProtocolMessage::Parse(parse)).unwrap();
+        assert!(matches!(result, HandleResult::Drop));
+    }
+
+    #[test]
+    fn parse_already_prepared_returns_rewrite_in_extended_anonymous() {
+        let mut ps = new_extended_anonymous();
+        // Simulate the statement being already prepared on this connection.
+        ps.prepared("stmt1");
+        let parse = Parse::named("stmt1", "SELECT 1");
+        let result = ps.handle(&ProtocolMessage::Parse(parse)).unwrap();
+        // Already-prepared Parse is dropped, but since we're in extended_anonymous mode
+        // the named Parse that's not cached still gets a Rewrite.
+        // Actually, contains() returns true -> Drop is returned before rewrite_anonymous check.
+        assert!(matches!(result, HandleResult::Drop));
+    }
+
+    // -------------------------------------------------------
+    // Bind message tests
+    // -------------------------------------------------------
+
+    #[test]
+    fn bind_named_not_in_cache_extended_mode_forwards() {
+        let mut ps = new_extended();
+        let bind = Bind::new_statement("stmt1");
+        let result = ps.handle(&ProtocolMessage::Bind(bind)).unwrap();
+        // Not in cache, no global parse -> Forward
+        assert!(matches!(result, HandleResult::Forward));
+    }
+
+    #[test]
+    fn bind_named_not_in_cache_extended_anonymous_rewrites() {
+        let mut ps = new_extended_anonymous();
+        let bind = Bind::new_statement("stmt1");
+        let result = ps.handle(&ProtocolMessage::Bind(bind)).unwrap();
+        match result {
+            HandleResult::Rewrite(ProtocolMessage::Bind(b)) => {
+                assert!(b.anonymous(), "Bind should be anonymized");
+            }
+            other => panic!("expected Rewrite(Bind), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn bind_anonymous_unchanged_in_extended_anonymous() {
+        let mut ps = new_extended_anonymous();
+        let bind = Bind::new_statement("");
+        let result = ps.handle(&ProtocolMessage::Bind(bind)).unwrap();
+        assert!(matches!(result, HandleResult::Forward));
+    }
+
+    #[test]
+    fn bind_named_in_global_cache_extended_mode_prepends() {
+        let mut ps = new_extended();
+        let name = insert_global("my_stmt", "SELECT $1");
+        let bind = Bind::new_statement(&name);
+        let result = ps.handle(&ProtocolMessage::Bind(bind)).unwrap();
+        match result {
+            HandleResult::Prepend(ProtocolMessage::Parse(p)) => {
+                assert_eq!(p.query(), "SELECT $1");
+            }
+            other => panic!("expected Prepend(Parse), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn bind_named_in_global_cache_extended_anonymous_prepend_rewrite() {
+        let mut ps = new_extended_anonymous();
+        let name = insert_global("bind_test", "SELECT $1");
+        let bind = Bind::new_statement(&name);
+        let result = ps.handle(&ProtocolMessage::Bind(bind)).unwrap();
+        match result {
+            HandleResult::PrependRewrite { prepend, rewrite } => {
+                // The prepended Parse should be anonymized.
+                if let ProtocolMessage::Parse(p) = &prepend {
+                    assert!(p.anonymous(), "prepended Parse should be anonymous");
+                    assert_eq!(p.query(), "SELECT $1");
+                } else {
+                    panic!("expected prepend to be Parse");
+                }
+                // The rewritten Bind should be anonymized.
+                if let ProtocolMessage::Bind(b) = &rewrite {
+                    assert!(b.anonymous(), "rewritten Bind should be anonymous");
+                } else {
+                    panic!("expected rewrite to be Bind");
+                }
+            }
+            other => panic!("expected PrependRewrite, got {:?}", other),
+        }
+    }
+
+    // -------------------------------------------------------
+    // Describe message tests
+    // -------------------------------------------------------
+
+    #[test]
+    fn describe_named_not_in_cache_extended_anonymous_rewrites() {
+        let mut ps = new_extended_anonymous();
+        let describe = Describe::new_statement("stmt1");
+        let result = ps.handle(&ProtocolMessage::Describe(describe)).unwrap();
+        match result {
+            HandleResult::Rewrite(ProtocolMessage::Describe(d)) => {
+                assert!(d.anonymous(), "Describe should be anonymized");
+            }
+            other => panic!("expected Rewrite(Describe), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn describe_named_in_global_cache_extended_anonymous_prepend_rewrite() {
+        let mut ps = new_extended_anonymous();
+        let name = insert_global("desc_test", "SELECT $1");
+        let describe = Describe::new_statement(&name);
+        let result = ps.handle(&ProtocolMessage::Describe(describe)).unwrap();
+        match result {
+            HandleResult::PrependRewrite { prepend, rewrite } => {
+                if let ProtocolMessage::Parse(p) = &prepend {
+                    assert!(p.anonymous(), "prepended Parse should be anonymous");
+                } else {
+                    panic!("expected prepend to be Parse");
+                }
+                if let ProtocolMessage::Describe(d) = &rewrite {
+                    assert!(d.anonymous(), "rewritten Describe should be anonymous");
+                } else {
+                    panic!("expected rewrite to be Describe");
+                }
+            }
+            other => panic!("expected PrependRewrite, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn describe_named_not_in_cache_extended_mode_forwards() {
+        let mut ps = new_extended();
+        let describe = Describe::new_statement("stmt1");
+        let result = ps.handle(&ProtocolMessage::Describe(describe)).unwrap();
+        assert!(matches!(result, HandleResult::Forward));
+    }
+
+    #[test]
+    fn describe_portal_unchanged_in_extended_anonymous() {
+        let mut ps = new_extended_anonymous();
+        let describe = Describe::new_portal("myportal");
+        let result = ps.handle(&ProtocolMessage::Describe(describe)).unwrap();
+        // Portal describes are not rewritten.
+        assert!(matches!(result, HandleResult::Forward));
+    }
+
+    // -------------------------------------------------------
+    // Close message tests
+    // -------------------------------------------------------
+
+    #[test]
+    fn close_named_is_dropped_in_both_modes() {
+        for mut ps in [new_extended(), new_extended_anonymous()] {
+            let result = ps
+                .handle(&ProtocolMessage::Close(Close::named("stmt1")))
+                .unwrap();
+            assert!(
+                matches!(result, HandleResult::Drop),
+                "named Close should be dropped"
+            );
+        }
+    }
+
+    // -------------------------------------------------------
+    // Forward response: cache clearing in extended_anonymous
+    // -------------------------------------------------------
+
+    #[test]
+    fn forward_clears_local_cache_on_ready_for_query_in_extended_anonymous() {
+        let mut ps = new_extended_anonymous();
+        ps.prepared("stmt1");
+        ps.prepared("stmt2");
+        assert_eq!(ps.len(), 2);
+
+        // Simulate a ReadyForQuery message.
+        // First we need to add a 'Z' to the state so we can action it.
+        ps.state.add('Z');
+        let rfq = Message::new(ReadyForQuery::idle().to_bytes().unwrap());
+        ps.forward(&rfq).unwrap();
+
+        // In extended_anonymous mode, cache should be cleared after done.
+        assert_eq!(ps.len(), 0, "local cache should be cleared after RFQ");
+    }
+
+    #[test]
+    fn forward_keeps_cache_on_ready_for_query_in_extended_mode() {
+        let mut ps = new_extended();
+        ps.prepared("stmt1");
+        ps.prepared("stmt2");
+        assert_eq!(ps.len(), 2);
+
+        ps.state.add('Z');
+        let rfq = Message::new(ReadyForQuery::idle().to_bytes().unwrap());
+        ps.forward(&rfq).unwrap();
+
+        // In extended mode, cache should be preserved.
+        assert_eq!(
+            ps.len(),
+            2,
+            "local cache should be preserved in extended mode"
+        );
+    }
+
+    // -------------------------------------------------------
+    // Full Parse-Bind-Execute-Sync cycle tests
+    // -------------------------------------------------------
+
+    #[test]
+    fn full_cycle_extended_anonymous_all_messages_anonymized() {
+        let mut ps = new_extended_anonymous();
+
+        // Parse
+        let parse = Parse::named("stmt1", "SELECT $1");
+        let result = ps.handle(&ProtocolMessage::Parse(parse)).unwrap();
+        match &result {
+            HandleResult::Rewrite(ProtocolMessage::Parse(p)) => {
+                assert!(p.anonymous());
+            }
+            other => panic!("expected Rewrite(Parse), got {:?}", other),
+        }
+
+        // Bind
+        let bind = Bind::new_params(
+            "stmt1",
+            &[Parameter {
+                len: 1,
+                data: "1".as_bytes().into(),
+            }],
+        );
+        let result = ps.handle(&ProtocolMessage::Bind(bind)).unwrap();
+        match &result {
+            HandleResult::Rewrite(ProtocolMessage::Bind(b)) => {
+                assert!(b.anonymous());
+            }
+            other => panic!("expected Rewrite(Bind), got {:?}", other),
+        }
+
+        // Execute
+        let result = ps
+            .handle(&ProtocolMessage::Execute(Execute::new()))
+            .unwrap();
+        assert!(matches!(result, HandleResult::Forward));
+
+        // Sync
+        let result = ps.handle(&ProtocolMessage::Sync(Sync)).unwrap();
+        assert!(matches!(result, HandleResult::Forward));
+    }
+
+    #[test]
+    fn full_cycle_extended_mode_no_rewriting() {
+        let mut ps = new_extended();
+
+        let parse = Parse::named("stmt1", "SELECT $1");
+        let result = ps.handle(&ProtocolMessage::Parse(parse)).unwrap();
+        assert!(matches!(result, HandleResult::Forward));
+
+        let bind = Bind::new_params(
+            "stmt1",
+            &[Parameter {
+                len: 1,
+                data: "1".as_bytes().into(),
+            }],
+        );
+        let result = ps.handle(&ProtocolMessage::Bind(bind)).unwrap();
+        assert!(matches!(result, HandleResult::Forward));
+
+        let result = ps
+            .handle(&ProtocolMessage::Execute(Execute::new()))
+            .unwrap();
+        assert!(matches!(result, HandleResult::Forward));
+
+        let result = ps.handle(&ProtocolMessage::Sync(Sync)).unwrap();
+        assert!(matches!(result, HandleResult::Forward));
+    }
+
+    // -------------------------------------------------------
+    // Simple query is unaffected by mode
+    // -------------------------------------------------------
+
+    #[test]
+    fn simple_query_unaffected_by_extended_anonymous() {
+        let mut ps = new_extended_anonymous();
+        let result = ps
+            .handle(&ProtocolMessage::Query(Query::new("SELECT 1")))
+            .unwrap();
+        assert!(matches!(result, HandleResult::Forward));
+    }
+
+    // -------------------------------------------------------
+    // Execute/Sync are always forwarded regardless of mode
+    // -------------------------------------------------------
+
+    #[test]
+    fn execute_and_sync_always_forward() {
+        for mut ps in [new_extended(), new_extended_anonymous()] {
+            let result = ps
+                .handle(&ProtocolMessage::Execute(Execute::new()))
+                .unwrap();
+            assert!(matches!(result, HandleResult::Forward));
+
+            let result = ps.handle(&ProtocolMessage::Sync(Sync)).unwrap();
+            assert!(matches!(result, HandleResult::Forward));
+        }
+    }
+
+    use crate::net::messages::ReadyForQuery;
+    use crate::net::Message;
 }

--- a/pgdog/src/backend/prepared_statements.rs
+++ b/pgdog/src/backend/prepared_statements.rs
@@ -201,10 +201,9 @@ impl PreparedStatements {
                         self.state.add('1');
                         self.parses.push_back(parse.name().to_string());
                     }
-                    // If we're naming prepared statements,
-                    // but client is using anonymous ones,
-                    // we should make them anonymous here too
-                    // so we don't store them in Postgres for no reason.
+                    // The client is sending named prepared statements,
+                    // but we're in ExtendedAnonymous mode so we rewrite
+                    // them to anonymous to avoid storing them in Postgres.
                     if self.level.rewrite_anonymous() {
                         let mut parse = parse.clone();
                         parse.anonymize();
@@ -444,7 +443,8 @@ mod test {
     use super::*;
     use crate::frontend::PreparedStatements as FrontendPreparedStatements;
     use crate::net::{
-        bind::Parameter, Bind, Describe, Execute, Parse, ProtocolMessage, Query, Sync,
+        bind::Parameter, messages::ReadyForQuery, Bind, Describe, Execute, Message, Parse,
+        ProtocolMessage, Query, Sync,
     };
     use pgdog_config::PreparedStatements as PreparedStatementsLevel;
 
@@ -520,9 +520,7 @@ mod test {
         ps.prepared("stmt1");
         let parse = Parse::named("stmt1", "SELECT 1");
         let result = ps.handle(&ProtocolMessage::Parse(parse)).unwrap();
-        // Already-prepared Parse is dropped, but since we're in extended_anonymous mode
-        // the named Parse that's not cached still gets a Rewrite.
-        // Actually, contains() returns true -> Drop is returned before rewrite_anonymous check.
+        // contains() returns true so Drop is returned before the rewrite_anonymous check.
         assert!(matches!(result, HandleResult::Drop));
     }
 
@@ -815,7 +813,4 @@ mod test {
             assert!(matches!(result, HandleResult::Forward));
         }
     }
-
-    use crate::net::messages::ReadyForQuery;
-    use crate::net::Message;
 }

--- a/pgdog/src/backend/prepared_statements.rs
+++ b/pgdog/src/backend/prepared_statements.rs
@@ -1,8 +1,6 @@
 use lru::LruCache;
 use std::{collections::VecDeque, sync::Arc};
 
-use parking_lot::RwLock;
-
 use crate::{
     frontend::{self, prepared_statements::GlobalCache},
     net::{
@@ -11,6 +9,8 @@ use crate::{
         ToBytes,
     },
 };
+use parking_lot::RwLock;
+use pgdog_config::PreparedStatements as PreparedStatementsLevel;
 
 use super::Error;
 use super::{
@@ -29,6 +29,11 @@ pub enum HandleResult {
     Forward,
     Drop,
     Prepend(ProtocolMessage),
+    Rewrite(ProtocolMessage),
+    PrependRewrite {
+        prepend: ProtocolMessage,
+        rewrite: ProtocolMessage,
+    },
 }
 
 /// Server-specific prepared statements.
@@ -47,6 +52,7 @@ pub struct PreparedStatements {
     describes: VecDeque<String>,
     capacity: usize,
     memory_used: usize,
+    level: PreparedStatementsLevel,
 }
 
 impl Default for PreparedStatements {
@@ -66,6 +72,7 @@ impl PreparedStatements {
             describes: VecDeque::new(),
             capacity: usize::MAX,
             memory_used: 0,
+            level: PreparedStatementsLevel::default(),
         }
     }
 
@@ -73,6 +80,11 @@ impl PreparedStatements {
     #[inline]
     pub fn set_capacity(&mut self, capacity: usize) {
         self.capacity = capacity;
+    }
+
+    #[inline]
+    pub fn set_prepared_statements_level(&mut self, level: PreparedStatementsLevel) {
+        self.level = level;
     }
 
     /// Get prepared statements capacity.
@@ -87,15 +99,30 @@ impl PreparedStatements {
                 if !bind.anonymous() {
                     let message = self.check_prepared(bind.statement())?;
                     match message {
-                        Some(message) => {
+                        Some(mut message) => {
                             self.state.add_ignore('1');
                             self.parses.push_back(bind.statement().to_string());
                             self.state.add('2');
-                            return Ok(HandleResult::Prepend(message));
+                            if self.level.rewrite_anonymous() {
+                                message.anonymize();
+                                let mut bind = bind.clone();
+                                bind.anonymize();
+                                return Ok(HandleResult::PrependRewrite {
+                                    prepend: message,
+                                    rewrite: ProtocolMessage::Bind(bind),
+                                });
+                            } else {
+                                return Ok(HandleResult::Prepend(message));
+                            }
                         }
 
                         None => {
                             self.state.add('2');
+                            if self.level.rewrite_anonymous() {
+                                let mut bind = bind.clone();
+                                bind.anonymize();
+                                return Ok(HandleResult::Rewrite(ProtocolMessage::Bind(bind)));
+                            }
                         }
                     }
                 } else {
@@ -107,22 +134,44 @@ impl PreparedStatements {
                     let message = self.check_prepared(describe.statement())?;
 
                     match message {
-                        Some(message) => {
+                        Some(mut message) => {
                             self.state.add_ignore('1');
                             self.parses.push_back(describe.statement().to_string());
                             self.state.add(ExecutionCode::DescriptionOrNothing); // t
                             self.state.add(ExecutionCode::DescriptionOrNothing); // T
-                            return Ok(HandleResult::Prepend(message));
+
+                            if self.level.rewrite_anonymous() {
+                                // Save the RowDescription because
+                                // we don't actually save prepared statements in the server
+                                // anymore so they can be different every time.
+                                self.describes.push_back(describe.statement().to_string());
+
+                                message.anonymize();
+                                let mut describe = describe.clone();
+                                describe.anonymize();
+                                return Ok(HandleResult::PrependRewrite {
+                                    prepend: message,
+                                    rewrite: ProtocolMessage::Describe(describe),
+                                });
+                            } else {
+                                return Ok(HandleResult::Prepend(message));
+                            }
                         }
 
                         None => {
                             self.state.add(ExecutionCode::DescriptionOrNothing); // t
                             self.state.add(ExecutionCode::DescriptionOrNothing);
                             // T
+                            self.describes.push_back(describe.statement().to_string());
+                            if self.level.rewrite_anonymous() {
+                                let mut describe = describe.clone();
+                                describe.anonymize();
+                                return Ok(HandleResult::Rewrite(ProtocolMessage::Describe(
+                                    describe,
+                                )));
+                            }
                         }
                     }
-
-                    self.describes.push_back(describe.statement().to_string());
                 } else if describe.is_portal() {
                     self.state.add(ExecutionCode::DescriptionOrNothing);
                 } else if describe.is_statement() {
@@ -151,6 +200,15 @@ impl PreparedStatements {
                     } else {
                         self.state.add('1');
                         self.parses.push_back(parse.name().to_string());
+                    }
+                    // If we're naming prepared statements,
+                    // but client is using anonymous ones,
+                    // we should make them anonymous here too
+                    // so we don't store them in Postgres for no reason.
+                    if self.level.rewrite_anonymous() {
+                        let mut parse = parse.clone();
+                        parse.anonymize();
+                        return Ok(HandleResult::Rewrite(ProtocolMessage::Parse(parse)));
                     }
                 } else {
                     self.state.add('1');
@@ -235,7 +293,15 @@ impl PreparedStatements {
                 self.state.action(code)?;
             }
 
+            'Z' => {}
+
             _ => (),
+        }
+
+        // Reset cache, forcing all Bind/Execute, Describe, solo requests
+        // to always re-prepare the statement next time it's sent.
+        if !self.has_more_messages() && self.level.rewrite_anonymous() {
+            self.clear();
         }
 
         match action {

--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -385,6 +385,11 @@ impl Server {
             HandleResult::Drop => [None, None],
             HandleResult::Prepend(ref prepare) => [Some(prepare), Some(message)],
             HandleResult::Forward => [Some(message), None],
+            HandleResult::Rewrite(ref message) => [Some(message), None],
+            HandleResult::PrependRewrite {
+                ref prepend,
+                ref rewrite,
+            } => [Some(prepend), Some(rewrite)],
         };
 
         for message in queue.iter().flatten() {

--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -3645,6 +3645,13 @@ pub mod test {
                 0,
                 "cache should be cleared after RFQ in extended_anonymous mode"
             );
+            // Verify Postgres has no named prepared statements stored.
+            server.sync_prepared_statements().await.unwrap();
+            assert_eq!(
+                server.prepared_statements.len(),
+                0,
+                "Postgres should have no prepared statements in extended_anonymous mode"
+            );
         }
     }
 
@@ -3678,6 +3685,9 @@ pub mod test {
         }
 
         assert!(server.done());
+        assert_eq!(server.prepared_statements.len(), 0);
+        // Verify Postgres has no named prepared statements stored.
+        server.sync_prepared_statements().await.unwrap();
         assert_eq!(server.prepared_statements.len(), 0);
     }
 
@@ -3727,6 +3737,13 @@ pub mod test {
 
             assert!(server.done());
         }
+        // Verify Postgres has no named prepared statements stored.
+        server.sync_prepared_statements().await.unwrap();
+        assert_eq!(
+            server.prepared_statements.len(),
+            0,
+            "Postgres should have no prepared statements after repeated anonymous usage"
+        );
     }
 
     #[tokio::test]
@@ -3757,6 +3774,9 @@ pub mod test {
         }
 
         assert!(server.done());
+        // Verify Postgres has no named prepared statements stored.
+        server.sync_prepared_statements().await.unwrap();
+        assert_eq!(server.prepared_statements.len(), 0);
     }
 
     #[tokio::test]
@@ -3788,6 +3808,9 @@ pub mod test {
 
         // Server should still be usable.
         verify_server_usable(&mut server).await;
+        // Verify Postgres has no named prepared statements stored.
+        server.sync_prepared_statements().await.unwrap();
+        assert_eq!(server.prepared_statements.len(), 0);
     }
 
     #[tokio::test]
@@ -3836,6 +3859,9 @@ pub mod test {
         }
 
         assert!(server.done());
+        // Verify Postgres has no named prepared statements stored.
+        server.sync_prepared_statements().await.unwrap();
+        assert_eq!(server.prepared_statements.len(), 0);
     }
 
     #[tokio::test]
@@ -3881,5 +3907,12 @@ pub mod test {
             // Cache should always be empty after RFQ in extended_anonymous mode.
             assert!(server.prepared_statements.ensure_capacity().is_empty());
         }
+        // Verify Postgres has no named prepared statements stored.
+        server.sync_prepared_statements().await.unwrap();
+        assert_eq!(
+            server.prepared_statements.len(),
+            0,
+            "Postgres should have no prepared statements despite many named parses"
+        );
     }
 }

--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -3591,4 +3591,295 @@ pub mod test {
         assert!(server.force_close());
         assert_eq!(server.stats().get_state(), State::ForceClose);
     }
+
+    // -------------------------------------------------------
+    // Extended anonymous mode integration tests
+    // -------------------------------------------------------
+
+    /// Set a server's prepared_statements level to ExtendedAnonymous.
+    fn set_extended_anonymous(server: &mut Server) {
+        use pgdog_config::PreparedStatements as PSLevel;
+        server
+            .prepared_statements_mut()
+            .set_prepared_statements_level(PSLevel::ExtendedAnonymous);
+    }
+
+    #[tokio::test]
+    async fn test_extended_anonymous_parse_bind_execute() {
+        use crate::net::bind::Parameter;
+        let mut server = test_server().await;
+        set_extended_anonymous(&mut server);
+
+        for _ in 0..10 {
+            let parse = Parse::named("stmt1", "SELECT $1::int");
+            let bind = Bind::new_params(
+                "stmt1",
+                &[Parameter {
+                    len: 1,
+                    data: "5".as_bytes().into(),
+                }],
+            );
+
+            server
+                .send(
+                    &vec![
+                        ProtocolMessage::from(parse),
+                        ProtocolMessage::from(bind),
+                        Execute::new().into(),
+                        Sync.into(),
+                    ]
+                    .into(),
+                )
+                .await
+                .unwrap();
+
+            for c in ['1', '2', 'D', 'C', 'Z'] {
+                let msg = server.read().await.unwrap();
+                assert_eq!(msg.code(), c);
+            }
+
+            assert!(server.done());
+            // In extended_anonymous mode, local cache is cleared after each transaction.
+            assert_eq!(
+                server.prepared_statements.len(),
+                0,
+                "cache should be cleared after RFQ in extended_anonymous mode"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_extended_anonymous_describe() {
+        let mut server = test_server().await;
+        set_extended_anonymous(&mut server);
+
+        let parse = Parse::named("desc_stmt", "SELECT 1::int AS num, 'hello'::text AS msg");
+        let describe = Describe::new_statement("desc_stmt");
+        let bind = Bind::new_statement("desc_stmt");
+        let execute = Execute::new();
+
+        server
+            .send(
+                &vec![
+                    ProtocolMessage::from(parse),
+                    describe.into(),
+                    bind.into(),
+                    execute.into(),
+                    Sync.into(),
+                ]
+                .into(),
+            )
+            .await
+            .unwrap();
+
+        for c in ['1', 't', 'T', '2', 'D', 'C', 'Z'] {
+            let msg = server.read().await.unwrap();
+            assert_eq!(msg.code(), c);
+        }
+
+        assert!(server.done());
+        assert_eq!(server.prepared_statements.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_extended_anonymous_repeated_same_statement() {
+        use crate::net::bind::Parameter;
+        let mut server = test_server().await;
+        set_extended_anonymous(&mut server);
+
+        // Using the same statement name repeatedly should work because
+        // in extended_anonymous mode, Parse is always anonymized, so Postgres
+        // never stores a named statement. No "already exists" errors.
+        for i in 0..20 {
+            let parse = Parse::named("repeat_stmt", "SELECT $1::int");
+            let bind = Bind::new_params(
+                "repeat_stmt",
+                &[Parameter {
+                    len: 1,
+                    data: "1".as_bytes().into(),
+                }],
+            );
+
+            server
+                .send(
+                    &vec![
+                        ProtocolMessage::from(parse),
+                        ProtocolMessage::from(bind),
+                        Execute::new().into(),
+                        Sync.into(),
+                    ]
+                    .into(),
+                )
+                .await
+                .unwrap();
+
+            for c in ['1', '2', 'D', 'C', 'Z'] {
+                let msg = server.read().await.unwrap();
+                assert_eq!(
+                    msg.code(),
+                    c,
+                    "iteration {}: expected '{}' got '{}'",
+                    i,
+                    c,
+                    msg.code()
+                );
+            }
+
+            assert!(server.done());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_extended_anonymous_close_is_dropped() {
+        let mut server = test_server().await;
+        set_extended_anonymous(&mut server);
+
+        // Parse + Sync first.
+        server
+            .send(&vec![Parse::named("to_close", "SELECT 1").into(), Sync.into()].into())
+            .await
+            .unwrap();
+
+        for c in ['1', 'Z'] {
+            let msg = server.read().await.unwrap();
+            assert_eq!(msg.code(), c);
+        }
+
+        // Close should be dropped (simulated CloseComplete).
+        server
+            .send(&vec![Close::named("to_close").into(), Sync.into()].into())
+            .await
+            .unwrap();
+
+        for c in ['3', 'Z'] {
+            let msg = server.read().await.unwrap();
+            assert_eq!(msg.code(), c);
+        }
+
+        assert!(server.done());
+    }
+
+    #[tokio::test]
+    async fn test_extended_anonymous_error_recovery() {
+        let mut server = test_server().await;
+        set_extended_anonymous(&mut server);
+
+        // Send a bad query via extended protocol.
+        server
+            .send(
+                &vec![
+                    Parse::named("bad_stmt", "SELECT * FROM nonexistent_table_xyz").into(),
+                    Bind::new_statement("bad_stmt").into(),
+                    Execute::new().into(),
+                    Sync.into(),
+                ]
+                .into(),
+            )
+            .await
+            .unwrap();
+
+        // Should get error then RFQ.
+        let msg = server.read().await.unwrap();
+        assert_eq!(msg.code(), 'E');
+        let msg = server.read().await.unwrap();
+        assert_eq!(msg.code(), 'Z');
+
+        assert!(server.done());
+
+        // Server should still be usable.
+        verify_server_usable(&mut server).await;
+    }
+
+    #[tokio::test]
+    async fn test_extended_anonymous_mixed_with_simple_query() {
+        use crate::net::bind::Parameter;
+        let mut server = test_server().await;
+        set_extended_anonymous(&mut server);
+
+        // Extended protocol.
+        server
+            .send(
+                &vec![
+                    Parse::named("mix_stmt", "SELECT $1::int").into(),
+                    Bind::new_params(
+                        "mix_stmt",
+                        &[Parameter {
+                            len: 1,
+                            data: "7".as_bytes().into(),
+                        }],
+                    )
+                    .into(),
+                    Execute::new().into(),
+                    Sync.into(),
+                ]
+                .into(),
+            )
+            .await
+            .unwrap();
+
+        for c in ['1', '2', 'D', 'C', 'Z'] {
+            let msg = server.read().await.unwrap();
+            assert_eq!(msg.code(), c);
+        }
+
+        assert!(server.done());
+
+        // Simple query right after.
+        server
+            .send(&vec![Query::new("SELECT 42").into()].into())
+            .await
+            .unwrap();
+
+        for c in ['T', 'D', 'C', 'Z'] {
+            let msg = server.read().await.unwrap();
+            assert_eq!(msg.code(), c);
+        }
+
+        assert!(server.done());
+    }
+
+    #[tokio::test]
+    async fn test_extended_anonymous_no_evictions() {
+        use crate::net::bind::Parameter;
+        let mut server = test_server().await;
+        set_extended_anonymous(&mut server);
+        server.prepared_statements_mut().set_capacity(3);
+
+        // Send many different "named" statements.
+        // Because they're all anonymized, no named statements are stored in Postgres,
+        // so there should be no evictions.
+        for i in 0..20 {
+            let name = format!("evict_test_{}", i);
+            let parse = Parse::named(&name, "SELECT $1::int");
+            let bind = Bind::new_params(
+                &name,
+                &[Parameter {
+                    len: 1,
+                    data: "1".as_bytes().into(),
+                }],
+            );
+
+            server
+                .send(
+                    &vec![
+                        ProtocolMessage::from(parse),
+                        ProtocolMessage::from(bind),
+                        Execute::new().into(),
+                        Sync.into(),
+                    ]
+                    .into(),
+                )
+                .await
+                .unwrap();
+
+            for c in ['1', '2', 'D', 'C', 'Z'] {
+                let msg = server.read().await.unwrap();
+                assert_eq!(msg.code(), c);
+            }
+
+            assert!(server.done());
+            // Cache should always be empty after RFQ in extended_anonymous mode.
+            assert!(server.prepared_statements.ensure_capacity().is_empty());
+        }
+    }
 }

--- a/pgdog/src/frontend/client/query_engine/test/extended_anonymous.rs
+++ b/pgdog/src/frontend/client/query_engine/test/extended_anonymous.rs
@@ -1,0 +1,203 @@
+use pgdog_config::PreparedStatements as PreparedStatementsLevel;
+
+use crate::{
+    expect_message,
+    net::{
+        bind::Parameter, BindComplete, CommandComplete, DataRow, Parameters, ParseComplete,
+        ReadyForQuery, RowDescription,
+    },
+};
+
+use super::{change_config, prelude::*};
+
+fn set_extended_anonymous() {
+    change_config(|g| {
+        g.prepared_statements = PreparedStatementsLevel::ExtendedAnonymous;
+    });
+}
+
+/// Extended protocol with named prepared statement works in extended_anonymous mode.
+/// The same sequence of messages that works in regular extended mode must also work here.
+#[tokio::test]
+async fn test_extended_anonymous_basic() {
+    let mut client = TestClient::new_replicas(Parameters::default()).await;
+    set_extended_anonymous();
+
+    client.send(Parse::named("test", "SELECT $1")).await;
+    client
+        .send(Bind::new_params(
+            "test",
+            &[Parameter {
+                len: 3,
+                data: "123".into(),
+            }],
+        ))
+        .await;
+    client.send(Execute::new()).await;
+    client.send(Sync).await;
+    client.try_process().await.unwrap();
+
+    expect_message!(client.read().await, ParseComplete); // '1'
+    expect_message!(client.read().await, BindComplete); // '2'
+    let row = expect_message!(client.read().await, DataRow); // 'D'
+    assert_eq!(
+        row.get::<String>(0, crate::net::Format::Text),
+        Some("123".into())
+    );
+    expect_message!(client.read().await, CommandComplete); // 'C'
+    let rfq = expect_message!(client.read().await, ReadyForQuery); // 'Z'
+    assert_eq!(rfq.status, 'I');
+}
+
+/// Extended protocol with Describe works in extended_anonymous mode.
+#[tokio::test]
+async fn test_extended_anonymous_with_describe() {
+    let mut client = TestClient::new_replicas(Parameters::default()).await;
+    set_extended_anonymous();
+
+    client.send(Parse::named("desc_test", "SELECT $1")).await;
+    client
+        .send(Bind::new_params(
+            "desc_test",
+            &[Parameter {
+                len: 3,
+                data: "456".into(),
+            }],
+        ))
+        .await;
+    client.send(Describe::new_statement("desc_test")).await;
+    client.send(Execute::new()).await;
+    client.send(Sync).await;
+    client.try_process().await.unwrap();
+
+    expect_message!(client.read().await, ParseComplete); // '1'
+    expect_message!(client.read().await, BindComplete); // '2'
+                                                        // Describe returns ParameterDescription + RowDescription
+    client.read().await; // 't'
+    expect_message!(client.read().await, RowDescription); // 'T'
+    let row = expect_message!(client.read().await, DataRow); // 'D'
+    assert_eq!(
+        row.get::<String>(0, crate::net::Format::Text),
+        Some("456".into())
+    );
+    expect_message!(client.read().await, CommandComplete); // 'C'
+    let rfq = expect_message!(client.read().await, ReadyForQuery); // 'Z'
+    assert_eq!(rfq.status, 'I');
+}
+
+/// Transaction state is tracked correctly in extended_anonymous mode.
+#[tokio::test]
+async fn test_extended_anonymous_transaction_state() {
+    let mut client = TestClient::new_replicas(Parameters::default()).await;
+    set_extended_anonymous();
+
+    // BEGIN
+    client.send(Query::new("BEGIN")).await;
+    client.try_process().await.unwrap();
+
+    assert!(client.client().transaction.is_some());
+    expect_message!(client.read().await, CommandComplete);
+    let rfq = expect_message!(client.read().await, ReadyForQuery);
+    assert_eq!(rfq.status, 'T');
+
+    // Extended protocol inside transaction
+    client.send(Parse::named("tx_test", "SELECT $1")).await;
+    client
+        .send(Bind::new_params(
+            "tx_test",
+            &[Parameter {
+                len: 1,
+                data: "1".as_bytes().into(),
+            }],
+        ))
+        .await;
+    client.send(Execute::new()).await;
+    client.send(Sync).await;
+    client.try_process().await.unwrap();
+
+    assert!(client.client().transaction.is_some());
+
+    expect_message!(client.read().await, ParseComplete);
+    expect_message!(client.read().await, BindComplete);
+    expect_message!(client.read().await, DataRow);
+    expect_message!(client.read().await, CommandComplete);
+    let rfq = expect_message!(client.read().await, ReadyForQuery);
+    assert_eq!(rfq.status, 'T');
+
+    // COMMIT
+    client.send(Query::new("COMMIT")).await;
+    client.try_process().await.unwrap();
+
+    expect_message!(client.read().await, CommandComplete);
+    let rfq = expect_message!(client.read().await, ReadyForQuery);
+    assert_eq!(rfq.status, 'I');
+    assert!(client.client().transaction.is_none());
+}
+
+/// Close message in extended_anonymous mode is handled gracefully.
+#[tokio::test]
+async fn test_extended_anonymous_close() {
+    let mut client = TestClient::new_replicas(Parameters::default()).await;
+    set_extended_anonymous();
+
+    // Parse first
+    client.send(Parse::named("close_test", "SELECT 1")).await;
+    client.send(Sync).await;
+    client.try_process().await.unwrap();
+
+    expect_message!(client.read().await, ParseComplete);
+    expect_message!(client.read().await, ReadyForQuery);
+
+    // Close
+    client.send(Close::named("close_test")).await;
+    client.send(Sync).await;
+    client.try_process().await.unwrap();
+
+    client.read().await; // CloseComplete '3'
+    expect_message!(client.read().await, ReadyForQuery);
+}
+
+/// Multiple rounds of the same statement name work in extended_anonymous mode.
+/// This verifies there are no "prepared statement already exists" errors.
+#[tokio::test]
+async fn test_extended_anonymous_repeated_statement_name() {
+    let mut client = TestClient::new_replicas(Parameters::default()).await;
+    set_extended_anonymous();
+
+    for i in 0..5 {
+        let val = format!("{}", i);
+        client.send(Parse::named("repeated", "SELECT $1")).await;
+        client
+            .send(Bind::new_params(
+                "repeated",
+                &[Parameter::new(val.as_bytes())],
+            ))
+            .await;
+        client.send(Execute::new()).await;
+        client.send(Sync).await;
+        client.try_process().await.unwrap();
+
+        expect_message!(client.read().await, ParseComplete);
+        expect_message!(client.read().await, BindComplete);
+        let row = expect_message!(client.read().await, DataRow);
+        assert_eq!(row.get::<String>(0, crate::net::Format::Text), Some(val));
+        expect_message!(client.read().await, CommandComplete);
+        let rfq = expect_message!(client.read().await, ReadyForQuery);
+        assert_eq!(rfq.status, 'I');
+    }
+}
+
+/// Simple query protocol is unaffected by extended_anonymous mode.
+#[tokio::test]
+async fn test_extended_anonymous_simple_query_unaffected() {
+    let mut client = TestClient::new_replicas(Parameters::default()).await;
+    set_extended_anonymous();
+
+    client.send_simple(Query::new("SELECT 42")).await;
+
+    expect_message!(client.read().await, RowDescription);
+    let row = expect_message!(client.read().await, DataRow);
+    assert_eq!(row.get::<i32>(0, crate::net::Format::Text), Some(42));
+    expect_message!(client.read().await, CommandComplete);
+    expect_message!(client.read().await, ReadyForQuery);
+}

--- a/pgdog/src/frontend/client/query_engine/test/mod.rs
+++ b/pgdog/src/frontend/client/query_engine/test/mod.rs
@@ -11,6 +11,7 @@ mod advisory_lock;
 mod close_parse;
 mod close_parse_global_cache;
 mod extended;
+mod extended_anonymous;
 mod fatal_error;
 mod graceful_disconnect;
 mod graceful_shutdown;

--- a/pgdog/src/frontend/client_request.rs
+++ b/pgdog/src/frontend/client_request.rs
@@ -221,6 +221,18 @@ impl ClientRequest {
         Ok(())
     }
 
+    /// Remove all naming identifiers from this request.
+    pub fn anonymize(&mut self) {
+        for message in &mut self.messages {
+            match message {
+                ProtocolMessage::Bind(bind) => bind.anonymize(),
+                ProtocolMessage::Parse(parse) => parse.anonymize(),
+                ProtocolMessage::Describe(describe) => describe.anonymize(),
+                _ => (),
+            }
+        }
+    }
+
     /// Get the route for this client request.
     pub fn route(&self) -> &Route {
         lazy_static! {

--- a/pgdog/src/frontend/client_request.rs
+++ b/pgdog/src/frontend/client_request.rs
@@ -221,18 +221,6 @@ impl ClientRequest {
         Ok(())
     }
 
-    /// Remove all naming identifiers from this request.
-    pub fn anonymize(&mut self) {
-        for message in &mut self.messages {
-            match message {
-                ProtocolMessage::Bind(bind) => bind.anonymize(),
-                ProtocolMessage::Parse(parse) => parse.anonymize(),
-                ProtocolMessage::Describe(describe) => describe.anonymize(),
-                _ => (),
-            }
-        }
-    }
-
     /// Get the route for this client request.
     pub fn route(&self) -> &Route {
         lazy_static! {

--- a/pgdog/src/net/messages/bind.rs
+++ b/pgdog/src/net/messages/bind.rs
@@ -177,6 +177,13 @@ impl Bind {
         self.original = None;
     }
 
+    /// Make this an anonymous Bind message.
+    pub fn anonymize(&mut self) {
+        if !self.anonymous() {
+            self.rename("");
+        }
+    }
+
     /// Is this Bind message anonymous?
     pub fn anonymous(&self) -> bool {
         self.statement.len() == 1

--- a/pgdog/src/net/messages/describe.rs
+++ b/pgdog/src/net/messages/describe.rs
@@ -74,6 +74,12 @@ impl Describe {
         self.original = None;
     }
 
+    pub fn anonymize(&mut self) {
+        if !self.anonymous() {
+            self.rename("");
+        }
+    }
+
     pub fn new_statement(name: &str) -> Describe {
         let mut payload = Payload::named('D');
         payload.put_u8(b'S');

--- a/pgdog/src/net/messages/parse.rs
+++ b/pgdog/src/net/messages/parse.rs
@@ -94,6 +94,13 @@ impl Parse {
         self.original = None;
     }
 
+    /// Make this an anonymous Parse.
+    pub fn anonymize(&mut self) {
+        if !self.anonymous() {
+            self.rename_fast("");
+        }
+    }
+
     pub fn data_types(&self) -> DataTypesIter<'_> {
         DataTypesIter {
             data_types: &self.data_types,

--- a/pgdog/src/net/protocol_message.rs
+++ b/pgdog/src/net/protocol_message.rs
@@ -42,6 +42,17 @@ impl ProtocolMessage {
         }
     }
 
+    pub fn anonymize(&mut self) {
+        use ProtocolMessage::*;
+
+        match self {
+            Bind(bind) => bind.anonymize(),
+            Parse(parse) => parse.anonymize(),
+            Describe(describe) => describe.anonymize(),
+            _ => (),
+        }
+    }
+
     pub fn len(&self) -> usize {
         match self {
             Self::Bind(bind) => bind.len(),

--- a/pgdog/tests/pgbouncer/pgdog.toml
+++ b/pgdog/tests/pgbouncer/pgdog.toml
@@ -3,7 +3,7 @@ workers = 2
 min_pool_size = 0
 prepared_statements_limit = 500
 openmetrics_port = 9090
-query_parser = "session_control_and_locks"
+prepared_statements = "extended"
 
 [[databases]]
 name = "pgdog"


### PR DESCRIPTION
When using `prepared_statements = "extended_anonymous"` we were overriding clients wishes and preparing statements on the server connections anyway. This introduced a bunch of problems like:

1. Stale plans
2. Schema changes caused errors
3. Additional memory usage in Postgres

From now on, when using `extended_anonymous`,  PgDog will only send unnamed extended messages to Postgres, ensuring they are discarded at the end of each request.