### PR TITLE
Give a more meaningful error message when a helper column is missing

### DIFF
--- a/pgdog/src/backend/pool/connection/aggregate.rs
+++ b/pgdog/src/backend/pool/connection/aggregate.rs
@@ -98,9 +98,7 @@ impl<'a> Accumulator<'a> {
 
     /// Transform COUNT(*), MIN, MAX, etc., from multiple shards into a single value.
     fn accumulate(&mut self, row: &DataRow, decoder: &Decoder) -> Result<bool, Error> {
-        let column = row
-            .get_column(self.target.column(), decoder)?
-            .ok_or(Error::DecoderRowError)?;
+        let column = row.get_column_checked(self.target.column(), decoder)?;
         match self.target.function() {
             AggregateFunction::Count => {
                 if !self.datum.is_null() {
@@ -145,9 +143,7 @@ impl<'a> Accumulator<'a> {
                         return Ok(false);
                     };
 
-                    let count = row
-                        .get_column(count_column, decoder)?
-                        .ok_or(Error::DecoderRowError)?;
+                    let count = row.get_column_checked(count_column, decoder)?;
 
                     if column.value.is_null() || count.value.is_null() {
                         return Ok(true);
@@ -289,9 +285,7 @@ impl VarianceState {
             return Ok(false);
         };
 
-        let count = row
-            .get_column(count_column, decoder)?
-            .ok_or(Error::DecoderRowError)?;
+        let count = row.get_column_checked(count_column, decoder)?;
 
         if count.value.is_null() {
             return Ok(true);
@@ -312,9 +306,7 @@ impl VarianceState {
             self.supported = false;
             return Ok(false);
         };
-        let sum = row
-            .get_column(sum_column, decoder)?
-            .ok_or(Error::DecoderRowError)?;
+        let sum = row.get_column_checked(sum_column, decoder)?;
         if sum.value.is_null() {
             self.supported = false;
             return Ok(false);
@@ -325,9 +317,7 @@ impl VarianceState {
             self.supported = false;
             return Ok(false);
         };
-        let sumsq = row
-            .get_column(sumsq_column, decoder)?
-            .ok_or(Error::DecoderRowError)?;
+        let sumsq = row.get_column_checked(sumsq_column, decoder)?;
         if sumsq.value.is_null() {
             self.supported = false;
             return Ok(false);

--- a/pgdog/src/net/error.rs
+++ b/pgdog/src/net/error.rs
@@ -107,6 +107,11 @@ pub enum Error {
     /// Carry enough context to identify the violation without a debugger.
     #[error("invariant violation: {0}")]
     InvariantViolation(String),
+
+    /// Column that is assumed to exist was not present. This indicates a
+    /// bug in PgDog, such as a helper column not being inserted.
+    #[error("missing column at index {0} that was assumed to be present (this indicates a bug in pgdog, please open an issue with details about your query)")]
+    RequiredColumnMissing(usize),
 }
 
 impl Error {

--- a/pgdog/src/net/messages/data_row.rs
+++ b/pgdog/src/net/messages/data_row.rs
@@ -137,6 +137,18 @@ impl DataRow {
         Ok(None)
     }
 
+    /// Get the column at index given row description. Error if not present.
+    /// This should only be used when the absence of a column represents a bug
+    /// in pgdog.
+    pub fn get_column_checked<'a>(
+        &self,
+        idx: usize,
+        decoder: &'a Decoder,
+    ) -> Result<Column<'a>, Error> {
+        self.get_column(idx, decoder)?
+            .ok_or(Error::RequiredColumnMissing(idx))
+    }
+
     /// Render the data row.
     pub fn into_row<'a>(&self, rd: &'a RowDescription) -> Result<Vec<Column<'a>>, Error> {
         let mut row = vec![];
@@ -230,6 +242,7 @@ impl From<DataRow> for Lsn {
 mod test {
     use super::*;
     use crate::net::{Decoder, Field};
+    use std::assert_matches;
 
     #[test]
     fn test_insert() {
@@ -298,9 +311,23 @@ mod test {
         let row = DataRow::from_columns(vec![Bytes::from_static(b"{1,2,3}")]);
         let column = row.get_column(0, &decoder).unwrap().unwrap();
 
-        assert!(
-            !matches!(column.value, Datum::Unknown(_)),
+        assert_matches!(
+            column.value,
+            Datum::Array(_),
             "array columns should participate in typed decoding"
         );
+    }
+
+    #[test]
+    fn get_column_checked_returns_err_on_missing_field() {
+        let rd = RowDescription::new(&[Field::bigint("stuff")]);
+        let decoder = Decoder::from(&rd);
+        let row = DataRow::from_columns(vec![Bytes::from_static(b"1")]);
+
+        let column = row.get_column_checked(0, &decoder);
+        assert_matches!(column, Ok(_));
+
+        let column = row.get_column_checked(1, &decoder);
+        assert_matches!(column, Err(Error::RequiredColumnMissing(1)));
     }
 }


### PR DESCRIPTION
Any time we're decoding a row expecting a specific column to exist, such as when we're grabbing the value of a helper column we added for an aggregate function, the absence of that column represents a bug in pgdog. We should provide a more meaningful error message than "decoder was missing data". Unfortunately, since the error comes from the absence of the description for a column, we don't have any useful information to provide for debugging beyond an index. But at minimum we can be clear this is due to a bug in pgdog, and ask the user to open an issue with details about the query that we can use to debug.