### PR TITLE
refactor: move User definition to pgdog-stats

### DIFF
--- a/pgdog-stats/src/lib.rs
+++ b/pgdog-stats/src/lib.rs
@@ -6,9 +6,11 @@ pub mod resharding;
 pub mod schema;
 pub mod server;
 pub mod state;
+pub mod user;
 
 pub use memory::*;
 pub use pool::*;
 pub use replication::*;
 pub use resharding::*;
 pub use schema::*;
+pub use user::*;

--- a/pgdog-stats/src/resharding.rs
+++ b/pgdog-stats/src/resharding.rs
@@ -3,7 +3,7 @@ use std::{sync::Arc, time::SystemTime};
 use pgdog_config::ServerAuth;
 use serde::{Deserialize, Serialize};
 
-use crate::Lsn;
+use crate::{Lsn, User};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct TableCopy {
@@ -120,13 +120,4 @@ impl std::fmt::Display for SyncState {
             Self::PostCutover => write!(f, "post_cutover"),
         }
     }
-}
-
-/// Database/user pair that identifies a database cluster pool.
-#[derive(Debug, PartialEq, Hash, Eq, Clone, Default, Serialize, Deserialize)]
-pub struct User {
-    /// User name.
-    pub user: String,
-    /// Database name.
-    pub database: String,
 }

--- a/pgdog-stats/src/user.rs
+++ b/pgdog-stats/src/user.rs
@@ -1,0 +1,16 @@
+use serde::{Deserialize, Serialize};
+
+/// Database/user pair that identifies a database cluster pool.
+#[derive(Debug, PartialEq, Hash, Eq, Clone, Default, Serialize, Deserialize)]
+pub struct User {
+    /// User name.
+    pub user: String,
+    /// Database name.
+    pub database: String,
+}
+
+impl std::fmt::Display for User {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{}", self.user, self.database)
+    }
+}

--- a/pgdog/src/backend/databases.rs
+++ b/pgdog/src/backend/databases.rs
@@ -265,29 +265,7 @@ pub async fn cutover(source: &str, destination: &str) -> Result<(), Error> {
     Ok(())
 }
 
-/// Database/user pair that identifies a database cluster pool.
-#[derive(Debug, PartialEq, Hash, Eq, Clone, Default)]
-pub struct User {
-    /// User name.
-    pub user: String,
-    /// Database name.
-    pub database: String,
-}
-
-impl From<User> for pgdog_stats::User {
-    fn from(value: User) -> Self {
-        Self {
-            user: value.user,
-            database: value.database,
-        }
-    }
-}
-
-impl std::fmt::Display for User {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}/{}", self.user, self.database)
-    }
-}
+pub use pgdog_stats::User;
 
 /// Convert to a database/user pair.
 pub trait ToUser {


### PR DESCRIPTION
Allows it to be re-used between EE and OS code.