### PR TITLE
fix(resharding): fix issues with copy_data (caused copy_data test to fail often)

### DIFF
--- a/integration/copy_data/commit_sync/cleanup.sql
+++ b/integration/copy_data/commit_sync/cleanup.sql
@@ -1,0 +1,5 @@
+-- Tear down the commit_sync test objects. Shared by setup_schema.sql, setup.sql,
+-- and run.sh's cleanup trap. DROP IF EXISTS keeps it a safe no-op on the shards
+-- (which have no publication) and on a fresh database.
+DROP PUBLICATION IF EXISTS commit_sync;
+DROP SCHEMA IF EXISTS commit_sync CASCADE;

--- a/integration/copy_data/commit_sync/pgdog.toml
+++ b/integration/copy_data/commit_sync/pgdog.toml
@@ -1,0 +1,51 @@
+# Single source -> three destination shards.
+#
+#   shard 0 -> 127.0.0.1:15500 -> 127.0.0.1:5432  (db shard_0)
+#   shard 1 -> 127.0.0.1:15501 -> 127.0.0.1:5432  (db shard_1)
+#   shard 2 -> 127.0.0.1:15502 -> 127.0.0.1:5432  (db shard_2, fault-injected)
+
+[general]
+resharding_copy_format = "binary"
+resharding_parallel_copies = 1
+resharding_copy_retry_max_attempts = 100
+resharding_copy_retry_min_delay = 10
+
+[[databases]]
+name = "source"
+host = "127.0.0.1"
+port = 5432
+database_name = "pgdog"
+
+[[sharded_tables]]
+database = "source"
+column = "tenant_id"
+data_type = "bigint"
+
+[[databases]]
+name = "destination"
+host = "127.0.0.1"
+port = 15500
+database_name = "shard_0"
+shard = 0
+
+[[databases]]
+name = "destination"
+host = "127.0.0.1"
+port = 15501
+database_name = "shard_1"
+shard = 1
+
+[[databases]]
+name = "destination"
+host = "127.0.0.1"
+port = 15502
+database_name = "shard_2"
+shard = 2
+
+[[sharded_tables]]
+database = "destination"
+column = "tenant_id"
+data_type = "bigint"
+
+[admin]
+password = "pgdog"

--- a/integration/copy_data/commit_sync/run.sh
+++ b/integration/copy_data/commit_sync/run.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+# COPY_DATA cross-shard atomic-commit test (3 shards).
+#
+# Verifies that data-sync's per-shard COPY is atomic and recovers from a transient shard
+# failure. One shard's link is severed at the COPY commit handshake (its CopyDone), then
+# healed while data-sync retries: the retry must re-copy cleanly and load every row. If
+# the first attempt had left any shard partially committed, the retry would refuse the
+# non-empty tables and data-sync would fail instead.
+#
+# Setup: source database (pgdog) sharded by tenant_id into three shards. The shards are
+# the same Postgres on :5432 (databases shard_0/1/2), each reached through its own
+# toxiproxy listener (15500/15501/15502) so one shard's link can be cut. Source
+# data (setup.sql): three tenants x 2000 fixed-size rows, one tenant per shard.
+#
+# pgdog.toml options that matter here:
+#   resharding_copy_format = "binary"     fixed-width rows, so the toxic can be sized by row count
+#   resharding_parallel_copies = 1        one stream per shard, so the failure point is deterministic
+#   resharding_copy_retry_*               high number of retries and slow delay to verify the rollback multiple times until toxic is active
+#
+# Steps:
+#   1. Load source data and create the empty destination table on each shard.
+#   2. Start toxiproxy with one proxy per shard.
+#   3. Size a byte-limit toxic on shard 2 that severs its link at the CopyDone handshake.
+#   4. Apply the toxic and run data-sync in the background; once the first attempt fails
+#      and it enters its retry backoff, remove the toxic so the next retry reaches shard 2.
+#   5. The retry must recover: data-sync exits cleanly and every shard holds all its rows
+#      (2000/shard, 6000 total).
+#
+# Requires: Postgres on 5432 with databases pgdog/shard_0/shard_1/shard_2
+#           (integration/setup.sh), integration/toxiproxy-{server,cli}, target/debug/pgdog.
+set -euo pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+INTEGRATION_DIR=$( cd -- "${SCRIPT_DIR}/../.." &> /dev/null && pwd )
+PGDOG_BIN=${PGDOG_BIN:-"${SCRIPT_DIR}/../../../target/debug/pgdog"}
+PGDOG_CONFIG="${SCRIPT_DIR}/pgdog.toml"
+USERS_CONFIG="${SCRIPT_DIR}/users.toml"
+TOXI_CLI="${INTEGRATION_DIR}/toxiproxy-cli"
+TOXI_SERVER="${INTEGRATION_DIR}/toxiproxy-server"
+
+export PGHOST=127.0.0.1 PGPORT=5432 PGUSER=pgdog PGPASSWORD=pgdog
+
+SLOT="commit_sync_slot"
+SHARD0_PROXY="commit_sync_shard_0"
+SHARD1_PROXY="commit_sync_shard_1"
+SHARD2_PROXY="commit_sync_shard_2"
+SHARD2_TENANT=1   # tenant routed to the fault-injected shard (see setup.sql)
+
+src_psql()    { psql -d pgdog   -qX "$@"; }
+shard0_psql() { psql -d shard_0 -qX "$@"; }
+shard1_psql() { psql -d shard_1 -qX "$@"; }
+shard2_psql() { psql -d shard_2 -qX "$@"; }
+count()       { "$1" -tAc "SELECT count(*) FROM commit_sync.items"; }
+
+drop_slots() {
+    # Match the persistent slot data-sync creates ("<--replication-slot>_<shard>", e.g.
+    # commit_sync_slot_0); temporary copy slots auto-drop on disconnect.
+    src_psql -tAc "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE slot_name LIKE '${SLOT}%' OR temporary" >/dev/null 2>&1 || true
+}
+
+cleanup() {
+    # Killing toxiproxy-server drops all proxies and toxics (it holds them in memory).
+    killall toxiproxy-server 2>/dev/null || true
+    drop_slots
+    # Tear down schema + publication on every database (see cleanup.sql) so nothing
+    # (data, publication, or WAL-pinning slot) lingers.
+    src_psql    -f "${SCRIPT_DIR}/cleanup.sql" >/dev/null 2>&1 || true
+    shard0_psql -f "${SCRIPT_DIR}/cleanup.sql" >/dev/null 2>&1 || true
+    shard1_psql -f "${SCRIPT_DIR}/cleanup.sql" >/dev/null 2>&1 || true
+    shard2_psql -f "${SCRIPT_DIR}/cleanup.sql" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+run_data_sync() {
+    "${PGDOG_BIN}" --config "${PGDOG_CONFIG}" --users "${USERS_CONFIG}" \
+        data-sync --sync-only --skip-schema-sync \
+        --from-database source --to-database destination \
+        --publication commit_sync --replication-slot "${SLOT}"
+}
+
+# Step 1: load source schema + data, and create the destination table empty on each shard.
+echo "[commit_sync] Step 1: loading source schema + data and empty destination tables..."
+src_psql    -f "${SCRIPT_DIR}/setup.sql"
+shard0_psql -f "${SCRIPT_DIR}/setup_schema.sql"
+shard1_psql -f "${SCRIPT_DIR}/setup_schema.sql"
+shard2_psql -f "${SCRIPT_DIR}/setup_schema.sql"
+
+# Step 2: start toxiproxy and create one proxy per shard (one severable link each).
+echo "[commit_sync] Step 2: starting toxiproxy and creating one proxy per shard..."
+killall toxiproxy-server 2>/dev/null || true
+"${TOXI_SERVER}" >/dev/null 2>&1 &
+until "${TOXI_CLI}" list >/dev/null 2>&1; do sleep 0.2; done
+"${TOXI_CLI}" create --listen "127.0.0.1:15500" --upstream "127.0.0.1:5432" "${SHARD0_PROXY}"
+"${TOXI_CLI}" create --listen "127.0.0.1:15501" --upstream "127.0.0.1:5432" "${SHARD1_PROXY}"
+"${TOXI_CLI}" create --listen "127.0.0.1:15502" --upstream "127.0.0.1:5432" "${SHARD2_PROXY}"
+
+SRC=$(count src_psql)
+EXPECTED=$(src_psql -tAc "SELECT count(*) FROM commit_sync.items WHERE tenant_id = ${SHARD2_TENANT}")
+echo "[commit_sync] source rows: ${SRC} (expected ${EXPECTED} per shard)"
+
+# Step 3: size the toxic to let every data byte through and sever only the trailing
+# CopyDone, so the failure lands in copy_done() after shards 0/1 have committed.
+#
+# Bytes shard 2 receives, in order (CopyData framing = 1-byte tag + 4-byte length):
+#   header  CopyData: 5 + 19 (PGCOPY signature 11 + flags 4 + extension 4)   = 24 B (Shard::All)
+#   row     CopyData: 5 + 2 (field count) + 12 (id) + 12 (tenant_id)
+#                     + 4 (payload length prefix) + PAYLOAD_LEN              = 35 + PAYLOAD_LEN
+#   trailer CopyData: 5 + 2 (-1 terminator)                                  = 7 B  (Shard::All)
+# then a 5-byte CopyDone. limit_data closes the link once this many upstream bytes have
+# passed, so the streamed total drops the CopyDone (any value in [total, total+4] works).
+PAYLOAD_LEN=512   # repeat('x', PAYLOAD_LEN) in setup.sql
+ROW_WIRE=$(( 35 + PAYLOAD_LEN ))
+HEADER_WIRE=24    # CopyData(5) + PGCOPY header(19), sent to every shard
+TRAILER_WIRE=7    # CopyData(5) + -1 terminator(2), sent to every shard
+LIMIT=$(( HEADER_WIRE + EXPECTED * ROW_WIRE + TRAILER_WIRE ))
+echo "[commit_sync] Step 3: toxic limit=${LIMIT} bytes (header ${HEADER_WIRE} + ${EXPECTED} rows x ${ROW_WIRE} B + trailer ${TRAILER_WIRE}); severs the CopyDone"
+
+# Step 4: sever shard 2 at its CopyDone, run data-sync in the background, then heal it while
+# it is still retrying. The first attempt fails fast; with resharding_copy_retry_min_delay
+# = 10ms (exponential backoff capped at 32x, ~320ms) and 100 max attempts, data-sync keeps
+# retrying throughout the wait, rolling back each time. Holding the toxic for
+# WAIT_BEFORE_HEAL seconds lets several attempts fail, then removing it lets a later retry pass.
+WAIT_BEFORE_HEAL=${WAIT_BEFORE_HEAL:-5}
+echo "[commit_sync] Step 4: severing shard 2 at its CopyDone, healing after ${WAIT_BEFORE_HEAL}s..."
+"${TOXI_CLI}" toxic add --toxicName cut --type limit_data --upstream --attribute bytes="${LIMIT}" "${SHARD2_PROXY}"
+drop_slots
+
+run_data_sync &
+SYNC_PID=$!
+
+sleep "${WAIT_BEFORE_HEAL}"
+
+# At heal time data-sync should still be running: the first attempt failed and it is
+# backing off before the next retry. kill -0 sends no signal but succeeds only while the
+# process exists; if it already exited, the copy finished before we healed and the shard-2
+# fault was never exercised.
+SYNC_IN_PROGRESS=1
+kill -0 "${SYNC_PID}" 2>/dev/null || SYNC_IN_PROGRESS=0
+"${TOXI_CLI}" toxic delete --toxicName cut "${SHARD2_PROXY}" 2>/dev/null || true
+
+SYNC_EXIT_CODE=0
+wait "${SYNC_PID}" || SYNC_EXIT_CODE=$?
+echo "[commit_sync] Step 4: data-sync exited rc=${SYNC_EXIT_CODE} (sync_in_progress=${SYNC_IN_PROGRESS})"
+
+# Step 5: the retry must recover. data-sync should exit cleanly and every shard should
+# hold all of its rows. A first attempt that committed any shard would make the retry
+# refuse the non-empty tables, so data-sync would exit non-zero instead.
+D0=$(count shard0_psql); D1=$(count shard1_psql); D2=$(count shard2_psql)
+TOTAL=$((D0 + D1 + D2))
+echo "[commit_sync] Step 5: source=${SRC} shard_0=${D0} shard_1=${D1} shard_2=${D2} total=${TOTAL}"
+
+if [ "${SYNC_IN_PROGRESS}" -eq 0 ]; then
+    echo "[commit_sync] SKIP: copy finished before healing; the shard-2 fault was not exercised (check toxic sizing or lower WAIT_BEFORE_HEAL)."
+    exit 1
+fi
+if [ "${SYNC_EXIT_CODE}" -ne 0 ]; then
+    echo "[commit_sync] FAIL: data-sync did not recover on retry (rc=${SYNC_EXIT_CODE}); shards ${D0}/${D1}/${D2}."
+    exit 1
+fi
+if [ "${SRC}" -ne "${TOTAL}" ] || [ "${D0}" -ne "${EXPECTED}" ] || [ "${D1}" -ne "${EXPECTED}" ] || [ "${D2}" -ne "${EXPECTED}" ]; then
+    echo "[commit_sync] FAIL: row count mismatch (source=${SRC} total=${TOTAL}; split ${D0}/${D1}/${D2})"
+    exit 1
+fi
+
+echo "[commit_sync] PASS: data-sync recovered on retry; all ${SRC} rows copied (split ${D0}/${D1}/${D2})."

--- a/integration/copy_data/commit_sync/setup.sql
+++ b/integration/copy_data/commit_sync/setup.sql
@@ -1,0 +1,19 @@
+-- Source schema + data for the COPY_DATA partial-commit reproduction (3 shards).
+--
+-- Routing is deterministic (hash of tenant_id, 3 shards):
+--   tenant 1 -> shard 2  (the fault-injected shard)
+--   tenant 2 -> shard 0
+--   tenant 3 -> shard 1
+--
+-- All three shards get the same number of equally-sized rows. The toxic on shard 2 is
+-- sized so that shard 2's whole row payload streams through and the connection is severed
+-- only at the copy_done handshake. Because the destination COPY defers its commit until
+-- every shard has staged, that mid-COPY fault rolls every shard back: no partial commit.
+
+\ir setup_schema.sql
+
+CREATE PUBLICATION commit_sync FOR TABLE commit_sync.items;
+
+INSERT INTO commit_sync.items SELECT g, 1, repeat('x', 512) FROM generate_series(1, 2000) AS g;
+INSERT INTO commit_sync.items SELECT g, 2, repeat('x', 512) FROM generate_series(1, 2000) AS g;
+INSERT INTO commit_sync.items SELECT g, 3, repeat('x', 512) FROM generate_series(1, 2000) AS g;

--- a/integration/copy_data/commit_sync/setup_schema.sql
+++ b/integration/copy_data/commit_sync/setup_schema.sql
@@ -1,0 +1,15 @@
+-- Schema shared by the source and every destination shard for the commit_sync test.
+-- data-sync runs with --skip-schema-sync, so the destination tables must pre-exist;
+-- the source is built from the same definition. Created empty: setup.sql layers the
+-- publication and source rows on top of this.
+
+\ir cleanup.sql
+
+CREATE SCHEMA commit_sync;
+
+CREATE TABLE commit_sync.items (
+    id        BIGINT NOT NULL,
+    tenant_id BIGINT NOT NULL,
+    payload   TEXT   NOT NULL,
+    PRIMARY KEY (id, tenant_id)
+);

--- a/integration/copy_data/commit_sync/users.toml
+++ b/integration/copy_data/commit_sync/users.toml
@@ -1,0 +1,11 @@
+[[users]]
+database = "source"
+name = "pgdog"
+password = "pgdog"
+schema_admin = true
+
+[[users]]
+database = "destination"
+name = "pgdog"
+password = "pgdog"
+schema_admin = true

--- a/integration/copy_data/retry_test/run.sh
+++ b/integration/copy_data/retry_test/run.sh
@@ -14,8 +14,10 @@ USERS_CONFIG="${SCRIPT_DIR}/users.toml"
 PGDOG_PORT=${PGDOG_PORT:-6440}
 export PGPASSWORD=pgdog
 
-# Worst case: remaining retry backoff (≤16s) + copy of ~60k rows (~5s) + replication startup (~1s).
-REPLICATION_TIMEOUT=60
+# Replication retry is fixed 500ms x 8 attempts (resharding_replication_retry_* in pgdog.toml),
+# a ~4s budget per failure; a CI shard restart completes well within it. 120s covers the COPY of
+# ~100k rows + replication catch-up with headroom on slow CI.
+REPLICATION_TIMEOUT=120
 
 PGDOG_PID=""
 
@@ -42,6 +44,14 @@ shard1_count() { shard1_psql -tAc "SELECT COUNT(*) FROM $1"; }
 
 # Pass a psql helper as $1; checks whether the canary row is present on that node.
 has_canary() { local fn=$1 name=${2:-${CANARY}}; "${fn}" -tAc "SELECT 1 FROM copy_data.settings WHERE setting_name='${name}' LIMIT 1" 2>/dev/null | grep -q 1; }
+
+# Dump pgdog admin state. Call on any failure path that needs context.
+dump_state() {
+    echo "[retry_test] --- SHOW TASKS ---"
+    admin_psql -c 'SHOW TASKS' || true
+    echo "[retry_test] --- SHOW REPLICATION_SLOTS ---"
+    admin_psql -c 'SHOW REPLICATION_SLOTS' || true
+}
 
 pushd "${COMPOSE_DIR}"
 
@@ -104,6 +114,7 @@ WAIT_ATTEMPTS=0
 until src_psql -tAc "SELECT 1 FROM pg_replication_slots WHERE temporary = true LIMIT 1" 2>/dev/null | grep -q 1; do
     WAIT_ATTEMPTS=$((WAIT_ATTEMPTS + 1))
     if [ "${WAIT_ATTEMPTS}" -ge 200 ]; then
+        dump_state
         echo "[retry_test] FAIL: COPY_DATA never created a replication slot after $((WAIT_ATTEMPTS / 20))s"
         exit 1
     fi
@@ -164,10 +175,7 @@ done
 if [ "${REPLICATION_TASK_SEEN}" -ne 1 ]; then
     echo "[retry_test] FAIL: no Replication task within ${REPLICATION_TIMEOUT}s after shard_1 was restored"
     echo "[retry_test]   replication did not start after the copy completed"
-    echo "[retry_test] --- SHOW TASKS ---"
-    admin_psql -c 'SHOW TASKS' || true
-    echo "[retry_test] --- SHOW REPLICATION_SLOTS ---"
-    admin_psql -c 'SHOW REPLICATION_SLOTS' || true
+    dump_state
     exit 1
 fi
 echo "[retry_test] OK: Replication task is live."
@@ -194,7 +202,7 @@ done
 if [ "${CANARY_DELIVERED}" -ne 1 ]; then
     echo "[retry_test] FAIL: canary ${CANARY} not replicated within ${REPLICATION_TIMEOUT}s"
     echo "[retry_test]   Replication task was running but the stream did not deliver"
-    admin_psql -c 'SHOW REPLICATION_SLOTS' || true
+    dump_state
     exit 1
 fi
 echo "[retry_test] OK: canary replicated to both shards."
@@ -223,6 +231,18 @@ until pg_isready -h 127.0.0.1 -p 15433 -U pgdog -d pgdog1 -q; do
 done
 echo "[retry_test] shard_0 is ready."
 
+# Replication task must still be alive after the outage. If it exited (e.g. retry budget
+# exhausted, non-retryable error) waiting for the canary would just time out after the full
+# REPLICATION_TIMEOUT (${REPLICATION_TIMEOUT}s) with no useful signal. Check this BEFORE waiting
+# for canary delivery to localise the failure.
+if ! admin_psql -tAc 'SHOW TASKS' 2>/dev/null | grep -q '|replication|'; then
+    echo "[retry_test] FAIL: replication task is no longer present after shard_0 restart"
+    echo "[retry_test]   the apply task likely errored and exited; not a delivery-latency issue"
+    dump_state
+    exit 1
+fi
+echo "[retry_test] OK: replication task is still present after shard_0 restart."
+
 RETRY_DELIVERED=0
 for _ in $(seq 1 "${REPLICATION_TIMEOUT}"); do
     if has_canary shard0_psql "${RETRY_CANARY}" && has_canary shard1_psql "${RETRY_CANARY}"; then
@@ -239,7 +259,7 @@ done
 if [ "${RETRY_DELIVERED}" -ne 1 ]; then
     echo "[retry_test] FAIL: retry canary ${RETRY_CANARY} not replicated within ${REPLICATION_TIMEOUT}s"
     echo "[retry_test]   replication did not retry and recover after shard_0 outage"
-    admin_psql -c 'SHOW REPLICATION_SLOTS;' || true
+    dump_state
     exit 1
 fi
 echo "[retry_test] OK: retry canary replicated to both shards after shard_0 outage."

--- a/integration/copy_data/run.sh
+++ b/integration/copy_data/run.sh
@@ -4,8 +4,10 @@
 # Tests:
 #   data_sync/run.sh  — 0→2 and 2→2 resharding with live write traffic
 #                       (uses local postgres from integration/setup.sh)
-#   retry_test/run.sh — data-sync retry loop under mid-copy shard failure
-#                       (manages its own docker-compose stack)
+#   retry_test/run.sh  — data-sync retry loop under mid-copy shard failure
+#                        (manages its own docker-compose stack)
+#   commit_sync/run.sh — cross-shard atomic commit: a mid-copy shard failure must leave
+#                        no shard partially committed (uses local postgres + toxiproxy)
 set -e
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
@@ -15,5 +17,8 @@ bash "${SCRIPT_DIR}/data_sync/run.sh"
 
 echo "=== [copy_data] retry_test ==="
 bash "${SCRIPT_DIR}/retry_test/run.sh"
+
+echo "=== [copy_data] commit_sync ==="
+bash "${SCRIPT_DIR}/commit_sync/run.sh"
 
 echo "=== [copy_data] all tests passed ==="

--- a/integration/copy_data/setup.sql
+++ b/integration/copy_data/setup.sql
@@ -93,18 +93,18 @@ SELECT
                     END,
         'notifications', (random() > 0.5)
     ) AS settings
-FROM generate_series(1, 10000) AS gs(id);
+FROM generate_series(1, 100000) AS gs(id);
 
 
 WITH u AS (
-  -- Pull the 10k users we inserted earlier
+  -- Pull the 100k users we inserted earlier
   SELECT id AS user_id, tenant_id
   FROM copy_data.users
-  WHERE id BETWEEN 1 AND 10000
+  WHERE id BETWEEN 1 AND 100000
   ORDER BY id
 ),
 orders_base AS (
-  -- One order per user (10k orders), deterministic order_id = user_id
+  -- One order per user (100k orders), deterministic order_id = user_id
   SELECT
       u.user_id AS order_id,
       u.user_id,
@@ -154,7 +154,7 @@ order_totals AS (
 ins_orders AS (
   INSERT INTO copy_data.orders (id, user_id, tenant_id, amount, created_at, refunded_at)
   SELECT
-      ot.order_id,        -- id = user_id = 1..10000
+      ot.order_id,        -- id = user_id = 1..100000
       ot.user_id,
       ot.tenant_id,
       ot.order_amount,
@@ -179,11 +179,11 @@ SELECT
     (ARRAY['login', 'logout', 'click', 'purchase', 'view', 'error'])[
         floor(random() * 6 + 1)::int
     ] AS action
-FROM generate_series(1, 10000);
+FROM generate_series(1, 100000);
 
 
 INSERT INTO copy_data.with_identity (tenant_id)
-SELECT floor(random() * 10000)::bigint FROM generate_series(1, 10000);
+SELECT floor(random() * 10000)::bigint FROM generate_series(1, 100000);
 
 INSERT INTO copy_data.countries (code, name) VALUES
     ('US', 'United States'), ('GB', 'United Kingdom'), ('DE', 'Germany'),

--- a/pgdog/src/backend/error.rs
+++ b/pgdog/src/backend/error.rs
@@ -170,6 +170,12 @@ impl Error {
             Self::Io(_) => true,
             Self::Net(inner) => inner.is_retryable(),
             Self::Pool(inner) => inner.is_retryable(),
+            // Postgres ErrorResponse wrapped at the backend boundary, e.g. a destination shard
+            // returning FATAL 57P01 mid-replication-apply, or a transient connect-time error.
+            // Delegates to the single SQLSTATE retry list in ErrorResponse::is_retryable.
+            Self::ExecutionError(resp)
+            | Self::ConnectionError(resp)
+            | Self::PreparedStatementError(resp) => resp.is_retryable(),
             // Connection dropped between operations.
             Self::NotConnected
             | Self::DirectToShardNotConnected

--- a/pgdog/src/backend/replication/logical/error.rs
+++ b/pgdog/src/backend/replication/logical/error.rs
@@ -278,33 +278,44 @@ mod tests {
         assert!(Error::ReplicationTimeout.is_retryable());
     }
 
+    /// Regression: replication apply receives Postgres errors wrapped as
+    /// `Backend(ExecutionError)` / `Backend(ConnectionError)`, not `PgError`.
+    /// Before the fix, the Backend arm bypassed the SQLSTATE list and the publisher
+    /// retry loop never fired on shard kill (57P01) -- see `copy_data/retry_test`.
+    /// All three wrappers must route through `ErrorResponse::is_retryable`.
     #[test]
-    fn pg_error_retryable() {
+    fn sqlstate_classification_routes_through_all_wrappers() {
+        use crate::backend::Error as BE;
         use crate::net::messages::ErrorResponse;
-        let retryable_codes = [
-            "08000", "08001", "08003", "08004", "08006", "08007", "57P01", "57P02", "57P03",
-            "53300", "55P03",
-        ];
-        for code in retryable_codes {
-            let err = Error::PgError(Box::new(ErrorResponse {
-                code: code.into(),
-                ..Default::default()
-            }));
-            assert!(err.is_retryable(), "expected {code} to be retryable");
-        }
-    }
 
-    #[test]
-    fn pg_error_not_retryable() {
-        use crate::net::messages::ErrorResponse;
-        // 08P01 protocol_violation \ constraint/schema errors \ data errors.
-        let not_retryable = ["08P01", "23505", "42P01", "42501", ""];
-        for code in not_retryable {
-            let err = Error::PgError(Box::new(ErrorResponse {
+        fn resp(code: &str) -> ErrorResponse {
+            ErrorResponse {
                 code: code.into(),
                 ..Default::default()
-            }));
-            assert!(!err.is_retryable(), "expected {code} to NOT be retryable");
+            }
+        }
+
+        let wrappers: [(&str, fn(ErrorResponse) -> Error); 3] = [
+            ("PgError", |r| Error::PgError(Box::new(r))),
+            ("Backend(ExecutionError)", |r| {
+                Error::Backend(BE::ExecutionError(Box::new(r)))
+            }),
+            ("Backend(ConnectionError)", |r| {
+                Error::Backend(BE::ConnectionError(Box::new(r)))
+            }),
+        ];
+
+        for (label, wrap) in wrappers {
+            // 57P01 admin_shutdown is the canonical retryable case (shard restart).
+            assert!(
+                wrap(resp("57P01")).is_retryable(),
+                "{label}(57P01) must be retryable"
+            );
+            // 23505 unique_violation is a deterministic data error; retrying repeats it.
+            assert!(
+                !wrap(resp("23505")).is_retryable(),
+                "{label}(23505) must NOT be retryable"
+            );
         }
     }
 
@@ -332,11 +343,6 @@ mod tests {
     #[test]
     fn not_retryable_via_backend_wrapper() {
         use crate::backend::Error as BE;
-        use crate::net::messages::ErrorResponse;
-
-        // Postgres-level error response: permanent, not a network fault.
-        let pg_err = ErrorResponse::default();
-        assert!(!Error::Backend(BE::ConnectionError(Box::new(pg_err))).is_retryable());
 
         // Protocol violations are not transient.
         assert!(!Error::Backend(BE::ProtocolOutOfSync).is_retryable());

--- a/pgdog/src/backend/replication/logical/publisher/parallel_sync.rs
+++ b/pgdog/src/backend/replication/logical/publisher/parallel_sync.rs
@@ -19,10 +19,12 @@ use tracing::{info, warn};
 use super::super::Error;
 use super::AbortSignal;
 use crate::backend::{
-    pool::Address,
+    pool::{Address, Request},
     replication::{publisher::Table, status::TableCopy},
     Cluster, Pool,
 };
+use crate::net::messages::Protocol;
+use crate::util::escape_identifier;
 
 struct ParallelSync {
     table: Table,
@@ -79,24 +81,8 @@ impl ParallelSync {
                 }
                 Err(err) if !err.is_retryable() || attempt >= max_retries => {
                     tracker.error(&err);
-                    // COPY is usually atomic, but rows may remain if the connection dropped
-                    // after COMMIT. Warn so the user can truncate manually before retrying.
-                    match self.table.destination_has_rows(&self.dest).await {
-                        Ok(true) => warn!(
-                            "data sync for \"{}\".\"{}\" failed with rows remaining in destination; \
-                             truncate manually before retrying: TRUNCATE \"{}\".\"{}\";",
-                            self.table.table.schema,
-                            self.table.table.name,
-                            self.table.table.destination_schema(),
-                            self.table.table.destination_name(),
-                        ),
-                        Ok(false) => {} // destination is clean; next run starts fresh
-                        Err(check_err) => warn!(
-                            "could not check destination row count for \"{}\".\"{}\" after failure: {check_err}",
-                            self.table.table.schema,
-                            self.table.table.name,
-                        ),
-                    }
+                    // Terminal failure: warn if rows remain so the operator can truncate.
+                    let _ = self.destination_has_rows().await;
                     return Err(err);
                 }
                 Err(err) => {
@@ -116,11 +102,65 @@ impl ParallelSync {
                     tracker.reset();
 
                     sleep(backoff).await;
+
+                    // Not idempotent (no truncate): if a prior attempt left rows on a
+                    // reachable shard, the re-copy can only collide, so stop instead of
+                    // retrying. A shard we cannot probe is logged (not blocked on), since we
+                    // cannot prove it dirty. Checked after the backoff so a RELOAD-churned
+                    // pool can recover first.
                     // FUTURE: truncate before retry to handle the COPY-committed-but-dropped
                     // race (rows remain → PK violations). Safe once source-guard checks exist.
+                    if self.destination_has_rows().await {
+                        return Err(err);
+                    }
                 }
             }
         }
+    }
+
+    /// Returns `true` if any reachable destination shard holds rows from a prior COPY
+    /// attempt. Every shard is probed; a shard whose probe errors (e.g. its pool was
+    /// shut down by a RELOAD) is logged at WARN and not counted, since we cannot prove
+    /// it dirty. Emits a single WARN listing the shards that do hold rows.
+    async fn destination_has_rows(&self) -> bool {
+        let schema = self.table.table.destination_schema();
+        let name = self.table.table.destination_name();
+        let sql = format!(
+            "SELECT 1 FROM \"{}\".\"{}\" LIMIT 1",
+            escape_identifier(schema),
+            escape_identifier(name),
+        );
+
+        let mut shards_with_rows = vec![];
+        for (shard, _) in self.dest.shards().iter().enumerate() {
+            let result: Result<bool, Error> = async {
+                let mut server = self.dest.primary(shard, &Request::default()).await?;
+                Ok(server
+                    .execute_checked(sql.as_str())
+                    .await?
+                    .iter()
+                    .any(|m| m.code() == 'D'))
+            }
+            .await;
+
+            match result {
+                Ok(true) => shards_with_rows.push(shard),
+                Ok(false) => {}
+                Err(err) => warn!(
+                    "could not verify destination rows on shard {shard}: {err}; \
+                     proceeding as if empty"
+                ),
+            }
+        }
+
+        if !shards_with_rows.is_empty() {
+            warn!(
+                "destination \"{schema}\".\"{name}\" holds rows from a prior COPY attempt on shard(s) {shards_with_rows:?}; \
+                 truncate before re-running the copy: TRUNCATE \"{schema}\".\"{name}\";",
+            );
+        }
+
+        !shards_with_rows.is_empty()
     }
 }
 

--- a/pgdog/src/backend/replication/logical/publisher/table.rs
+++ b/pgdog/src/backend/replication/logical/publisher/table.rs
@@ -10,12 +10,10 @@ use crate::backend::pool::Address;
 use crate::backend::replication::publisher::progress::Progress;
 use crate::backend::replication::publisher::Lsn;
 
-use crate::backend::pool::Request;
 use crate::backend::replication::status::TableCopy;
 use crate::backend::{Cluster, Server, ShardedTables};
 use crate::config::config;
 use crate::frontend::router::parser::Column;
-use crate::net::messages::Protocol;
 use crate::net::replication::StatusUpdate;
 use crate::util::escape_identifier;
 
@@ -514,28 +512,6 @@ impl Table {
         );
 
         Ok(self.lsn)
-    }
-
-    /// Returns `true` if the destination table has any rows on any shard.
-    ///
-    /// COPY is transactional and normally auto-rolls back on failure, leaving
-    /// the destination empty. This check catches the rare race where COPY
-    /// committed but an error was returned afterward (e.g., network drop during
-    /// CommandComplete), resulting in rows the retry would collide with.
-    pub async fn destination_has_rows(&self, dest: &Cluster) -> Result<bool, Error> {
-        let sql = format!(
-            "SELECT 1 FROM \"{}\".\"{}\" LIMIT 1",
-            escape_identifier(self.table.destination_schema()),
-            escape_identifier(self.table.destination_name()),
-        );
-        for (shard, _) in dest.shards().iter().enumerate() {
-            let mut server = dest.primary(shard, &Request::default()).await?;
-            let messages = server.execute_checked(sql.as_str()).await?;
-            if messages.iter().any(|m| m.code() == 'D') {
-                return Ok(true);
-            }
-        }
-        Ok(false)
     }
 }
 

--- a/pgdog/src/backend/replication/logical/subscriber/copy.rs
+++ b/pgdog/src/backend/replication/logical/subscriber/copy.rs
@@ -9,7 +9,10 @@ use crate::{
     backend::{replication::subscriber::ParallelConnection, Cluster, ConnectReason},
     config::Role,
     frontend::router::parser::{CopyParser, Shard},
-    net::{CopyData, CopyDone, ErrorResponse, FromBytes, Protocol, Query, ToBytes},
+    net::{
+        CopyData, CopyDone, ErrorResponse, FromBytes, Message, Protocol, ProtocolMessage, Query,
+        ToBytes,
+    },
 };
 
 use super::super::{CopyStatement, Error};
@@ -102,6 +105,64 @@ impl CopySubscriber {
         Ok(())
     }
 
+    /// Send a single protocol message on a shard connection and confirm the backend replied
+    /// with `CommandComplete` followed by `ReadyForQuery`. On an `ErrorResponse` the connection
+    /// is drained through the trailing `ReadyForQuery` and the error is surfaced as
+    /// `Error::PgError`.
+    async fn send_and_confirm(
+        server: &mut ParallelConnection,
+        message: ProtocolMessage,
+    ) -> Result<(), Error> {
+        server.send_one(&message).await?;
+        server.flush().await?;
+
+        let command_complete = Self::read_skipping_async(server).await?;
+        match command_complete.code() {
+            'C' => (),
+            'E' => {
+                let error = ErrorResponse::from_bytes(command_complete.to_bytes())?;
+                // Drain through the trailing ReadyForQuery so the connection isn't left
+                // mid-protocol.
+                Self::drain_to_ready(server).await;
+                return Err(error.into());
+            }
+            c => return Err(Error::OutOfSync(c)),
+        }
+
+        let rfq = Self::read_skipping_async(server).await?;
+        if rfq.code() != 'Z' {
+            return Err(Error::OutOfSync(rfq.code()));
+        }
+
+        Ok(())
+    }
+
+    /// Read the next message from the server, skipping asynchronous protocol messages that
+    /// Postgres may interleave at any time: `NoticeResponse` (`'N'`), `ParameterStatus`
+    /// (`'S'`), and `NotificationResponse` (`'A'`). The underlying `Server::read` surfaces these
+    /// unfiltered, so without skipping them a trigger-emitted `NOTICE` (e.g. fired during
+    /// `CopyDone` finalisation or at `COMMIT`) would be misread as an out-of-sync reply and turn
+    /// a successful copy into a spurious failure.
+    async fn read_skipping_async(server: &mut ParallelConnection) -> Result<Message, Error> {
+        loop {
+            let message = server.read().await?;
+            if !matches!(message.code(), 'N' | 'S' | 'A') {
+                return Ok(message);
+            }
+        }
+    }
+
+    /// Drain messages until the trailing `ReadyForQuery`, leaving the connection at a clean
+    /// protocol boundary after an `ErrorResponse`. Best-effort: stops on the first read error
+    /// (e.g. the backend closed the connection), so it cannot block indefinitely.
+    async fn drain_to_ready(server: &mut ParallelConnection) {
+        while let Ok(message) = server.read().await {
+            if message.code() == 'Z' {
+                break;
+            }
+        }
+    }
+
     /// Start COPY on all shards.
     pub async fn start_copy(&mut self) -> Result<(), Error> {
         let stmt = Query::new(self.stmt.copy_in());
@@ -111,8 +172,13 @@ impl CopySubscriber {
         }
 
         for server in &mut self.connections {
-            debug!("{} [{}]", stmt.query(), server.addr());
+            // Open an explicit transaction so the COPY is not autocommit: the commit is
+            // deferred to copy_done(), so a CopyDone failure on any shard rolls back every
+            // shard (none commit). The commit pass itself is per-shard, not atomic across shards.
+            // TODO: implement complete 2pc to copy data to minimize chances of partial commits even more
+            Self::send_and_confirm(server, Query::new("BEGIN").into()).await?;
 
+            debug!("{} [{}]", stmt.query(), server.addr());
             server.send_one(&stmt.clone().into()).await?;
             server.flush().await?;
 
@@ -135,28 +201,45 @@ impl CopySubscriber {
     pub async fn copy_done(&mut self) -> Result<(), Error> {
         self.flush().await?;
 
+        // Stage pass: send CopyDone to every shard and read CommandComplete + ReadyForQuery.
+        // Because each shard is inside an explicit transaction, CopyDone only finalises the
+        // COPY (writes pages, builds indexes, checks constraints) — it does NOT commit.
+        // The ReadyForQuery status byte is 'T' (in-transaction).
+        // A failure here leaves every shard in an open transaction that rolls back when its
+        // connection closes → no partial commit.
         for server in &mut self.connections {
-            server.send_one(&CopyDone.into()).await?;
-            server.flush().await?;
-
-            let command_complete = server.read().await?;
-            match command_complete.code() {
-                'E' => {
-                    let error = ErrorResponse::from_bytes(command_complete.to_bytes())?;
-                    if error.code == "08P01" && error.message == "insufficient data left in message"
+            // A binary COPY width mismatch (e.g. an int column copied into a bigint) surfaces as
+            // protocol_violation "insufficient data left in message"; reclassify it so the
+            // operator gets actionable guidance instead of a generic protocol error.
+            Self::send_and_confirm(server, CopyDone.into())
+                .await
+                .map_err(|error| match error {
+                    Error::PgError(pg)
+                        if pg.code == "08P01"
+                            && pg.message == "insufficient data left in message" =>
                     {
-                        return Err(Error::BinaryFormatMismatch(Box::new(error)));
-                    } else {
-                        return Err(Error::PgError(Box::new(error)));
+                        Error::BinaryFormatMismatch(pg)
                     }
-                }
-                'C' => (),
-                c => return Err(Error::OutOfSync(c)),
-            }
+                    other => other,
+                })?;
+        }
 
-            let rfq = server.read().await?;
-            if rfq.code() != 'Z' {
-                return Err(Error::OutOfSync(rfq.code()));
+        // Commit pass: every shard has staged its rows and is sitting in an open transaction.
+        // Commit them. The data is already written, so COMMIT is cheap and very likely to
+        // succeed. Sequential and NOT atomic across shards: if a COMMIT fails after one or more
+        // earlier shards have already committed, those shards stay committed — the only residual
+        // partial-commit window (full cross-shard atomicity via 2PC is intentionally out of
+        // scope). Shards not yet committed roll back on connection close. The
+        // destination_has_rows() guard in parallel_sync.rs prevents a doomed retry if this
+        // window is ever hit.
+        for (shard, server) in self.connections.iter_mut().enumerate() {
+            if let Err(error) = Self::send_and_confirm(server, Query::new("COMMIT").into()).await {
+                tracing::error!(
+                    "COMMIT failed on destination shard {shard} during copy_done: {error}; \
+                     shards committed before it stay committed, the rest roll back on \
+                     connection close"
+                );
+                return Err(error);
             }
         }
 
@@ -214,7 +297,9 @@ mod test {
     use bytes::Bytes;
 
     use crate::{
-        backend::{pool::Request, replication::publisher::PublicationTable},
+        backend::{
+            pool::Request, replication::publisher::PublicationTable, server::test::test_server,
+        },
         config::config,
         frontend::router::parser::binary::{header::Header, Data, Tuple},
     };
@@ -288,5 +373,51 @@ mod test {
             .unwrap();
 
         cluster.shutdown();
+    }
+
+    #[tokio::test]
+    async fn send_and_confirm_skips_async_messages() {
+        crate::logger();
+
+        let server = test_server().await;
+        let mut conn = ParallelConnection::new(server).unwrap();
+
+        // RAISE WARNING emits a NoticeResponse ('N') before the statement's
+        // CommandComplete. Without async-message skipping this was misread as
+        // OutOfSync('N'); it must now be transparently skipped.
+        CopySubscriber::send_and_confirm(
+            &mut conn,
+            Query::new("DO $$ BEGIN RAISE WARNING 'noise'; END $$").into(),
+        )
+        .await
+        .unwrap();
+
+        // The connection is left at a clean ReadyForQuery boundary, so it can be
+        // handed back to the pool.
+        let server = conn.reattach().await.unwrap();
+        assert!(server.in_sync());
+    }
+
+    #[tokio::test]
+    async fn send_and_confirm_drains_to_ready_after_error_with_notice() {
+        crate::logger();
+
+        let server = test_server().await;
+        let mut conn = ParallelConnection::new(server).unwrap();
+
+        // A NoticeResponse precedes the ErrorResponse. The notice is skipped, the
+        // error is surfaced, and drain_to_ready consumes the trailing ReadyForQuery
+        // so the connection is not left mid-protocol.
+        let result = CopySubscriber::send_and_confirm(
+            &mut conn,
+            Query::new("DO $$ BEGIN RAISE WARNING 'noise'; RAISE EXCEPTION 'boom'; END $$").into(),
+        )
+        .await;
+
+        assert!(matches!(result, Err(Error::PgError(_))));
+
+        // drain_to_ready left the connection at a ReadyForQuery boundary.
+        let server = conn.reattach().await.unwrap();
+        assert!(server.in_sync());
     }
 }

--- a/pgdog/src/net/messages/error_response.rs
+++ b/pgdog/src/net/messages/error_response.rs
@@ -216,9 +216,6 @@ impl ErrorResponse {
     }
 
     /// Whether this Postgres error is transient and the operation can be retried.
-    /// Covers connection exceptions (class 08, excluding protocol violation 08P01),
-    /// operator-intervention shutdowns (57P01/57P02/57P03), and resource pressure
-    /// (53300 too_many_connections), and lock timeout (55P03 lock_not_available).
     pub fn is_retryable(&self) -> bool {
         matches!(
             self.code.as_str(),
@@ -226,6 +223,8 @@ impl ErrorResponse {
             // 08P01 (protocol_violation) is intentionally excluded: that signals a
             // client-side bug and retrying would just repeat the same violation.
             "08000" | "08001" | "08003" | "08004" | "08006" | "08007"
+            // Serialization conflict / deadlock — Postgres aborts one txn; retry succeeds.
+            | "40001" | "40P01"
             // Operator-intervention: admin shutdown, crash, or startup not ready.
             | "57P01" | "57P02" | "57P03"
             // Too many connections — transient resource limit.


### PR DESCRIPTION
Found multiple issues that caused copy_data/retry_test to fail occasionally.

- Sometime copy_data failed because it finished too fast and the retry_test haven't caught on some checkpoints because of this -- I increased the amount of generated data for test to lower such events
- Not all suitable errors were handled as retryable, mostly because of wrappers -- fixed in the error definitions
- The fail on second shard caused the partial commit that broke the retries due to unique constraints on first shard. Multiple things to resolve this:
a. refactor flow, check and the error message in the case we fail and found some rows on destination tables. 
b. add new test commit_sync that specifically challenge the partial commit and fails if we reproduce it
c. wrap copy_data in transaction to make sure the last CopyDone actually reached all the server (means the backends are healthy) and only after that commit the transaction. (2pc desirable?)