### PR TITLE
Unify env var manipulation in tests

### DIFF
--- a/pgdog-config/src/general.rs
+++ b/pgdog-config/src/general.rs
@@ -1374,26 +1374,26 @@ impl General {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::env;
+    use crate::test_utils::*;
 
     #[test]
     fn test_env_workers() {
-        env::set_var("PGDOG_WORKERS", "8");
+        let _guard = set_env_var("PGDOG_WORKERS", "8");
         assert_eq!(General::workers(), 8);
-        env::remove_var("PGDOG_WORKERS");
+        let _guard = remove_env_var("PGDOG_WORKERS");
         assert_eq!(General::workers(), 2);
     }
 
     #[test]
     fn test_env_pool_sizes() {
-        env::set_var("PGDOG_DEFAULT_POOL_SIZE", "50");
-        env::set_var("PGDOG_MIN_POOL_SIZE", "5");
+        let _guard = set_env_var("PGDOG_DEFAULT_POOL_SIZE", "50");
+        let _guard = set_env_var("PGDOG_MIN_POOL_SIZE", "5");
 
         assert_eq!(General::default_pool_size(), 50);
         assert_eq!(General::min_pool_size(), 5);
 
-        env::remove_var("PGDOG_DEFAULT_POOL_SIZE");
-        env::remove_var("PGDOG_MIN_POOL_SIZE");
+        let _guard = remove_env_var("PGDOG_DEFAULT_POOL_SIZE");
+        let _guard = remove_env_var("PGDOG_MIN_POOL_SIZE");
 
         assert_eq!(General::default_pool_size(), 10);
         assert_eq!(General::min_pool_size(), 1);
@@ -1401,11 +1401,11 @@ mod tests {
 
     #[test]
     fn test_env_timeouts() {
-        env::set_var("PGDOG_HEALTHCHECK_INTERVAL", "60000");
-        env::set_var("PGDOG_HEALTHCHECK_TIMEOUT", "10000");
-        env::set_var("PGDOG_CONNECT_TIMEOUT", "10000");
-        env::set_var("PGDOG_CHECKOUT_TIMEOUT", "15000");
-        env::set_var("PGDOG_IDLE_TIMEOUT", "120000");
+        let _guard = set_env_var("PGDOG_HEALTHCHECK_INTERVAL", "60000");
+        let _guard = set_env_var("PGDOG_HEALTHCHECK_TIMEOUT", "10000");
+        let _guard = set_env_var("PGDOG_CONNECT_TIMEOUT", "10000");
+        let _guard = set_env_var("PGDOG_CHECKOUT_TIMEOUT", "15000");
+        let _guard = set_env_var("PGDOG_IDLE_TIMEOUT", "120000");
 
         assert_eq!(General::healthcheck_interval(), 60000);
         assert_eq!(General::healthcheck_timeout(), 10000);
@@ -1413,11 +1413,11 @@ mod tests {
         assert_eq!(General::checkout_timeout(), 15000);
         assert_eq!(General::idle_timeout(), 120000);
 
-        env::remove_var("PGDOG_HEALTHCHECK_INTERVAL");
-        env::remove_var("PGDOG_HEALTHCHECK_TIMEOUT");
-        env::remove_var("PGDOG_CONNECT_TIMEOUT");
-        env::remove_var("PGDOG_CHECKOUT_TIMEOUT");
-        env::remove_var("PGDOG_IDLE_TIMEOUT");
+        let _guard = remove_env_var("PGDOG_HEALTHCHECK_INTERVAL");
+        let _guard = remove_env_var("PGDOG_HEALTHCHECK_TIMEOUT");
+        let _guard = remove_env_var("PGDOG_CONNECT_TIMEOUT");
+        let _guard = remove_env_var("PGDOG_CHECKOUT_TIMEOUT");
+        let _guard = remove_env_var("PGDOG_IDLE_TIMEOUT");
 
         assert_eq!(General::healthcheck_interval(), 30000);
         assert_eq!(General::healthcheck_timeout(), 5000);
@@ -1428,27 +1428,24 @@ mod tests {
 
     #[test]
     fn test_env_invalid_values() {
-        env::set_var("PGDOG_WORKERS", "invalid");
-        env::set_var("PGDOG_DEFAULT_POOL_SIZE", "not_a_number");
+        let _guard = set_env_var("PGDOG_WORKERS", "invalid");
+        let _guard = set_env_var("PGDOG_DEFAULT_POOL_SIZE", "not_a_number");
 
         assert_eq!(General::workers(), 2);
         assert_eq!(General::default_pool_size(), 10);
-
-        env::remove_var("PGDOG_WORKERS");
-        env::remove_var("PGDOG_DEFAULT_POOL_SIZE");
     }
 
     #[test]
     fn test_env_host_port() {
         // Test existing env var functionality
-        env::set_var("PGDOG_HOST", "192.168.1.1");
-        env::set_var("PGDOG_PORT", "8432");
+        let _guard = set_env_var("PGDOG_HOST", "192.168.1.1");
+        let _guard = set_env_var("PGDOG_PORT", "8432");
 
         assert_eq!(General::host(), "192.168.1.1");
         assert_eq!(General::port(), 8432);
 
-        env::remove_var("PGDOG_HOST");
-        env::remove_var("PGDOG_PORT");
+        let _guard = remove_env_var("PGDOG_HOST");
+        let _guard = remove_env_var("PGDOG_PORT");
 
         assert_eq!(General::host(), "0.0.0.0");
         assert_eq!(General::port(), 6432);
@@ -1457,71 +1454,71 @@ mod tests {
     #[test]
     fn test_env_enum_fields() {
         // Test pooler mode
-        env::set_var("PGDOG_POOLER_MODE", "session");
+        let _guard = set_env_var("PGDOG_POOLER_MODE", "session");
         assert_eq!(General::pooler_mode(), PoolerMode::Session);
-        env::remove_var("PGDOG_POOLER_MODE");
+        let _guard = remove_env_var("PGDOG_POOLER_MODE");
         assert_eq!(General::pooler_mode(), PoolerMode::Transaction);
 
         // Test load balancing strategy
-        env::set_var("PGDOG_LOAD_BALANCING_STRATEGY", "round_robin");
+        let _guard = set_env_var("PGDOG_LOAD_BALANCING_STRATEGY", "round_robin");
         assert_eq!(
             General::load_balancing_strategy(),
             LoadBalancingStrategy::RoundRobin
         );
-        env::remove_var("PGDOG_LOAD_BALANCING_STRATEGY");
+        let _guard = remove_env_var("PGDOG_LOAD_BALANCING_STRATEGY");
         assert_eq!(
             General::load_balancing_strategy(),
             LoadBalancingStrategy::Random
         );
 
         // Test read-write strategy
-        env::set_var("PGDOG_READ_WRITE_STRATEGY", "aggressive");
+        let _guard = set_env_var("PGDOG_READ_WRITE_STRATEGY", "aggressive");
         assert_eq!(
             General::read_write_strategy(),
             ReadWriteStrategy::Aggressive
         );
-        env::remove_var("PGDOG_READ_WRITE_STRATEGY");
+        let _guard = remove_env_var("PGDOG_READ_WRITE_STRATEGY");
         assert_eq!(
             General::read_write_strategy(),
             ReadWriteStrategy::Conservative
         );
 
         // Test read-write split
-        env::set_var("PGDOG_READ_WRITE_SPLIT", "exclude_primary");
+        let _guard = set_env_var("PGDOG_READ_WRITE_SPLIT", "exclude_primary");
         assert_eq!(General::read_write_split(), ReadWriteSplit::ExcludePrimary);
-        env::remove_var("PGDOG_READ_WRITE_SPLIT");
+        let _guard = remove_env_var("PGDOG_READ_WRITE_SPLIT");
         assert_eq!(General::read_write_split(), ReadWriteSplit::IncludePrimary);
 
         // Test TLS verify mode
-        env::set_var("PGDOG_TLS_VERIFY", "verify_full");
+        let _guard = set_env_var("PGDOG_TLS_VERIFY", "verify_full");
         assert_eq!(General::default_tls_verify(), TlsVerifyMode::VerifyFull);
-        env::remove_var("PGDOG_TLS_VERIFY");
+        let _guard = remove_env_var("PGDOG_TLS_VERIFY");
         assert_eq!(General::default_tls_verify(), TlsVerifyMode::Prefer);
 
         // Test prepared statements
-        env::set_var("PGDOG_PREPARED_STATEMENTS", "full");
+        let _guard = set_env_var("PGDOG_PREPARED_STATEMENTS", "full");
         assert_eq!(General::prepared_statements(), PreparedStatements::Full);
-        env::remove_var("PGDOG_PREPARED_STATEMENTS");
+        let _guard = remove_env_var("PGDOG_PREPARED_STATEMENTS");
         assert_eq!(General::prepared_statements(), PreparedStatements::Extended);
 
         // Test auth type
-        env::set_var("PGDOG_AUTH_TYPE", "md5");
+        let _guard = set_env_var("PGDOG_AUTH_TYPE", "md5");
         assert_eq!(General::auth_type(), AuthType::Md5);
-        env::remove_var("PGDOG_AUTH_TYPE");
+        let _guard = remove_env_var("PGDOG_AUTH_TYPE");
         assert_eq!(General::auth_type(), AuthType::Scram);
     }
 
     #[test]
     fn test_env_additional_timeouts() {
-        env::set_var("PGDOG_IDLE_HEALTHCHECK_INTERVAL", "45000");
-        env::set_var("PGDOG_IDLE_HEALTHCHECK_DELAY", "10000");
-        env::set_var("PGDOG_BAN_TIMEOUT", "600000");
-        env::set_var("PGDOG_ROLLBACK_TIMEOUT", "10000");
-        env::set_var("PGDOG_SHUTDOWN_TIMEOUT", "120000");
-        env::set_var("PGDOG_SHUTDOWN_TERMINATION_TIMEOUT", "15000");
-        env::set_var("PGDOG_CONNECT_ATTEMPT_DELAY", "1000");
-        env::set_var("PGDOG_QUERY_TIMEOUT", "30000");
-        env::set_var("PGDOG_CLIENT_IDLE_TIMEOUT", "3600000");
+        let _guard = set_env_var("PGDOG_IDLE_HEALTHCHECK_INTERVAL", "45000");
+        let _guard = set_env_var("PGDOG_IDLE_HEALTHCHECK_DELAY", "10000");
+        let _guard = set_env_var("PGDOG_BAN_TIMEOUT", "600000");
+        let _guard = set_env_var("PGDOG_ROLLBACK_TIMEOUT", "10000");
+        let _guard = set_env_var("PGDOG_SHUTDOWN_TIMEOUT", "120000");
+        let _guard = set_env_var("PGDOG_SHUTDOWN_TERMINATION_TIMEOUT", "15000");
+        let _guard = set_env_var("PGDOG_CONNECT_ATTEMPT_DELAY", "1000");
+        let _guard = set_env_var("PGDOG_QUERY_TIMEOUT", "30000");
+        let _guard = set_env_var("PGDOG_CLIENT_IDLE_TIMEOUT", "3600000");
 
         assert_eq!(General::idle_healthcheck_interval(), 45000);
         assert_eq!(General::idle_healthcheck_delay(), 10000);
@@ -1536,15 +1533,15 @@ mod tests {
         assert_eq!(General::default_query_timeout(), 30000);
         assert_eq!(General::default_client_idle_timeout(), 3600000);
 
-        env::remove_var("PGDOG_IDLE_HEALTHCHECK_INTERVAL");
-        env::remove_var("PGDOG_IDLE_HEALTHCHECK_DELAY");
-        env::remove_var("PGDOG_BAN_TIMEOUT");
-        env::remove_var("PGDOG_ROLLBACK_TIMEOUT");
-        env::remove_var("PGDOG_SHUTDOWN_TIMEOUT");
-        env::remove_var("PGDOG_SHUTDOWN_TERMINATION_TIMEOUT");
-        env::remove_var("PGDOG_CONNECT_ATTEMPT_DELAY");
-        env::remove_var("PGDOG_QUERY_TIMEOUT");
-        env::remove_var("PGDOG_CLIENT_IDLE_TIMEOUT");
+        let _guard = remove_env_var("PGDOG_IDLE_HEALTHCHECK_INTERVAL");
+        let _guard = remove_env_var("PGDOG_IDLE_HEALTHCHECK_DELAY");
+        let _guard = remove_env_var("PGDOG_BAN_TIMEOUT");
+        let _guard = remove_env_var("PGDOG_ROLLBACK_TIMEOUT");
+        let _guard = remove_env_var("PGDOG_SHUTDOWN_TIMEOUT");
+        let _guard = remove_env_var("PGDOG_SHUTDOWN_TERMINATION_TIMEOUT");
+        let _guard = remove_env_var("PGDOG_CONNECT_ATTEMPT_DELAY");
+        let _guard = remove_env_var("PGDOG_QUERY_TIMEOUT");
+        let _guard = remove_env_var("PGDOG_CLIENT_IDLE_TIMEOUT");
 
         assert_eq!(General::idle_healthcheck_interval(), 30000);
         assert_eq!(General::idle_healthcheck_delay(), 5000);
@@ -1557,11 +1554,11 @@ mod tests {
 
     #[test]
     fn test_env_path_fields() {
-        env::set_var("PGDOG_TLS_CERTIFICATE", "/path/to/cert.pem");
-        env::set_var("PGDOG_TLS_PRIVATE_KEY", "/path/to/key.pem");
-        env::set_var("PGDOG_TLS_SERVER_CA_CERTIFICATE", "/path/to/ca.pem");
-        env::set_var("PGDOG_TLS_CLIENT_CA_CERTIFICATE", "/path/to/client-ca.pem");
-        env::set_var("PGDOG_QUERY_LOG", "/var/log/pgdog/queries.log");
+        let _guard = set_env_var("PGDOG_TLS_CERTIFICATE", "/path/to/cert.pem");
+        let _guard = set_env_var("PGDOG_TLS_PRIVATE_KEY", "/path/to/key.pem");
+        let _guard = set_env_var("PGDOG_TLS_SERVER_CA_CERTIFICATE", "/path/to/ca.pem");
+        let _guard = set_env_var("PGDOG_TLS_CLIENT_CA_CERTIFICATE", "/path/to/client-ca.pem");
+        let _guard = set_env_var("PGDOG_QUERY_LOG", "/var/log/pgdog/queries.log");
 
         assert_eq!(
             General::tls_certificate(),
@@ -1584,11 +1581,11 @@ mod tests {
             Some(PathBuf::from("/var/log/pgdog/queries.log"))
         );
 
-        env::remove_var("PGDOG_TLS_CERTIFICATE");
-        env::remove_var("PGDOG_TLS_PRIVATE_KEY");
-        env::remove_var("PGDOG_TLS_SERVER_CA_CERTIFICATE");
-        env::remove_var("PGDOG_TLS_CLIENT_CA_CERTIFICATE");
-        env::remove_var("PGDOG_QUERY_LOG");
+        let _guard = remove_env_var("PGDOG_TLS_CERTIFICATE");
+        let _guard = remove_env_var("PGDOG_TLS_PRIVATE_KEY");
+        let _guard = remove_env_var("PGDOG_TLS_SERVER_CA_CERTIFICATE");
+        let _guard = remove_env_var("PGDOG_TLS_CLIENT_CA_CERTIFICATE");
+        let _guard = remove_env_var("PGDOG_QUERY_LOG");
 
         assert_eq!(General::tls_certificate(), None);
         assert_eq!(General::tls_private_key(), None);
@@ -1599,26 +1596,26 @@ mod tests {
 
     #[test]
     fn test_query_log_stdout_env() {
-        env::set_var("PGDOG_QUERY_LOG_STDOUT", "true");
+        let _guard = set_env_var("PGDOG_QUERY_LOG_STDOUT", "true");
         assert!(General::query_log_stdout());
 
-        env::remove_var("PGDOG_QUERY_LOG_STDOUT");
+        let _guard = remove_env_var("PGDOG_QUERY_LOG_STDOUT");
         assert!(!General::query_log_stdout());
     }
 
     #[test]
     fn test_env_numeric_fields() {
-        env::set_var("PGDOG_BROADCAST_PORT", "7432");
-        env::set_var("PGDOG_OPENMETRICS_PORT", "9090");
-        env::set_var("PGDOG_PREPARED_STATEMENTS_LIMIT", "1000");
-        env::set_var("PGDOG_QUERY_CACHE_LIMIT", "500");
-        env::set_var("PGDOG_CONNECT_ATTEMPTS", "3");
-        env::set_var("PGDOG_MIRROR_QUEUE", "256");
-        env::set_var("PGDOG_MIRROR_EXPOSURE", "0.5");
-        env::set_var("PGDOG_DNS_TTL", "60000");
-        env::set_var("PGDOG_PUB_SUB_CHANNEL_SIZE", "100");
-        env::set_var("PGDOG_LOG_MIN_DURATION_PARSE", "5");
-        env::set_var("PGDOG_LOG_QUERY_SAMPLE_LENGTH", "200");
+        let _guard = set_env_var("PGDOG_BROADCAST_PORT", "7432");
+        let _guard = set_env_var("PGDOG_OPENMETRICS_PORT", "9090");
+        let _guard = set_env_var("PGDOG_PREPARED_STATEMENTS_LIMIT", "1000");
+        let _guard = set_env_var("PGDOG_QUERY_CACHE_LIMIT", "500");
+        let _guard = set_env_var("PGDOG_CONNECT_ATTEMPTS", "3");
+        let _guard = set_env_var("PGDOG_MIRROR_QUEUE", "256");
+        let _guard = set_env_var("PGDOG_MIRROR_EXPOSURE", "0.5");
+        let _guard = set_env_var("PGDOG_DNS_TTL", "60000");
+        let _guard = set_env_var("PGDOG_PUB_SUB_CHANNEL_SIZE", "100");
+        let _guard = set_env_var("PGDOG_LOG_MIN_DURATION_PARSE", "5");
+        let _guard = set_env_var("PGDOG_LOG_QUERY_SAMPLE_LENGTH", "200");
 
         assert_eq!(General::broadcast_port(), 7432);
         assert_eq!(General::openmetrics_port(), Some(9090));
@@ -1632,17 +1629,17 @@ mod tests {
         assert_eq!(General::default_log_min_duration_parse(), Some(5));
         assert_eq!(General::log_query_sample_length(), 200);
 
-        env::remove_var("PGDOG_BROADCAST_PORT");
-        env::remove_var("PGDOG_OPENMETRICS_PORT");
-        env::remove_var("PGDOG_PREPARED_STATEMENTS_LIMIT");
-        env::remove_var("PGDOG_QUERY_CACHE_LIMIT");
-        env::remove_var("PGDOG_CONNECT_ATTEMPTS");
-        env::remove_var("PGDOG_MIRROR_QUEUE");
-        env::remove_var("PGDOG_MIRROR_EXPOSURE");
-        env::remove_var("PGDOG_DNS_TTL");
-        env::remove_var("PGDOG_PUB_SUB_CHANNEL_SIZE");
-        env::remove_var("PGDOG_LOG_MIN_DURATION_PARSE");
-        env::remove_var("PGDOG_LOG_QUERY_SAMPLE_LENGTH");
+        let _guard = remove_env_var("PGDOG_BROADCAST_PORT");
+        let _guard = remove_env_var("PGDOG_OPENMETRICS_PORT");
+        let _guard = remove_env_var("PGDOG_PREPARED_STATEMENTS_LIMIT");
+        let _guard = remove_env_var("PGDOG_QUERY_CACHE_LIMIT");
+        let _guard = remove_env_var("PGDOG_CONNECT_ATTEMPTS");
+        let _guard = remove_env_var("PGDOG_MIRROR_QUEUE");
+        let _guard = remove_env_var("PGDOG_MIRROR_EXPOSURE");
+        let _guard = remove_env_var("PGDOG_DNS_TTL");
+        let _guard = remove_env_var("PGDOG_PUB_SUB_CHANNEL_SIZE");
+        let _guard = remove_env_var("PGDOG_LOG_MIN_DURATION_PARSE");
+        let _guard = remove_env_var("PGDOG_LOG_QUERY_SAMPLE_LENGTH");
 
         assert_eq!(General::broadcast_port(), General::port() + 1);
         assert_eq!(General::openmetrics_port(), None);
@@ -1659,20 +1656,20 @@ mod tests {
 
     #[test]
     fn test_env_boolean_fields() {
-        env::set_var("PGDOG_DRY_RUN", "true");
-        env::set_var("PGDOG_CROSS_SHARD_DISABLED", "yes");
-        env::set_var("PGDOG_LOG_CONNECTIONS", "false");
-        env::set_var("PGDOG_LOG_DISCONNECTIONS", "0");
+        let _guard = set_env_var("PGDOG_DRY_RUN", "true");
+        let _guard = set_env_var("PGDOG_CROSS_SHARD_DISABLED", "yes");
+        let _guard = set_env_var("PGDOG_LOG_CONNECTIONS", "false");
+        let _guard = set_env_var("PGDOG_LOG_DISCONNECTIONS", "0");
 
         assert!(General::dry_run());
         assert!(General::cross_shard_disabled());
         assert!(!General::log_connections());
         assert!(!General::log_disconnections());
 
-        env::remove_var("PGDOG_DRY_RUN");
-        env::remove_var("PGDOG_CROSS_SHARD_DISABLED");
-        env::remove_var("PGDOG_LOG_CONNECTIONS");
-        env::remove_var("PGDOG_LOG_DISCONNECTIONS");
+        let _guard = remove_env_var("PGDOG_DRY_RUN");
+        let _guard = remove_env_var("PGDOG_CROSS_SHARD_DISABLED");
+        let _guard = remove_env_var("PGDOG_LOG_CONNECTIONS");
+        let _guard = remove_env_var("PGDOG_LOG_DISCONNECTIONS");
 
         assert!(!General::dry_run());
         assert!(!General::cross_shard_disabled());
@@ -1682,17 +1679,17 @@ mod tests {
 
     #[test]
     fn test_env_log_settings() {
-        env::set_var("PGDOG_LOG_FORMAT", "json");
-        env::set_var("RUST_LOG", "pgdog=debug,info");
+        let _guard = set_env_var("PGDOG_LOG_FORMAT", "json");
+        let _guard = set_env_var("RUST_LOG", "pgdog=debug,info");
 
         assert_eq!(General::log_format(), LogFormat::Json);
         assert_eq!(General::log_level(), "pgdog=debug,info");
 
-        env::set_var("PGDOG_LOG_FORMAT", "json_flattened");
+        let _guard = set_env_var("PGDOG_LOG_FORMAT", "json_flattened");
         assert_eq!(General::log_format(), LogFormat::JsonFlattened);
 
-        env::remove_var("PGDOG_LOG_FORMAT");
-        env::remove_var("RUST_LOG");
+        let _guard = remove_env_var("PGDOG_LOG_FORMAT");
+        let _guard = remove_env_var("RUST_LOG");
 
         assert_eq!(General::log_format(), LogFormat::Text);
         assert_eq!(General::log_level(), "info");
@@ -1700,8 +1697,8 @@ mod tests {
 
     #[test]
     fn test_env_other_fields() {
-        env::set_var("PGDOG_BROADCAST_ADDRESS", "192.168.1.100");
-        env::set_var("PGDOG_OPENMETRICS_NAMESPACE", "pgdog_metrics");
+        let _guard = set_env_var("PGDOG_BROADCAST_ADDRESS", "192.168.1.100");
+        let _guard = set_env_var("PGDOG_OPENMETRICS_NAMESPACE", "pgdog_metrics");
 
         assert_eq!(
             General::broadcast_address(),
@@ -1712,8 +1709,8 @@ mod tests {
             Some("pgdog_metrics".to_string())
         );
 
-        env::remove_var("PGDOG_BROADCAST_ADDRESS");
-        env::remove_var("PGDOG_OPENMETRICS_NAMESPACE");
+        let _guard = remove_env_var("PGDOG_BROADCAST_ADDRESS");
+        let _guard = remove_env_var("PGDOG_OPENMETRICS_NAMESPACE");
 
         assert_eq!(General::broadcast_address(), None);
         assert_eq!(General::openmetrics_namespace(), None);
@@ -1721,27 +1718,23 @@ mod tests {
 
     #[test]
     fn test_env_invalid_enum_values() {
-        env::set_var("PGDOG_POOLER_MODE", "invalid_mode");
-        env::set_var("PGDOG_AUTH_TYPE", "not_an_auth");
-        env::set_var("PGDOG_TLS_VERIFY", "bad_verify");
+        let _guard = set_env_var("PGDOG_POOLER_MODE", "invalid_mode");
+        let _guard = set_env_var("PGDOG_AUTH_TYPE", "not_an_auth");
+        let _guard = set_env_var("PGDOG_TLS_VERIFY", "bad_verify");
 
         // Should fall back to defaults for invalid values
         assert_eq!(General::pooler_mode(), PoolerMode::Transaction);
         assert_eq!(General::auth_type(), AuthType::Scram);
         assert_eq!(General::default_tls_verify(), TlsVerifyMode::Prefer);
-
-        env::remove_var("PGDOG_POOLER_MODE");
-        env::remove_var("PGDOG_AUTH_TYPE");
-        env::remove_var("PGDOG_TLS_VERIFY");
     }
 
     #[test]
     fn test_general_default_uses_env_vars() {
         // Set some environment variables
-        env::set_var("PGDOG_WORKERS", "8");
-        env::set_var("PGDOG_POOLER_MODE", "session");
-        env::set_var("PGDOG_AUTH_TYPE", "trust");
-        env::set_var("PGDOG_DRY_RUN", "true");
+        let _guard = set_env_var("PGDOG_WORKERS", "8");
+        let _guard = set_env_var("PGDOG_POOLER_MODE", "session");
+        let _guard = set_env_var("PGDOG_AUTH_TYPE", "trust");
+        let _guard = set_env_var("PGDOG_DRY_RUN", "true");
 
         let general = General::default();
 
@@ -1749,10 +1742,5 @@ mod tests {
         assert_eq!(general.pooler_mode, PoolerMode::Session);
         assert_eq!(general.auth_type, AuthType::Trust);
         assert!(general.dry_run);
-
-        env::remove_var("PGDOG_WORKERS");
-        env::remove_var("PGDOG_POOLER_MODE");
-        env::remove_var("PGDOG_AUTH_TYPE");
-        env::remove_var("PGDOG_DRY_RUN");
     }
 }

--- a/pgdog-config/src/lib.rs
+++ b/pgdog-config/src/lib.rs
@@ -14,6 +14,9 @@ pub mod replication;
 pub mod rewrite;
 pub mod sharding;
 pub mod system_catalogs;
+#[cfg(test)]
+#[path = "../../pgdog/src/test_utils.rs"]
+pub(crate) mod test_utils;
 pub mod url;
 pub mod users;
 pub mod util;

--- a/pgdog-config/src/otel.rs
+++ b/pgdog-config/src/otel.rs
@@ -104,6 +104,7 @@ impl Otel {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::test_utils::set_env_var;
 
     #[test]
     fn headers_from_toml() {
@@ -163,16 +164,9 @@ mod test {
 
     #[test]
     fn namespace_from_env() {
-        unsafe {
-            env::remove_var("PGDOG_OTEL_NAMESPACE");
-            env::set_var("PGDOG_OTEL_NAMESPACE", "pgdog_");
-        }
+        let _guard = set_env_var("PGDOG_OTEL_NAMESPACE", "pgdog_");
 
         let otel: Otel = toml::from_str("").expect("parse");
         assert_eq!(otel.namespace.as_deref(), Some("pgdog_"));
-
-        unsafe {
-            env::remove_var("PGDOG_OTEL_NAMESPACE");
-        }
     }
 }

--- a/pgdog/src/backend/auth/azure_workload_identity.rs
+++ b/pgdog/src/backend/auth/azure_workload_identity.rs
@@ -38,40 +38,18 @@ pub(crate) async fn token(addr: Address) -> Result<(String, SystemTime), Error> 
 #[cfg(test)]
 mod tests {
     use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
-    use std::env;
 
     use super::*;
     use crate::config::ServerAuth;
+    use crate::test_utils::set_env_var;
     use pgdog_config::Role;
-
-    struct EnvVarGuard {
-        key: &'static str,
-        previous: Option<String>,
-    }
-
-    impl EnvVarGuard {
-        fn set(key: &'static str, value: &str) -> Self {
-            let previous = env::var(key).ok();
-            env::set_var(key, value);
-            Self { key, previous }
-        }
-    }
-
-    impl Drop for EnvVarGuard {
-        fn drop(&mut self) {
-            match self.previous.take() {
-                Some(v) => env::set_var(self.key, v),
-                None => env::remove_var(self.key),
-            }
-        }
-    }
 
     #[tokio::test]
     #[ignore = "requires AKS environment with Workload Identity injection"]
     async fn test_token_contains_expected_query_fields() {
-        let _azure_client_id = EnvVarGuard::set("AZURE_CLIENT_ID", "EXAMPLE");
-        let _azure_tenant_id = EnvVarGuard::set("AZURE_TENANT_ID", "EXAMPLE");
-        let _azure_token_file_path = EnvVarGuard::set("AZURE_FEDERATED_TOKEN_FILE", "/tmp/example");
+        let _azure_client_id = set_env_var("AZURE_CLIENT_ID", "EXAMPLE");
+        let _azure_tenant_id = set_env_var("AZURE_TENANT_ID", "EXAMPLE");
+        let _azure_token_file_path = set_env_var("AZURE_FEDERATED_TOKEN_FILE", "/tmp/example");
 
         let addr = Address {
             host: "my-awesome-db.postgres.database.azure.com".into(),

--- a/pgdog/src/backend/auth/rds_iam.rs
+++ b/pgdog/src/backend/auth/rds_iam.rs
@@ -86,32 +86,10 @@ pub(crate) async fn token(addr: Address) -> Result<(String, SystemTime), Error> 
 #[cfg(test)]
 mod tests {
     use pgdog_config::Role;
-    use std::env;
 
     use super::*;
     use crate::config::ServerAuth;
-
-    struct EnvVarGuard {
-        key: &'static str,
-        previous: Option<String>,
-    }
-
-    impl EnvVarGuard {
-        fn set(key: &'static str, value: &str) -> Self {
-            let previous = env::var(key).ok();
-            env::set_var(key, value);
-            Self { key, previous }
-        }
-    }
-
-    impl Drop for EnvVarGuard {
-        fn drop(&mut self) {
-            match self.previous.take() {
-                Some(v) => env::set_var(self.key, v),
-                None => env::remove_var(self.key),
-            }
-        }
-    }
+    use crate::test_utils::set_env_var;
 
     fn make_addr() -> Address {
         Address {
@@ -199,9 +177,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_token_contains_expected_query_fields() {
-        let _access_key = EnvVarGuard::set("AWS_ACCESS_KEY_ID", "AKIDEXAMPLE");
-        let _secret_key = EnvVarGuard::set("AWS_SECRET_ACCESS_KEY", "SECRETEXAMPLE");
-        let _session = EnvVarGuard::set("AWS_SESSION_TOKEN", "SESSIONEXAMPLE");
+        let _access_key = set_env_var("AWS_ACCESS_KEY_ID", "AKIDEXAMPLE");
+        let _secret_key = set_env_var("AWS_SECRET_ACCESS_KEY", "SECRETEXAMPLE");
+        let _session = set_env_var("AWS_SESSION_TOKEN", "SESSIONEXAMPLE");
 
         let addr = make_addr();
         let (token, expires_at) = token(addr).await.unwrap();

--- a/pgdog/src/frontend/client/query_engine/test/rewrite_offset.rs
+++ b/pgdog/src/frontend/client/query_engine/test/rewrite_offset.rs
@@ -6,6 +6,7 @@ use crate::frontend::router::parser::Limit;
 
 use super::prelude::*;
 use super::{test_client, test_sharded_client};
+use crate::test_utils::*;
 
 async fn run_test(messages: Vec<ProtocolMessage>) -> Option<OffsetPlan> {
     let mut client = test_sharded_client();
@@ -118,9 +119,7 @@ async fn test_offset_limit_no_select() {
 
 #[tokio::test]
 async fn test_offset_with_unique_id_simple() {
-    unsafe {
-        std::env::set_var("NODE_ID", "pgdog-1");
-    }
+    let _guard = set_env_var("NODE_ID", "pgdog-1");
     let sql = "SELECT pgdog.unique_id() FROM test LIMIT 10 OFFSET 5";
     let mut client = test_sharded_client();
     client.client_request = ClientRequest::from(vec![ProtocolMessage::Query(Query::new(sql))]);
@@ -180,9 +179,7 @@ async fn test_offset_with_unique_id_simple() {
 
 #[tokio::test]
 async fn test_offset_with_unique_id_extended() {
-    unsafe {
-        std::env::set_var("NODE_ID", "pgdog-1");
-    }
+    let _guard = set_env_var("NODE_ID", "pgdog-1");
     let sql = "SELECT pgdog.unique_id(), $1 FROM test LIMIT $2 OFFSET $3";
     let mut client = test_sharded_client();
     client.client_request = ClientRequest::from(vec![

--- a/pgdog/src/frontend/router/parser/rewrite/statement/auto_id.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/auto_id.rs
@@ -256,6 +256,7 @@ mod tests {
     use crate::backend::{ShardedTables, ShardingSchema};
     use crate::frontend::router::parser::StatementRewriteContext;
     use crate::frontend::PreparedStatements;
+    use crate::test_utils::set_env_var;
 
     fn make_schema_with_bigint_pk() -> Schema {
         let mut columns = IndexMap::new();
@@ -350,9 +351,7 @@ mod tests {
         db_schema: &Schema,
         mode: RewriteMode,
     ) -> Result<(String, RewritePlan), Error> {
-        unsafe {
-            std::env::set_var("NODE_ID", "pgdog-1");
-        }
+        let _guard = set_env_var("NODE_ID", "pgdog-1");
         let mut ast = pg_query::parse(sql).unwrap().protobuf;
         let mut prepared = PreparedStatements::default();
         let schema = sharding_schema_with_mode(mode);
@@ -563,9 +562,7 @@ mod tests {
         db_schema: &Schema,
         schema: &ShardingSchema,
     ) -> Result<(String, RewritePlan), Error> {
-        unsafe {
-            std::env::set_var("NODE_ID", "pgdog-1");
-        }
+        let _guard = set_env_var("NODE_ID", "pgdog-1");
         let mut ast = pg_query::parse(sql).unwrap().protobuf;
         let mut prepared = PreparedStatements::default();
         let mut rewriter = StatementRewrite::new(StatementRewriteContext {

--- a/pgdog/src/frontend/router/parser/rewrite/statement/plan.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/plan.rs
@@ -164,13 +164,12 @@ impl RewritePlan {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::set_env_var;
     use std::collections::HashSet;
 
     #[test]
     fn test_apply_bind_no_unique_ids() {
-        unsafe {
-            std::env::set_var("NODE_ID", "pgdog-1");
-        }
+        let _guard = set_env_var("NODE_ID", "pgdog-1");
         let plan = RewritePlan::default();
         let mut bind = Bind::default();
         plan.apply_bind(&mut bind).unwrap();
@@ -179,9 +178,7 @@ mod tests {
 
     #[test]
     fn test_apply_bind_text_format() {
-        unsafe {
-            std::env::set_var("NODE_ID", "pgdog-1");
-        }
+        let _guard = set_env_var("NODE_ID", "pgdog-1");
         let plan = RewritePlan {
             unique_ids: 1,
             ..Default::default()
@@ -201,9 +198,7 @@ mod tests {
 
     #[test]
     fn test_apply_bind_binary_format_uniform() {
-        unsafe {
-            std::env::set_var("NODE_ID", "pgdog-1");
-        }
+        let _guard = set_env_var("NODE_ID", "pgdog-1");
         let plan = RewritePlan {
             params: 1,
             unique_ids: 1,
@@ -228,9 +223,7 @@ mod tests {
 
     #[test]
     fn test_apply_bind_binary_format_one_to_one() {
-        unsafe {
-            std::env::set_var("NODE_ID", "pgdog-1");
-        }
+        let _guard = set_env_var("NODE_ID", "pgdog-1");
         let plan = RewritePlan {
             params: 2,
             unique_ids: 1,
@@ -257,9 +250,7 @@ mod tests {
 
     #[test]
     fn test_apply_bind_multiple_unique_ids() {
-        unsafe {
-            std::env::set_var("NODE_ID", "pgdog-1");
-        }
+        let _guard = set_env_var("NODE_ID", "pgdog-1");
         let plan = RewritePlan {
             unique_ids: 3,
             ..Default::default()
@@ -279,9 +270,7 @@ mod tests {
 
     #[test]
     fn test_apply_bind_appends_to_existing_params() {
-        unsafe {
-            std::env::set_var("NODE_ID", "pgdog-1");
-        }
+        let _guard = set_env_var("NODE_ID", "pgdog-1");
         let plan = RewritePlan {
             params: 2,
             unique_ids: 2,

--- a/pgdog/src/frontend/router/parser/rewrite/statement/unique_id.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/unique_id.rs
@@ -120,6 +120,7 @@ mod tests {
     use crate::backend::ShardingSchema;
     use crate::frontend::router::parser::StatementRewriteContext;
     use crate::frontend::PreparedStatements;
+    use crate::test_utils::set_env_var;
 
     fn default_schema() -> ShardingSchema {
         ShardingSchema {
@@ -261,9 +262,7 @@ mod tests {
 
     #[test]
     fn test_rewrite_select_simple() {
-        unsafe {
-            std::env::set_var("NODE_ID", "pgdog-1");
-        }
+        let _guard = set_env_var("NODE_ID", "pgdog-1");
         let mut ast = pg_query::parse("SELECT pgdog.unique_id()")
             .unwrap()
             .protobuf;
@@ -298,9 +297,7 @@ mod tests {
 
     #[test]
     fn test_rewrite_select_simple_multiple_unique_ids() {
-        unsafe {
-            std::env::set_var("NODE_ID", "pgdog-1");
-        }
+        let _guard = set_env_var("NODE_ID", "pgdog-1");
         let mut ast = pg_query::parse("SELECT pgdog.unique_id(), pgdog.unique_id()")
             .unwrap()
             .protobuf;

--- a/pgdog/src/lib.rs
+++ b/pgdog/src/lib.rs
@@ -14,6 +14,8 @@ pub mod plugin;
 pub mod sighup;
 pub mod state;
 pub mod stats;
+#[cfg(test)]
+pub mod test_utils;
 #[cfg(feature = "tui")]
 pub mod tui;
 pub mod unique_id;

--- a/pgdog/src/stats/otel.rs
+++ b/pgdog/src/stats/otel.rs
@@ -323,6 +323,7 @@ mod test {
     use crate::stats::pools::PoolMetric;
 
     use super::*;
+    use crate::test_utils::*;
 
     #[test]
     fn gauge_metric_produces_gauge_json() {
@@ -493,10 +494,8 @@ mod test {
         let _test_lock = TEST_LOCK.lock();
 
         // Ensure no env overrides leak from other tests.
-        unsafe {
-            std::env::remove_var("OTEL_SERVICE_NAME");
-            std::env::remove_var("OTEL_RESOURCE_ATTRIBUTES");
-        }
+        let _guard = remove_env_var("OTEL_SERVICE_NAME");
+        let _guard = remove_env_var("OTEL_RESOURCE_ATTRIBUTES");
 
         let metric = Metric::new(PoolMetric {
             name: "test".into(),
@@ -532,34 +531,34 @@ mod test {
         let _test_lock = TEST_LOCK.lock();
 
         // Clean slate.
-        unsafe {
-            std::env::remove_var("OTEL_SERVICE_NAME");
-            std::env::remove_var("OTEL_RESOURCE_ATTRIBUTES");
+        let _guard = remove_env_var("OTEL_SERVICE_NAME");
+        let _guard = remove_env_var("OTEL_RESOURCE_ATTRIBUTES");
 
-            // 1. OTEL_SERVICE_NAME overrides service.name.
-            std::env::set_var("OTEL_SERVICE_NAME", "my-pgdog");
+        // 1. OTEL_SERVICE_NAME overrides service.name.
+        {
+            let _guard = set_env_var("OTEL_SERVICE_NAME", "my-pgdog");
             let attrs = resource_attributes();
             let svc = attrs.iter().find(|a| a.key == "service.name").unwrap();
             assert_eq!(svc.value.string_value, "my-pgdog");
-            std::env::remove_var("OTEL_SERVICE_NAME");
+        }
 
-            // 2. OTEL_RESOURCE_ATTRIBUTES adds and overrides.
-            std::env::set_var("OTEL_RESOURCE_ATTRIBUTES", "env=prod,service.name=custom");
+        // 2. OTEL_RESOURCE_ATTRIBUTES adds and overrides.
+        {
+            let _guard = set_env_var("OTEL_RESOURCE_ATTRIBUTES", "env=prod,service.name=custom");
             let attrs = resource_attributes();
             let svc = attrs.iter().find(|a| a.key == "service.name").unwrap();
             assert_eq!(svc.value.string_value, "custom");
             let env_attr = attrs.iter().find(|a| a.key == "env").unwrap();
             assert_eq!(env_attr.value.string_value, "prod");
-            std::env::remove_var("OTEL_RESOURCE_ATTRIBUTES");
+        }
 
-            // 3. OTEL_SERVICE_NAME takes precedence over OTEL_RESOURCE_ATTRIBUTES.
-            std::env::set_var("OTEL_RESOURCE_ATTRIBUTES", "service.name=from-attrs");
-            std::env::set_var("OTEL_SERVICE_NAME", "from-svc-name");
+        // 3. OTEL_SERVICE_NAME takes precedence over OTEL_RESOURCE_ATTRIBUTES.
+        {
+            let _guard = set_env_var("OTEL_RESOURCE_ATTRIBUTES", "service.name=from-attrs");
+            let _guard = set_env_var("OTEL_SERVICE_NAME", "from-svc-name");
             let attrs = resource_attributes();
             let svc = attrs.iter().find(|a| a.key == "service.name").unwrap();
             assert_eq!(svc.value.string_value, "from-svc-name");
-            std::env::remove_var("OTEL_RESOURCE_ATTRIBUTES");
-            std::env::remove_var("OTEL_SERVICE_NAME");
         }
     }
 

--- a/pgdog/src/test_utils.rs
+++ b/pgdog/src/test_utils.rs
@@ -1,0 +1,30 @@
+use std::convert::AsRef;
+use std::env;
+use std::ffi::{OsStr, OsString};
+
+pub(crate) fn set_env_var<T: AsRef<OsStr>>(key: T, value: impl AsRef<OsStr>) -> EnvVarGuard<T> {
+    let previous = env::var_os(&key);
+    env::set_var(&key, value);
+    EnvVarGuard { key, previous }
+}
+
+pub(crate) fn remove_env_var<T: AsRef<OsStr>>(key: T) -> EnvVarGuard<T> {
+    let previous = env::var_os(&key);
+    env::remove_var(&key);
+    EnvVarGuard { key, previous }
+}
+
+#[must_use = "if unused, env var will immediately revert"]
+pub(crate) struct EnvVarGuard<T: AsRef<OsStr>> {
+    key: T,
+    previous: Option<OsString>,
+}
+
+impl<T: AsRef<OsStr>> Drop for EnvVarGuard<T> {
+    fn drop(&mut self) {
+        match self.previous.take() {
+            Some(v) => env::set_var(&self.key, v),
+            None => env::remove_var(&self.key),
+        }
+    }
+}

--- a/pgdog/src/unique_id.rs
+++ b/pgdog/src/unique_id.rs
@@ -230,7 +230,8 @@ impl UniqueId {
 
 #[cfg(test)]
 mod test {
-    use std::{collections::HashSet, env::set_var};
+    use crate::test_utils::set_env_var;
+    use std::collections::HashSet;
 
     use super::*;
 
@@ -259,9 +260,7 @@ mod test {
 
     #[test]
     fn test_unique_ids() {
-        unsafe {
-            set_var("NODE_ID", "pgdog-1");
-        }
+        let _guard = set_env_var("NODE_ID", "pgdog-1");
         let num_ids = 10_000;
 
         let mut ids = HashSet::new();

--- a/pgdog/src/util.rs
+++ b/pgdog/src/util.rs
@@ -273,9 +273,8 @@ pub fn raise_nofile_limit() -> u64 {
 #[cfg(test)]
 mod test {
 
-    use std::env::{remove_var, set_var};
-
     use super::*;
+    use crate::test_utils::*;
 
     #[test]
     fn test_human_duration() {
@@ -311,9 +310,7 @@ mod test {
 
     #[test]
     fn test_instance_id_format() {
-        unsafe {
-            remove_var("NODE_ID");
-        }
+        let _guard = remove_env_var("NODE_ID");
         let id = instance_id();
         assert_eq!(id.len(), 8);
         // All characters should be valid hex digits (0-9, a-f)
@@ -334,9 +331,7 @@ mod test {
 
     #[test]
     fn test_node_id_error() {
-        unsafe {
-            remove_var("NODE_ID");
-        }
+        let _guard = remove_env_var("NODE_ID");
         assert!(node_id().is_err());
     }
 
@@ -417,12 +412,9 @@ mod test {
         );
     }
 
-    // These should run in separate processes (if using nextest).
     #[test]
     fn test_node_id_set() {
-        unsafe {
-            set_var("NODE_ID", "pgdog-1");
-        }
+        let _guard = set_env_var("NODE_ID", "pgdog-1");
         assert_eq!(node_id(), Ok(1));
     }
 


### PR DESCRIPTION
In the 2024 edition, set_var and remove_var have been changed to be unsafe functions. The behavior remains the same, however even in tests we should not have an `unsafe` block without a safety comment. To avoid having 1023721983 comments saying `SAFTEY: cargo nextest runs one test per process and does not use threads`, we should move all this behavior into the same place.