### PR TITLE
Don't track drop_columns independently, allow duplicate expr rewrites

### DIFF
--- a/pgdog/src/backend/pool/connection/aggregate.rs
+++ b/pgdog/src/backend/pool/connection/aggregate.rs
@@ -939,7 +939,6 @@ mod test {
         rows.push_back(shard1);
 
         let mut plan = AggregateRewritePlan::default();
-        plan.add_drop_column(1);
         plan.add_helper(HelperMapping {
             target_column: 0,
             helper_column: 1,
@@ -980,8 +979,6 @@ mod test {
         rows.push_back(shard1);
 
         let mut plan = AggregateRewritePlan::default();
-        plan.add_drop_column(2);
-        plan.add_drop_column(3);
         plan.add_helper(HelperMapping {
             target_column: 0,
             helper_column: 2,
@@ -1041,9 +1038,6 @@ mod test {
         rows.push_back(shard1);
 
         let mut plan = AggregateRewritePlan::default();
-        plan.add_drop_column(1);
-        plan.add_drop_column(2);
-        plan.add_drop_column(3);
         plan.add_helper(HelperMapping {
             target_column: 0,
             helper_column: 1,
@@ -1100,9 +1094,6 @@ mod test {
         rows.push_back(shard1);
 
         let mut plan = AggregateRewritePlan::default();
-        plan.add_drop_column(1);
-        plan.add_drop_column(2);
-        plan.add_drop_column(3);
         plan.add_helper(HelperMapping {
             target_column: 0,
             helper_column: 1,

--- a/pgdog/src/backend/pool/connection/buffer.rs
+++ b/pgdog/src/backend/pool/connection/buffer.rs
@@ -162,13 +162,11 @@ impl Buffer {
     }
 
     fn drop_helper_columns(rows: &mut VecDeque<DataRow>, plan: &AggregateRewritePlan) {
-        if plan.drop_columns().is_empty() {
+        if plan.is_noop() {
             return;
         }
 
-        let mut drop = plan.drop_columns().to_vec();
-        drop.sort_unstable();
-        drop.dedup();
+        let drop = plan.drop_columns().collect();
 
         for row in rows.iter_mut() {
             row.drop_columns(&drop);

--- a/pgdog/src/backend/pool/connection/multi_shard/mod.rs
+++ b/pgdog/src/backend/pool/connection/multi_shard/mod.rs
@@ -207,7 +207,7 @@ impl MultiShard {
                     // Only send it to the client once all shards sent it,
                     // so we don't get early requests from clients.
                     let plan = self.route.aggregate_rewrite_plan();
-                    if plan.drop_columns().is_empty() {
+                    if plan.is_noop() {
                         forward = Some(message);
                     } else {
                         let client_rd = rd.drop_columns(plan.drop_columns());

--- a/pgdog/src/frontend/router/parser/rewrite/statement/aggregate/engine.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/aggregate/engine.rs
@@ -311,14 +311,6 @@ mod tests {
     }
 
     #[test]
-    fn rewrite_engine_skips_when_count_exists() {
-        let sql = "SELECT COUNT(price), AVG(price) FROM menu";
-        let (mut ast, output) = rewrite(sql);
-        assert!(output.plan.is_noop());
-        assert_eq!(select(&mut ast).target_list.len(), 2);
-    }
-
-    #[test]
     fn rewrite_engine_handles_mismatched_pair() {
         let (mut ast, output) = rewrite("SELECT COUNT(price::numeric), AVG(price) FROM menu");
         assert_eq!(output.plan.drop_columns().collect::<Vec<_>>(), &[2]);

--- a/pgdog/src/frontend/router/parser/rewrite/statement/aggregate/engine.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/aggregate/engine.rs
@@ -25,15 +25,6 @@ impl AggregatesRewrite {
         let base_len = select.target_list.len();
 
         for target in aggregate.targets() {
-            if aggregate.targets().iter().any(|other| {
-                matches!(other.function(), AggregateFunction::Count)
-                    && other.expr_id() == target.expr_id()
-                    && other.is_distinct() == target.is_distinct()
-            }) && matches!(target.function(), AggregateFunction::Avg)
-            {
-                continue;
-            }
-
             let Some(node) = select.target_list.get(target.column()) else {
                 continue;
             };
@@ -75,20 +66,6 @@ impl AggregatesRewrite {
                     target.column()
                 );
 
-                let alias_exists = select.target_list.iter().any(|existing| {
-                    if let Some(NodeEnum::ResTarget(res)) = existing.node.as_ref() {
-                        res.name == helper_alias
-                    } else {
-                        false
-                    }
-                }) || planned_aliases
-                    .iter()
-                    .any(|existing| existing == &helper_alias);
-
-                if alias_exists {
-                    continue;
-                }
-
                 let helper_column = base_len + helper_nodes.len();
 
                 let helper_res = ResTarget {
@@ -105,7 +82,6 @@ impl AggregatesRewrite {
                 });
                 planned_aliases.push(helper_alias.clone());
 
-                plan.add_drop_column(helper_column);
                 plan.add_helper(HelperMapping {
                     target_column: target.column(),
                     helper_column,
@@ -317,7 +293,7 @@ mod tests {
     fn rewrite_engine_adds_helper() {
         let (mut ast, output) = rewrite("SELECT AVG(price) FROM menu");
         assert!(!output.plan.is_noop());
-        assert_eq!(output.plan.drop_columns(), &[1]);
+        assert_eq!(output.plan.drop_columns().collect::<Vec<_>>(), &[1]);
         assert_eq!(output.plan.helpers().len(), 1);
         let helper = &output.plan.helpers()[0];
         assert_eq!(helper.target_column, 0);
@@ -345,7 +321,7 @@ mod tests {
     #[test]
     fn rewrite_engine_handles_mismatched_pair() {
         let (mut ast, output) = rewrite("SELECT COUNT(price::numeric), AVG(price) FROM menu");
-        assert_eq!(output.plan.drop_columns(), &[2]);
+        assert_eq!(output.plan.drop_columns().collect::<Vec<_>>(), &[2]);
         assert_eq!(output.plan.helpers().len(), 1);
         let helper = &output.plan.helpers()[0];
         assert_eq!(helper.target_column, 1);
@@ -368,7 +344,7 @@ mod tests {
     #[test]
     fn rewrite_engine_multiple_avg_helpers() {
         let (mut ast, output) = rewrite("SELECT AVG(price), AVG(discount) FROM menu");
-        assert_eq!(output.plan.drop_columns(), &[2, 3]);
+        assert_eq!(output.plan.drop_columns().collect::<Vec<_>>(), &[2, 3]);
         assert_eq!(output.plan.helpers().len(), 2);
 
         let helper_price = &output.plan.helpers()[0];
@@ -397,7 +373,7 @@ mod tests {
     fn rewrite_engine_stddev_helpers() {
         let (mut ast, output) = rewrite("SELECT STDDEV(price) FROM menu");
         assert!(!output.plan.is_noop());
-        assert_eq!(output.plan.drop_columns(), &[1, 2, 3]);
+        assert_eq!(output.plan.drop_columns().collect::<Vec<_>>(), &[1, 2, 3]);
         assert_eq!(output.plan.helpers().len(), 3);
 
         let kinds: Vec<HelperKind> = output

--- a/pgdog/src/frontend/router/parser/rewrite/statement/aggregate/plan.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/aggregate/plan.rs
@@ -34,8 +34,6 @@ pub struct HelperMapping {
 /// Plan describing how the proxy rewrites a query and its results.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct AggregateRewritePlan {
-    /// Column indexes (0-based) to drop from the row description/results after execution.
-    drop_columns: Vec<usize>,
     helpers: Vec<HelperMapping>,
 }
 
@@ -43,24 +41,17 @@ impl AggregateRewritePlan {
     /// Create new no-op aggregate rewrite plan.
     pub fn new() -> Self {
         Self {
-            drop_columns: Vec::new(),
             helpers: Vec::new(),
         }
     }
 
     /// Is this plan a no-op? Doesn't do anything.
     pub fn is_noop(&self) -> bool {
-        self.drop_columns.is_empty() && self.helpers.is_empty()
+        self.helpers.is_empty()
     }
 
-    pub fn drop_columns(&self) -> &[usize] {
-        &self.drop_columns
-    }
-
-    pub fn add_drop_column(&mut self, column: usize) {
-        if !self.drop_columns.contains(&column) {
-            self.drop_columns.push(column);
-        }
+    pub fn drop_columns(&self) -> impl Iterator<Item = usize> + '_ {
+        self.helpers.iter().map(|h| h.helper_column)
     }
 
     pub fn helpers(&self) -> &[HelperMapping] {
@@ -91,16 +82,8 @@ mod tests {
     fn rewrite_plan_noop() {
         let plan = AggregateRewritePlan::new();
         assert!(plan.is_noop());
-        assert!(plan.drop_columns().is_empty());
+        assert!(plan.drop_columns().count() == 0);
         assert!(plan.helpers().is_empty());
-    }
-
-    #[test]
-    fn rewrite_plan_drop_columns() {
-        let mut plan = AggregateRewritePlan::new();
-        plan.add_drop_column(1);
-        plan.add_drop_column(4);
-        assert_eq!(plan.drop_columns(), &[1, 4]);
     }
 
     #[test]

--- a/pgdog/src/net/messages/data_row.rs
+++ b/pgdog/src/net/messages/data_row.rs
@@ -1,6 +1,7 @@
 //! DataRow (B) message.
 
 use crate::net::Decoder;
+use std::collections::BTreeSet;
 
 use super::{
     code, prelude::*, Datum, Double, Float, Format, FromDataType, Numeric, RowDescription,
@@ -50,33 +51,14 @@ impl DataRow {
     }
 
     /// Drop columns by 0-based index, ignoring indexes out of bounds.
-    pub fn drop_columns(&mut self, drop: &[usize]) {
-        if drop.is_empty() {
-            return;
-        }
-
-        let mut indices = drop.to_vec();
-        indices.sort_unstable();
-        indices.dedup();
-
-        if indices.is_empty() {
-            return;
-        }
-
-        let mut dropped = indices.into_iter().peekable();
-        let mut retained = Vec::with_capacity(self.columns.len());
-
-        for (idx, column) in self.columns.drain(..).enumerate() {
-            match dropped.peek() {
-                Some(&drop_idx) if drop_idx == idx => {
-                    dropped.next();
-                }
-                _ => retained.push(column),
-            }
-        }
-
-        // Any remaining indexes are beyond the current column count; ignore.
-        self.columns = retained;
+    // FIXME(sage): Fairly certain this is never a disjoint set of indices,
+    // just a number of columns to remove at the end
+    pub fn drop_columns(&mut self, drop: &BTreeSet<usize>) {
+        let mut idx = 0;
+        self.columns.retain(|_| {
+            idx += 1;
+            !drop.contains(&(idx - 1))
+        });
     }
 
     /// Create data row from columns.
@@ -293,7 +275,7 @@ mod test {
         dr.add("b");
         dr.add("c");
 
-        dr.drop_columns(&[1, 5]);
+        dr.drop_columns(&[1, 5].into_iter().collect());
 
         assert_eq!(dr.len(), 2);
         assert_eq!(dr.get::<String>(0, Format::Text).unwrap(), "a");

--- a/pgdog/src/net/messages/row_description.rs
+++ b/pgdog/src/net/messages/row_description.rs
@@ -1,5 +1,6 @@
 //! RowDescription (B) message.
 
+use std::collections::BTreeSet;
 use std::ops::Deref;
 use std::sync::Arc;
 
@@ -226,21 +227,15 @@ impl RowDescription {
     }
 
     /// Return a new row description without the specified columns (0-based indexes).
-    pub fn drop_columns(&self, drop: &[usize]) -> Self {
-        if drop.is_empty() {
-            return self.clone();
-        }
-
-        let mut indices = drop.to_vec();
-        indices.sort_unstable();
-        indices.dedup();
+    pub fn drop_columns(&self, drop: impl IntoIterator<Item = usize>) -> Self {
+        let indices = drop.into_iter().collect::<BTreeSet<_>>();
 
         let fields = self
             .fields
             .iter()
             .enumerate()
             .filter_map(|(idx, field)| {
-                if indices.binary_search(&idx).is_ok() {
+                if indices.contains(&idx) {
                     None
                 } else {
                     Some(field.clone())


### PR DESCRIPTION
There is never a case where we call add_helper without also calling add_drop_column. In fact, we rely on those two things always being in sync. Rather than tracking them separately, we can just maintain that invariant in the struct itself.

I opted to just return an iterator rather than continuing to keep a duplicate data structure that we keep in sync, because the performance cost should be essentially zero, and it means we don't need to keep this data structure in place.

I also removed an optimization that I believe motivated this and some other messy structures. We go to great lengths to not add a helper COUNT column if there is an existing COUNT, either from the client's selection or from a previous aggregate. This has led to a lot of very leaky code where every aggregate is potentially intertwined with every other, and is completely unnecessary. PG is already more than capable of deduplicating identical expressions in a selection, and you can even verify this yourself in the query plan. The only thing we're saving by deduplicating on our end is 8 bytes of network overhead, which is not a meaningful cost.

The removal of the separate drop_columns still works fine without breaking anything even with the deduplication, but I've opted to include them both in a single commit for convenience