### PR TITLE
Refactor and improve the functionality of AVG

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4225,9 +4225,20 @@ dependencies = [
  "postgres-types",
  "rand 0.8.6",
  "rkyv",
+ "rust_decimal_macros",
  "serde",
  "serde_json",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "rust_decimal_macros"
+version = "1.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74a5a6f027e892c7a035c6fddb50435a1fbf5a734ffc0c2a9fed4d0221440519"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/pgdog-postgres-types/src/datum.rs
+++ b/pgdog-postgres-types/src/datum.rs
@@ -3,6 +3,7 @@ use std::fmt;
 
 use bytes::Bytes;
 use pgdog_vector::{Float, Vector};
+use rust_decimal::Decimal;
 use uuid::Uuid;
 
 use crate::{
@@ -122,6 +123,36 @@ impl ToDataRowColumn for Datum {
     }
 }
 
+impl<T> From<Option<T>> for Datum
+where
+    Datum: From<T>,
+{
+    fn from(val: Option<T>) -> Self {
+        match val {
+            Some(v) => v.into(),
+            None => Datum::Null,
+        }
+    }
+}
+
+impl From<i64> for Datum {
+    fn from(i: i64) -> Self {
+        Datum::Bigint(i)
+    }
+}
+
+impl From<f64> for Datum {
+    fn from(f: f64) -> Self {
+        Datum::Double(f.into())
+    }
+}
+
+impl From<Decimal> for Datum {
+    fn from(d: Decimal) -> Self {
+        Datum::Numeric(d.into())
+    }
+}
+
 impl Datum {
     pub fn new(
         bytes: &[u8],
@@ -203,6 +234,20 @@ impl Datum {
             Datum::Array(a) => DataType::Array(a.element_oid),
             Datum::Null => DataType::Other(0),
             Datum::Unknown(..) => DataType::Other(0),
+        }
+    }
+
+    pub fn as_i64(&self) -> Result<i64, Error> {
+        match *self {
+            Datum::Bigint(i) => Ok(i),
+            Datum::Integer(i) => Ok(i.into()),
+            Datum::SmallInt(i) => Ok(i.into()),
+            Datum::Float(f) => Ok(f.0 as i64),
+            Datum::Double(f) => Ok(f.0 as i64),
+            _ => Err(Error::InvalidCast {
+                from: self.data_type(),
+                to: DataType::Bigint,
+            }),
         }
     }
 }

--- a/pgdog-postgres-types/src/double.rs
+++ b/pgdog-postgres-types/src/double.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::fmt::Display;
 use std::hash::{Hash, Hasher};
+use std::ops::Mul;
 
 use crate::Data;
 
@@ -42,6 +43,14 @@ impl PartialEq for Double {
 }
 
 impl Eq for Double {}
+
+impl Mul<f64> for Double {
+    type Output = Self;
+
+    fn mul(self, rhs: f64) -> Self::Output {
+        Double(self.0 * rhs)
+    }
+}
 
 impl FromDataType for Double {
     fn decode(bytes: &[u8], encoding: Format) -> Result<Self, Error> {

--- a/pgdog-postgres-types/src/error.rs
+++ b/pgdog-postgres-types/src/error.rs
@@ -54,4 +54,7 @@ pub enum Error {
 
     #[error("invalid operation {op} for {ty}")]
     InvalidOperation { op: &'static str, ty: DataType },
+
+    #[error("cannot cast from {from} to {to}")]
+    InvalidCast { from: DataType, to: DataType },
 }

--- a/pgdog-postgres-types/src/numeric.rs
+++ b/pgdog-postgres-types/src/numeric.rs
@@ -2,7 +2,7 @@ use std::{
     cmp::Ordering,
     fmt::Display,
     hash::Hash,
-    ops::{Add, AddAssign},
+    ops::{Add, AddAssign, Mul},
     str::FromStr,
 };
 
@@ -104,6 +104,17 @@ impl Add for Numeric {
 impl AddAssign for Numeric {
     fn add_assign(&mut self, rhs: Self) {
         *self = *self + rhs;
+    }
+}
+
+impl Mul<Decimal> for Numeric {
+    type Output = Self;
+
+    fn mul(self, rhs: Decimal) -> Self::Output {
+        match self.value {
+            NumericValue::Number(n) => Self::from(n * rhs),
+            NumericValue::NaN => self,
+        }
     }
 }
 
@@ -284,6 +295,14 @@ impl Numeric {
     /// Get the underlying Decimal value if not NaN
     pub fn as_decimal(&self) -> Option<&Decimal> {
         match &self.value {
+            NumericValue::Number(n) => Some(n),
+            NumericValue::NaN => None,
+        }
+    }
+
+    /// Get the underlying Decimal value if not NaN
+    pub fn as_decimal_mut(&mut self) -> Option<&mut Decimal> {
+        match &mut self.value {
             NumericValue::Number(n) => Some(n),
             NumericValue::NaN => None,
         }

--- a/pgdog/Cargo.toml
+++ b/pgdog/Cargo.toml
@@ -54,7 +54,7 @@ uuid = { version = "1", features = ["v4", "serde"] }
 url = "2"
 ratatui = { version = "0.30.0-alpha.1", optional = true }
 rmp-serde = "1"
-rust_decimal = { version = "1.36", features = ["db-postgres"] }
+rust_decimal = { version = "1.36", features = ["db-postgres", "macros"] }
 chrono = "0.4"
 hyper = { version = "1", features = ["full"] }
 http-body-util = "0.1"

--- a/pgdog/src/backend/pool/connection/aggregate.rs
+++ b/pgdog/src/backend/pool/connection/aggregate.rs
@@ -1,6 +1,6 @@
 //! Aggregate buffer.
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, VecDeque, hash_map::Entry};
 use std::mem;
 
 use crate::{
@@ -21,6 +21,8 @@ use rust_decimal::Decimal;
 use rust_decimal::prelude::{FromPrimitive, ToPrimitive};
 
 use super::Error;
+
+mod avg;
 
 /// GROUP BY <columns>
 #[derive(Hash, PartialEq, Eq, Debug)]
@@ -50,7 +52,7 @@ impl Grouping {
 struct Accumulator<'a> {
     target: &'a AggregateTarget,
     datum: Datum,
-    avg: Option<AvgState>,
+    avg: Option<avg::Avg>,
     variance: Option<VarianceState>,
 }
 
@@ -58,7 +60,7 @@ impl<'a> Accumulator<'a> {
     pub fn from_aggregate(
         aggregate: &'a Aggregate,
         helpers: &HashMap<(usize, bool), HelperColumns>,
-    ) -> Vec<Self> {
+    ) -> Result<Vec<Self>, Error> {
         aggregate
             .targets()
             .iter()
@@ -76,7 +78,16 @@ impl<'a> Accumulator<'a> {
                 };
 
                 if matches!(target.function(), AggregateFunction::Avg) {
-                    accumulator.avg = Some(AvgState::new(helper.count));
+                    let Some(count_helper) = helper.count else {
+                        // FIXME(sage): This should be statically enforced
+                        return Err(Error::UnsupportedAggregation {
+                            function: String::from("avg"),
+                            reason: String::from(
+                                "internal count helper was missing (this is a bug in pgdog)",
+                            ),
+                        });
+                    };
+                    accumulator.avg = Some(avg::Avg::new(target.column(), count_helper));
                 }
 
                 if matches!(
@@ -93,7 +104,7 @@ impl<'a> Accumulator<'a> {
                     ));
                 }
 
-                accumulator
+                Ok(accumulator)
             })
             .collect()
     }
@@ -136,31 +147,11 @@ impl<'a> Accumulator<'a> {
             }
             AggregateFunction::Avg => {
                 if let Some(state) = self.avg.as_mut() {
-                    if !state.supported {
-                        return Ok(false);
-                    }
-
-                    let Some(count_column) = state.count_column else {
-                        state.supported = false;
-                        return Ok(false);
-                    };
-
-                    let count = row.get_column_checked(count_column, decoder)?;
-
-                    if column.value.is_null() || count.value.is_null() {
-                        return Ok(true);
-                    }
-
-                    match multiply_for_average(&column.value, &count.value) {
-                        Some(weighted) => {
-                            checked_add_assign(&mut state.weighted_sum, weighted)?;
-                            checked_add_assign(&mut state.total_count, count.value.clone())?;
-                        }
-                        _ => {
-                            state.supported = false;
-                            return Ok(false);
-                        }
-                    }
+                    let count = row
+                        .get_column_checked(state.count_helper, decoder)?
+                        .value
+                        .as_i64()?;
+                    state.accumulate(column.value, count);
                 }
             }
             AggregateFunction::StddevPop
@@ -184,26 +175,8 @@ impl<'a> Accumulator<'a> {
     }
 
     fn finalize(&mut self) -> Result<bool, Error> {
-        if let Some(state) = self.avg.as_mut() {
-            if !state.supported {
-                return Ok(false);
-            }
-
-            if state.count_column.is_none() {
-                return Ok(false);
-            }
-
-            if state.total_count.is_null() {
-                self.datum = Datum::Null;
-                return Ok(true);
-            }
-
-            if let Some(result) = divide_for_average(&state.weighted_sum, &state.total_count) {
-                self.datum = result;
-                return Ok(true);
-            }
-
-            return Ok(false);
+        if let Some(state) = self.avg.take() {
+            self.datum = state.finalize()?;
         }
 
         if let Some(state) = self.variance.as_mut() {
@@ -217,25 +190,6 @@ impl<'a> Accumulator<'a> {
         }
 
         Ok(true)
-    }
-}
-
-#[derive(Debug)]
-struct AvgState {
-    count_column: Option<usize>,
-    weighted_sum: Datum,
-    total_count: Datum,
-    supported: bool,
-}
-
-impl AvgState {
-    fn new(count_column: Option<usize>) -> Self {
-        Self {
-            count_column,
-            weighted_sum: Datum::Null,
-            total_count: Datum::Null,
-            supported: count_column.is_some(),
-        }
     }
 }
 
@@ -543,9 +497,13 @@ impl<'a> Aggregates<'a> {
 
         for row in self.rows {
             let grouping = Grouping::new(row, self.aggregate.group_by(), self.decoder)?;
-            let entry = self.mappings.entry(grouping).or_insert_with(|| {
-                Accumulator::from_aggregate(self.aggregate, &self.helper_columns)
-            });
+            let entry = match self.mappings.entry(grouping) {
+                Entry::Occupied(o) => o.into_mut(),
+                Entry::Vacant(v) => v.insert(Accumulator::from_aggregate(
+                    self.aggregate,
+                    &self.helper_columns,
+                )?),
+            };
 
             for aggregate in entry {
                 if !aggregate.accumulate(row, self.decoder)? {
@@ -633,58 +591,9 @@ fn checked_add_assign(lhs: &mut Datum, rhs: Datum) -> Result<(), TypeError> {
     Ok(())
 }
 
-fn multiply_for_average(value: &Datum, count: &Datum) -> Option<Datum> {
-    let multiplier_i128 = datum_as_i128(count)?;
-
-    match value {
-        Datum::Double(double) => {
-            let multiplier = multiplier_i128 as f64;
-            Some(Datum::Double(Double(double.0 * multiplier)))
-        }
-        Datum::Float(float) => {
-            let multiplier = multiplier_i128 as f64;
-            Some(Datum::Float(Float((float.0 as f64 * multiplier) as f32)))
-        }
-        Datum::Numeric(numeric) => {
-            let mut decimal = numeric.as_decimal()?.to_owned();
-            if decimal.is_integer() {
-                decimal.normalize_assign();
-            }
-            let product = decimal * Decimal::from_i128(multiplier_i128)?;
-            Some(Datum::Numeric(Numeric::from(product)))
-        }
-        _ => None,
-    }
-}
-
-fn divide_for_average(sum: &Datum, count: &Datum) -> Option<Datum> {
-    if sum.is_null() || count.is_null() {
-        return Some(Datum::Null);
-    }
-
-    let divisor_i128 = datum_as_i128(count)?;
-    if divisor_i128 == 0 {
-        return Some(Datum::Null);
-    }
-
-    match sum {
-        Datum::Double(double) => Some(Datum::Double(Double(double.0 / divisor_i128 as f64))),
-        Datum::Float(float) => Some(Datum::Float(Float(
-            (float.0 as f64 / divisor_i128 as f64) as f32,
-        ))),
-        Datum::Numeric(numeric) => {
-            let decimal = numeric.as_decimal()?;
-            let divisor = Decimal::from_i128(divisor_i128)?;
-            if divisor == Decimal::ZERO {
-                Some(Datum::Null)
-            } else {
-                let mut result = decimal / divisor;
-                result.rescale(decimal.scale());
-                Some(Datum::Numeric(Numeric::new(result)))
-            }
-        }
-        _ => None,
-    }
+fn checked_add(mut lhs: Datum, rhs: Datum) -> Result<Datum, TypeError> {
+    checked_add_assign(&mut lhs, rhs)?;
+    Ok(lhs)
 }
 
 fn datum_as_i128(datum: &Datum) -> Option<i128> {
@@ -756,36 +665,6 @@ mod test {
     use pg_query::{NodeEnum, protobuf::SelectStmt};
     use std::assert_matches;
     use std::collections::VecDeque;
-
-    #[test]
-    fn multiply_for_average_double() {
-        let value = Datum::Double(Double(10.0));
-        let count = Datum::Bigint(3);
-        let result = multiply_for_average(&value, &count).unwrap();
-        match result {
-            Datum::Double(Double(v)) => assert!((v - 30.0).abs() < f64::EPSILON),
-            _ => panic!("unexpected datum variant"),
-        }
-    }
-
-    #[test]
-    fn divide_for_average_double() {
-        let sum = Datum::Double(Double(30.0));
-        let count = Datum::Bigint(3);
-        let result = divide_for_average(&sum, &count).unwrap();
-        match result {
-            Datum::Double(Double(v)) => assert!((v - 10.0).abs() < f64::EPSILON),
-            _ => panic!("unexpected datum variant"),
-        }
-    }
-
-    #[test]
-    fn divide_for_average_zero_count() {
-        let sum = Datum::Double(Double(30.0));
-        let count = Datum::Bigint(0);
-        let result = divide_for_average(&sum, &count).unwrap();
-        assert!(matches!(result, Datum::Null));
-    }
 
     fn integer_field(name: &str) -> Field {
         Field {

--- a/pgdog/src/backend/pool/connection/aggregate/avg.rs
+++ b/pgdog/src/backend/pool/connection/aggregate/avg.rs
@@ -1,0 +1,182 @@
+use super::{Error, checked_add};
+use crate::net::messages::Datum;
+use rust_decimal::prelude::*;
+
+#[derive(Debug)]
+pub(crate) struct Avg {
+    pub(crate) count_helper: usize,
+    values_and_weights: Vec<(Datum, i64)>,
+}
+
+impl Avg {
+    pub(crate) fn new(_column: usize, count_helper: usize) -> Self {
+        Self {
+            count_helper,
+            values_and_weights: Vec::new(),
+        }
+    }
+
+    pub(crate) fn accumulate(&mut self, value: Datum, count: i64) {
+        self.values_and_weights.push((value, count));
+    }
+
+    pub(crate) fn finalize(self) -> Result<Datum, Error> {
+        let total_count: i64 = self.values_and_weights.iter().map(|i| i.1).sum();
+        let total_count = Decimal::from(total_count);
+
+        // Ensure we limit numeric results to the number of significant digits
+        // that PG would have provided
+        let numeric_scale = self
+            .values_and_weights
+            .iter()
+            .filter_map(|(value, _)| match value {
+                Datum::Numeric(n) => n.as_decimal().map(|d| d.normalize().scale()),
+                _ => None,
+            })
+            .max();
+
+        let mut result =
+            self.values_and_weights
+                .into_iter()
+                .fold(Ok(Datum::Null), |acc, (value, weight)| {
+                    checked_mul_add(value, Decimal::from(weight) / total_count, acc?)
+                });
+        if let Ok(Datum::Numeric(n)) = &mut result
+            && let Some(d) = n.as_decimal_mut()
+            && let Some(scale) = numeric_scale
+        {
+            d.rescale(scale)
+        }
+        result
+    }
+}
+
+fn checked_mul_add(lhs: Datum, mul: Decimal, rhs: Datum) -> Result<Datum, Error> {
+    match (lhs, rhs) {
+        (Datum::Double(lhs), Datum::Double(rhs)) => {
+            Ok(Datum::from(lhs.0.mul_add(mul.as_f64(), rhs.0)))
+        }
+        (lhs, rhs) => checked_add(checked_mul(lhs, mul)?, rhs).map_err(Into::into),
+    }
+}
+
+fn checked_mul(lhs: Datum, rhs: Decimal) -> Result<Datum, Error> {
+    match lhs {
+        Datum::Numeric(i) => Ok(Datum::Numeric(i * rhs)),
+        Datum::Double(f) => Ok(Datum::Double(f * rhs.as_f64())),
+        Datum::Null if rhs.is_zero() => Ok(Datum::Null),
+        Datum::Null => Err(Error::UnsupportedAggregation {
+            function: String::from("avg"),
+            reason: String::from(
+                "Received NULL as a result for avg from a shard with a count \
+                other than 0. This should be impossible",
+            ),
+        }),
+        Datum::Interval(..) => Err(Error::UnsupportedAggregation {
+            function: String::from("avg"),
+            reason: String::from("avg(interval) is not yet supported"),
+        }),
+        Datum::Unknown(..) => Err(Error::UnsupportedAggregation {
+            function: String::from("avg"),
+            reason: String::from("avg for extension types is not supported"),
+        }),
+        datum => Err(Error::UnsupportedAggregation {
+            function: String::from("avg"),
+            reason: format!(
+                "Received type {}, which is not a type postgresql should \
+                return from avg. This is likely a bug in pgdog.",
+                datum.data_type()
+            ),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pgdog_postgres_types::Numeric;
+    use rust_decimal::dec;
+
+    // Average number of downloads each version of the top 10 crates on
+    // crates.io gets per day over the last 90 days, if crates.io were
+    // sharded by crate_id
+    const TEST_DATA: &[(f64, i64)] = &[
+        (96724.170212765957, 4089),
+        (186386.974947807933, 1916),
+        (33537.298768879299, 7879),
+        (97637.501614987080, 3096),
+        (33534.787317691820, 7885),
+        (104947.738952164009, 4390),
+        (60095.478251906823, 4851),
+        (14353.621700556566, 18147),
+        (11857.550375469337, 28764),
+        (42577.351057747284, 6996),
+    ];
+
+    #[test]
+    fn avg_with_numeric_data() {
+        let mut state = Avg::new(0, 0);
+        for &(avg, count) in TEST_DATA {
+            state.accumulate(Decimal::from_f64(avg).unwrap().into(), count);
+        }
+        let expected: Datum = Decimal::from_f64(36758.559474168589).unwrap().into();
+        assert_eq!(state.finalize().unwrap(), expected);
+    }
+
+    #[test]
+    fn avg_with_double_data() {
+        let mut state = Avg::new(0, 0);
+        for &(avg, count) in TEST_DATA {
+            state.accumulate(avg.into(), count);
+        }
+        assert_eq!(state.finalize().unwrap(), Datum::from(36758.559474168589));
+    }
+
+    #[test]
+    fn avg_with_very_large_decimal() {
+        let mut state = Avg::new(0, 0);
+        state.accumulate(Decimal::MAX.into(), 2);
+        state.accumulate(Decimal::MAX.into(), 3);
+        assert_eq!(state.finalize().unwrap(), Datum::from(Decimal::MAX));
+    }
+
+    #[test]
+    fn avg_with_very_large_double() {
+        let mut state = Avg::new(0, 0);
+        state.accumulate(f64::MAX.into(), 2);
+        state.accumulate(f64::MAX.into(), 3);
+        assert_eq!(state.finalize().unwrap(), Datum::from(f64::MAX));
+    }
+
+    #[test]
+    fn avg_with_nulls() {
+        let mut state = Avg::new(0, 0);
+        state.accumulate(1.0.into(), 1);
+        state.accumulate(Datum::Null, 0);
+        assert_eq!(state.finalize().unwrap(), Datum::from(1.0));
+    }
+
+    #[test]
+    fn integer_numerics_have_trailing_zeroes_removed() {
+        let mut state = Avg::new(0, 0);
+        state.accumulate(dec!(850.0000000000000000).into(), 6);
+        state.accumulate(dec!(48343436988849539).into(), 9);
+        assert_eq!(state.finalize().unwrap(), dec!(29006062193310063).into())
+    }
+
+    #[test]
+    fn avg_numeric_nan_returns_nan() {
+        let mut state = Avg::new(0, 0);
+        state.accumulate(Datum::Numeric(Numeric::nan()), 1);
+        state.accumulate(dec!(1).into(), 1_000_000);
+        assert_eq!(state.finalize().unwrap(), Datum::Numeric(Numeric::nan()));
+    }
+
+    #[test]
+    fn avg_double_nan_returns_nan() {
+        let mut state = Avg::new(0, 0);
+        state.accumulate(f64::NAN.into(), 1);
+        state.accumulate(1.0.into(), 1_000_000);
+        assert_eq!(state.finalize().unwrap(), Datum::from(f64::NAN));
+    }
+}


### PR DESCRIPTION
This is pulled out from a larger refactor of all aggregate functions. As such, the state of this commit is a bit messy, and you'll have to trust me that it's a "it'll get worse before it gets better". But I pulled this out of that branch as it has significant behavioral improvements, is chunky enough to be reviewed on its own, and to prevent a long running branch that could become stale

The new home of the AVG logic represents what I plan on the shape of the aggregate accumulator to look like long term. Each function in a smaller module that is concerned *only* with accumulating state, and not with deserializing data, error handling, etc. The result is code that is easier to read and *much* easier to unit test. Things are a bit funky in the short term though, such as the unused firts argument to Avg::new. This is because long term I intend for Accumulator to just be an enum, where we store the target column in each variant.

The new Avg code also has several improvements over the old code:

- Reduced floating point errors, making us much less likely to diverge from the answer unsharded PG would give (this is demonstrated in `avg_with_double_data`, where the old code diverged by far more than epsilon
- Error handling that happens earlier, and more strictly, reducing the amount of "if we set the unsupported flag at some point in the past bail and maybe error but we don't actually have that info anymore"
- Removal of overflow. The old code required the sum of the averages from each shard to be representable. The new code does not.

I've also simplified and clarified how we rescale numeric results. As part of writing this it became clear that this isn't just a "match the bits PG sends" issue, but one of correctness. Any precision we calculate beyond what PG sends us will be a lie, since we aren't operating on the original data

Our handling of agg(distinct) hasn't changed, we'll still silently do the wrong thing in many cases. Explicit erroring for that followed by full support will both fall out of the larger structural change in the refactor once everything else is moved.