### PR TITLE
Allow disabling idle healthchecks

### DIFF
--- a/.schema/pgdog.schema.json
+++ b/.schema/pgdog.schema.json
@@ -785,7 +785,7 @@
           "minimum": 0
         },
         "idle_healthcheck_interval": {
-          "description": "Frequency of healthchecks performed by PgDog on idle connections.\n\n_Default:_ `30000`\n\nhttps://docs.pgdog.dev/configuration/pgdog.toml/general/#idle_healthcheck_interval",
+          "description": "Frequency of healthchecks performed by PgDog on idle connections.\nSet to `0` to disable idle healthchecks.\n\n_Default:_ `30000`\n\nhttps://docs.pgdog.dev/configuration/pgdog.toml/general/#idle_healthcheck_interval",
           "type": "integer",
           "format": "uint64",
           "default": 30000,

--- a/example.pgdog.toml
+++ b/example.pgdog.toml
@@ -49,6 +49,7 @@ pooler_mode = "transaction"
 healthcheck_interval = 30_000
 # How often to check databases with a health check. This happens independently from clients
 # and runs on a separate loop. This is helpful if databases aren't frequently used.
+# Set to 0 to disable idle health checks.
 #
 # Default: 30 seconds
 idle_healthcheck_interval = 30_000

--- a/pgdog-config/src/general.rs
+++ b/pgdog-config/src/general.rs
@@ -126,6 +126,7 @@ pub struct General {
     pub healthcheck_interval: u64,
 
     /// Frequency of healthchecks performed by PgDog on idle connections.
+    /// Set to `0` to disable idle healthchecks.
     ///
     /// _Default:_ `30000`
     ///

--- a/pgdog/src/backend/pool/monitor.rs
+++ b/pgdog/src/backend/pool/monitor.rs
@@ -91,13 +91,17 @@ impl Monitor {
         // Delay starting health checks to give
         // time for the pool to spin up.
         let pool = self.pool.clone();
-        let (delay, replication_mode) = {
+        let (delay, interval, replication_mode) = {
             let lock = pool.lock();
             let config = lock.config();
-            (config.idle_healthcheck_delay(), config.replication_mode)
+            (
+                config.idle_healthcheck_delay(),
+                config.idle_healthcheck_interval(),
+                config.replication_mode,
+            )
         };
 
-        if !replication_mode {
+        if !replication_mode && interval > Duration::ZERO {
             spawn(async move {
                 sleep(delay).await;
                 Self::healthchecks(pool).await

--- a/pgdog/src/backend/pool/test/mod.rs
+++ b/pgdog/src/backend/pool/test/mod.rs
@@ -531,6 +531,44 @@ async fn test_idle_healthcheck_loop() {
 }
 
 #[tokio::test]
+async fn test_idle_healthcheck_loop_disabled_with_zero_interval() {
+    crate::logger();
+
+    let config = Config {
+        inner: pgdog_stats::Config {
+            max: 1,
+            min: 0,
+            idle_healthcheck_interval: Duration::ZERO,
+            idle_healthcheck_delay: Duration::from_millis(10),
+            healthcheck_timeout: Duration::from_millis(10),
+            ..Config::default().inner
+        },
+    };
+
+    let pool = Pool::new(&PoolConfig {
+        address: Address {
+            host: "127.0.0.1".into(),
+            port: 1,
+            database_name: "pgdog".into(),
+            user: "pgdog".into(),
+            passwords: vec!["pgdog".into()],
+            ..Default::default()
+        },
+        config,
+    });
+    pool.launch();
+
+    let initial_healthchecks = pool.state().stats.counts.healthchecks;
+
+    sleep(Duration::from_millis(350)).await;
+
+    let after_healthchecks = pool.state().stats.counts.healthchecks;
+
+    assert_eq!(after_healthchecks, initial_healthchecks);
+    assert!(pool.healthy());
+}
+
+#[tokio::test]
 async fn test_checkout_timeout() {
     crate::logger();
 


### PR DESCRIPTION
Close https://github.com/pgdogdev/pgdog/issues/1029

Treat `idle_healthcheck_interval = 0` as disabled so deployments can avoid background idle healthchecks when they are not useful.

This only disables background idle healthchecks. Checkout-time healthchecks controlled by `healthcheck_interval` should keep their current behavior, with `healthcheck_interval = 0` meaning “check every checkout.” - Please let me know if you'd like me to work on changing behaviour there too, as now `0` can mean something different. I think this different behaviour makes sense but it has to be clearly documented.