### PR TITLE
fix: multi-tuple INSERTs with go/pq

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3330,9 +3330,11 @@ dependencies = [
 name = "pgdog-macros"
 version = "0.1.1"
 dependencies = [
+ "futures",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+ "tokio",
 ]
 
 [[package]]

--- a/integration/go/go_pq/go_pq_test.go
+++ b/integration/go/go_pq/go_pq_test.go
@@ -144,9 +144,6 @@ func TestAdvisoryLockWithTransaction(t *testing.T) {
 	assert.Nil(t, err)
 	defer adminConn.Close()
 
-	_, err = adminConn.Exec("SET prepared_statements TO 'extended_anonymous'")
-	assert.Nil(t, err)
-
 	_, err = adminConn.Exec("SET query_parser TO 'on'")
 	assert.Nil(t, err)
 

--- a/integration/go/go_pq/multi_insert_test.go
+++ b/integration/go/go_pq/multi_insert_test.go
@@ -1,0 +1,233 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	_ "github.com/lib/pq"
+)
+
+const shardedDSN = "postgres://pgdog:pgdog@127.0.0.1:6432/pgdog_sharded?sslmode=disable"
+const adminDSN = "postgres://admin:pgdog@127.0.0.1:6432/admin?sslmode=disable"
+
+// enableSplitInserts turns on the rewrite engine so multi-tuple INSERTs into
+// sharded tables are split per-row and routed to the shard each row hashes to,
+// instead of being broadcast to every shard. The settings are global, so this
+// is applied via the admin connection and affects the data connection too.
+func enableSplitInserts(t *testing.T, admin *sql.DB) {
+	for _, stmt := range []string{
+		"SET two_phase_commit TO false",
+		"SET rewrite_enabled TO true",
+		"SET rewrite_split_inserts TO rewrite",
+	} {
+		_, err := admin.Exec(stmt)
+		assert.Nil(t, err, "enable split inserts: %s", stmt)
+	}
+}
+
+// resetRewrite restores the defaults from integration/pgdog.toml so this test
+// doesn't leak rewrite behavior into the rest of the suite.
+func resetRewrite(t *testing.T, admin *sql.DB) {
+	for _, stmt := range []string{
+		"SET rewrite_split_inserts TO error",
+		"SET rewrite_enabled TO false",
+		"SET two_phase_commit TO false",
+	} {
+		_, err := admin.Exec(stmt)
+		assert.Nil(t, err, "reset rewrite: %s", stmt)
+	}
+}
+
+// countOnShard returns how many rows with the given id live on a specific
+// shard. The `/* pgdog_shard: N */` comment pins the query to one shard so we
+// can prove where a row actually landed rather than trusting pgdog's routing
+// to read it back.
+func countOnShard(t *testing.T, conn *sql.DB, shard int, id int64) int {
+	var count int
+	query := fmt.Sprintf("/* pgdog_shard: %d */ SELECT COUNT(*) FROM sharded WHERE id = %d", shard, id)
+	assert.Nil(t, conn.QueryRow(query).Scan(&count), "count id=%d on shard %d", id, shard)
+	return count
+}
+
+// deleteIds removes the given ids from the sharded table. pgdog routes each
+// DELETE to the shard the id hashes to, which is exactly what we want for a
+// clean slate before and after each test.
+func deleteIds(t *testing.T, conn *sql.DB, ids []int64) {
+	for _, id := range ids {
+		_, err := conn.Exec("DELETE FROM sharded WHERE id = $1", id)
+		assert.Nil(t, err, "delete id=%d", id)
+	}
+}
+
+// TestMultiTupleInsertSplitAcrossShards inserts a single multi-tuple INSERT
+// whose two rows hash to different shards and verifies each row is placed on
+// its own shard (and only there). id=1 hashes to shard 0, id=11 to shard 1.
+func TestMultiTupleInsertSplitAcrossShards(t *testing.T) {
+	admin, err := sql.Open("postgres", adminDSN)
+	assert.Nil(t, err)
+	defer admin.Close()
+
+	enableSplitInserts(t, admin)
+	defer resetRewrite(t, admin)
+
+	conn, err := sql.Open("postgres", shardedDSN)
+	assert.Nil(t, err)
+	defer conn.Close()
+
+	ids := []int64{1, 11}
+	deleteIds(t, conn, ids)
+	defer deleteIds(t, conn, ids)
+
+	_, err = conn.Exec("INSERT INTO sharded (id, value) VALUES (1, 'one'), (11, 'eleven')")
+	assert.Nil(t, err, "multi-tuple insert split across shards")
+
+	// id=1 lives on shard 0 only.
+	assert.Equal(t, 1, countOnShard(t, conn, 0, 1), "id=1 should be on shard 0")
+	assert.Equal(t, 0, countOnShard(t, conn, 1, 1), "id=1 should not be on shard 1")
+
+	// id=11 lives on shard 1 only.
+	assert.Equal(t, 1, countOnShard(t, conn, 1, 11), "id=11 should be on shard 1")
+	assert.Equal(t, 0, countOnShard(t, conn, 0, 11), "id=11 should not be on shard 0")
+
+	// The values came through intact; pgdog routes these SELECTs to the
+	// correct shard automatically.
+	var value string
+	assert.Nil(t, conn.QueryRow("SELECT value FROM sharded WHERE id = $1", 1).Scan(&value))
+	assert.Equal(t, "one", value)
+	assert.Nil(t, conn.QueryRow("SELECT value FROM sharded WHERE id = $1", 11).Scan(&value))
+	assert.Equal(t, "eleven", value)
+}
+
+// TestMultiTupleInsertSplitParameterized exercises the same split path with a
+// parameterized (extended-protocol) multi-tuple INSERT, since splitting has to
+// renumber the bind parameters for each row it pulls out.
+func TestMultiTupleInsertSplitParameterized(t *testing.T) {
+	admin, err := sql.Open("postgres", adminDSN)
+	assert.Nil(t, err)
+	defer admin.Close()
+
+	enableSplitInserts(t, admin)
+	defer resetRewrite(t, admin)
+
+	conn, err := sql.Open("postgres", shardedDSN)
+	assert.Nil(t, err)
+	defer conn.Close()
+
+	ids := []int64{1, 11}
+	deleteIds(t, conn, ids)
+	defer deleteIds(t, conn, ids)
+
+	_, err = conn.Exec(
+		"INSERT INTO sharded (id, value) VALUES ($1, $2), ($3, $4)",
+		1, "one", 11, "eleven",
+	)
+	assert.Nil(t, err, "parameterized multi-tuple insert split across shards")
+
+	assert.Equal(t, 1, countOnShard(t, conn, 0, 1), "id=1 should be on shard 0")
+	assert.Equal(t, 1, countOnShard(t, conn, 1, 11), "id=11 should be on shard 1")
+
+	var value string
+	assert.Nil(t, conn.QueryRow("SELECT value FROM sharded WHERE id = $1", 1).Scan(&value))
+	assert.Equal(t, "one", value)
+	assert.Nil(t, conn.QueryRow("SELECT value FROM sharded WHERE id = $1", 11).Scan(&value))
+	assert.Equal(t, "eleven", value)
+}
+
+// TestMultiTupleInsertSplitManyRows inserts many rows in a single statement and
+// checks two things at once: every row is stored exactly once (no broadcast
+// duplication), and the rows are actually distributed across both shards (not
+// all funneled to one). The set includes id=1 (shard 0) and id=11 (shard 1) so
+// the distribution check always has a row on each side.
+func TestMultiTupleInsertSplitManyRows(t *testing.T) {
+	admin, err := sql.Open("postgres", adminDSN)
+	assert.Nil(t, err)
+	defer admin.Close()
+
+	enableSplitInserts(t, admin)
+	defer resetRewrite(t, admin)
+
+	conn, err := sql.Open("postgres", shardedDSN)
+	assert.Nil(t, err)
+	defer conn.Close()
+
+	ids := []int64{1, 2, 3, 4, 5, 11, 12, 13, 14, 15}
+	deleteIds(t, conn, ids)
+	defer deleteIds(t, conn, ids)
+
+	_, err = conn.Exec(`INSERT INTO sharded (id, value) VALUES
+		(1, 'v1'), (2, 'v2'), (3, 'v3'), (4, 'v4'), (5, 'v5'),
+		(11, 'v11'), (12, 'v12'), (13, 'v13'), (14, 'v14'), (15, 'v15')`)
+	assert.Nil(t, err, "multi-tuple insert with many rows")
+
+	shard0Rows, shard1Rows := 0, 0
+	for _, id := range ids {
+		onShard0 := countOnShard(t, conn, 0, id)
+		onShard1 := countOnShard(t, conn, 1, id)
+
+		// Each row must exist exactly once, on exactly one shard. A broadcast
+		// would put it on both (total 2); a dropped row would put it on none.
+		assert.Equal(t, 1, onShard0+onShard1, "id=%d should exist exactly once across shards", id)
+
+		shard0Rows += onShard0
+		shard1Rows += onShard1
+	}
+
+	// The split actually fanned out: both shards received at least one row.
+	assert.Greater(t, shard0Rows, 0, "shard 0 should have received some rows")
+	assert.Greater(t, shard1Rows, 0, "shard 1 should have received some rows")
+	assert.Equal(t, len(ids), shard0Rows+shard1Rows, "every row should be accounted for")
+}
+
+// TestMultiTupleInsertSplitManyRowsParameterized is the parameterized variant
+// of TestMultiTupleInsertSplitManyRows: the same many-row INSERT, but with
+// every value sent as an extended-protocol bind parameter. This stresses the
+// per-tuple parameter renumbering the splitter performs ($1..$20 in the
+// original statement become $1, $2 in each single-tuple split).
+func TestMultiTupleInsertSplitManyRowsParameterized(t *testing.T) {
+	admin, err := sql.Open("postgres", adminDSN)
+	assert.Nil(t, err)
+	defer admin.Close()
+
+	enableSplitInserts(t, admin)
+	defer resetRewrite(t, admin)
+
+	conn, err := sql.Open("postgres", shardedDSN)
+	assert.Nil(t, err)
+	defer conn.Close()
+
+	ids := []int64{1, 2, 3, 4, 5, 11, 12, 13, 14, 15}
+	deleteIds(t, conn, ids)
+	defer deleteIds(t, conn, ids)
+
+	// Build "VALUES ($1, $2), ($3, $4), ..." with one bound pair per row.
+	tuples := make([]string, len(ids))
+	args := make([]any, 0, len(ids)*2)
+	for i, id := range ids {
+		tuples[i] = fmt.Sprintf("($%d, $%d)", i*2+1, i*2+2)
+		args = append(args, id, fmt.Sprintf("v%d", id))
+	}
+	query := "INSERT INTO sharded (id, value) VALUES " + strings.Join(tuples, ", ")
+
+	_, err = conn.Exec(query, args...)
+	assert.Nil(t, err, "parameterized multi-tuple insert with many rows")
+
+	shard0Rows, shard1Rows := 0, 0
+	for _, id := range ids {
+		onShard0 := countOnShard(t, conn, 0, id)
+		onShard1 := countOnShard(t, conn, 1, id)
+
+		// Each row must exist exactly once, on exactly one shard.
+		assert.Equal(t, 1, onShard0+onShard1, "id=%d should exist exactly once across shards", id)
+
+		shard0Rows += onShard0
+		shard1Rows += onShard1
+	}
+
+	assert.Greater(t, shard0Rows, 0, "shard 0 should have received some rows")
+	assert.Greater(t, shard1Rows, 0, "shard 1 should have received some rows")
+	assert.Equal(t, len(ids), shard0Rows+shard1Rows, "every row should be accounted for")
+}

--- a/pgdog-macros/Cargo.toml
+++ b/pgdog-macros/Cargo.toml
@@ -13,3 +13,7 @@ proc-macro = true
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "2.0", features = ["full"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
+futures = "0.3"

--- a/pgdog-macros/src/lib.rs
+++ b/pgdog-macros/src/lib.rs
@@ -4,7 +4,10 @@
 //!
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{ItemFn, parse_macro_input};
+use syn::{ItemFn, LitInt, parse_macro_input};
+
+/// Default number of attempts when `#[flaky]` is used without an explicit count.
+const DEFAULT_FLAKY_ATTEMPTS: usize = 3;
 
 /// Generates required methods for PgDog to run at plugin load time.
 ///
@@ -102,6 +105,100 @@ pub fn fini(_attr: TokenStream, item: TokenStream) -> TokenStream {
             #input_fn
 
             #fn_name();
+        }
+    };
+
+    TokenStream::from(expanded)
+}
+
+/// Retry a flaky test until it passes or the attempt budget is exhausted.
+///
+/// Place this **above** the test attribute. It works for both synchronous
+/// (`#[test]`) and asynchronous (`#[tokio::test]`) tests:
+///
+/// ```ignore
+/// #[flaky]            // retries up to 3 times (the default)
+/// #[tokio::test]
+/// async fn sometimes_flaky() {
+///     assert!(roll_the_dice());
+/// }
+///
+/// #[flaky(5)]         // retries up to 5 times
+/// #[test]
+/// fn also_flaky() {
+///     assert!(roll_the_dice());
+/// }
+/// ```
+///
+/// Each attempt that panics is caught and logged to stderr, then the test is
+/// retried. The final attempt is run uncaught so that a genuine failure
+/// propagates with its original panic message and backtrace.
+///
+/// The async variant relies on `futures` and `std` being available in the
+/// consuming crate (both are present in PgDog).
+#[proc_macro_attribute]
+pub fn flaky(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let attempts: usize = if attr.is_empty() {
+        DEFAULT_FLAKY_ATTEMPTS
+    } else {
+        let lit = parse_macro_input!(attr as LitInt);
+        match lit.base10_parse() {
+            Ok(0) | Ok(1) => 1,
+            Ok(n) => n,
+            Err(err) => return err.to_compile_error().into(),
+        }
+    };
+
+    let ItemFn {
+        attrs,
+        vis,
+        sig,
+        block,
+    } = parse_macro_input!(item as ItemFn);
+
+    let test_name = sig.ident.to_string();
+
+    // The last attempt is run uncaught so a real failure keeps its original
+    // panic message and backtrace. Earlier attempts are caught and retried.
+    let retried = attempts.saturating_sub(1);
+
+    let body = if sig.asyncness.is_some() {
+        quote! {
+            use ::futures::future::FutureExt;
+            for __flaky_attempt in 1..=#retried {
+                match ::std::panic::AssertUnwindSafe(async #block).catch_unwind().await {
+                    ::std::result::Result::Ok(__flaky_value) => return __flaky_value,
+                    ::std::result::Result::Err(_) => {
+                        eprintln!(
+                            "[flaky] test `{}` failed on attempt {}/{}, retrying...",
+                            #test_name, __flaky_attempt, #attempts,
+                        );
+                    }
+                }
+            }
+            (async #block).await
+        }
+    } else {
+        quote! {
+            for __flaky_attempt in 1..=#retried {
+                match ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| #block)) {
+                    ::std::result::Result::Ok(__flaky_value) => return __flaky_value,
+                    ::std::result::Result::Err(_) => {
+                        eprintln!(
+                            "[flaky] test `{}` failed on attempt {}/{}, retrying...",
+                            #test_name, __flaky_attempt, #attempts,
+                        );
+                    }
+                }
+            }
+            #block
+        }
+    };
+
+    let expanded = quote! {
+        #(#attrs)*
+        #vis #sig {
+            #body
         }
     };
 

--- a/pgdog-macros/tests/flaky.rs
+++ b/pgdog-macros/tests/flaky.rs
@@ -1,0 +1,96 @@
+//! Tests for the `#[flaky]` retry attribute macro.
+//!
+//! Each test uses an atomic counter so that it panics on its first few
+//! attempts and only succeeds once `#[flaky]` has retried it enough times.
+//! If retries did not happen, these tests would fail.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use pgdog_macros::flaky;
+
+/// Panic on the first `fail_until - 1` calls, succeed afterwards. Returns the
+/// 1-based attempt number that was just executed.
+fn flake(counter: &AtomicUsize, fail_until: usize) -> usize {
+    let attempt = counter.fetch_add(1, Ordering::SeqCst) + 1;
+    assert!(
+        attempt >= fail_until,
+        "induced flake on attempt {attempt} (need {fail_until})"
+    );
+    attempt
+}
+
+static SYNC_DEFAULT: AtomicUsize = AtomicUsize::new(0);
+
+#[flaky]
+#[test]
+fn sync_default_retries() {
+    // Fails twice, passes on the 3rd (default) attempt.
+    let attempt = flake(&SYNC_DEFAULT, 3);
+    assert_eq!(attempt, 3);
+}
+
+static SYNC_EXPLICIT: AtomicUsize = AtomicUsize::new(0);
+
+#[flaky(5)]
+#[test]
+fn sync_explicit_count() {
+    let attempt = flake(&SYNC_EXPLICIT, 5);
+    assert_eq!(attempt, 5);
+}
+
+static ASYNC_DEFAULT: AtomicUsize = AtomicUsize::new(0);
+
+#[flaky]
+#[tokio::test]
+async fn async_default_retries() {
+    tokio::task::yield_now().await;
+    let attempt = flake(&ASYNC_DEFAULT, 3);
+    tokio::task::yield_now().await;
+    assert_eq!(attempt, 3);
+}
+
+static ASYNC_EXPLICIT: AtomicUsize = AtomicUsize::new(0);
+
+#[flaky(4)]
+#[tokio::test]
+async fn async_explicit_count() {
+    tokio::task::yield_now().await;
+    let attempt = flake(&ASYNC_EXPLICIT, 4);
+    assert_eq!(attempt, 4);
+}
+
+// A test that never flakes must still pass and only run once.
+static SYNC_STABLE: AtomicUsize = AtomicUsize::new(0);
+
+#[flaky(3)]
+#[test]
+fn sync_stable_runs_once() {
+    SYNC_STABLE.fetch_add(1, Ordering::SeqCst);
+    assert_eq!(SYNC_STABLE.load(Ordering::SeqCst), 1);
+}
+
+// `#[flaky]` should preserve a `Result`-returning async test signature.
+#[flaky]
+#[tokio::test]
+async fn async_returns_result() -> Result<(), String> {
+    tokio::task::yield_now().await;
+    Ok(())
+}
+
+// When every attempt fails, the final (uncaught) attempt must propagate the
+// original panic message. `#[should_panic(expected = ...)]` proves both that
+// the budget is exhausted and that the original message survives.
+#[flaky(2)]
+#[test]
+#[should_panic(expected = "boom")]
+fn exhausts_budget_then_panics() {
+    panic!("boom");
+}
+
+#[flaky(2)]
+#[tokio::test]
+#[should_panic(expected = "async boom")]
+async fn async_exhausts_budget_then_panics() {
+    tokio::task::yield_now().await;
+    panic!("async boom");
+}

--- a/pgdog/src/backend/pool/connection/mirror/mod.rs
+++ b/pgdog/src/backend/pool/connection/mirror/mod.rs
@@ -232,6 +232,9 @@ mod test {
         );
     }
 
+    // This test relies on data written to multiple databases.
+    // It's flaky. Not sure why yet.
+    #[pgdog_plugin::macros::flaky]
     #[tokio::test]
     async fn test_mirror() {
         config::load_test();

--- a/pgdog/src/backend/pool/test/mod.rs
+++ b/pgdog/src/backend/pool/test/mod.rs
@@ -96,6 +96,8 @@ async fn test_pool_checkout() {
     assert_eq!(conn.id(), &id);
 }
 
+// This test flakes in CI because of iffy hardware I think.
+#[pgdog_plugin::macros::flaky]
 #[tokio::test]
 async fn test_concurrency() {
     let pool = pool();

--- a/pgdog/src/frontend/router/parser/rewrite/statement/insert.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/insert.rs
@@ -51,10 +51,12 @@ impl InsertSplit {
     /// Build a ClientRequest from this split and the original request.
     pub fn build_request(&self, request: &ClientRequest) -> ClientRequest {
         let mut new_request = ClientRequest::default();
+        let mut has_parse = false;
 
         for message in &request.messages {
             let new_message = match message {
                 ProtocolMessage::Parse(parse) => {
+                    has_parse = true;
                     let mut new_parse = parse.clone();
                     new_parse.set_query(&self.stmt);
 
@@ -77,6 +79,24 @@ impl InsertSplit {
             };
             new_request.messages.push(new_message);
             new_request.ast = Some(self.ast.clone());
+        }
+
+        // When the driver prepared the statement in a separate round-trip
+        // (lib/pq: Parse/Describe/Sync, then Bind/Execute/Sync), the execute
+        // batch carries no Parse of its own and relies on `last_parse` being
+        // injected before the Bind. Rewrite that saved Parse to this split's
+        // single-tuple statement so the backend prepares the right one;
+        // otherwise it would still hold the original multi-tuple statement and
+        // reject the Bind's parameter count.
+        if !has_parse {
+            if let Some(parse) = &request.last_parse {
+                let mut split_parse = parse.clone();
+                split_parse.set_query(&self.stmt);
+                if let Some(name) = self.statement_name() {
+                    split_parse.rename_fast(name);
+                }
+                new_request.last_parse = Some(split_parse);
+            }
         }
 
         new_request

--- a/pgdog/src/frontend/router/parser/rewrite/statement/plan.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/plan.rs
@@ -139,7 +139,10 @@ impl RewritePlan {
             }
         }
 
-        if !self.insert_split.is_empty() {
+        // Only rewrite executable requests. Some clients prepare the statement
+        // separately (e.g. go/pq with Parse, Describe, Sync). We don't need to rewrite
+        // those since insert split will return the same row(s) as multi-tuple insert.
+        if !self.insert_split.is_empty() && request.is_executable() {
             let requests = build_split_requests(&self.insert_split, request);
             return Ok(RewriteResult::InsertSplit(requests));
         }

--- a/pgdog/tests/tls_cache.rs
+++ b/pgdog/tests/tls_cache.rs
@@ -4,6 +4,8 @@ use std::{
     time::{Duration, Instant},
 };
 
+// Timing tests are flaky by their nature.
+#[pgdog_plugin::macros::flaky]
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn tls_acceptor_reuse_is_fast() {
     pgdog::logger();


### PR DESCRIPTION
fix #981

`go/pq` and some other drivers send `Parse` and `Bind` in separate requests, so we need to keep track of current `Parse` statement since we don't rewrite extended unnamed prepared statements anymore to named.

Also add the soon cursed `flaky` macro to allow to retry flaky tests automatically.