### PR TITLE
Refactor the trivial aggregate functions to more easily unit test

### DIFF
--- a/pgdog/src/backend/pool/connection/aggregate.rs
+++ b/pgdog/src/backend/pool/connection/aggregate.rs
@@ -23,6 +23,8 @@ use rust_decimal::prelude::{FromPrimitive, ToPrimitive};
 use super::Error;
 
 mod avg;
+mod cmp;
+mod count;
 
 /// GROUP BY <columns>
 #[derive(Hash, PartialEq, Eq, Debug)]
@@ -52,8 +54,8 @@ impl Grouping {
 struct Accumulator<'a> {
     target: &'a AggregateTarget,
     datum: Datum,
-    avg: Option<avg::Avg>,
     variance: Option<VarianceState>,
+    state: State,
 }
 
 impl<'a> Accumulator<'a> {
@@ -73,22 +75,9 @@ impl<'a> Accumulator<'a> {
                 let mut accumulator = Accumulator {
                     target,
                     datum: Datum::Null,
-                    avg: None,
                     variance: None,
+                    state: State::new(target, helper)?,
                 };
-
-                if matches!(target.function(), AggregateFunction::Avg) {
-                    let Some(count_helper) = helper.count else {
-                        // FIXME(sage): This should be statically enforced
-                        return Err(Error::UnsupportedAggregation {
-                            function: String::from("avg"),
-                            reason: String::from(
-                                "internal count helper was missing (this is a bug in pgdog)",
-                            ),
-                        });
-                    };
-                    accumulator.avg = Some(avg::Avg::new(target.column(), count_helper));
-                }
 
                 if matches!(
                     target.function(),
@@ -112,46 +101,17 @@ impl<'a> Accumulator<'a> {
     /// Transform COUNT(*), MIN, MAX, etc., from multiple shards into a single value.
     fn accumulate(&mut self, row: &DataRow, decoder: &Decoder) -> Result<bool, Error> {
         let column = row.get_column_checked(self.target.column(), decoder)?;
+        self.state.accumulate(row, decoder)?;
         match self.target.function() {
-            AggregateFunction::Count => {
-                if !self.datum.is_null() {
-                    checked_add_assign(&mut self.datum, column.value)?;
-                } else {
-                    self.datum = column.value;
-                }
-            }
-            AggregateFunction::Max => {
-                if !self.datum.is_null() {
-                    if self.datum < column.value {
-                        self.datum = column.value;
-                    }
-                } else {
-                    self.datum = column.value;
-                }
-            }
-            AggregateFunction::Min => {
-                if !self.datum.is_null() {
-                    if self.datum > column.value {
-                        self.datum = column.value;
-                    }
-                } else {
-                    self.datum = column.value;
-                }
-            }
+            AggregateFunction::Avg
+            | AggregateFunction::Count
+            | AggregateFunction::Max
+            | AggregateFunction::Min => {}
             AggregateFunction::Sum => {
                 if !self.datum.is_null() {
                     checked_add_assign(&mut self.datum, column.value)?;
                 } else {
                     self.datum = column.value;
-                }
-            }
-            AggregateFunction::Avg => {
-                if let Some(state) = self.avg.as_mut() {
-                    let count = row
-                        .get_column_checked(state.count_helper, decoder)?
-                        .value
-                        .as_i64()?;
-                    state.accumulate(column.value, count);
                 }
             }
             AggregateFunction::StddevPop
@@ -175,8 +135,9 @@ impl<'a> Accumulator<'a> {
     }
 
     fn finalize(&mut self) -> Result<bool, Error> {
-        if let Some(state) = self.avg.take() {
-            self.datum = state.finalize()?;
+        match self.state.take().finalize()? {
+            Datum::Null => {}
+            d => self.datum = d,
         }
 
         if let Some(state) = self.variance.as_mut() {
@@ -190,6 +151,85 @@ impl<'a> Accumulator<'a> {
         }
 
         Ok(true)
+    }
+}
+
+#[derive(Debug)]
+enum State {
+    Avg(avg::Avg),
+    Cmp(cmp::Cmp),
+    Count(count::Count),
+    // FIXME(sage): Temporary variant while refactor is in progress
+    Dummy,
+}
+
+impl State {
+    /// Construct a new aggregate state based on the function provided
+    /// Errors if the function is not one we support.
+    fn new(target: &AggregateTarget, helper: HelperColumns) -> Result<Self, Error> {
+        match (target.function(), target.is_distinct()) {
+            (AggregateFunction::Avg, false) => Ok(Self::Avg(avg::Avg::new(
+                target.column(),
+                helper.count.ok_or_else(|| Error::UnsupportedAggregation {
+                    function: String::from("avg"),
+                    reason: String::from(
+                        "internal count helper was missing (this is a bug in pgdog)",
+                    ),
+                })?,
+            ))),
+            (AggregateFunction::Avg, true) => Err(Error::UnsupportedAggregation {
+                function: String::from("avg"),
+                reason: String::from("avg(DISTINCT ...) is not yet supported"),
+            }),
+            (AggregateFunction::Count, false) => {
+                Ok(Self::Count(count::Count::new(target.column())))
+            }
+            (AggregateFunction::Count, true) => Err(Error::UnsupportedAggregation {
+                function: String::from("count"),
+                reason: String::from("count(DISTINCT ...) is not yet supported"),
+            }),
+            (AggregateFunction::Max, _) => Ok(Self::Cmp(cmp::Cmp::max(target.column()))),
+            (AggregateFunction::Min, _) => Ok(Self::Cmp(cmp::Cmp::min(target.column()))),
+            // FIXME: Unsupported, need to error
+            _ => Ok(Self::Dummy),
+        }
+    }
+
+    /// Merge the result from a single shard into the accumulated state.
+    fn accumulate(&mut self, row: &DataRow, decoder: &Decoder) -> Result<(), Error> {
+        match self {
+            State::Avg(state) => {
+                let value = row.get_column_checked(state.column, decoder)?.value;
+                let weight = row
+                    .get_column_checked(state.count_helper, decoder)?
+                    .value
+                    .as_i64()?;
+                state.accumulate(value, weight);
+                Ok(())
+            }
+            State::Cmp(state) => state
+                .accumulate(row.get_column_checked(state.column, decoder)?.value)
+                .map_err(Into::into),
+            State::Count(state) => {
+                state.accumulate(row.get_column_checked(state.column, decoder)?.value)
+            }
+            State::Dummy => Ok(()),
+        }
+    }
+
+    /// Perform any final work needed and compute the result of the function
+    fn finalize(self) -> Result<Datum, Error> {
+        match self {
+            State::Avg(state) => Ok(state.finalize()?),
+            State::Cmp(state) => Ok(state.finalize()),
+            State::Count(state) => Ok(state.finalize()),
+            State::Dummy => Ok(Datum::Null),
+        }
+    }
+
+    // FIXME(sage): Get rid of this when Dummy is gone
+    fn take(&mut self) -> Self {
+        std::mem::replace(self, State::Dummy)
     }
 }
 

--- a/pgdog/src/backend/pool/connection/aggregate/avg.rs
+++ b/pgdog/src/backend/pool/connection/aggregate/avg.rs
@@ -3,24 +3,26 @@ use crate::net::messages::Datum;
 use rust_decimal::prelude::*;
 
 #[derive(Debug)]
-pub(crate) struct Avg {
-    pub(crate) count_helper: usize,
+pub(super) struct Avg {
+    pub(super) column: usize,
+    pub(super) count_helper: usize,
     values_and_weights: Vec<(Datum, i64)>,
 }
 
 impl Avg {
-    pub(crate) fn new(_column: usize, count_helper: usize) -> Self {
+    pub(super) fn new(column: usize, count_helper: usize) -> Self {
         Self {
+            column,
             count_helper,
             values_and_weights: Vec::new(),
         }
     }
 
-    pub(crate) fn accumulate(&mut self, value: Datum, count: i64) {
+    pub(super) fn accumulate(&mut self, value: Datum, count: i64) {
         self.values_and_weights.push((value, count));
     }
 
-    pub(crate) fn finalize(self) -> Result<Datum, Error> {
+    pub(super) fn finalize(self) -> Result<Datum, Error> {
         let total_count: i64 = self.values_and_weights.iter().map(|i| i.1).sum();
         let total_count = Decimal::from(total_count);
 

--- a/pgdog/src/backend/pool/connection/aggregate/cmp.rs
+++ b/pgdog/src/backend/pool/connection/aggregate/cmp.rs
@@ -1,0 +1,85 @@
+use super::TypeError;
+use crate::net::messages::Datum;
+use std::cmp::{Ordering, PartialOrd};
+
+#[derive(Debug)]
+pub(super) struct Cmp {
+    pub(super) column: usize,
+    ordering: Ordering,
+    value: Datum,
+}
+
+impl Cmp {
+    pub(super) fn max(column: usize) -> Self {
+        Self {
+            column,
+            ordering: Ordering::Less,
+            value: Datum::Null,
+        }
+    }
+
+    pub(super) fn min(column: usize) -> Self {
+        Self {
+            column,
+            ordering: Ordering::Greater,
+            value: Datum::Null,
+        }
+    }
+
+    pub(super) fn accumulate(&mut self, value: Datum) -> Result<(), TypeError> {
+        if self.value.is_null() {
+            self.value = value;
+            Ok(())
+        } else if !value.is_null() {
+            match self.value.partial_cmp(&value) {
+                Some(ord) if ord == self.ordering => Ok(self.value = value),
+                Some(_) => Ok(()),
+                None => Err(TypeError::IncompatibleTypes(
+                    self.value.data_type(),
+                    value.data_type(),
+                )),
+            }
+        } else {
+            Ok(())
+        }
+    }
+
+    pub(super) fn finalize(self) -> Datum {
+        self.value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::assert_matches;
+
+    #[test]
+    fn test_max() {
+        let mut state = Cmp::max(0);
+        state.accumulate(Datum::Null).unwrap();
+        state.accumulate(1i64.into()).unwrap();
+        state.accumulate(Datum::Null).unwrap();
+        state.accumulate(3i64.into()).unwrap();
+        state.accumulate(2i64.into()).unwrap();
+        assert_eq!(state.finalize(), Datum::from(3i64));
+    }
+
+    #[test]
+    fn test_min() {
+        let mut state = Cmp::min(0);
+        state.accumulate(Datum::Null).unwrap();
+        state.accumulate(1i64.into()).unwrap();
+        state.accumulate(Datum::Null).unwrap();
+        state.accumulate(3i64.into()).unwrap();
+        state.accumulate(2i64.into()).unwrap();
+        assert_eq!(state.finalize(), Datum::from(1i64));
+    }
+
+    #[test]
+    fn mixed_types_produces_error() {
+        let mut state = Cmp::max(0);
+        state.accumulate(1i64.into()).unwrap();
+        assert_matches!(state.accumulate(1f64.into()), Err(_));
+    }
+}

--- a/pgdog/src/backend/pool/connection/aggregate/count.rs
+++ b/pgdog/src/backend/pool/connection/aggregate/count.rs
@@ -1,0 +1,48 @@
+use super::Error;
+use crate::net::messages::Datum;
+
+#[derive(Debug)]
+pub(super) struct Count {
+    pub(super) column: usize,
+    total: Option<i64>,
+}
+
+impl Count {
+    pub(super) fn new(column: usize) -> Self {
+        Self {
+            column,
+            total: None,
+        }
+    }
+
+    pub(super) fn accumulate(&mut self, value: Datum) -> Result<(), Error> {
+        if value.is_null() {
+            return Ok(());
+        }
+
+        *self.total.get_or_insert(0) += value.as_i64()?;
+        Ok(())
+    }
+
+    pub(super) fn finalize(self) -> Datum {
+        self.total.into()
+    }
+}
+
+#[test]
+fn count_with_null() {
+    let mut state = Count::new(0);
+    state.accumulate(Datum::Null).unwrap();
+    state.accumulate(1i64.into()).unwrap();
+    state.accumulate(Datum::Null).unwrap();
+    state.accumulate(2i64.into()).unwrap();
+    assert_eq!(state.finalize(), 3i64.into());
+}
+
+#[test]
+fn count_with_only_null() {
+    let mut state = Count::new(0);
+    state.accumulate(Datum::Null).unwrap();
+    state.accumulate(Datum::Null).unwrap();
+    assert_eq!(state.finalize(), Datum::Null);
+}


### PR DESCRIPTION
This takes the really trivial aggregate functions, and moves their behavior into the structure I am moving all of them towards over time. The primary benefit for these functions is purely that they're much easier to unit test, and have fewer edge cases to consider in those tests.

At this point the shape that I'm moving towards should be a bit more clear. After we've moved everything out of Accumulator, it and State will become a single type, and we'll refactor the helper columns to always be present and not a mess of options.

`State::accumulate` has a decent bit of duplication of fetching the column. But I do not want the variants to care about decoding things, and keeping it as a field separate from those structs will lead to spaghetti. In the short term, duplication is cheaper than the wrong abstraction

There's a `Dummy` variant on `State` that I don't want to have there long term. It's there because I don't want `State::new` to return an `Option`, and `Accumulator::finalize` takes `&mut self` instead of `self` and I can't flip that switch until everything is moved. Ideally `State::Dummy` would never make it into main, but a long running branch becoming stale is a worse outcome than a bit of scaffold code living in main for a day or two