### PR TITLE
fix: BEGIN in session mode with cross-shard disabled check

### DIFF
--- a/integration/python/test_session_mode.py
+++ b/integration/python/test_session_mode.py
@@ -26,6 +26,16 @@ async def async_session_conn(schema):
         statement_cache_size=0,
     )
 
+async def async_session_conn_no_search_path():
+    return await asyncpg.connect(
+        user="pgdog_session_no_cross_shard",
+        password="pgdog",
+        database="pgdog_schema_no_cross",
+        host="127.0.0.1",
+        port=6432,
+        statement_cache_size=0,
+    )
+
 
 def test_session_simple_queries():
     for schema in ["shard_0", "shard_1"]:
@@ -336,3 +346,13 @@ async def test_async_session_multiple_statements_in_transaction():
         await conn.execute("DROP TABLE test_async_session_multi")
         await conn.close()
     no_out_of_sync()
+
+@pytest.mark.asyncio
+async def test_no_search_path_session_mode():
+    for _ in range(25):
+        conn = await async_session_conn_no_search_path()
+        await conn.execute("CREATE SCHEMA IF NOT EXISTS shard_0")
+        await conn.execute("CREATE TABLE IF NOT EXISTS shard_0.py_test_no_search_path_session_mode (id BIGINT)")
+
+        async with conn.transaction():
+            await conn.execute("SELECT * FROM shard_0.py_test_no_search_path_session_mode LIMIT 1")

--- a/pgdog/src/backend/pool/connection/binding.rs
+++ b/pgdog/src/backend/pool/connection/binding.rs
@@ -62,6 +62,23 @@ impl Binding {
         }
     }
 
+    /// Number of PostgreSQL servers we are connected to.
+    ///
+    /// For direct-to-shard queries, that'll be 1. For cross-shard queries,
+    /// that should be how many shards are configured, since we connect to all
+    /// shards (no lazy shard loading yet).
+    ///
+    /// If we're not connected, e.g. [`Self::connected`] is false, then this returns 0.
+    ///
+    pub fn connected_servers(&self) -> usize {
+        match self {
+            Binding::Direct(Some(_)) => 1,
+            Binding::MultiShard(ref servers, _) => servers.len(),
+            Binding::Admin(_) => 1,
+            _ => 0,
+        }
+    }
+
     pub(super) async fn read(&mut self) -> Result<Message, Error> {
         match self {
             Binding::Direct(guard) => {

--- a/pgdog/src/frontend/client/query_engine/query.rs
+++ b/pgdog/src/frontend/client/query_engine/query.rs
@@ -335,6 +335,11 @@ impl QueryEngine {
         &mut self,
         context: &mut QueryEngineContext<'_>,
     ) -> Result<bool, Error> {
+        // Admin database queries are not checked.
+        if context.admin {
+            return Ok(true);
+        }
+
         // Check for cross-shard queries.
         if context.cross_shard_disabled.is_none() {
             context.cross_shard_disabled = Some(
@@ -347,13 +352,29 @@ impl QueryEngine {
 
         let cross_shard_disabled = context.cross_shard_disabled.unwrap_or_default();
 
-        debug!("cross-shard queries disabled: {}", cross_shard_disabled,);
+        debug!("cross-shard queries disabled: {}", cross_shard_disabled);
 
-        if cross_shard_disabled
-            && context.client_request.route().is_cross_shard()
-            && !context.admin
-            && context.client_request.is_executable()
-        {
+        // This check is disabled.
+        if !cross_shard_disabled {
+            return Ok(true);
+        }
+
+        let query_is_cross_shard = context.client_request.route().is_cross_shard();
+
+        // The query is direct-to-shard, we're good.
+        if !query_is_cross_shard {
+            return Ok(true);
+        }
+
+        let connected_shards = self.backend.connected_servers();
+
+        // Only run check if we are not connected yet or we are actually connected
+        // to more than one shard.
+        //
+        // The second check is only relevant for session mode - we stay connected
+        // until client disconnects. We don't want this check to trigger on queries that we think
+        // should be cross-shard (e.g. BEGIN, COMMIT).
+        if connected_shards == 0 || connected_shards > 1 {
             let query = context.client_request.query()?;
             let error = ErrorResponse::cross_shard_disabled(query.as_ref().map(|q| q.query()));
 
@@ -363,10 +384,10 @@ impl QueryEngine {
                 self.backend.disconnect();
             }
 
-            Ok(false)
-        } else {
-            Ok(true)
+            return Ok(false);
         }
+
+        Ok(true)
     }
 
     fn two_pc_check(&mut self, context: &mut QueryEngineContext<'_>) {

--- a/pgdog/src/frontend/client/query_engine/query.rs
+++ b/pgdog/src/frontend/client/query_engine/query.rs
@@ -367,13 +367,21 @@ impl QueryEngine {
         }
 
         let connected_shards = self.backend.connected_servers();
+        let is_executable = context.client_request.is_executable();
+
+        // This is a Parse-only request, so it's safe
+        // to route it to any shard - it won't do any damage
+        // and we need a real response from a server.
+        if !is_executable {
+            return Ok(true);
+        }
 
         // Only run check if we are not connected yet or we are actually connected
         // to more than one shard.
         //
-        // The second check is only relevant for session mode - we stay connected
+        // The connected_shards > 1 check is only relevant for session mode - we stay connected
         // until client disconnects. We don't want this check to trigger on queries that we think
-        // should be cross-shard (e.g. BEGIN, COMMIT).
+        // should be cross-shard (e.g. BEGIN, COMMIT) but aren't really.
         if connected_shards == 0 || connected_shards > 1 {
             let query = context.client_request.query()?;
             let error = ErrorResponse::cross_shard_disabled(query.as_ref().map(|q| q.query()));


### PR DESCRIPTION
In session mode, clients are connected to servers until they disconnect. For sharded deployments, this effectively means the first query determines which shard the client will be using going forward.

Our query parser determines that `BEGIN`, `ROLLBACK` and other transaction control statements are cross-shard (which is correct). But, in session mode, we can't (and shouldn't) re-connect to more shards if we're already connected, so this triggers a false positive `no sharding key` error if `cross_shard_disabled = true`.

This change adds an additional constraint to the check: only run if it we're connected to 0 shards (not connected yet) or 2 or more shards (the connection is actually cross-shard), where this check actually matters.