### PR TITLE
test(resharding): add benchmarks for copy_data & replication

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -1,0 +1,138 @@
+# Benchmarks
+
+Performance benchmarks for PgDog. Results are stored in
+`target/pgdog_benches/` and compared automatically between runs.
+
+## Structure
+
+```
+benches/
+  bench.sh          shared runner library
+  compare.py        result comparison table
+  resharding/       resharding benchmark suite
+    pgdog.toml      config: 3 source shards (pgdog1-3) → 4 destination shards (shard_0-3)
+    users.toml
+    setup.sql       schema + tables + publication (run per source shard)
+    fill.sql        synthetic data generator (BENCH_SCALE env var or \set scale)
+    prepare.sh      hyperfine --prepare: drop destination schema, run schema-sync
+    copy_data/
+      run.sh        entry point: setup sources, then benchmark data-sync --sync-only
+```
+
+## Running
+
+```sh
+# Setup sources and benchmark (compares against the previous run automatically)
+bash benches/resharding/copy_data/run.sh
+
+# Save as a named baseline
+bash benches/resharding/copy_data/run.sh --save-baseline main
+
+# Compare against a named baseline (errors immediately if it does not exist)
+bash benches/resharding/copy_data/run.sh --baseline main
+
+# Fewer runs for a quick check
+RUNS=1 WARMUP=0 bash benches/resharding/copy_data/run.sh
+```
+
+### Flow
+
+1. **Setup** (once per invocation): drops and recreates `bench_copy` schema on each
+   source shard (`pgdog1`, `pgdog2`, `pgdog3`), then fills each shard with its own
+   slice of rows using a stepped `generate_series` keyed on `tenant_id`, so the source
+   data is pre-distributed before the copy benchmark runs.
+   Set `BENCH_SCALE=N` before running, or edit `\set scale` in `resharding/fill.sql` directly.
+
+2. **Benchmark** (timed, N runs): hyperfine calls `prepare.sh` before each iteration
+   (drops destination schema, runs `schema-sync`), then times `data-sync --sync-only`.
+   This measures pure data-copy throughput with no WAL replication involved.
+
+On first run there is no history yet:
+
+```
+No previous run found -- run again to see comparison.
+```
+
+On subsequent runs a comparison table is printed automatically:
+
+```
+copy_data
+
+                  latest         current      change
+  ----------  ----------  -------------  ----------
+        mean    24.904 s       22.194 s     -10.88%
+      median    24.100 s       21.900 s      -9.13%
+         min    24.904 s       22.194 s     -10.88%
+         max    24.904 s       22.194 s     -10.88%
+      stddev      1.200 s        0.900 s     -25.00%
+        user     2.226 s       11.234 s    +404.63%
+      system   962.045ms        1.419 s     +47.50%
+     max_mem      48.3 MB        46.1 MB      -4.55%
+
+  Performance has improved.
+```
+
+`latest` is always the previous run. Named baselines persist in
+`target/pgdog_benches/` until manually removed.
+
+If a run is interrupted, the result file is left empty. The next run detects
+this, skips the snapshot, and prints a notice instead of crashing. The run
+after that resumes normal comparison automatically.
+
+## Default approach: bench.sh + compare.py
+
+`bench.sh` is a sourceable shell library that provides a single function:
+
+```sh
+bench_run NAME COMMAND [--prepare CMD] [--save-baseline NAME] [--baseline NAME]
+```
+
+It handles:
+- Building pgdog in release mode (sets `PGDOG_BIN`, skipped if already set)
+- Setting `RUST_LOG=error` to suppress log I/O overhead
+- Running the command under [hyperfine](https://github.com/sharkdp/hyperfine)
+- Passing `--prepare CMD` to hyperfine when provided (runs before each timed iteration)
+- Saving results as JSON to `target/pgdog_benches/<name>.json`
+- Snapshotting the previous result to `<name>.prev.json` before each run
+- Calling `compare.py` to render the comparison table
+
+`compare.py` reads two hyperfine JSON files and prints a Criterion-style table
+with mean, median, min, max, stddev, user time, system time, and peak memory
+(`max_mem` — peak of `memory_usage_byte` samples), relative change per field, and an overall pass/regression verdict. It is independent of `bench.sh`
+and can be called directly:
+
+```sh
+python3 benches/compare.py target/pgdog_benches/before.json \
+                            target/pgdog_benches/after.json \
+                            --prev-label before --curr-label after
+```
+
+Benchmarks are not required to use this approach. A test can drive hyperfine
+differently, use a different timing tool entirely, or produce its own output —
+`bench.sh` is a convenience, not a contract.
+
+## Adding a new benchmark
+
+Create `benches/<suite>/run.sh`, source `bench.sh`, and call `bench_run`:
+
+```sh
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BENCH_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+source "${BENCH_DIR}/bench.sh"
+
+bench_run "<name>" "<command to benchmark>" "$@"
+```
+
+To reset state between hyperfine iterations, pass `--prepare`:
+
+```sh
+bench_run "<name>" "<command>" --prepare "<reset command>" "$@"
+```
+
+The benchmarked script reads these variables from the environment at runtime,
+so the same env vars control both the benchmark harness and the integration
+test when run directly — the integration test simply uses its own defaults.

--- a/benches/bench.sh
+++ b/benches/bench.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Shared benchmark runner. Source this file and call bench_run.
+#
+# Usage in a test script:
+#   source "${ROOT_DIR}/benches/bench.sh"
+#   bench_run "test_name" "command to run" "$@"
+#
+# Flags forwarded from the caller:
+#   --prepare CMD          command hyperfine runs before each timed run (reset state)
+#   --save-baseline NAME   save results as a named baseline
+#   --baseline NAME        compare against a named baseline (default: previous temp)
+#
+# Environment:
+#   RUNS    hyperfine run count  (default: 3)
+#   WARMUP  hyperfine warmup     (default: 1)
+
+BENCH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BENCH_COMPARE="${BENCH_DIR}/compare.py"
+
+bench_run() {
+    local name="$1" cmd="$2"
+    shift 2
+
+    # -- Parse flags ---------------------------------------------------------
+    local prepare_cmd="" save_baseline="" baseline=""
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --prepare)       prepare_cmd="$2";    shift 2 ;;
+            --save-baseline) save_baseline="$2"; shift 2 ;;
+            --baseline)      baseline="$2";      shift 2 ;;
+            *) echo "bench_run: unknown flag '$1'" >&2; return 2 ;;
+        esac
+    done
+
+    # -- Logging ------------------------------------------------------------
+    # Suppress all log output so it does not skew timing measurements.
+    export RUST_LOG=error
+
+    # -- Build ---------------------------------------------------------------
+    if [ -z "${PGDOG_BIN:-}" ]; then
+        local root_dir
+        root_dir="$(cd "${BENCH_DIR}/.." && pwd)"
+        echo "Building pgdog (release)..."
+        cargo build --release --manifest-path "${root_dir}/Cargo.toml"
+        export PGDOG_BIN="${root_dir}/target/release/pgdog"
+    fi
+    echo "Binary: $(${PGDOG_BIN} --version 2>&1 || true)"
+    echo ""
+
+    # -- Paths ---------------------------------------------------------------
+    local results_dir="${BENCH_DIR}/../target/pgdog_benches"
+    mkdir -p "${results_dir}"
+
+    local latest_file="${results_dir}/${name}.json"
+    local prev_file prev_label
+
+    if [ -n "${baseline}" ]; then
+        # Named baseline: verify it exists before proceeding.
+        prev_file="${results_dir}/${name}.${baseline}.json"
+        prev_label="${baseline}"
+        if [ ! -f "${prev_file}" ]; then
+            echo "ERROR: baseline '${baseline}' not found (${prev_file})"
+            exit 1
+        fi
+    else
+        # Auto baseline: snapshot current latest before overwriting it.
+        # Skip if the file is empty — an interrupted run leaves a zero-byte file.
+        prev_file="${results_dir}/${name}.prev.json"
+        prev_label="latest"
+        [ -s "${latest_file}" ] && cp "${latest_file}" "${prev_file}"
+    fi
+
+    # -- Run ----------------------------------------------------------------
+    local hyperfine_args=(
+        --runs "${RUNS:-3}"
+        --warmup "${WARMUP:-1}"
+        --show-output
+        --export-json "${latest_file}"
+        --command-name "${name}"
+    )
+    if [ -n "${prepare_cmd}" ]; then
+        hyperfine_args+=(--prepare "${prepare_cmd}")
+    fi
+    hyperfine "${hyperfine_args[@]}" "${cmd}"
+
+    # -- Save named baseline ------------------------------------------------
+    if [ -n "${save_baseline}" ]; then
+        local named_file="${results_dir}/${name}.${save_baseline}.json"
+        if [ -s "${latest_file}" ]; then
+            cp "${latest_file}" "${named_file}"
+            echo "Saved baseline '${save_baseline}' -> ${named_file}"
+        else
+            echo "WARNING: run did not complete cleanly, baseline '${save_baseline}' not saved."
+        fi
+    fi
+
+    # -- Compare ------------------------------------------------------------
+    echo ""
+    if [ -s "${prev_file}" ]; then
+        python3 "${BENCH_COMPARE}" "${prev_file}" "${latest_file}" \
+            --prev-label "${prev_label}" --curr-label "current"
+    else
+        echo "No previous run found -- run again to see comparison."
+        echo ""
+    fi
+}

--- a/benches/compare.py
+++ b/benches/compare.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+Compare two hyperfine JSON results and print a Criterion-style table.
+
+Usage:
+    compare.py PREVIOUS.json CURRENT.json [--prev-label NAME] [--curr-label NAME]
+"""
+
+import json
+import sys
+import argparse
+
+GREEN  = "\033[32m"
+RED    = "\033[31m"
+YELLOW = "\033[33m"
+BOLD   = "\033[1m"
+RESET  = "\033[0m"
+
+
+def supports_color() -> bool:
+    return hasattr(sys.stdout, "isatty") and sys.stdout.isatty()
+
+
+def color(text: str, code: str) -> str:
+    return f"{code}{text}{RESET}" if supports_color() else text
+
+
+def fmt_time(seconds: float | None) -> str:
+    if seconds is None:
+        return "N/A"
+    if seconds >= 60:
+        return f"{seconds / 60:.2f} min"
+    if seconds >= 1:
+        return f"{seconds:.3f} s"
+    if seconds >= 0.001:
+        return f"{seconds * 1000:.3f} ms"
+    return f"{seconds * 1e6:.3f} us"
+
+
+def fmt_bytes(n: int | float | None) -> str:
+    if n is None:
+        return "N/A"
+    for unit, threshold in (("GB", 1 << 30), ("MB", 1 << 20), ("KB", 1 << 10)):
+        if n >= threshold:
+            return f"{n / threshold:.1f} {unit}"
+    return f"{int(n)} B"
+
+
+def fmt_pct(prev: float | None, curr: float | None) -> tuple[str, float | None]:
+    """Returns (formatted string, raw delta %) or ('N/A', None)."""
+    if prev is None or curr is None or prev == 0:
+        return "N/A", None
+    delta = (curr - prev) / prev * 100
+    sign = "+" if delta >= 0 else ""
+    return f"{sign}{delta:.2f}%", delta
+
+
+def load(path: str) -> dict:
+    try:
+        with open(path) as f:
+            data = json.load(f)
+        return data["results"][0]
+    except (json.JSONDecodeError, KeyError, IndexError, OSError) as e:
+        print(f"(skipping comparison: {path} is empty or incomplete — {e})")
+        sys.exit(0)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("prev", help="previous baseline JSON")
+    ap.add_argument("curr", help="current result JSON")
+    ap.add_argument("--prev-label", default="previous")
+    ap.add_argument("--curr-label", default="current")
+    args = ap.parse_args()
+
+    prev = load(args.prev)
+    curr = load(args.curr)
+
+    name = curr.get("command", "benchmark")
+
+    def peak_mem(result: dict) -> float | None:
+        samples = result.get("memory_usage_byte") or []
+        return max(samples) if samples else None
+
+    rows = [
+        ("mean",    prev.get("mean"),    curr.get("mean")),
+        ("median",  prev.get("median"),  curr.get("median")),
+        ("min",     prev.get("min"),     curr.get("min")),
+        ("max",     prev.get("max"),     curr.get("max")),
+        ("stddev",  prev.get("stddev"),  curr.get("stddev")),
+        ("user",    prev.get("user"),    curr.get("user")),
+        ("system",  prev.get("system"),  curr.get("system")),
+        ("max_mem", peak_mem(prev),       peak_mem(curr)),
+    ]
+    w_label  = 10
+    w_time   = 14
+    w_change = 10
+
+    header_prev = args.prev_label[:w_time].rjust(w_time)
+    header_curr = args.curr_label[:w_time].rjust(w_time)
+
+    print(f"\n{color(name, BOLD)}\n")
+    print(f"  {'':>{w_label}}  {header_prev}  {header_curr}  {'change':>{w_change}}")
+    print(f"  {'-' * w_label}  {'-' * w_time}  {'-' * w_time}  {'-' * w_change}")
+
+    mean_delta = None
+    for label, pv, cv in rows:
+        pct_str, delta = fmt_pct(pv, cv)
+
+        if label == "mean":
+            mean_delta = delta
+
+        if delta is None or abs(delta) < 1.0:
+            pct_colored = pct_str
+        elif delta < 0:
+            # lower is better for time; higher is worse for memory
+            pct_colored = color(pct_str, RED if label == "max_mem" else GREEN)
+        else:
+            pct_colored = color(pct_str, GREEN if label == "max_mem" else RED)
+
+        fmt = fmt_bytes if label == "max_mem" else fmt_time
+        print(
+            f"  {label:>{w_label}}  "
+            f"{fmt(pv):>{w_time}}  "
+            f"{fmt(cv):>{w_time}}  "
+            f"{pct_colored:>{w_change}}"
+        )
+
+    # Verdict
+    print()
+    if mean_delta is None:
+        pass
+    elif abs(mean_delta) < 1.0:
+        print(f"  No change (<1%).")
+    elif mean_delta < 0:
+        print(f"  {color('Performance has improved.', GREEN)}")
+    else:
+        print(f"  {color('Performance has regressed.', RED)}")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/benches/resharding/README.md
+++ b/benches/resharding/README.md
@@ -1,0 +1,65 @@
+# Resharding benchmarks
+
+Two suites measure different phases of the resharding pipeline:
+
+| Suite | Script | What is timed |
+|---|---|---|
+| `copy_data` | `copy_data/run.sh` | Bulk COPY throughput, 3 source shards → 4 destination shards |
+| `replication` | `replication/run.sh` | WAL streaming throughput draining a pre-seeded backlog |
+
+## Prerequisites
+
+- Running Postgres with the databases defined in `pgdog.toml`
+- `PGDOG_BIN` pointing at the pgdog binary
+- `bench.sh` in the parent directory (hyperfine wrapper)
+
+## Running
+
+```sh
+# copy throughput
+bash benches/resharding/copy_data/run.sh
+
+# WAL replication throughput
+bash benches/resharding/replication/run.sh
+
+# scale up the dataset
+BENCH_SCALE=10000000 bash benches/resharding/copy_data/run.sh
+
+# save a baseline then compare
+bash benches/resharding/copy_data/run.sh --save-baseline main
+bash benches/resharding/copy_data/run.sh --baseline main
+```
+
+## Network simulation with toxiproxy
+
+Pass `USE_TOXI=1` to any suite to route pgdog connections through
+[toxiproxy](https://github.com/Shopify/toxiproxy). The run script starts
+the proxy automatically before the bench and tears it down on exit.
+
+Two proxies are created:
+
+| Proxy | Port | Shards | Direction |
+|---|---|---|---|
+| `resharding_source` | 15400 | pgdog1, pgdog2, pgdog3 | downstream (PG → pgdog) |
+| `resharding_destination` | 15401 | shard_0–shard_3 | upstream (pgdog → PG) |
+
+Toxic settings are configurable via environment variables:
+
+| Variable | Effect |
+|---|---|
+| `SOURCE_LATENCY_MS` | Added latency on source reads |
+| `DEST_LATENCY_MS` | Added latency on destination writes |
+| `SOURCE_BW_KBPS` | Bandwidth cap on source reads (KB/s) |
+| `DEST_BW_KBPS` | Bandwidth cap on destination writes (KB/s) |
+
+```sh
+# run with default toxic settings
+USE_TOXI=1 bash benches/resharding/copy_data/run.sh
+
+# simulate slow destination writes
+DEST_BW_KBPS=5000 DEST_LATENCY_MS=20 USE_TOXI=1 bash benches/resharding/copy_data/run.sh
+
+# compare proxied vs direct
+bash benches/resharding/copy_data/run.sh --save-baseline direct
+USE_TOXI=1 bash benches/resharding/copy_data/run.sh --baseline direct
+```

--- a/benches/resharding/copy_data/prepare.sh
+++ b/benches/resharding/copy_data/prepare.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# hyperfine --prepare: reset destination shards and re-sync schema.
+#
+# Runs before every timed data-copy iteration:
+#   1. Drop inactive replication slots on all source shards.
+#   2. Drop bench_copy schema on all 4 destination shards.
+#   3. Re-create it via pgdog schema-sync.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SETUP_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# PGDOG_BIN and PGDOG_CONFIG are exported by run.sh; this script is not standalone.
+PGDOG_CONFIG="${PGDOG_CONFIG:-${SETUP_DIR}/pgdog.toml}"
+
+export PGHOST=127.0.0.1
+export PGPORT=5432
+export PGUSER=pgdog
+export PGPASSWORD=pgdog
+
+SOURCE_DBS=(pgdog1 pgdog2 pgdog3)
+DEST_DBS=(shard_0 shard_1 shard_2 shard_3)
+
+echo "============================================================"
+echo ">>>>> prepare"
+echo "============================================================"
+
+echo "============================================================"
+echo ">>>>> [1/3] dropping inactive replication slots (sources)"
+echo "============================================================"
+for db in "${SOURCE_DBS[@]}"; do
+    psql -d "${db}" -qX -c \
+        "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE slot_name LIKE 'bench_copy%' AND NOT active;"
+done
+
+echo ""
+echo "============================================================"
+echo ">>>>> [2/3] dropping bench_copy schema (destinations)"
+echo "============================================================"
+for db in "${DEST_DBS[@]}"; do
+    psql -d "${db}" -qX -c "DROP SCHEMA IF EXISTS bench_copy CASCADE;"
+done
+
+echo ""
+echo "============================================================"
+echo ">>>>> [3/3] schema-sync: source → destination"
+echo "============================================================"
+"${PGDOG_BIN}" \
+    --config "${PGDOG_CONFIG}" \
+    --users  "${SETUP_DIR}/users.toml" \
+    schema-sync \
+    --from-database source \
+    --to-database   destination \
+    --publication   bench_copy
+echo "============================================================"
+echo ">>>>> schema-sync done"
+echo "============================================================"
+echo ""

--- a/benches/resharding/copy_data/run.sh
+++ b/benches/resharding/copy_data/run.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Benchmark: copy_data — data-copy throughput (3 sources → 4 destination shards).
+#
+# Flow:
+#   1. Setup: recreate bench_copy schema on each source shard and fill with data
+#      directly via a stepped generate_series(:shard_index+1, :scale, :num_shards),
+#      so each shard receives only its own slice of tenant_ids.
+#   2. Benchmark: hyperfine runs data-sync --sync-only, calling prepare.sh
+#      before each iteration (drops + resyncs destination schema).
+#
+# Usage:
+#   bash benches/resharding/copy_data/run.sh [bench.sh flags]
+#   bash benches/resharding/copy_data/run.sh --save-baseline main
+#   bash benches/resharding/copy_data/run.sh --baseline main
+#
+# Tuning:
+#   BENCH_SCALE=N  rows (inline tables); TOAST tables use scale/100
+#   USE_TOXI=1     route pgdog through toxiproxy (started/stopped automatically)
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SETUP_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+BENCH_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+source "${BENCH_DIR}/bench.sh"
+
+export PGHOST=127.0.0.1
+export PGPORT=5432
+export PGUSER=pgdog
+export PGPASSWORD=pgdog
+
+SOURCE_DBS=(pgdog1 pgdog2 pgdog3)
+NUM_SHARDS=${#SOURCE_DBS[@]}
+export BENCH_SCALE=${BENCH_SCALE:-5000000}
+
+PGDOG_CONFIG="${SETUP_DIR}/pgdog.toml"
+if [[ "${USE_TOXI:-0}" == "1" ]]; then
+    PGDOG_CONFIG="${SETUP_DIR}/pgdog.toxi.toml"
+    # Register teardown before setup so a partial-setup failure still tears down.
+    trap 'bash "${SETUP_DIR}/toxi/teardown.sh"' EXIT
+    bash "${SETUP_DIR}/toxi/setup.sh"
+fi
+export PGDOG_CONFIG
+
+echo "============================================================"
+echo ">>>>> setup"
+echo "============================================================"
+
+for i in "${!SOURCE_DBS[@]}"; do
+    db="${SOURCE_DBS[$i]}"
+    echo ""
+    echo "============================================================"
+    echo ">>>>> [shard ${i}/${NUM_SHARDS}] ${db}: setup"
+    echo "============================================================"
+    psql -d "${db}" -qX -f "${SETUP_DIR}/setup.sql"
+    psql -d "${db}" -qX \
+        -v num_shards="${NUM_SHARDS}" \
+        -v shard_index="${i}" \
+        -f "${SETUP_DIR}/fill.sql"
+done
+
+echo ""
+echo "============================================================"
+echo ">>>>> benchmark"
+echo "============================================================"
+echo ""
+
+DATA_COPY_CMD="\${PGDOG_BIN} \
+    --config '${PGDOG_CONFIG}' \
+    --users  '${SETUP_DIR}/users.toml' \
+    data-sync \
+    --sync-only \
+    --from-database source \
+    --to-database   destination \
+    --publication   bench_copy \
+    --replication-slot bench_copy_slot_copy"
+
+bench_run "resharding.copy_data" "${DATA_COPY_CMD}" \
+    --prepare "${SCRIPT_DIR}/prepare.sh" \
+    "$@"

--- a/benches/resharding/fill.sql
+++ b/benches/resharding/fill.sql
@@ -1,0 +1,107 @@
+-- Benchmark data generator: bench_copy
+--
+-- Four data shapes in one file:
+--
+--   sessions   : scale rows — UUID/TIMESTAMPTZ-heavy, fully inline.
+--                Best-case for binary format: 8 UUID×20B + 4 TS×21B = 244 B/row
+--                saved vs text, on both source routing and destination ingest.
+--
+--   documents  : scale/100 rows — body ≈ 32 KB (STORAGE EXTERNAL).
+--   files      : scale/100 rows — content ≈ 4 KB bytea (TOAST).
+--   ledger     : scale/100 rows — notes ≈ 16 KB (STORAGE EXTERNAL).
+--
+-- The TOAST tables share their row count so a single BENCH_SCALE knob controls
+-- everything: inline rows = scale, TOAST rows = scale/100.
+--
+-- Override default scale: BENCH_SCALE=N psql ... -f fill.sql
+-- Shard slice: pass -v num_shards=N -v shard_index=I to insert only the
+--   rows that belong on shard I.  Defaults to a single shard (all rows).
+\getenv scale BENCH_SCALE
+\if :{?scale}
+\else
+\set scale 100000
+\endif
+\if :{?num_shards}
+\else
+\set num_shards 1
+\endif
+\if :{?shard_index}
+\else
+\set shard_index 0
+\endif
+-- ── sessions (inline, UUID + TIMESTAMPTZ heavy) ────────────────────────────────
+INSERT INTO bench_copy.sessions (
+    id, tenant_id, user_id, device_id, session_id, correlation_id,
+    request_id, trace_id,
+    started_at, ended_at, last_seen_at, expires_at,
+    duration_ms, score, event_count, byte_count
+)
+SELECT
+    gen_random_uuid(),
+    gs.i,
+    md5((gs.i % 100000)::text)::uuid,
+    md5((gs.i % 10000)::text)::uuid,
+    gen_random_uuid(),
+    gen_random_uuid(),
+    gen_random_uuid(),
+    md5(gs.i::text)::uuid,
+    now() - ((gs.i % 365) || ' days')::interval,
+    now() - ((gs.i % 365) || ' days')::interval + '1 hour'::interval,
+    now() - ((gs.i % 7)   || ' days')::interval,
+    now() + ((gs.i % 30)  || ' days')::interval,
+    ROUND((0.1 + (gs.i % 60000) * 0.001)::numeric, 3)::float8,
+    ROUND((gs.i % 1000)::numeric / 1000.0, 6)::float8,
+    (gs.i % 10000),
+    (gs.i % 1000000)::bigint * 1024
+FROM generate_series(:shard_index + 1, :scale, :num_shards) AS gs(i);
+
+-- ── documents (body ≈ 32 KB, STORAGE EXTERNAL) ────────────────────────────────
+INSERT INTO bench_copy.documents (id, tenant_id, title, body, tags, metadata, created_at, updated_at)
+SELECT
+    gen_random_uuid(),
+    gs.i,
+    format('doc_title_%s', gs.i),
+    repeat(md5(gs.i::text), 1024),
+    ARRAY[
+        'tag_' || ((gs.i % 20) + 1)::text,
+        'cat_' || ((gs.i % 8)  + 1)::text,
+        CASE WHEN gs.i % 3 = 0 THEN 'featured' ELSE 'standard' END
+    ],
+    jsonb_build_object(
+        'version',    (gs.i % 10) + 1,
+        'published',  (gs.i % 2 = 0),
+        'word_count', 500 + (gs.i % 2000)
+    ),
+    now() - ((gs.i % 730) || ' days')::interval,
+    now() - ((gs.i % 365) || ' days')::interval
+FROM generate_series(:shard_index + 1, :scale / 100, :num_shards) AS gs(i);
+
+-- files (omni, no tenant_id) -- copied to every destination shard. content ~4 KB TOAST.
+INSERT INTO bench_copy.files (id, name, mime_type, content, size_bytes, checksum, uploaded_at)
+SELECT
+    gs.i,
+    format('file_%s.bin', gs.i),
+    (ARRAY['application/octet-stream', 'image/png', 'application/pdf'])[((gs.i % 3) + 1)],
+    decode(repeat(md5(gs.i::text), 256), 'hex'),
+    4096,
+    md5(gs.i::text),
+    now() - ((gs.i % 365) || ' days')::interval
+FROM generate_series(1, :scale / 100) AS gs(i);
+
+-- ── ledger (notes ≈ 16 KB, STORAGE EXTERNAL) ─────────────────────────────────
+INSERT INTO bench_copy.ledger (id, tenant_id, ref_code, amount, rate, currency, notes, checkpoints, posted_at)
+SELECT
+    gen_random_uuid(),
+    gs.i,
+    'REF-' || lpad(gs.i::text, 10, '0'),
+    ROUND((1.0 + (gs.i % 1000000) * 0.01)::numeric, 6),
+    ROUND((0.85 + (gs.i % 50) * 0.003)::numeric, 6)::float8,
+    (ARRAY['USD', 'EUR', 'GBP', 'JPY', 'CAD', 'AUD', 'CHF'])[((gs.i % 7) + 1)],
+    repeat(md5(('ledger_' || gs.i)::text), 512),
+    ARRAY(
+        SELECT now() - ((gs.i % 365) || ' days')::interval
+                     - ((j * 30) || ' days')::interval
+        FROM generate_series(0, (gs.i % 5)) AS j
+    ),
+    now() - ((gs.i % 365) || ' days')::interval
+FROM generate_series(:shard_index + 1, :scale / 100, :num_shards) AS gs(i);

--- a/benches/resharding/pgdog.toml
+++ b/benches/resharding/pgdog.toml
@@ -1,0 +1,58 @@
+[general]
+resharding_copy_format = "binary"
+resharding_parallel_copies = 5
+
+[[databases]]
+name = "source"
+host = "127.0.0.1"
+database_name = "pgdog1"
+shard = 0
+
+[[databases]]
+name = "source"
+host = "127.0.0.1"
+database_name = "pgdog2"
+shard = 1
+
+[[databases]]
+name = "source"
+host = "127.0.0.1"
+database_name = "pgdog3"
+shard = 2
+
+[[sharded_tables]]
+database = "source"
+column = "tenant_id"
+data_type = "bigint"
+
+[[databases]]
+name = "destination"
+host = "127.0.0.1"
+database_name = "shard_0"
+shard = 0
+
+[[databases]]
+name = "destination"
+host = "127.0.0.1"
+database_name = "shard_1"
+shard = 1
+
+[[databases]]
+name = "destination"
+host = "127.0.0.1"
+database_name = "shard_2"
+shard = 2
+
+[[databases]]
+name = "destination"
+host = "127.0.0.1"
+database_name = "shard_3"
+shard = 3
+
+[[sharded_tables]]
+database = "destination"
+column = "tenant_id"
+data_type = "bigint"
+
+[admin]
+password = "pgdog"

--- a/benches/resharding/pgdog.toxi.toml
+++ b/benches/resharding/pgdog.toxi.toml
@@ -1,0 +1,73 @@
+# pgdog configuration for resharding benchmarks with toxiproxy.
+#
+# All source shards connect through resharding_source  (port 15400).
+# All destination shards connect through resharding_destination (port 15401).
+# Set up the proxies first:
+#
+#   bash benches/resharding/toxi/setup.sh
+#
+[general]
+resharding_copy_format = "binary"
+resharding_parallel_copies = 5
+
+[[databases]]
+name = "source"
+host = "127.0.0.1"
+port = 15400
+database_name = "pgdog1"
+shard = 0
+
+[[databases]]
+name = "source"
+host = "127.0.0.1"
+port = 15400
+database_name = "pgdog2"
+shard = 1
+
+[[databases]]
+name = "source"
+host = "127.0.0.1"
+port = 15400
+database_name = "pgdog3"
+shard = 2
+
+[[sharded_tables]]
+database = "source"
+column = "tenant_id"
+data_type = "bigint"
+
+[[databases]]
+name = "destination"
+host = "127.0.0.1"
+port = 15401
+database_name = "shard_0"
+shard = 0
+
+[[databases]]
+name = "destination"
+host = "127.0.0.1"
+port = 15401
+database_name = "shard_1"
+shard = 1
+
+[[databases]]
+name = "destination"
+host = "127.0.0.1"
+port = 15401
+database_name = "shard_2"
+shard = 2
+
+[[databases]]
+name = "destination"
+host = "127.0.0.1"
+port = 15401
+database_name = "shard_3"
+shard = 3
+
+[[sharded_tables]]
+database = "destination"
+column = "tenant_id"
+data_type = "bigint"
+
+[admin]
+password = "pgdog"

--- a/benches/resharding/replication/prepare.sh
+++ b/benches/resharding/replication/prepare.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# hyperfine --prepare: reset schema, COPY empty tables (creates/reuses slot), fill sources.
+#
+# The COPY phase runs against empty tables — trivial, just establishes the slot
+# at the current LSN. fill.sql then queues the WAL backlog the timed command drains.
+# Slot lifecycle (bench_copy_slot_replication) is owned by this script:
+# dropped at the start of each prepare so every run starts from a fresh LSN.
+
+set -euo pipefail
+
+# Inherit PGDOG_CONFIG from run.sh (defaults to pgdog.toml for standalone use).
+# SETUP_DIR is also exported by run.sh.
+PGDOG_CONFIG="${PGDOG_CONFIG:-${SETUP_DIR}/pgdog.toml}"
+
+SOURCE_DBS=(pgdog1 pgdog2 pgdog3)
+DEST_DBS=(shard_0 shard_1 shard_2 shard_3)
+
+echo "============================================================"
+echo ">>>>> prepare"
+echo "============================================================"
+
+echo ""
+echo "============================================================"
+echo ">>>>> [1/6] dropping stale replication slots"
+echo "============================================================"
+for db in "${SOURCE_DBS[@]}"; do
+    psql -d "${db}" -qX -c \
+        "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE slot_name LIKE 'bench_copy%' AND NOT active;"
+done
+
+echo ""
+echo "============================================================"
+echo ">>>>> [2/6] resetting source schema (empty tables)"
+echo "============================================================"
+for db in "${SOURCE_DBS[@]}"; do
+    psql -d "${db}" -qX -f "${SETUP_DIR}/setup.sql"
+done
+
+echo ""
+echo "============================================================"
+echo ">>>>> [3/6] resetting destination schema"
+echo "============================================================"
+for db in "${DEST_DBS[@]}"; do
+    psql -d "${db}" -qX -c "DROP SCHEMA IF EXISTS bench_copy CASCADE" > /dev/null
+done
+
+echo ""
+echo "============================================================"
+echo ">>>>> [4/6] establishing replication slot via COPY (empty tables)"
+echo "============================================================"
+# COPY empty tables; creates the slot at the current LSN.  Exit immediately after COPY (--sync-only).
+"${PGDOG_BIN}" \
+    --config "${PGDOG_CONFIG}" \
+    --users  "${SETUP_DIR}/users.toml" \
+    data-sync \
+    --from-database source \
+    --to-database   destination \
+    --publication   bench_copy \
+    --replication-slot bench_copy_slot_replication \
+    --sync-only
+
+echo ""
+echo "============================================================"
+echo ">>>>> [5/6] filling source shards in parallel (WAL backlog)"
+echo "============================================================"
+FILL_PIDS=()
+for db in "${SOURCE_DBS[@]}"; do
+    psql -d "${db}" -qX -f "${SETUP_DIR}/fill.sql" &
+    FILL_PIDS+=("$!")
+done
+echo "  waiting for all fills to complete..."
+wait "${FILL_PIDS[@]}"
+
+echo ""
+echo "============================================================"
+echo ">>>>> [6/6] inserting replication sentinels into each source"
+echo "============================================================"
+# Insert the same sentinel row on every source.  bench_copy.files is the omni table
+# (no tenant_id) so it replicates to all destination shards.  id = -1 is outside the
+# generate_series range (1..scale/100) so it never collides with fill data.
+for db in "${SOURCE_DBS[@]}"; do
+    psql -d "${db}" -qX -c \
+        "INSERT INTO bench_copy.files (id, name, mime_type, content, size_bytes, checksum, uploaded_at) \
+         VALUES (-1, 'sentinel', 'application/octet-stream', decode('', 'hex'), 0, 'sentinel', now())"
+    echo "  [${db}] sentinel inserted"
+done
+
+echo ""
+echo "============================================================"
+echo ">>>>> WAL backlog + sentinels ready"
+echo "============================================================"
+echo ""

--- a/benches/resharding/replication/run.sh
+++ b/benches/resharding/replication/run.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Benchmark: WAL replication throughput (3 sources → 4 destination shards).
+#
+# Measures time for pgdog to drain a pre-seeded WAL backlog via --replicate-only.
+# COPY happens in prepare (untimed); prepare also writes per-source sentinel rows.
+# The timed command streams WAL and exits once all sentinels appear on all shards.
+#
+# Usage:
+#   bash benches/resharding/replication/run.sh [bench.sh flags]
+#   bash benches/resharding/replication/run.sh --save-baseline main
+#   bash benches/resharding/replication/run.sh --baseline main
+#
+# Tuning:
+#   BENCH_SCALE=N    sessions per source shard; TOAST rows = N/100
+#   RUNS=N WARMUP=N  forwarded to hyperfine via environment
+#   USE_TOXI=1       route pgdog through toxiproxy (started/stopped automatically)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SETUP_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+BENCH_DIR="$(cd "${SETUP_DIR}/.." && pwd)"
+
+source "${BENCH_DIR}/bench.sh"
+
+export PGHOST=127.0.0.1
+export PGPORT=5432
+export PGUSER=pgdog
+export PGPASSWORD=pgdog
+export SETUP_DIR  # inherited by prepare.sh
+
+DEST_DBS=(shard_0 shard_1 shard_2 shard_3)
+export BENCH_SCALE=${BENCH_SCALE:-50000}
+
+PGDOG_CONFIG="${SETUP_DIR}/pgdog.toml"
+if [[ "${USE_TOXI:-0}" == "1" ]]; then
+    PGDOG_CONFIG="${SETUP_DIR}/pgdog.toxi.toml"
+    # Register teardown before setup so a partial-setup failure still tears down.
+    trap 'bash "${SETUP_DIR}/toxi/teardown.sh"' EXIT
+    bash "${SETUP_DIR}/toxi/setup.sh"
+fi
+export PGDOG_CONFIG
+
+echo "============================================================"
+echo ">>>>> benchmark"
+echo "============================================================"
+bench_run "resharding.streaming" \
+    "${SCRIPT_DIR}/stream.sh" \
+    --prepare "${SCRIPT_DIR}/prepare.sh" \
+    "$@"

--- a/benches/resharding/replication/stream.sh
+++ b/benches/resharding/replication/stream.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Timed command: stream WAL backlog to completion, detected via sentinel rows.
+#
+# Starts pgdog in --replicate-only mode (no COPY; slot was established in prepare),
+# then polls all 4 destination shards for the sentinel row written by prepare.sh.
+# When the sentinel is present on every shard, replication has drained the entire
+# backlog.  pgdog is then stopped cleanly and the script exits 0.
+#
+# PGDOG_BIN and SETUP_DIR are exported by run.sh via bench_run().
+set -euo pipefail
+
+DEST_DBS=(shard_0 shard_1 shard_2 shard_3)
+# Sentinel id written by prepare.sh into bench_copy.files on every source.
+SENTINEL_ID=-1
+
+# Inherit PGDOG_CONFIG from run.sh (defaults to pgdog.toml for standalone use).
+PGDOG_CONFIG="${PGDOG_CONFIG:-${SETUP_DIR}/pgdog.toml}"
+POLL_INTERVAL=0.5  # seconds between destination polls
+
+# Start replication in the background.  Schema sync is skipped because prepare.sh
+# already ran it via --sync-only.
+"${PGDOG_BIN}" \
+    --config "${PGDOG_CONFIG}" \
+    --users  "${SETUP_DIR}/users.toml" \
+    data-sync \
+    --from-database source \
+    --to-database   destination \
+    --publication   bench_copy \
+    --replication-slot bench_copy_slot_replication \
+    --skip-schema-sync \
+    --replicate-only &
+PGDOG_PID=$!
+
+# Ensure pgdog is killed on any exit path
+trap 'kill "${PGDOG_PID}" 2>/dev/null || true; sleep 5; kill -9 "${PGDOG_PID}" 2>/dev/null || true' EXIT
+
+echo "  pgdog replication started (pid=${PGDOG_PID}), polling for sentinels..."
+
+# Poll until the sentinel row appears on all destination shards.
+while true; do
+    all_found=true
+    for db in "${DEST_DBS[@]}"; do
+        count=$(psql -d "${db}" -qXAt -c \
+            "SELECT COUNT(*) FROM bench_copy.files WHERE id = ${SENTINEL_ID}" 2>/dev/null || echo 0)
+        if [[ "${count}" -lt 1 ]]; then
+            all_found=false
+            break
+        fi
+    done
+    $all_found && break
+    sleep "${POLL_INTERVAL}"
+done
+
+echo "  all sentinels confirmed — replication backlog drained"

--- a/benches/resharding/setup.sql
+++ b/benches/resharding/setup.sql
@@ -1,0 +1,82 @@
+-- Benchmark schema setup: bench_copy
+--
+-- Creates schema + tables on SOURCE databases (pgdog1/pgdog2/pgdog3).
+-- Run once at benchmark start; safe to re-run (DROP IF EXISTS).
+--
+-- Tables exercise two distinct copy paths:
+--   sessions   : UUID/TIMESTAMPTZ-heavy, fully inline -- shows binary format benefit.
+--   documents  : body ~32 KB (STORAGE EXTERNAL) -- TOAST read path.
+--   files      : omni (no tenant_id) -- 4 KB TOAST bytea, copied to all shards.
+--   ledger     : notes ~16 KB (STORAGE EXTERNAL) + NUMERIC.
+--
+-- The destination schema is created by pgdog schema-sync, not here.
+
+DROP SCHEMA IF EXISTS bench_copy CASCADE;
+CREATE SCHEMA bench_copy;
+
+-- ── 1. sessions ───────────────────────────────────────────────────────────────
+-- UUID/TIMESTAMPTZ-heavy, zero TOAST. Best-case for binary format:
+-- 8 UUID cols × 20 B + 4 TIMESTAMPTZ × 21 B = 244 B/row less on wire vs text.
+CREATE TABLE bench_copy.sessions (
+    id              UUID        NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+    tenant_id       BIGINT      NOT NULL,
+    user_id         UUID        NOT NULL,
+    device_id       UUID        NOT NULL,
+    session_id      UUID        NOT NULL,
+    correlation_id  UUID        NOT NULL,
+    request_id      UUID        NOT NULL,
+    trace_id        UUID        NOT NULL,
+    started_at      TIMESTAMPTZ NOT NULL,
+    ended_at        TIMESTAMPTZ NOT NULL,
+    last_seen_at    TIMESTAMPTZ NOT NULL,
+    expires_at      TIMESTAMPTZ NOT NULL,
+    duration_ms     FLOAT8      NOT NULL DEFAULT 0.0,
+    score           FLOAT8      NOT NULL DEFAULT 0.0,
+    event_count     BIGINT      NOT NULL DEFAULT 0,
+    byte_count      BIGINT      NOT NULL DEFAULT 0
+);
+
+-- ── 2. documents ──────────────────────────────────────────────────────────────
+-- body ~32 KB forced out of the main heap (STORAGE EXTERNAL).
+CREATE TABLE bench_copy.documents (
+    id          UUID        NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+    tenant_id   BIGINT      NOT NULL,
+    title       TEXT        NOT NULL,
+    body        TEXT        NOT NULL,
+    tags        TEXT[]      NOT NULL DEFAULT '{}',
+    metadata    JSONB       NOT NULL DEFAULT '{}',
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+ALTER TABLE bench_copy.documents ALTER COLUMN body SET STORAGE EXTERNAL;
+
+-- ── 3. files (omni) ─────────────────────────────────────────────────────────────
+-- No tenant_id: copied to every destination shard. content ~4 KB bytea TOAST.
+CREATE TABLE bench_copy.files (
+    id           BIGINT      NOT NULL PRIMARY KEY,
+    name         TEXT        NOT NULL,
+    mime_type    TEXT        NOT NULL DEFAULT 'application/octet-stream',
+    content      BYTEA       NOT NULL,
+    size_bytes   BIGINT      NOT NULL DEFAULT 0,
+    checksum     TEXT        NOT NULL DEFAULT '',
+    uploaded_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- ── 4. ledger ─────────────────────────────────────────────────────────────────
+-- notes ~16 KB (STORAGE EXTERNAL). NUMERIC columns for exact financials.
+CREATE TABLE bench_copy.ledger (
+    id            UUID          NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+    tenant_id     BIGINT        NOT NULL,
+    ref_code      TEXT          NOT NULL,
+    amount        NUMERIC(18,6) NOT NULL DEFAULT 0,
+    rate          FLOAT8        NOT NULL DEFAULT 1.0,
+    currency      TEXT          NOT NULL DEFAULT 'USD',
+    notes         TEXT          NOT NULL DEFAULT '',
+    checkpoints   TIMESTAMPTZ[] NOT NULL DEFAULT '{}',
+    posted_at     TIMESTAMPTZ   NOT NULL DEFAULT now()
+);
+ALTER TABLE bench_copy.ledger ALTER COLUMN notes SET STORAGE EXTERNAL;
+
+-- ── Publication ───────────────────────────────────────────────────────────────
+DROP PUBLICATION IF EXISTS bench_copy;
+CREATE PUBLICATION bench_copy FOR TABLES IN SCHEMA bench_copy;

--- a/benches/resharding/toxi/setup.sh
+++ b/benches/resharding/toxi/setup.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Set up toxiproxy for resharding benchmarks.
+#
+# Two proxies, both upstream 127.0.0.1:5432:
+#
+#   Name                     Listen port   Used by
+#   ──────────────────────────────────────────────
+#   resharding_source        15400         pgdog1, pgdog2, pgdog3
+#   resharding_destination   15401         shard_0, shard_1, shard_2, shard_3
+#
+# Toxics applied to each proxy (all configurable via env):
+#   SOURCE_LATENCY_MS   -- latency on source reads,      --downstream (PG -> pgdog)
+#   DEST_LATENCY_MS     -- latency on destination writes, --upstream   (pgdog -> PG)
+#   SOURCE_BW_KBPS      -- bandwidth cap on source reads,      --downstream
+#   DEST_BW_KBPS        -- bandwidth cap on destination writes, --upstream
+#
+# Usage:
+#   bash benches/resharding/toxi/setup.sh
+#   SOURCE_LATENCY_MS=20 DEST_BW_KBPS=10000 bash benches/resharding/toxi/setup.sh
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+CLI="${REPO_ROOT}/integration/toxiproxy-cli"
+SERVER="${REPO_ROOT}/integration/toxiproxy-server"
+UPSTREAM="127.0.0.1:5432"
+
+SOURCE_LATENCY_MS="${SOURCE_LATENCY_MS:-0}"
+DEST_LATENCY_MS="${DEST_LATENCY_MS:-0}"
+SOURCE_BW_KBPS="${SOURCE_BW_KBPS:-10000}"
+DEST_BW_KBPS="${DEST_BW_KBPS:-10000}"
+
+# ── Start server ─────────────────────────────────────────────────────────────
+echo "Starting toxiproxy-server..."
+bash "${SCRIPT_DIR}/teardown.sh"
+"${SERVER}" > /dev/null 2>&1 &
+
+# Wait for API readiness.
+until "${CLI}" list >/dev/null 2>&1; do sleep 0.2; done
+
+# ── Helper ───────────────────────────────────────────────────────────────────
+create_proxy() {
+    local name="$1" port="$2"
+    "${CLI}" delete "${name}" 2>/dev/null || true
+    "${CLI}" create --listen "127.0.0.1:${port}" --upstream "${UPSTREAM}" "${name}"
+}
+
+# ── Proxies ───────────────────────────────────────────────────────────────────
+create_proxy resharding_source      15400
+create_proxy resharding_destination 15401
+
+# ── Toxics ───────────────────────────────────────────────────────────────────
+echo ""
+echo "Applying toxics..."
+
+"${CLI}" toxic add \
+    --toxicName latency \
+    --type      latency \
+    --downstream \
+    --attribute  latency="${SOURCE_LATENCY_MS}" \
+    resharding_source
+
+"${CLI}" toxic add \
+    --toxicName bandwidth \
+    --type      bandwidth \
+    --downstream \
+    --attribute  rate="${SOURCE_BW_KBPS}" \
+    resharding_source
+
+"${CLI}" toxic add \
+    --toxicName latency \
+    --type      latency \
+    --upstream \
+    --attribute  latency="${DEST_LATENCY_MS}" \
+    resharding_destination
+
+"${CLI}" toxic add \
+    --toxicName bandwidth \
+    --type      bandwidth \
+    --upstream \
+    --attribute  rate="${DEST_BW_KBPS}" \
+    resharding_destination
+
+echo ""
+"${CLI}" list
+echo ""
+echo "Toxiproxy ready (API port=8474)."
+echo "  source      latency=${SOURCE_LATENCY_MS}ms  bandwidth=${SOURCE_BW_KBPS} KB/s"
+echo "  destination latency=${DEST_LATENCY_MS}ms  bandwidth=${DEST_BW_KBPS} KB/s"
+echo ""
+echo "Run teardown.sh to stop, or just re-run setup.sh to restart."

--- a/benches/resharding/toxi/teardown.sh
+++ b/benches/resharding/toxi/teardown.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+killall toxiproxy-server 2>/dev/null && echo "Stopped toxiproxy-server." || echo "toxiproxy-server was not running."

--- a/benches/resharding/users.toml
+++ b/benches/resharding/users.toml
@@ -1,0 +1,11 @@
+[[users]]
+database = "source"
+name = "pgdog"
+password = "pgdog"
+schema_admin = true
+
+[[users]]
+database = "destination"
+name = "pgdog"
+password = "pgdog"
+schema_admin = true


### PR DESCRIPTION
Add benchmarks scripts (with hyperfine inside) for pure copy_data and replication to measure its performance.

It looks like this 
<img width="1222" height="388" alt="image" src="https://github.com/user-attachments/assets/02fde058-79a0-4f8d-8b09-2bd05c9b210e" />

This is example of run for copy_data test for comparing text vs binary copy_format.

Here are only benchmarks on base of which I'm going to make some improvements and fixes