### PR TITLE
feat: add `query_log_stdout` config for pgcat-style query logging

### DIFF
--- a/.schema/pgdog.schema.json
+++ b/.schema/pgdog.schema.json
@@ -85,6 +85,7 @@
         "pub_sub_channel_size": 0,
         "query_cache_limit": 1000,
         "query_log": null,
+        "query_log_stdout": false,
         "query_parser": "auto",
         "query_parser_enabled": false,
         "query_parser_engine": "pg_query_protobuf",
@@ -971,6 +972,11 @@
             "null"
           ],
           "default": null
+        },
+        "query_log_stdout": {
+          "description": "Log queries to stdout (pgcat-style). Format: `[pool: db][user: user] query`",
+          "type": "boolean",
+          "default": false
         },
         "query_parser": {
           "description": "Toggle the query parser to enable/disable query parsing and all of its benefits. By default, the query parser is turned on automatically, so only disable it if you know what you're doing.\n\n_Default:_ `auto`\n\nhttps://docs.pgdog.dev/configuration/pgdog.toml/general/#query_parser",

--- a/.schema/pgdog.schema.json
+++ b/.schema/pgdog.schema.json
@@ -974,7 +974,7 @@
           "default": null
         },
         "query_log_stdout": {
-          "description": "Log queries to stdout (pgcat-style). Format: `[pool: db][user: user] query`",
+          "description": "Log queries to stdout. Format: `query [database: db, user: user]`",
           "type": "boolean",
           "default": false
         },

--- a/pgdog-config/src/general.rs
+++ b/pgdog-config/src/general.rs
@@ -269,6 +269,10 @@ pub struct General {
     #[serde(default)]
     pub query_log: Option<PathBuf>,
 
+    /// Log queries to stdout (pgcat-style). Format: `[pool: db][user: user] query`
+    #[serde(default = "General::query_log_stdout")]
+    pub query_log_stdout: bool,
+
     /// Minimum parse duration in milliseconds that triggers a warning log with the query text.
     /// Queries whose parsing takes longer than this value are logged at WARN level.
     /// Set to `0` or omit to disable.
@@ -800,6 +804,7 @@ impl Default for General {
             broadcast_address: Self::broadcast_address(),
             broadcast_port: Self::broadcast_port(),
             query_log: Self::query_log(),
+            query_log_stdout: Self::query_log_stdout(),
             log_min_duration_parse: Self::default_log_min_duration_parse(),
             log_query_sample_length: Self::log_query_sample_length(),
             openmetrics_port: Self::openmetrics_port(),
@@ -1186,6 +1191,10 @@ impl General {
 
     fn query_log() -> Option<PathBuf> {
         Self::env_option_string("PGDOG_QUERY_LOG").map(PathBuf::from)
+    }
+
+    fn query_log_stdout() -> bool {
+        Self::env_bool_or_default("PGDOG_QUERY_LOG_STDOUT", false)
     }
 
     fn default_log_min_duration_parse() -> Option<u64> {
@@ -1585,6 +1594,15 @@ mod tests {
         assert_eq!(General::tls_server_ca_certificate(), None);
         assert_eq!(General::tls_client_ca_certificate(), None);
         assert_eq!(General::query_log(), None);
+    }
+
+    #[test]
+    fn test_query_log_stdout_env() {
+        env::set_var("PGDOG_QUERY_LOG_STDOUT", "true");
+        assert!(General::query_log_stdout());
+
+        env::remove_var("PGDOG_QUERY_LOG_STDOUT");
+        assert!(!General::query_log_stdout());
     }
 
     #[test]

--- a/pgdog-config/src/general.rs
+++ b/pgdog-config/src/general.rs
@@ -269,7 +269,7 @@ pub struct General {
     #[serde(default)]
     pub query_log: Option<PathBuf>,
 
-    /// Log queries to stdout (pgcat-style). Format: `[pool: db][user: user] query`
+    /// Log queries to stdout. Format: `query [database: db, user: user]`
     #[serde(default = "General::query_log_stdout")]
     pub query_log_stdout: bool,
 

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -89,6 +89,8 @@ pub struct Client {
     sticky: Sticky,
     /// Client database.
     database: String,
+    /// Log queries to stdout.
+    query_log_stdout: bool,
 }
 
 impl Client {
@@ -379,6 +381,7 @@ impl Client {
             stream_buffer: MessageBuffer::new(config.config.memory.message_buffer),
             sticky: Sticky::from_params(&params),
             database: database.to_string(),
+            query_log_stdout: false,
         }))
     }
 
@@ -410,6 +413,7 @@ impl Client {
             sticky: Sticky::from_params(&connect_params),
             params: connect_params,
             database: "pgdog".to_string(),
+            query_log_stdout: false,
         }
     }
 
@@ -580,6 +584,7 @@ impl Client {
         // Configure prepared statements cache.
         self.prepared_statements.level = config.prepared_statements();
         self.timeouts = Timeouts::from_config(&config.config.general);
+        self.query_log_stdout = config.config.general.query_log_stdout;
 
         while !self.client_request.is_complete() {
             let idle_timeout = self

--- a/pgdog/src/frontend/client/query_engine/context.rs
+++ b/pgdog/src/frontend/client/query_engine/context.rs
@@ -39,6 +39,8 @@ pub struct QueryEngineContext<'a> {
     pub(super) sticky: Sticky,
     /// Rewrite result.
     pub(super) rewrite_result: Option<RewriteResult>,
+    /// Log queries to stdout.
+    pub(super) query_log_stdout: bool,
 }
 
 impl<'a> QueryEngineContext<'a> {
@@ -60,6 +62,7 @@ impl<'a> QueryEngineContext<'a> {
             rollback: false,
             sticky: client.sticky,
             rewrite_result: None,
+            query_log_stdout: client.query_log_stdout,
         }
     }
 
@@ -86,6 +89,7 @@ impl<'a> QueryEngineContext<'a> {
             rollback: false,
             sticky: Sticky::new(),
             rewrite_result: None,
+            query_log_stdout: false,
         }
     }
 

--- a/pgdog/src/frontend/client/query_engine/mod.rs
+++ b/pgdog/src/frontend/client/query_engine/mod.rs
@@ -26,6 +26,7 @@ pub mod multi_step;
 pub mod notify_buffer;
 pub mod pub_sub;
 pub mod query;
+mod query_log_stdout;
 pub mod rewrite;
 pub mod route_query;
 pub mod set;
@@ -39,6 +40,7 @@ pub mod two_pc;
 pub mod unknown_command;
 
 use self::query::ExplainResponseState;
+use self::query_log_stdout::log_query_stdout;
 pub(crate) use advisory_lock::AdvisoryLocks;
 pub use context::QueryEngineContext;
 use notify_buffer::NotifyBuffer;
@@ -107,6 +109,8 @@ impl QueryEngine {
         self.stats
             .received(context.client_request.total_message_len());
         self.set_state(State::Active); // Client is active.
+
+        log_query_stdout(context);
 
         // Rewrite prepared statements.
         self.rewrite_extended(context)?;

--- a/pgdog/src/frontend/client/query_engine/query_log_stdout.rs
+++ b/pgdog/src/frontend/client/query_engine/query_log_stdout.rs
@@ -1,0 +1,21 @@
+use tracing::info;
+
+use super::QueryEngineContext;
+use crate::util::user_database_from_params;
+
+pub(super) fn log_query_stdout(context: &QueryEngineContext<'_>) {
+    if !context.query_log_stdout {
+        return;
+    }
+
+    if let Ok(Some(query)) = context.client_request.query() {
+        let (user, database) = user_database_from_params(context.params);
+        let query_one_line = query.query().replace(['\r', '\n'], " ");
+        info!(
+            "{} [database: {}, user: {}]",
+            query_one_line.trim(),
+            database,
+            user
+        );
+    }
+}

--- a/pgdog/src/frontend/router/parser/query/mod.rs
+++ b/pgdog/src/frontend/router/parser/query/mod.rs
@@ -3,7 +3,7 @@ use std::{collections::HashSet, ops::Deref};
 
 use crate::{
     backend::{databases::databases, ShardingSchema},
-    config::{config, Role},
+    config::Role,
     frontend::router::{
         context::RouterContext,
         parser::{OrderBy, Shard},
@@ -40,7 +40,7 @@ use pgdog_plugin::pg_query::{
 };
 use plugins::PluginOutput;
 
-use tracing::{debug, info, trace};
+use tracing::{debug, trace};
 
 /// Query parser.
 ///
@@ -98,20 +98,6 @@ impl QueryParser {
 
     /// Parse a query and return a command.
     pub fn parse(&mut self, context: RouterContext) -> Result<Command, Error> {
-        if config().config.general.query_log_stdout {
-            if let Some(ref q) = context.query {
-                let db = context.cluster.name();
-                let user = context.cluster.user();
-                let query_one_line = q.query().replace(['\r', '\n'], " ");
-                info!(
-                    "{} [database: {}, user: {}]",
-                    query_one_line.trim(),
-                    db,
-                    user
-                );
-            }
-        }
-
         let mut context = QueryParserContext::new(context)?;
 
         let mut command = if context.query().is_ok() {

--- a/pgdog/src/frontend/router/parser/query/mod.rs
+++ b/pgdog/src/frontend/router/parser/query/mod.rs
@@ -3,7 +3,7 @@ use std::{collections::HashSet, ops::Deref};
 
 use crate::{
     backend::{databases::databases, ShardingSchema},
-    config::Role,
+    config::{config, Role},
     frontend::router::{
         context::RouterContext,
         parser::{OrderBy, Shard},
@@ -40,7 +40,7 @@ use pgdog_plugin::pg_query::{
 };
 use plugins::PluginOutput;
 
-use tracing::{debug, trace};
+use tracing::{debug, info, trace};
 
 /// Query parser.
 ///
@@ -98,6 +98,15 @@ impl QueryParser {
 
     /// Parse a query and return a command.
     pub fn parse(&mut self, context: RouterContext) -> Result<Command, Error> {
+        if config().config.general.query_log_stdout {
+            if let Some(ref q) = context.query {
+                let db = context.cluster.name();
+                let user = context.cluster.user();
+                let query_one_line = q.query().replace(['\r', '\n'], " ");
+                info!("[pool: {}][user: {}] {}", db, user, query_one_line.trim());
+            }
+        }
+
         let mut context = QueryParserContext::new(context)?;
 
         let mut command = if context.query().is_ok() {

--- a/pgdog/src/frontend/router/parser/query/mod.rs
+++ b/pgdog/src/frontend/router/parser/query/mod.rs
@@ -103,7 +103,12 @@ impl QueryParser {
                 let db = context.cluster.name();
                 let user = context.cluster.user();
                 let query_one_line = q.query().replace(['\r', '\n'], " ");
-                info!("[pool: {}][user: {}] {}", db, user, query_one_line.trim());
+                info!(
+                    "{} [database: {}, user: {}]",
+                    query_one_line.trim(),
+                    db,
+                    user
+                );
             }
         }
 


### PR DESCRIPTION
# Summary

Adds a `query_log_stdout` general config option that logs every query to stdout in pgcat-style format: `[pool: db][user: user] query`.

- Configurable via `pgdog.toml` or `PGDOG_QUERY_LOG_STDOUT`
- Defaults to `false`
- Logs at the start of query parsing so queries are captured even when the parser is bypassed

# Test plan

- [x] Run pgdog with `query_log_stdout = true` and confirm queries appear in logs