### PR TITLE
fix: admin password not checked when using passthrough auth

### DIFF
--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -243,7 +243,12 @@ impl Client {
         //
         // This is likely because passthrough authentication is enabled.
         //
-        let auth_result = if passthrough {
+        let auth_result = if admin {
+            // The admin database is virtual and never present in the cluster
+            // map, so authenticate directly against the configured admin password.
+            let passwords = [PasswordKind::Plain(admin_password.clone())];
+            Self::check_password(&mut stream, user, auth_type, &passwords).await?
+        } else if passthrough {
             // Get the password. We always need it because we need to check if
             // it's current and hasn't been changed.
             stream
@@ -261,11 +266,6 @@ impl Client {
             } else {
                 AuthResult::NoPassthroughNoUser
             }
-        } else if admin {
-            // The admin database is virtual and never present in the cluster
-            // map, so authenticate directly against the configured admin password.
-            let passwords = [PasswordKind::Plain(admin_password.clone())];
-            Self::check_password(&mut stream, user, auth_type, &passwords).await?
         } else {
             match databases::databases().cluster((user, database)) {
                 Ok(cluster) => {

--- a/pgdog/src/frontend/client/test/auth.rs
+++ b/pgdog/src/frontend/client/test/auth.rs
@@ -1,0 +1,58 @@
+//! Client authentication tests.
+
+use pgdog_config::{AuthType, PassthroughAuth};
+
+use crate::{
+    config::{config, set},
+    expect_message,
+    net::{Authentication, ErrorResponse, Parameters, Password},
+};
+
+use super::SpawnedClient;
+
+/// Connect to the admin database and answer the plaintext password
+/// request with the given password.
+async fn login_admin(password: &str) -> SpawnedClient {
+    let cfg = config();
+    let mut params = Parameters::default();
+    params.insert("user", cfg.config.admin.user.as_str());
+    params.insert("database", cfg.config.admin.name.as_str());
+
+    let mut client = SpawnedClient::new_with_login(params).await;
+
+    // Both the admin and the passthrough branches request the password
+    // in plaintext; what matters is what happens with the answer.
+    let request = expect_message!(client.read().await, Authentication);
+    assert!(matches!(request, Authentication::ClearTextPassword));
+
+    client.send(Password::new_password(password)).await;
+    client
+}
+
+/// Admin connections must be authenticated against the admin password even
+/// when passthrough auth is enabled. Regression test for the passthrough
+/// branch running first and accepting any password for the admin database.
+#[tokio::test]
+async fn test_admin_password_checked_with_passthrough_auth() {
+    crate::logger();
+    crate::config::load_test();
+
+    let mut cfg = (*config()).clone();
+    cfg.config.general.auth_type = AuthType::Plain;
+    cfg.config.general.passthrough_auth = PassthroughAuth::EnabledPlain;
+    cfg.config.admin.password = "admin-password".into();
+    set(cfg).unwrap();
+
+    // The wrong password is rejected instead of being passed through.
+    let mut client = login_admin("not-the-admin-password").await;
+    let error = ErrorResponse::try_from(client.read().await).unwrap();
+    assert_eq!(error.code, "28000");
+    client.join().await;
+
+    // The correct password is accepted.
+    let mut client = login_admin("admin-password").await;
+    let response = expect_message!(client.read().await, Authentication);
+    assert!(matches!(response, Authentication::Ok));
+    client.read_until('Z').await;
+    client.join().await;
+}

--- a/pgdog/src/frontend/client/test/mod.rs
+++ b/pgdog/src/frontend/client/test/mod.rs
@@ -30,6 +30,7 @@ use crate::{
 
 use super::Stream;
 
+pub mod auth;
 pub mod target_session_attrs;
 pub mod test_client;
 pub use test_client::{SpawnedClient, TestClient};

--- a/pgdog/src/frontend/client/test/test_client.rs
+++ b/pgdog/src/frontend/client/test/test_client.rs
@@ -16,7 +16,7 @@ use crate::{
         client::query_engine::QueryEngine,
         router::{parser::Shard, sharding::ContextBuilder},
     },
-    net::{ErrorResponse, Message, Parameters, Protocol, Stream},
+    net::{ErrorResponse, Message, Parameters, Protocol, ProtocolVersion, Stream},
 };
 
 /// Try to convert a Message to the specified type.
@@ -298,6 +298,31 @@ impl SpawnedClient {
     pub async fn new_default(params: Parameters) -> Self {
         crate::config::load_test();
         Self::new(params).await
+    }
+
+    /// Spawn a client through the full login path, including authentication.
+    ///
+    /// Config needs to be loaded.
+    pub async fn new_with_login(params: Parameters) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let handle = tokio::spawn(async move {
+            let (stream, addr) = listener.accept().await.unwrap();
+            let stream = Stream::plain(stream, 4096);
+            Client::spawn(stream, params, addr, config(), ProtocolVersion::V3_0)
+                .await
+                .unwrap();
+        });
+
+        let conn = TcpStream::connect(format!("127.0.0.1:{}", port))
+            .await
+            .unwrap();
+
+        Self {
+            conn,
+            handle: Some(handle),
+        }
     }
 
     pub async fn new_sharded(params: Parameters) -> Self {


### PR DESCRIPTION
When `passthrough_authentication` is enabled, we weren't checking the admin password correctly, allowing logins into the admin DB. We now always use password auth for admin DBs, using the password configured in `pgdog.toml`/`users.toml`.