### PR TITLE
Arc<String> -> Arc<str>

### DIFF
--- a/pgdog/src/admin/show_query_cache.rs
+++ b/pgdog/src/admin/show_query_cache.rs
@@ -45,7 +45,7 @@ impl Command for ShowQueryCache {
             let mut data_row = DataRow::new();
             let stats = { *query.1.stats.lock() };
             data_row
-                .add(query.0.as_str())
+                .add(&*query.0)
                 .add(stats.hits)
                 .add(stats.direct)
                 .add(stats.multi);

--- a/pgdog/src/frontend/router/parser/cache/ast.rs
+++ b/pgdog/src/frontend/router/parser/cache/ast.rs
@@ -45,7 +45,7 @@ pub struct AstInner {
     /// Fingerprint.
     pub fingerprint: OnceCell<Fingerprint>,
     /// Original query.
-    pub query_without_comment: Arc<String>,
+    pub query_without_comment: Arc<str>,
 }
 
 impl AstInner {
@@ -56,7 +56,7 @@ impl AstInner {
             stats: Mutex::new(Stats::new()),
             rewrite_plan: RewritePlan::default(),
             fingerprint: OnceCell::new(),
-            query_without_comment: Arc::new(String::new()),
+            query_without_comment: "".into(),
         }
     }
 }
@@ -126,7 +126,7 @@ impl Ast {
                 ast,
                 rewrite_plan,
                 fingerprint: OnceCell::new(),
-                query_without_comment: Arc::new(query.query_without_comment.to_string()),
+                query_without_comment: query.query_without_comment.into(),
             }),
         })
     }

--- a/pgdog/src/frontend/router/parser/cache/cache_impl.rs
+++ b/pgdog/src/frontend/router/parser/cache/cache_impl.rs
@@ -3,7 +3,6 @@ use once_cell::sync::Lazy;
 use parking_lot::lock_api::MutexGuard;
 use pg_query::normalize;
 use pgdog_config::QueryParserEngine;
-use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::time::Duration;
 
@@ -44,22 +43,11 @@ impl Stats {
     }
 }
 
-/// Newtype wrapper around `Arc<String>` that lets us look up cache entries with any `&str`.
-/// Stdlib only provides `Arc<T>: Borrow<T>`, not `Arc<String>: Borrow<str>`.
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
-pub(super) struct CacheKey(pub(super) Arc<String>);
-
-impl Borrow<str> for CacheKey {
-    fn borrow(&self) -> &str {
-        self.0.as_str()
-    }
-}
-
 /// Mutex-protected query cache.
 #[derive(Debug)]
 pub(super) struct Inner {
     /// Least-recently-used cache.
-    queries: LruCache<CacheKey, Ast>,
+    queries: LruCache<Arc<str>, Ast>,
     /// Cache global stats.
     pub(super) stats: Stats,
 }
@@ -167,7 +155,7 @@ impl Cache {
         if cacheable {
             guard
                 .queries
-                .put(CacheKey(entry.query_without_comment.clone()), entry.clone());
+                .put(entry.query_without_comment.clone(), entry.clone());
         }
         guard.stats.misses += 1;
         guard.stats.parse_time += parse_time;
@@ -231,7 +219,7 @@ impl Cache {
         entry.update_stats(route);
 
         let mut guard = self.inner.lock();
-        guard.queries.put(CacheKey(Arc::new(normalized)), entry);
+        guard.queries.put(normalized.into(), entry);
         guard.stats.misses += 1;
 
         Ok(())
@@ -265,13 +253,13 @@ impl Cache {
     }
 
     /// Get a copy of all queries stored in the cache.
-    pub fn queries() -> HashMap<Arc<String>, Ast> {
+    pub fn queries() -> HashMap<Arc<str>, Ast> {
         Self::get()
             .inner
             .lock()
             .queries
             .iter()
-            .map(|i| (i.0 .0.clone(), i.1.clone()))
+            .map(|i| (i.0.clone(), i.1.clone()))
             .collect()
     }
 

--- a/pgdog/src/frontend/router/parser/cache/test.rs
+++ b/pgdog/src/frontend/router/parser/cache/test.rs
@@ -270,15 +270,14 @@ fn test_cache_key_strips_leading_comment() {
 
     let ast = run_prepared("/* trace_id=abc */ SELECT 1 FROM cache_key_leading");
     assert_eq!(
-        ast.query_without_comment.as_str(),
-        "SELECT 1 FROM cache_key_leading",
+        &*ast.query_without_comment, "SELECT 1 FROM cache_key_leading",
         "cache key must be the query without the leading comment"
     );
 
     // The LRU map key must also be the stripped query.
     let queries = Cache::queries();
     assert!(
-        queries.contains_key(&"SELECT 1 FROM cache_key_leading".to_string()),
+        queries.contains_key("SELECT 1 FROM cache_key_leading"),
         "cache map key must be the comment-stripped query"
     );
 }
@@ -290,8 +289,7 @@ fn test_cache_key_strips_trailing_comment() {
 
     let ast = run_prepared("SELECT 1 FROM cache_key_trailing /* trace_id=xyz */");
     assert_eq!(
-        ast.query_without_comment.as_str(),
-        "SELECT 1 FROM cache_key_trailing",
+        &*ast.query_without_comment, "SELECT 1 FROM cache_key_trailing",
         "cache key must be the query without the trailing comment"
     );
 }
@@ -304,8 +302,7 @@ fn test_cache_key_no_comment_unchanged() {
     let q = "SELECT 1 FROM cache_key_plain";
     let ast = run_prepared(q);
     assert_eq!(
-        ast.query_without_comment.as_str(),
-        q,
+        &*ast.query_without_comment, q,
         "cache key must equal the original query when there is no comment"
     );
 }
@@ -329,7 +326,7 @@ fn test_cache_key_shared_across_different_comments() {
         1,
         "all three queries must share a single cache entry"
     );
-    assert_eq!(matching[0].as_str(), "SELECT 1 FROM cache_key_shared");
+    assert_eq!(&**matching[0], "SELECT 1 FROM cache_key_shared");
 }
 
 #[test]

--- a/pgdog/src/frontend/router/parser/query/test/test_comments.rs
+++ b/pgdog/src/frontend/router/parser/query/test/test_comments.rs
@@ -63,7 +63,7 @@ fn test_shard_comment_with_rewrite_not_cached() {
     ]);
 
     let cached = Cache::queries();
-    let poisoned = cached.keys().any(|k| k.as_str() == stripped);
+    let poisoned = cached.keys().any(|k| **k == *stripped);
     assert!(
         !poisoned,
         "shard-commented query with a non-empty rewrite plan must not be \
@@ -93,7 +93,7 @@ fn test_shard_comment_without_rewrite_is_cached() {
 
     let cached = Cache::queries();
     assert!(
-        cached.keys().any(|k| k.as_str() == stripped),
+        cached.keys().any(|k| **k == *stripped),
         "shard-commented query with an empty rewrite plan must still be \
          cached under the stripped key"
     );


### PR DESCRIPTION
We're doing weird things to work around the fact that we're storing a String instead of a str. We're never mutating it, we can just store a str directly.