### PR TITLE
Change Datum to only perform checked addition

### DIFF
--- a/pgdog-postgres-types/src/array.rs
+++ b/pgdog-postgres-types/src/array.rs
@@ -6,7 +6,7 @@ use crate::{DataType, Datum};
 #[derive(Debug, Clone, PartialOrd, PartialEq, Eq, Hash)]
 pub struct Array {
     elements: Vec<Datum>,
-    element_oid: i32,
+    pub(crate) element_oid: i32,
     dim: Dimension,
 }
 

--- a/pgdog-postgres-types/src/datum.rs
+++ b/pgdog-postgres-types/src/datum.rs
@@ -1,5 +1,5 @@
 use std::cmp::{Ordering, PartialOrd};
-use std::ops::Add;
+use std::fmt;
 
 use bytes::Bytes;
 use pgdog_vector::{Float, Vector};
@@ -122,27 +122,6 @@ impl ToDataRowColumn for Datum {
     }
 }
 
-impl Add for Datum {
-    type Output = Datum;
-
-    fn add(self, rhs: Self) -> Self::Output {
-        use Datum::*;
-
-        match (self, rhs) {
-            (Bigint(a), Bigint(b)) => Bigint(a + b),
-            (Integer(a), Integer(b)) => Integer(a + b),
-            (SmallInt(a), SmallInt(b)) => SmallInt(a + b),
-            (Interval(a), Interval(b)) => Interval(a + b),
-            (Numeric(a), Numeric(b)) => Numeric(a + b),
-            (Float(a), Float(b)) => Float(crate::Float(a.0 + b.0)),
-            (Double(a), Double(b)) => Double(crate::Double(a.0 + b.0)),
-            (Datum::Null, b) => b,
-            (a, Datum::Null) => a,
-            _ => Datum::Null, // Might be good to raise an error.
-        }
-    }
-}
-
 impl Datum {
     pub fn new(
         bytes: &[u8],
@@ -202,6 +181,28 @@ impl Datum {
             Datum::Array(a) => a.encode(format),
             Datum::Null => Ok(Bytes::new()),
             Datum::Unknown(bytes) => Ok(bytes.clone()),
+        }
+    }
+
+    pub fn data_type(&self) -> DataType {
+        match self {
+            Datum::Bigint(..) => DataType::Bigint,
+            Datum::Integer(..) => DataType::Integer,
+            Datum::Uuid(..) => DataType::Uuid,
+            Datum::Text(..) => DataType::Text,
+            Datum::Boolean(..) => DataType::Bool,
+            Datum::Float(..) => DataType::Real,
+            Datum::Double(..) => DataType::DoublePrecision,
+            Datum::Numeric(..) => DataType::Numeric,
+            Datum::Timestamp(..) => DataType::Timestamp,
+            Datum::TimestampTz(..) => DataType::TimestampTz,
+            Datum::SmallInt(..) => DataType::SmallInt,
+            Datum::Interval(..) => DataType::Interval,
+            Datum::Vector(..) => DataType::Vector,
+            Datum::Oid(..) => DataType::Oid,
+            Datum::Array(a) => DataType::Array(a.element_oid),
+            Datum::Null => DataType::Other(0),
+            Datum::Unknown(..) => DataType::Other(0),
         }
     }
 }
@@ -267,17 +268,43 @@ impl DataType {
     }
 }
 
+impl fmt::Display for DataType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        use DataType::*;
+        match self {
+            Bigint => write!(f, "bigint"),
+            Integer => write!(f, "integer"),
+            Text => write!(f, "text"),
+            Interval => write!(f, "interval"),
+            Timestamp => write!(f, "timestamp"),
+            TimestampTz => write!(f, "timestamptz"),
+            Real => write!(f, "real"),
+            DoublePrecision => write!(f, "double precision"),
+            Bool => write!(f, "boolean"),
+            SmallInt => write!(f, "smallint"),
+            TinyInt => write!(f, "tinyint"),
+            Numeric => write!(f, "numeric"),
+            Other(i) => write!(f, "unknown type {i}"),
+            Uuid => write!(f, "uuid"),
+            Oid => write!(f, "oid"),
+            Vector => write!(f, "vector"),
+            Array(i) => write!(f, "{}[]", Self::from_oid(*i)),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use bytes::{BufMut, BytesMut};
+    use std::assert_matches;
 
     #[test]
     fn test_multidimensional_text_array_falls_back_to_unknown() {
         let input = b"{{1,2},{3,4}}";
         let datum = Datum::new(input, DataType::Array(23), Format::Text, false).unwrap();
 
-        assert!(matches!(datum, Datum::Unknown(_)));
+        assert_matches!(datum, Datum::Unknown(_));
         assert_eq!(
             datum.encode(Format::Text).unwrap(),
             Bytes::from_static(input)
@@ -303,7 +330,7 @@ mod tests {
         let input = buf.freeze();
         let datum = Datum::new(&input, DataType::Array(23), Format::Binary, false).unwrap();
 
-        assert!(matches!(datum, Datum::Unknown(_)));
+        assert_matches!(datum, Datum::Unknown(_));
         assert_eq!(datum.encode(Format::Binary).unwrap(), input);
     }
 }

--- a/pgdog-postgres-types/src/error.rs
+++ b/pgdog-postgres-types/src/error.rs
@@ -1,5 +1,6 @@
 //! Network errors.
 
+use crate::datum::DataType;
 use std::array::TryFromSliceError;
 
 use thiserror::Error;
@@ -47,4 +48,10 @@ pub enum Error {
 
     #[error("lsn decode error")]
     LsnDecode,
+
+    #[error("expected {0}, got {1}")]
+    IncompatibleTypes(DataType, DataType),
+
+    #[error("invalid operation {op} for {ty}")]
+    InvalidOperation { op: &'static str, ty: DataType },
 }

--- a/pgdog-postgres-types/src/interval.rs
+++ b/pgdog-postgres-types/src/interval.rs
@@ -1,11 +1,11 @@
-use std::{num::ParseIntError, ops::Add};
+use std::{num::ParseIntError, ops::Add, ops::AddAssign};
 
 use crate::Data;
 
 use super::*;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 
-#[derive(Eq, PartialEq, Ord, PartialOrd, Default, Debug, Clone, Hash)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Default, Debug, Clone, Copy, Hash)]
 pub struct Interval {
     years: i64,
     months: i32,
@@ -30,6 +30,12 @@ impl Add for Interval {
             seconds: self.seconds.saturating_add(rhs.seconds),
             micros: self.micros.saturating_add(rhs.micros),
         }
+    }
+}
+
+impl AddAssign for Interval {
+    fn add_assign(&mut self, rhs: Interval) {
+        *self = *self + rhs
     }
 }
 

--- a/pgdog-postgres-types/src/numeric.rs
+++ b/pgdog-postgres-types/src/numeric.rs
@@ -1,4 +1,10 @@
-use std::{cmp::Ordering, fmt::Display, hash::Hash, ops::Add, str::FromStr};
+use std::{
+    cmp::Ordering,
+    fmt::Display,
+    hash::Hash,
+    ops::{Add, AddAssign},
+    str::FromStr,
+};
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use postgres_types::{FromSql, ToSql, Type};
@@ -92,6 +98,12 @@ impl Add for Numeric {
             // Any operation with NaN yields NaN
             _ => Self::nan(),
         }
+    }
+}
+
+impl AddAssign for Numeric {
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
     }
 }
 

--- a/pgdog/src/backend/pool/connection/aggregate.rs
+++ b/pgdog/src/backend/pool/connection/aggregate.rs
@@ -1,6 +1,7 @@
 //! Aggregate buffer.
 
 use std::collections::{HashMap, VecDeque};
+use std::mem;
 
 use crate::{
     frontend::router::parser::{
@@ -15,6 +16,7 @@ use crate::{
         Decoder,
     },
 };
+use pgdog_postgres_types::Error as TypeError;
 use rust_decimal::prelude::{FromPrimitive, ToPrimitive};
 use rust_decimal::Decimal;
 
@@ -102,7 +104,7 @@ impl<'a> Accumulator<'a> {
         match self.target.function() {
             AggregateFunction::Count => {
                 if !self.datum.is_null() {
-                    self.datum = self.datum.clone() + column.value;
+                    checked_add_assign(&mut self.datum, column.value)?;
                 } else {
                     self.datum = column.value;
                 }
@@ -127,7 +129,7 @@ impl<'a> Accumulator<'a> {
             }
             AggregateFunction::Sum => {
                 if !self.datum.is_null() {
-                    self.datum = self.datum.clone() + column.value;
+                    checked_add_assign(&mut self.datum, column.value)?;
                 } else {
                     self.datum = column.value;
                 }
@@ -150,8 +152,8 @@ impl<'a> Accumulator<'a> {
                     }
 
                     if let Some(weighted) = multiply_for_average(&column.value, &count.value) {
-                        state.weighted_sum = state.weighted_sum.clone() + weighted;
-                        state.total_count = state.total_count.clone() + count.value.clone();
+                        checked_add_assign(&mut state.weighted_sum, weighted)?;
+                        checked_add_assign(&mut state.total_count, count.value.clone())?;
                     } else {
                         state.supported = false;
                         return Ok(false);
@@ -300,7 +302,7 @@ impl VarianceState {
             return Ok(true);
         }
 
-        self.total_count = self.total_count.clone() + count.value.clone();
+        checked_add_assign(&mut self.total_count, count.value.clone())?;
 
         let Some(sum_column) = self.sum_column else {
             self.supported = false;
@@ -311,7 +313,7 @@ impl VarianceState {
             self.supported = false;
             return Ok(false);
         }
-        self.total_sum = self.total_sum.clone() + sum.value.clone();
+        checked_add_assign(&mut self.total_sum, sum.value.clone())?;
 
         let Some(sumsq_column) = self.sumsq_column else {
             self.supported = false;
@@ -322,7 +324,7 @@ impl VarianceState {
             self.supported = false;
             return Ok(false);
         }
-        self.total_sumsq = self.total_sumsq.clone() + sumsq.value.clone();
+        checked_add_assign(&mut self.total_sumsq, sumsq.value.clone())?;
 
         Ok(true)
     }
@@ -597,6 +599,37 @@ impl<'a> Aggregates<'a> {
     }
 }
 
+/// Adds rhs to self. Returns an error if self + rhs are not the same type, or
+/// if self is a type that cannot be added.
+///
+/// The behavior of this function diverges from postgres when handling NULL.
+/// When calculating x + NULL, we will return x, while postgres will return NULL
+fn checked_add_assign(lhs: &mut Datum, rhs: Datum) -> Result<(), TypeError> {
+    use Datum::*;
+    match (lhs, rhs) {
+        (Bigint(a), Bigint(b)) => *a += b,
+        (Integer(a), Integer(b)) => *a += b,
+        (SmallInt(a), SmallInt(b)) => *a += b,
+        (Interval(a), Interval(b)) => *a += b,
+        (Numeric(a), Numeric(b)) => *a += b,
+        (Float(a), Float(b)) => a.0 += b.0,
+        (Double(a), Double(b)) => a.0 += b.0,
+        (a @ Datum::Null, b) => *a = b,
+        (_, Datum::Null) => {}
+        (a, b) if mem::discriminant(a) != mem::discriminant(&b) => {
+            return Err(TypeError::IncompatibleTypes(a.data_type(), b.data_type()));
+        }
+        (a, _) => {
+            return Err(TypeError::InvalidOperation {
+                op: "add",
+                ty: a.data_type(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
 fn multiply_for_average(value: &Datum, count: &Datum) -> Option<Datum> {
     let multiplier_i128 = datum_as_i128(count)?;
 
@@ -718,6 +751,7 @@ mod test {
     };
     use bytes::Bytes;
     use pg_query::{protobuf::SelectStmt, NodeEnum};
+    use std::assert_matches;
     use std::collections::VecDeque;
 
     #[test]
@@ -1312,5 +1346,20 @@ mod test {
 
         assert_eq!(intervals, r#"{"1 year 2 mons 1 day 04:05:06.7"}"#);
         assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn test_adding_types_which_cannot_be_added() {
+        let mut datum = Datum::Text("hello".to_owned());
+        // operator does not exist: text + text
+        let result = checked_add_assign(&mut datum, Datum::Text("goodbye".to_owned()));
+        assert_matches!(result, Err(TypeError::InvalidOperation { .. }));
+    }
+
+    #[test]
+    fn test_adding_incompatible_types() {
+        let mut datum = Datum::Integer(1);
+        let result = checked_add_assign(&mut datum, Datum::Text("1".to_owned()));
+        assert_matches!(result, Err(TypeError::IncompatibleTypes(..)));
     }
 }


### PR DESCRIPTION
Datum does not represent a type that can unconditionally add to itself. Currently, any time we encounter two types which do not match, or any types which can't be added, we silently return NULL. This changes that behavior to return a specific error. The Add impl is removed, as these cases will most likely represent a bug in pgdog and shouldn't be silently swallowed.

Two potential future changes stand out to me. The first is that we currently unconditionally error on types that differ, even though we can absolutely add Integer to Bigint for example. I'm not sure that we want to be responsible for maintaining the whole matrix of cross type addition that PG supports, so for the time being I maintained the current behavior.

The second is that how we handle NULL is currently the exact opposite of what PG does. I suspect this will be because all calls to addition come from the implementation of aggregate functions, where we might get NULL from a shard that returned no rows, and we don't want that NULL to cancel out the results from other shards.

That behavior in general is reasonable, but in such a generic function like Datum::add, diverging from PG is surprising behavior, and a potential footgun waiting to go off. I think instead we should have the aggregate functions be responsible for handling NULLs, and mirror PG in this more general case.

However, I opted not to make that change in this PR, as I'm not confident we have test coverage for this case, where a cross shard query returns results from one query and NULL from another. As I refactor this code further, I intend to make that change down the line.