### PR TITLE
Delete some unused config

### DIFF
--- a/integration/pgdog.toml
+++ b/integration/pgdog.toml
@@ -456,38 +456,3 @@ shard = 1
 
 [admin]
 password = "pgdog"
-
-# ------------------------------------------------------------------------------
-# ----- ActiveRecord Tables ----------------------------------------------------
-#
-#  ActiveRecord sends these queries at startup to figure out the schema.
-#  This will route them to only one shard instead of issuing cross-shard
-#  queries and getting incorrect results.
-#
-
-[[manual_queries]]
-fingerprint = "e78fe2c08de5f079" #[16685804461073231993]
-
-[[manual_queries]]
-fingerprint = "43258d068030bb3e" #[4838428433739463486]
-
-[[manual_queries]]
-fingerprint = "08aab2cee482a97d" #[624508100011010429]
-
-[[manual_queries]]
-fingerprint = "23cd60d5972d1712" #[2579824632033777426]
-
-[[manual_queries]]
-fingerprint = "bb38525ebeb46656" #[13490623250668217942]
-
-[[manual_queries]]
-fingerprint = "f4814b6fadabc4c1" #[17618446160277259457]
-
-[[manual_queries]]
-fingerprint = "04dc05f480b702d3"
-
-[[manual_queries]]
-fingerprint = "2d9944fc9caeaadd" # [3285733254894627549]
-
-# ------------------------------------------------------------------------------
-# ------------------------------------------------------------------------------


### PR DESCRIPTION
When I was looking through our integration test config I saw this section which worried me slightly since it implied Rails apps (or anything using an ORM which queries schema information at runtime) aren't working out of the box.

@levkk claims we route queries to `information_schema` correctly now so this config shouldn't be needed anymore. If you're reading this on main, it would seem CI agreed.