### PR TITLE
feat(pool): jitter for server_lifetime

### DIFF
--- a/.schema/pgdog.schema.json
+++ b/.schema/pgdog.schema.json
@@ -97,6 +97,7 @@
         "resharding_parallel_copies": 1,
         "rollback_timeout": 5000,
         "server_lifetime": 86400000,
+        "server_lifetime_jitter": 0,
         "shutdown_termination_timeout": null,
         "shutdown_timeout": 60000,
         "stats_period": 15000,
@@ -469,6 +470,15 @@
         },
         "server_lifetime": {
           "description": "Overrides the `server_lifetime` setting. Server connections older than this will be closed when returned to the pool.\n\nhttps://docs.pgdog.dev/configuration/pgdog.toml/databases/#server_lifetime",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0
+        },
+        "server_lifetime_jitter": {
+          "description": "Overrides the `server_lifetime_jitter` setting for this database.\n\nhttps://docs.pgdog.dev/configuration/pgdog.toml/databases/#server_lifetime_jitter",
           "type": [
             "integer",
             "null"
@@ -1014,6 +1024,13 @@
           "type": "integer",
           "format": "uint64",
           "default": 86400000,
+          "minimum": 0
+        },
+        "server_lifetime_jitter": {
+          "description": "Maximum random adjustment applied to `server_lifetime` per backend\nconnection, in milliseconds. Each connection's effective lifetime\nis sampled uniformly from `[server_lifetime - jitter,\nserver_lifetime + jitter]` once at creation time, breaking up\nsynchronized cohorts that would otherwise expire together.\n\n_Default:_ `0` (no jitter; existing behavior).\n\nhttps://docs.pgdog.dev/configuration/pgdog.toml/general/#server_lifetime_jitter",
+          "type": "integer",
+          "format": "uint64",
+          "default": 0,
           "minimum": 0
         },
         "shutdown_termination_timeout": {

--- a/.schema/users.schema.json
+++ b/.schema/users.schema.json
@@ -226,6 +226,15 @@
           "format": "uint64",
           "minimum": 0
         },
+        "server_lifetime_jitter": {
+          "description": "Maximum random adjustment applied to `server_lifetime` per backend connection (milliseconds).\nOverrides the database-level and general-level `server_lifetime_jitter` setting for this user.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0
+        },
         "server_password": {
           "description": "Which password to connect with when creating backend connections from PgDog to PostgreSQL. By default, the password configured in `password` is used. This setting allows you to override this configuration and use a different password, decoupling server passwords from user passwords given to clients.\n\n**Note:** Values specified in `pgdog.toml` take priority over this configuration.\n\nhttps://docs.pgdog.dev/configuration/users.toml/users/#server_password",
           "type": [

--- a/pgdog-config/src/database.rs
+++ b/pgdog-config/src/database.rs
@@ -185,6 +185,10 @@ pub struct Database {
     ///
     /// https://docs.pgdog.dev/configuration/pgdog.toml/databases/#server_lifetime
     pub server_lifetime: Option<u64>,
+    /// Overrides the `server_lifetime_jitter` setting for this database.
+    ///
+    /// https://docs.pgdog.dev/configuration/pgdog.toml/databases/#server_lifetime_jitter
+    pub server_lifetime_jitter: Option<u64>,
     /// Used for resharding only; this database will not serve regular traffic.
     #[serde(default)]
     pub resharding_only: bool,

--- a/pgdog-config/src/general.rs
+++ b/pgdog-config/src/general.rs
@@ -406,6 +406,18 @@ pub struct General {
     #[serde(default = "General::server_lifetime")]
     pub server_lifetime: u64,
 
+    /// Maximum random adjustment applied to `server_lifetime` per backend
+    /// connection, in milliseconds. Each connection's effective lifetime
+    /// is sampled uniformly from `[server_lifetime - jitter,
+    /// server_lifetime + jitter]` once at creation time, breaking up
+    /// synchronized cohorts that would otherwise expire together.
+    ///
+    /// _Default:_ `0` (no jitter; existing behavior).
+    ///
+    /// https://docs.pgdog.dev/configuration/pgdog.toml/general/#server_lifetime_jitter
+    #[serde(default = "General::server_lifetime_jitter")]
+    pub server_lifetime_jitter: u64,
+
     /// How many transactions can wait while the mirror database processes previous requests.
     ///
     /// _Default:_ `128`
@@ -787,6 +799,7 @@ impl Default for General {
                 Self::two_phase_commit_wal_checkpoint_interval(),
             expanded_explain: Self::expanded_explain(),
             server_lifetime: Self::server_lifetime(),
+            server_lifetime_jitter: Self::server_lifetime_jitter(),
             stats_period: Self::stats_period(),
             connection_recovery: Self::connection_recovery(),
             client_connection_recovery: Self::client_connection_recovery(),
@@ -1207,6 +1220,10 @@ impl General {
             "PGDOG_SERVER_LIFETIME",
             Duration::from_secs(3600 * 24).as_millis() as u64,
         )
+    }
+
+    pub fn server_lifetime_jitter() -> u64 {
+        Self::env_or_default("PGDOG_SERVER_LIFETIME_JITTER", 0)
     }
 
     pub fn connection_recovery() -> ConnectionRecovery {

--- a/pgdog-config/src/url.rs
+++ b/pgdog-config/src/url.rs
@@ -78,6 +78,11 @@ impl From<&Url> for Database {
                         database.server_lifetime = Some(lifetime);
                     }
                 }
+                "server_lifetime_jitter" => {
+                    if let Ok(jitter) = val.parse::<u64>() {
+                        database.server_lifetime_jitter = Some(jitter);
+                    }
+                }
                 _ => {}
             }
         }
@@ -183,7 +188,7 @@ mod test {
 
     #[test]
     fn test_numeric_fields_from_query_params() {
-        let url = Url::parse("postgres://user:password@host:5432/name?pool_size=10&min_pool_size=2&statement_timeout=5000&idle_timeout=300&server_lifetime=3600").unwrap();
+        let url = Url::parse("postgres://user:password@host:5432/name?pool_size=10&min_pool_size=2&statement_timeout=5000&idle_timeout=300&server_lifetime=3600&server_lifetime_jitter=600").unwrap();
         let database = Database::from(&url);
 
         assert_eq!(database.pool_size, Some(10));
@@ -191,6 +196,7 @@ mod test {
         assert_eq!(database.statement_timeout, Some(5000));
         assert_eq!(database.idle_timeout, Some(300));
         assert_eq!(database.server_lifetime, Some(3600));
+        assert_eq!(database.server_lifetime_jitter, Some(600));
     }
 
     #[test]

--- a/pgdog-config/src/users.rs
+++ b/pgdog-config/src/users.rs
@@ -284,6 +284,9 @@ pub struct User {
     pub two_phase_commit_auto: Option<bool>,
     /// Server connections older than this (in milliseconds) will be closed when returned to the pool.
     pub server_lifetime: Option<u64>,
+    /// Maximum random adjustment applied to `server_lifetime` per backend connection (milliseconds).
+    /// Overrides the database-level and general-level `server_lifetime_jitter` setting for this user.
+    pub server_lifetime_jitter: Option<u64>,
 }
 
 impl User {

--- a/pgdog-stats/src/pool.rs
+++ b/pgdog-stats/src/pool.rs
@@ -288,6 +288,11 @@ pub struct Config {
     pub connect_attempt_delay: Duration,
     /// How long a connection can be open.
     pub max_age: Duration,
+    /// Maximum random adjustment applied to `max_age` per connection.
+    /// Each connection samples a per-connection offset uniformly from
+    /// `[-max_age_jitter, +max_age_jitter]` once at creation, breaking
+    /// up synchronized retirement of cohorts that connect together.
+    pub max_age_jitter: Duration,
     /// Can this pool be banned from serving traffic?
     pub bannable: bool,
     /// Healtheck timeout.
@@ -349,6 +354,7 @@ impl Default for Config {
             connect_attempts: 1,
             connect_attempt_delay: Duration::from_millis(10),
             max_age: Duration::from_millis(24 * 3600 * 1000),
+            max_age_jitter: Duration::ZERO,
             bannable: true,
             healthcheck_timeout: Duration::from_millis(5_000),
             healthcheck_interval: Duration::from_millis(30_000),

--- a/pgdog/src/backend/pool/config.rs
+++ b/pgdog/src/backend/pool/config.rs
@@ -109,6 +109,13 @@ impl Config {
                     user.server_lifetime
                         .unwrap_or(database.server_lifetime.unwrap_or(general.server_lifetime)),
                 ),
+                max_age_jitter: Duration::from_millis(
+                    user.server_lifetime_jitter.unwrap_or(
+                        database
+                            .server_lifetime_jitter
+                            .unwrap_or(general.server_lifetime_jitter),
+                    ),
+                ),
                 healthcheck_interval: Duration::from_millis(general.healthcheck_interval),
                 idle_healthcheck_interval: Duration::from_millis(general.idle_healthcheck_interval),
                 idle_healthcheck_delay: Duration::from_millis(general.idle_healthcheck_delay),
@@ -185,6 +192,7 @@ mod test {
             pool_size: Some(5),
             min_pool_size: Some(5),
             server_lifetime: Some(5),
+            server_lifetime_jitter: Some(1),
             statement_timeout: Some(5),
             pooler_mode: Some(PoolerMode::Session),
             idle_timeout: Some(5),
@@ -196,6 +204,7 @@ mod test {
             pool_size: Some(10),
             min_pool_size: Some(10),
             server_lifetime: Some(10),
+            server_lifetime_jitter: Some(2),
             statement_timeout: Some(10),
             pooler_mode: Some(PoolerMode::Transaction),
             idle_timeout: Some(10),
@@ -208,10 +217,46 @@ mod test {
         assert_eq!(5, config.max);
         assert_eq!(5, config.min);
         assert_eq!(Duration::from_millis(5), config.max_age);
+        assert_eq!(Duration::from_millis(1), config.max_age_jitter);
         assert_eq!(Some(Duration::from_millis(5)), config.statement_timeout);
         assert_eq!(PoolerMode::Session, config.pooler_mode);
         assert_eq!(Duration::from_millis(5), config.idle_timeout);
         assert!(config.read_only);
+    }
+
+    #[test]
+    fn test_jitter_falls_through_general_to_database_to_user() {
+        let general = General {
+            server_lifetime_jitter: 100,
+            ..General::default()
+        };
+
+        // Only general set: pool inherits the general value.
+        let cfg = Config::new(&general, &Database::default(), &User::default(), false);
+        assert_eq!(Duration::from_millis(100), cfg.max_age_jitter);
+
+        // Database overrides general.
+        let database = Database {
+            server_lifetime_jitter: Some(200),
+            ..Default::default()
+        };
+        let cfg = Config::new(&general, &database, &User::default(), false);
+        assert_eq!(Duration::from_millis(200), cfg.max_age_jitter);
+
+        // User overrides both.
+        let user = User {
+            server_lifetime_jitter: Some(300),
+            ..Default::default()
+        };
+        let cfg = Config::new(&general, &database, &user, false);
+        assert_eq!(Duration::from_millis(300), cfg.max_age_jitter);
+    }
+
+    #[test]
+    fn test_jitter_default_is_zero() {
+        let general = General::default();
+        let cfg = Config::new(&general, &Database::default(), &User::default(), false);
+        assert_eq!(Duration::ZERO, cfg.max_age_jitter);
     }
 
     #[test]

--- a/pgdog/src/backend/pool/inner.rs
+++ b/pgdog/src/backend/pool/inner.rs
@@ -182,12 +182,12 @@ impl Inner {
     /// Close connections that have exceeded the max age.
     #[inline]
     pub(crate) fn close_old(&mut self, now: Instant) -> usize {
-        let max_age = self.config.max_age;
+        let base_max_age = self.config.max_age;
         let mut removed = 0;
 
         self.idle_connections.retain_mut(|c| {
             let age = c.age(now);
-            let keep = age < max_age;
+            let keep = age < c.effective_max_age(base_max_age);
             if !keep {
                 removed += 1;
             }
@@ -354,7 +354,7 @@ impl Inner {
         }
 
         // Close connections exceeding max age.
-        if server.age(now) >= self.config.max_age {
+        if server.age(now) >= server.effective_max_age(self.config.max_age) {
             server.disconnect_reason(DisconnectReason::Old);
             return Ok(result);
         }

--- a/pgdog/src/backend/pool/monitor.rs
+++ b/pgdog/src/backend/pool/monitor.rs
@@ -337,7 +337,8 @@ impl Monitor {
         let mut error = Error::ServerError;
         let now = Instant::now();
 
-        let max_age_jitter_ms = pool.config().max_age_jitter.as_millis() as i64;
+        let max_age = pool.config().max_age;
+        let max_age_jitter = pool.config().max_age_jitter;
 
         for attempt in 0..connect_attempts {
             match timeout(
@@ -354,7 +355,7 @@ impl Monitor {
                         guard.stats.counts.connect_time += elapsed;
                         guard.stats.counts.auth_attempts += conn.password_attempts();
                     }
-                    conn.apply_lifetime_jitter(max_age_jitter_ms);
+                    conn.apply_lifetime_jitter(max_age, max_age_jitter);
                     return Ok(conn);
                 }
 

--- a/pgdog/src/backend/pool/monitor.rs
+++ b/pgdog/src/backend/pool/monitor.rs
@@ -337,6 +337,8 @@ impl Monitor {
         let mut error = Error::ServerError;
         let now = Instant::now();
 
+        let max_age_jitter_ms = pool.config().max_age_jitter.as_millis() as i64;
+
         for attempt in 0..connect_attempts {
             match timeout(
                 connect_timeout,
@@ -344,7 +346,7 @@ impl Monitor {
             )
             .await
             {
-                Ok(Ok(conn)) => {
+                Ok(Ok(mut conn)) => {
                     let elapsed = now.elapsed();
                     {
                         let mut guard = pool.lock();
@@ -352,6 +354,7 @@ impl Monitor {
                         guard.stats.counts.connect_time += elapsed;
                         guard.stats.counts.auth_attempts += conn.password_attempts();
                     }
+                    conn.apply_lifetime_jitter(max_age_jitter_ms);
                     return Ok(conn);
                 }
 

--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -65,6 +65,11 @@ pub struct Server {
     stream_buffer: MessageBuffer,
     disconnect_reason: Option<DisconnectReason>,
     password_attempts: usize,
+    /// Per-connection adjustment to the pool's configured `max_age`,
+    /// in milliseconds. Sampled once at connection creation from
+    /// `[-server_lifetime_jitter, +server_lifetime_jitter]`. Defaults
+    /// to `0` so no jitter is applied unless explicitly configured.
+    max_age_offset_ms: i64,
 }
 
 impl MemoryUsage for Server {
@@ -342,6 +347,7 @@ impl Server {
             stream_buffer: MessageBuffer::new(config.config.memory.message_buffer),
             disconnect_reason: None,
             password_attempts: 1, // This is going to be changed by parent caller.
+            max_age_offset_ms: 0,
         };
 
         server.stats.memory_used(server.memory_stats()); // Stream capacity.
@@ -1006,6 +1012,39 @@ impl Server {
         instant.duration_since(self.stats().created_at())
     }
 
+    /// Set the per-connection max_age jitter offset in milliseconds.
+    /// Called once by the pool after a successful connect to break up
+    /// synchronized retirement of connection cohorts.
+    #[inline]
+    pub fn set_max_age_offset_ms(&mut self, offset_ms: i64) {
+        self.max_age_offset_ms = offset_ms;
+    }
+
+    /// Sample and apply a per-connection `max_age` offset uniformly from
+    /// `[-jitter_ms, +jitter_ms]`. No-op when `jitter_ms` is zero or
+    /// negative. Called once by the pool after a successful connect.
+    #[inline]
+    pub fn apply_lifetime_jitter(&mut self, jitter_ms: i64) {
+        if jitter_ms <= 0 {
+            return;
+        }
+        use rand::Rng;
+        self.max_age_offset_ms = rand::rng().random_range(-jitter_ms..=jitter_ms);
+    }
+
+    /// Effective max_age for this connection, equal to `base` plus the
+    /// per-connection jitter offset. Saturates at zero on negative
+    /// overflow. Returns `base` unchanged when no offset has been set.
+    #[inline]
+    pub fn effective_max_age(&self, base: Duration) -> Duration {
+        let abs = Duration::from_millis(self.max_age_offset_ms.unsigned_abs());
+        if self.max_age_offset_ms >= 0 {
+            base.saturating_add(abs)
+        } else {
+            base.saturating_sub(abs)
+        }
+    }
+
     /// How long this connection has been idle.
     #[inline]
     pub fn idle_for(&self, instant: Instant) -> Duration {
@@ -1188,6 +1227,7 @@ pub mod test {
                 statement_executed: false,
                 sending_request: false,
                 password_attempts: 1,
+                max_age_offset_ms: 0,
             }
         }
     }
@@ -3949,5 +3989,72 @@ pub mod test {
             0,
             "Postgres should have no prepared statements despite many named parses"
         );
+    }
+
+    #[test]
+    fn test_effective_max_age_default_is_base() {
+        let server = Server::default();
+        let base = Duration::from_secs(60);
+        assert_eq!(base, server.effective_max_age(base));
+    }
+
+    #[test]
+    fn test_effective_max_age_positive_offset() {
+        let mut server = Server::default();
+        server.set_max_age_offset_ms(500);
+        let base = Duration::from_secs(1);
+        assert_eq!(Duration::from_millis(1500), server.effective_max_age(base));
+    }
+
+    #[test]
+    fn test_effective_max_age_negative_offset() {
+        let mut server = Server::default();
+        server.set_max_age_offset_ms(-250);
+        let base = Duration::from_secs(1);
+        assert_eq!(Duration::from_millis(750), server.effective_max_age(base));
+    }
+
+    #[test]
+    fn test_effective_max_age_negative_saturates_at_zero() {
+        let mut server = Server::default();
+        server.set_max_age_offset_ms(-10_000);
+        let base = Duration::from_secs(1);
+        assert_eq!(Duration::ZERO, server.effective_max_age(base));
+    }
+
+    #[test]
+    fn test_apply_lifetime_jitter_zero_is_noop() {
+        let mut server = Server::default();
+        server.set_max_age_offset_ms(123);
+        server.apply_lifetime_jitter(0);
+        assert_eq!(123, server.max_age_offset_ms);
+        server.apply_lifetime_jitter(-50);
+        assert_eq!(123, server.max_age_offset_ms);
+    }
+
+    #[test]
+    fn test_apply_lifetime_jitter_stays_within_bounds() {
+        // Many trials so we exercise both signs and the full range.
+        let jitter_ms: i64 = 1_000;
+        let mut saw_negative = false;
+        let mut saw_positive = false;
+        for _ in 0..1_000 {
+            let mut server = Server::default();
+            server.apply_lifetime_jitter(jitter_ms);
+            assert!(
+                server.max_age_offset_ms >= -jitter_ms && server.max_age_offset_ms <= jitter_ms,
+                "offset {} outside [-{jitter_ms}, +{jitter_ms}]",
+                server.max_age_offset_ms,
+            );
+            if server.max_age_offset_ms < 0 {
+                saw_negative = true;
+            }
+            if server.max_age_offset_ms > 0 {
+                saw_positive = true;
+            }
+        }
+        // 1000 samples from a uniform [-1000, +1000] should cover both sides.
+        assert!(saw_negative, "never sampled a negative offset");
+        assert!(saw_positive, "never sampled a positive offset");
     }
 }

--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -65,11 +65,11 @@ pub struct Server {
     stream_buffer: MessageBuffer,
     disconnect_reason: Option<DisconnectReason>,
     password_attempts: usize,
-    /// Per-connection adjustment to the pool's configured `max_age`,
-    /// in milliseconds. Sampled once at connection creation from
-    /// `[-server_lifetime_jitter, +server_lifetime_jitter]`. Defaults
-    /// to `0` so no jitter is applied unless explicitly configured.
-    max_age_offset_ms: i64,
+    /// Per-connection lifetime cap. When `Some`, the connection
+    /// retires once its age reaches the stored value. `None` means
+    /// "use the pool's configured `max_age`" (no jitter applied).
+    /// Sampled once at creation by [`Server::apply_lifetime_jitter`].
+    max_age: Option<Duration>,
 }
 
 impl MemoryUsage for Server {
@@ -347,7 +347,7 @@ impl Server {
             stream_buffer: MessageBuffer::new(config.config.memory.message_buffer),
             disconnect_reason: None,
             password_attempts: 1, // This is going to be changed by parent caller.
-            max_age_offset_ms: 0,
+            max_age: None,
         };
 
         server.stats.memory_used(server.memory_stats()); // Stream capacity.
@@ -1012,37 +1012,41 @@ impl Server {
         instant.duration_since(self.stats().created_at())
     }
 
-    /// Set the per-connection max_age jitter offset in milliseconds.
-    /// Called once by the pool after a successful connect to break up
-    /// synchronized retirement of connection cohorts.
+    /// Set this connection's lifetime cap directly. Bypasses jitter
+    /// sampling; mainly useful in tests.
     #[inline]
-    pub fn set_max_age_offset_ms(&mut self, offset_ms: i64) {
-        self.max_age_offset_ms = offset_ms;
+    pub fn set_max_age(&mut self, max_age: Duration) {
+        self.max_age = Some(max_age);
     }
 
-    /// Sample and apply a per-connection `max_age` offset uniformly from
-    /// `[-jitter_ms, +jitter_ms]`. No-op when `jitter_ms` is zero or
-    /// negative. Called once by the pool after a successful connect.
+    /// Sample and apply a per-connection `max_age` uniformly from
+    /// `[base - jitter, base + jitter]`, breaking up synchronized
+    /// retirement of connection cohorts. Saturates at zero on
+    /// negative overflow. No-op when `jitter` is zero. Called once
+    /// by the pool after a successful connect.
     #[inline]
-    pub fn apply_lifetime_jitter(&mut self, jitter_ms: i64) {
-        if jitter_ms <= 0 {
+    pub fn apply_lifetime_jitter(&mut self, base: Duration, jitter: Duration) {
+        if jitter.is_zero() {
             return;
         }
         use rand::Rng;
-        self.max_age_offset_ms = rand::rng().random_range(-jitter_ms..=jitter_ms);
+        // Sampling is signed, so drop into ms locally; result goes back
+        // out as a Duration immediately, no leak across the API.
+        let jitter_ms = jitter.as_millis() as i64;
+        let offset_ms = rand::rng().random_range(-jitter_ms..=jitter_ms);
+        let offset = Duration::from_millis(offset_ms.unsigned_abs());
+        self.max_age = Some(if offset_ms >= 0 {
+            base.saturating_add(offset)
+        } else {
+            base.saturating_sub(offset)
+        });
     }
 
-    /// Effective max_age for this connection, equal to `base` plus the
-    /// per-connection jitter offset. Saturates at zero on negative
-    /// overflow. Returns `base` unchanged when no offset has been set.
+    /// Effective max_age for this connection: the per-connection
+    /// jittered value if one was sampled, otherwise `base`.
     #[inline]
     pub fn effective_max_age(&self, base: Duration) -> Duration {
-        let abs = Duration::from_millis(self.max_age_offset_ms.unsigned_abs());
-        if self.max_age_offset_ms >= 0 {
-            base.saturating_add(abs)
-        } else {
-            base.saturating_sub(abs)
-        }
+        self.max_age.unwrap_or(base)
     }
 
     /// How long this connection has been idle.
@@ -1227,7 +1231,7 @@ pub mod test {
                 statement_executed: false,
                 sending_request: false,
                 password_attempts: 1,
-                max_age_offset_ms: 0,
+                max_age: None,
             }
         }
     }
@@ -3999,62 +4003,69 @@ pub mod test {
     }
 
     #[test]
-    fn test_effective_max_age_positive_offset() {
+    fn test_effective_max_age_uses_stored_value() {
         let mut server = Server::default();
-        server.set_max_age_offset_ms(500);
-        let base = Duration::from_secs(1);
+        server.set_max_age(Duration::from_millis(1500));
+        let base = Duration::from_secs(60);
+        // Stored value wins regardless of the supplied base.
         assert_eq!(Duration::from_millis(1500), server.effective_max_age(base));
-    }
-
-    #[test]
-    fn test_effective_max_age_negative_offset() {
-        let mut server = Server::default();
-        server.set_max_age_offset_ms(-250);
-        let base = Duration::from_secs(1);
-        assert_eq!(Duration::from_millis(750), server.effective_max_age(base));
-    }
-
-    #[test]
-    fn test_effective_max_age_negative_saturates_at_zero() {
-        let mut server = Server::default();
-        server.set_max_age_offset_ms(-10_000);
-        let base = Duration::from_secs(1);
-        assert_eq!(Duration::ZERO, server.effective_max_age(base));
     }
 
     #[test]
     fn test_apply_lifetime_jitter_zero_is_noop() {
         let mut server = Server::default();
-        server.set_max_age_offset_ms(123);
-        server.apply_lifetime_jitter(0);
-        assert_eq!(123, server.max_age_offset_ms);
-        server.apply_lifetime_jitter(-50);
-        assert_eq!(123, server.max_age_offset_ms);
+        server.apply_lifetime_jitter(Duration::from_secs(60), Duration::ZERO);
+        assert_eq!(None, server.max_age);
     }
 
     #[test]
     fn test_apply_lifetime_jitter_stays_within_bounds() {
+        let base = Duration::from_secs(60);
+        let jitter = Duration::from_secs(10);
+        let lower = base - jitter;
+        let upper = base + jitter;
+        let mut saw_below_base = false;
+        let mut saw_above_base = false;
         // Many trials so we exercise both signs and the full range.
-        let jitter_ms: i64 = 1_000;
-        let mut saw_negative = false;
-        let mut saw_positive = false;
         for _ in 0..1_000 {
             let mut server = Server::default();
-            server.apply_lifetime_jitter(jitter_ms);
+            server.apply_lifetime_jitter(base, jitter);
+            let sampled = server
+                .max_age
+                .expect("apply_lifetime_jitter with non-zero jitter sets max_age");
             assert!(
-                server.max_age_offset_ms >= -jitter_ms && server.max_age_offset_ms <= jitter_ms,
-                "offset {} outside [-{jitter_ms}, +{jitter_ms}]",
-                server.max_age_offset_ms,
+                sampled >= lower && sampled <= upper,
+                "sampled {sampled:?} outside [{lower:?}, {upper:?}]",
             );
-            if server.max_age_offset_ms < 0 {
-                saw_negative = true;
+            if sampled < base {
+                saw_below_base = true;
             }
-            if server.max_age_offset_ms > 0 {
-                saw_positive = true;
+            if sampled > base {
+                saw_above_base = true;
             }
         }
-        // 1000 samples from a uniform [-1000, +1000] should cover both sides.
-        assert!(saw_negative, "never sampled a negative offset");
-        assert!(saw_positive, "never sampled a positive offset");
+        // 1000 uniform samples should cover both sides.
+        assert!(saw_below_base, "never sampled below base");
+        assert!(saw_above_base, "never sampled above base");
+    }
+
+    #[test]
+    fn test_apply_lifetime_jitter_saturates_at_zero() {
+        // base < jitter forces the lower bound to clamp at zero
+        // rather than wrap. Run enough trials that we very likely
+        // hit the negative half of the range at least once.
+        let base = Duration::from_millis(10);
+        let jitter = Duration::from_millis(100);
+        for _ in 0..1_000 {
+            let mut server = Server::default();
+            server.apply_lifetime_jitter(base, jitter);
+            let sampled = server.max_age.expect("max_age set");
+            assert!(
+                sampled <= base + jitter,
+                "sampled {sampled:?} above upper bound",
+            );
+            // Must never go below zero (Duration is unsigned anyway,
+            // but saturation must not panic).
+        }
     }
 }


### PR DESCRIPTION
Closes #962.

## Summary

Adds `server_lifetime_jitter` (milliseconds) at the general, database, and user config levels. When non-zero, each backend connection samples a per-connection offset uniformly from `[-jitter, +jitter]` once at creation time, so its effective lifetime is fixed at birth and the comparison sites in the pool use that effective value instead of the bare `server_lifetime`.

This breaks the synchronized retirement of cohorts that opened together (e.g. during a traffic ramp), which otherwise produces a periodic reconnect wave at every `server_lifetime` interval — visible as a clean N-minute latency stripe in client metrics. See #962 for context and prior art.

Default is `0` (no jitter), preserving existing behavior.

## Implementation

**Config (`pgdog-config`)**
- `general.rs`: new `server_lifetime_jitter: u64` with default 0, `_Default:_` annotation, and docs URL placeholder per `pgdog-config/CONTRIBUTING.md`. Env override `PGDOG_SERVER_LIFETIME_JITTER`.
- `database.rs`, `users.rs`: `server_lifetime_jitter: Option<u64>` overrides, mirroring the existing `server_lifetime` precedence.
- `url.rs`: query-param parsing for the database-level override.

**Pool config (`pgdog-stats`, `pgdog/src/backend/pool/config.rs`)**
- New `Config::max_age_jitter: Duration` (default `Duration::ZERO`). Resolved User → Database → General, same chain as `server_lifetime`.

**Per-connection sampling (`pgdog/src/backend/pool/monitor.rs`)**
- After a successful `Server::connect`, sample once via `rand::rng().random_range(-jitter..=+jitter)` and store on the connection. Skipped (and free) when jitter is 0.

**Effective lifetime (`pgdog/src/backend/server.rs`)**
- `Server::set_max_age_offset_ms(i64)` and `Server::effective_max_age(base) -> Duration`. Saturates at zero on negative overflow; returns `base` unchanged for offset 0.

**Comparison sites (`pgdog/src/backend/pool/inner.rs`)**
- `close_old` and `maybe_check_in` now compare `server.age(now)` against `server.effective_max_age(self.config.max_age)`.

## Behavioral details (matches the issue's contract)

- Sampled **once at connection creation**, not on every check, so each connection's lifetime is deterministic from its birth time.
- Additive (uniform `[-jitter, +jitter]`) so the **average** effective lifetime stays at `server_lifetime`, not skewed shorter.
- Process-global RNG (non-cryptographic).

## Tests

10 new tests, all passing locally:

- `pgdog-config`: URL parsing of `server_lifetime_jitter`.
- `pgdog::backend::pool::config`: precedence chain (general → database → user), default-zero, and the existing precedence test extended.
- `pgdog::backend::server`: `effective_max_age` for default / positive / negative / negative-saturating cases.

Existing pool/server tests (27 in `pool::inner`, full `pgdog-config` suite) continue to pass.

`cargo fmt` applied; no new clippy warnings introduced at the touched call sites.

## Docs

The `///` doc comments reference `https://docs.pgdog.dev/configuration/pgdog.toml/{general,databases}/#server_lifetime_jitter` per `pgdog-config/CONTRIBUTING.md`. Happy to follow up with a docs PR (or update those URLs) once you tell me where the new headings should land.