### PR TITLE
Normalize integer numerics when performing aggregate queries

### DIFF
--- a/integration/sql/cases/943_clickbench_q04_case.sql
+++ b/integration/sql/cases/943_clickbench_q04_case.sql
@@ -1,0 +1,6 @@
+-- description: ClickBench Citus query 4
+-- tags: sharded
+-- transactional: true
+-- only-targets: postgres_standard_text pgdog_sharded_text pgdog_sharded_binary
+
+SELECT AVG(UserID) FROM hits;

--- a/integration/sql/cases/943_clickbench_q04_setup.sql
+++ b/integration/sql/cases/943_clickbench_q04_setup.sql
@@ -1,0 +1,1 @@
+clickbench_setup.sql

--- a/integration/sql/cases/943_clickbench_q04_teardown.sql
+++ b/integration/sql/cases/943_clickbench_q04_teardown.sql
@@ -1,0 +1,1 @@
+clickbench_teardown.sql

--- a/pgdog/src/backend/pool/connection/aggregate.rs
+++ b/pgdog/src/backend/pool/connection/aggregate.rs
@@ -612,7 +612,10 @@ fn multiply_for_average(value: &Datum, count: &Datum) -> Option<Datum> {
             Some(Datum::Float(Float((float.0 as f64 * multiplier) as f32)))
         }
         Datum::Numeric(numeric) => {
-            let decimal = numeric.as_decimal()?;
+            let mut decimal = numeric.as_decimal()?.to_owned();
+            if decimal.is_integer() {
+                decimal.normalize_assign();
+            }
             let product = decimal * Decimal::from_i128(multiplier_i128)?;
             Some(Datum::Numeric(Numeric::from(product)))
         }


### PR DESCRIPTION
The AVG function in PG will always convert any integer types to numeric. The scale of that result does not appear to be clearly defined, but appears to be a scale of 16 for small numbers and 0 for larger ones. Unfortunately, since this behavior isn't documented or defined, it's difficult for us to match.

That said, normalizing integers in this case will prevent our values from diverging with larger values (e.g. very small fractional parts that a single shrad query would not return), while only causing us to diverge from PG by not including trailing zeroes on small integers (e.g. we will now return `85` instead of `85.0000000000000000`), which I believe is a net win overall