### PR TITLE
Skip an intermediate Vec in `Server::fetch_all`

### DIFF
--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -842,10 +842,8 @@ impl Server {
             .filter(|message| message.code() == 'D')
             .map(|message| message.to_bytes().unwrap())
             .map(DataRow::from_bytes)
-            .collect::<Result<Vec<DataRow>, crate::net::Error>>()?
-            .into_iter()
-            .map(|row| T::from(row))
-            .collect())
+            .map(|maybe_row| maybe_row.map(T::from))
+            .collect::<Result<Vec<T>, _>>()?)
     }
 
     /// Perform a healthcheck on this connection using the provided query.


### PR DESCRIPTION
This in theory could potentially do more work in the error case, since we're running `T::from` on all rows before the error occurred, but `From` is generally expected to be quite cheap, and is unlikely to be significantly more costly than the intermediate Vec. And we will *always* be doing less work in the success case which is more important