### PR TITLE
fix: clippy fixes

### DIFF
--- a/integration/rust/tests/integration/stddev.rs
+++ b/integration/rust/tests/integration/stddev.rs
@@ -64,7 +64,7 @@ async fn test_variance_double() {
     let conns = connections_sqlx().await;
 
     setup_schema(&conns, "test_variance_double", "DOUBLE PRECISION").await;
-    setup_data(&conns, "test_variance_double", &TEST_DATA).await;
+    setup_data(&conns, "test_variance_double", TEST_DATA).await;
 
     let sharded = &conns[1];
     let unsharded = &conns[0];
@@ -76,7 +76,7 @@ async fn test_variance_double() {
     assert_f64_close(data.get(2), expected.get(2), CLOSE_ENOUGH);
     assert_f64_close(data.get(3), expected.get(3), CLOSE_ENOUGH);
 
-    setup_data(&conns, "test_variance_double", &TEST_DATA_2).await;
+    setup_data(&conns, "test_variance_double", TEST_DATA_2).await;
 
     let data = sharded.fetch_one("SELECT var_pop(value), var_samp(value), stddev_pop(value), stddev_samp(value) FROM test_variance_double").await.unwrap();
     let expected = unsharded.fetch_one("SELECT var_pop(value), var_samp(value), stddev_pop(value), stddev_samp(value) FROM test_variance_double").await.unwrap();
@@ -93,7 +93,7 @@ async fn test_variance_float() {
     let conns = connections_sqlx().await;
 
     setup_schema(&conns, "test_variance_float", "real").await;
-    setup_data(&conns, "test_variance_float", &TEST_DATA).await;
+    setup_data(&conns, "test_variance_float", TEST_DATA).await;
 
     let sharded = &conns[1];
     let unsharded = &conns[0];
@@ -121,7 +121,7 @@ async fn test_variance_float() {
         CLOSEST_WE_CAN_GET_WITH_32_BITS,
     );
 
-    setup_data(&conns, "test_variance_float", &TEST_DATA_2).await;
+    setup_data(&conns, "test_variance_float", TEST_DATA_2).await;
 
     let data = sharded.fetch_one("SELECT var_pop(value), var_samp(value), stddev_pop(value), stddev_samp(value) FROM test_variance_float").await.unwrap();
     let expected = unsharded.fetch_one("SELECT var_pop(value), var_samp(value), stddev_pop(value), stddev_samp(value) FROM test_variance_float").await.unwrap();

--- a/integration/rust/tests/integration/unrecognized_aggregate.rs
+++ b/integration/rust/tests/integration/unrecognized_aggregate.rs
@@ -39,8 +39,6 @@ async fn unrecognized_aggregate_function_errors_only_on_cross_shard_queries() {
     let sharded_query = sharded
         .fetch_one("SELECT pgdog_sum(lol) FROM unrecognized_agg_test")
         .await;
-    let err = sharded_query
-        .err()
-        .expect("unrecognized aggregate executed successfully");
+    let err = sharded_query.expect_err("unrecognized aggregate executed successfully");
     assert!(err.to_string().contains("pgdog_sum is not yet supported"));
 }

--- a/pgdog-config/src/error.rs
+++ b/pgdog-config/src/error.rs
@@ -53,12 +53,11 @@ impl Error {
         let mut lines = lines.into_iter().peekable();
 
         while let Some(line) = lines.next() {
-            if span.start < line.1 {
-                if let Some(next) = lines.peek() {
-                    if next.1 > span.start {
-                        return Self::MissingField(message.into(), line.0);
-                    }
-                }
+            if span.start < line.1
+                && let Some(next) = lines.peek()
+                && next.1 > span.start
+            {
+                return Self::MissingField(message.into(), line.0);
             }
         }
 

--- a/pgdog-config/src/general.rs
+++ b/pgdog-config/src/general.rs
@@ -1344,10 +1344,10 @@ impl General {
 
     /// Get TLS config, if any.
     pub fn tls(&self) -> Option<(&PathBuf, &PathBuf)> {
-        if let Some(cert) = &self.tls_certificate {
-            if let Some(key) = &self.tls_private_key {
-                return Some((cert, key));
-            }
+        if let Some(cert) = &self.tls_certificate
+            && let Some(key) = &self.tls_private_key
+        {
+            return Some((cert, key));
         }
 
         None

--- a/pgdog-postgres-types/src/array.rs
+++ b/pgdog-postgres-types/src/array.rs
@@ -398,7 +398,8 @@ mod tests {
 
     #[test]
     fn test_text_decode_table() {
-        let cases: Vec<(&str, &str, i32, Vec<Option<&str>>, i32)> = vec![
+        type TestCase<'a> = (&'a str, &'a str, i32, Vec<Option<&'a str>>, i32);
+        let cases: Vec<TestCase<'_>> = vec![
             ("empty", "{}", 23, vec![], 1),
             ("single int", "{1}", 23, vec![Some("1")], 1),
             (

--- a/pgdog/src/admin/ban.rs
+++ b/pgdog/src/admin/ban.rs
@@ -46,10 +46,10 @@ impl Command for Ban {
         for database in databases().all().values() {
             for shard in database.shards() {
                 for (_role, ban, pool) in shard.pools_with_roles_and_bans() {
-                    if let Some(id) = self.id {
-                        if id != pool.id() {
-                            continue;
-                        }
+                    if let Some(id) = self.id
+                        && id != pool.id()
+                    {
+                        continue;
                     }
 
                     if self.unban {

--- a/pgdog/src/admin/healthcheck.rs
+++ b/pgdog/src/admin/healthcheck.rs
@@ -28,10 +28,10 @@ impl Command for Healthcheck {
         for database in databases().all().values() {
             for shard in database.shards() {
                 for pool in shard.pools() {
-                    if let Some(id) = self.id {
-                        if id != pool.id() {
-                            continue;
-                        }
+                    if let Some(id) = self.id
+                        && id != pool.id()
+                    {
+                        continue;
                     }
 
                     let _ = Monitor::healthcheck(&pool).await;

--- a/pgdog/src/admin/pause.rs
+++ b/pgdog/src/admin/pause.rs
@@ -44,15 +44,15 @@ impl Command for Pause {
 
     async fn execute(&self) -> Result<Vec<Message>, Error> {
         for (name, cluster) in databases().all() {
-            if let Some(ref user) = self.user {
-                if &name.user != user {
-                    continue;
-                }
+            if let Some(ref user) = self.user
+                && &name.user != user
+            {
+                continue;
             }
-            if let Some(ref database) = self.database {
-                if &name.database != database {
-                    continue;
-                }
+            if let Some(ref database) = self.database
+                && &name.database != database
+            {
+                continue;
             }
             for shard in cluster.shards() {
                 for pool in shard.pools() {

--- a/pgdog/src/backend/auth/rds_iam.rs
+++ b/pgdog/src/backend/auth/rds_iam.rs
@@ -31,10 +31,10 @@ fn infer_region_from_rds_host(host: &str) -> Option<String> {
 }
 
 fn resolve_region(addr: &Address) -> Result<String, Error> {
-    if let Some(region) = addr.server_iam_region.as_ref() {
-        if !region.is_empty() {
-            return Ok(region.clone());
-        }
+    if let Some(region) = addr.server_iam_region.as_ref()
+        && !region.is_empty()
+    {
+        return Ok(region.clone());
     }
 
     infer_region_from_rds_host(&addr.host).ok_or_else(|| {

--- a/pgdog/src/backend/databases.rs
+++ b/pgdog/src/backend/databases.rs
@@ -431,11 +431,11 @@ impl Databases {
         for (user, cluster) in &self.databases {
             let dest = destination.databases.get(user);
 
-            if let Some(dest) = dest {
-                if cluster.can_move_conns_to(dest) {
-                    cluster.move_conns_to(dest)?;
-                    moved += 1;
-                }
+            if let Some(dest) = dest
+                && cluster.can_move_conns_to(dest)
+            {
+                cluster.move_conns_to(dest)?;
+                moved += 1;
             }
         }
 
@@ -538,14 +538,14 @@ fn new_pool(user: &crate::config::User, config: &crate::config::Config) -> Optio
         if let Some(mappings) = mappings {
             sharded_table.mapping = Mapping::new(mappings);
 
-            if let Some(ref mapping) = sharded_table.mapping {
-                if !mapping_valid(mapping) {
-                    warn!(
-                        "sharded table name=\"{}\", column=\"{}\" has overlapping ranges",
-                        sharded_table.name.as_ref().unwrap_or(&String::from("")),
-                        sharded_table.column
-                    );
-                }
+            if let Some(ref mapping) = sharded_table.mapping
+                && !mapping_valid(mapping)
+            {
+                warn!(
+                    "sharded table name=\"{}\", column=\"{}\" has overlapping ranges",
+                    sharded_table.name.as_ref().unwrap_or(&String::from("")),
+                    sharded_table.column
+                );
             }
         }
     }

--- a/pgdog/src/backend/pool/connection/aggregate/avg.rs
+++ b/pgdog/src/backend/pool/connection/aggregate/avg.rs
@@ -37,12 +37,12 @@ impl Avg {
             })
             .max();
 
-        let mut result =
-            self.values_and_weights
-                .into_iter()
-                .fold(Ok(Datum::Null), |acc, (value, weight)| {
-                    checked_mul_add(value, Decimal::from(weight) / total_count, acc?)
-                });
+        let mut result = self
+            .values_and_weights
+            .into_iter()
+            .try_fold(Datum::Null, |acc, (value, weight)| {
+                checked_mul_add(value, Decimal::from(weight) / total_count, acc)
+            });
         if let Ok(Datum::Numeric(n)) = &mut result
             && let Some(d) = n.as_decimal_mut()
             && let Some(scale) = numeric_scale
@@ -103,16 +103,16 @@ mod tests {
     // crates.io gets per day over the last 90 days, if crates.io were
     // sharded by crate_id
     const TEST_DATA: &[(f64, i64)] = &[
-        (96724.170212765957, 4089),
-        (186386.974947807933, 1916),
-        (33537.298768879299, 7879),
-        (97637.501614987080, 3096),
-        (33534.787317691820, 7885),
-        (104947.738952164009, 4390),
-        (60095.478251906823, 4851),
-        (14353.621700556566, 18147),
-        (11857.550375469337, 28764),
-        (42577.351057747284, 6996),
+        (96_724.170_212_765_95, 4089),
+        (186_386.974_947_807_93, 1916),
+        (33_537.298_768_879_3, 7879),
+        (97_637.501_614_987_08, 3096),
+        (33_534.787_317_691_82, 7885),
+        (104_947.738_952_164_01, 4390),
+        (60_095.478_251_906_823, 4851),
+        (14_353.621_700_556_566, 18147),
+        (11_857.550_375_469_337, 28764),
+        (42_577.351_057_747_284, 6996),
     ];
 
     #[test]
@@ -121,7 +121,7 @@ mod tests {
         for &(avg, count) in TEST_DATA {
             state.accumulate(Decimal::from_f64(avg).unwrap().into(), count);
         }
-        let expected: Datum = Decimal::from_f64(36758.559474168589).unwrap().into();
+        let expected: Datum = Decimal::from_f64(36_758.559_474_168_589).unwrap().into();
         assert_eq!(state.finalize().unwrap(), expected);
     }
 
@@ -131,7 +131,10 @@ mod tests {
         for &(avg, count) in TEST_DATA {
             state.accumulate(avg.into(), count);
         }
-        assert_eq!(state.finalize().unwrap(), Datum::from(36758.559474168589));
+        assert_eq!(
+            state.finalize().unwrap(),
+            Datum::from(36_758.559_474_168_589)
+        );
     }
 
     #[test]
@@ -161,9 +164,12 @@ mod tests {
     #[test]
     fn integer_numerics_have_trailing_zeroes_removed() {
         let mut state = Avg::new(0, 0);
-        state.accumulate(dec!(850.0000000000000000).into(), 6);
-        state.accumulate(dec!(48343436988849539).into(), 9);
-        assert_eq!(state.finalize().unwrap(), dec!(29006062193310063).into())
+        state.accumulate(dec!(85_0.000_000_000_000_000_0).into(), 6);
+        state.accumulate(dec!(48_343_436_988_849_539).into(), 9);
+        assert_eq!(
+            state.finalize().unwrap(),
+            dec!(29_006_062_193_310_063).into()
+        )
     }
 
     #[test]

--- a/pgdog/src/backend/pool/connection/aggregate/cmp.rs
+++ b/pgdog/src/backend/pool/connection/aggregate/cmp.rs
@@ -32,7 +32,10 @@ impl Cmp {
             Ok(())
         } else if !value.is_null() {
             match self.value.partial_cmp(&value) {
-                Some(ord) if ord == self.ordering => Ok(self.value = value),
+                Some(ord) if ord == self.ordering => {
+                    let _: () = self.value = value;
+                    Ok(())
+                }
                 Some(_) => Ok(()),
                 None => Err(TypeError::IncompatibleTypes(
                     self.value.data_type(),

--- a/pgdog/src/backend/pool/connection/aggregate/cmp.rs
+++ b/pgdog/src/backend/pool/connection/aggregate/cmp.rs
@@ -33,7 +33,7 @@ impl Cmp {
         } else if !value.is_null() {
             match self.value.partial_cmp(&value) {
                 Some(ord) if ord == self.ordering => {
-                    let _: () = self.value = value;
+                    self.value = value;
                     Ok(())
                 }
                 Some(_) => Ok(()),

--- a/pgdog/src/backend/pool/connection/aggregate/variance.rs
+++ b/pgdog/src/backend/pool/connection/aggregate/variance.rs
@@ -114,7 +114,7 @@ fn compute_variance(sumsq: Decimal, sum: Decimal, count: i64, sample: bool, sqrt
     let count = Decimal::from(count);
     let mut result = (sumsq - sum * sum / count) / count;
     if sample {
-        result = result * (count / (count - dec!(1)));
+        result *= (count / (count - dec!(1)));
     }
     if sqrt {
         result = result.sqrt().unwrap_or(Decimal::ZERO);

--- a/pgdog/src/backend/pool/connection/aggregate/variance.rs
+++ b/pgdog/src/backend/pool/connection/aggregate/variance.rs
@@ -114,7 +114,7 @@ fn compute_variance(sumsq: Decimal, sum: Decimal, count: i64, sample: bool, sqrt
     let count = Decimal::from(count);
     let mut result = (sumsq - sum * sum / count) / count;
     if sample {
-        result *= (count / (count - dec!(1)));
+        result *= count / (count - dec!(1));
     }
     if sqrt {
         result = result.sqrt().unwrap_or(Decimal::ZERO);

--- a/pgdog/src/backend/pool/connection/buffer.rs
+++ b/pgdog/src/backend/pool/connection/buffer.rs
@@ -86,9 +86,7 @@ impl Buffer {
                 .filter_map(|col| {
                     let index = col.index();
                     let asc = col.asc();
-                    let Some(index) = index else {
-                        return None;
-                    };
+                    let index = index?;
                     let left = a.get_column(index, decoder);
                     let right = b.get_column(index, decoder);
 

--- a/pgdog/src/backend/pool/connection/buffer.rs
+++ b/pgdog/src/backend/pool/connection/buffer.rs
@@ -194,10 +194,10 @@ impl Buffer {
                                 }
 
                                 DistinctColumn::Name(name) => {
-                                    if let Some(index) = decoder.rd().field_index(name) {
-                                        if let Some(data) = row.column(index) {
-                                            dr.add(data);
-                                        }
+                                    if let Some(index) = decoder.rd().field_index(name)
+                                        && let Some(data) = row.column(index)
+                                    {
+                                        dr.add(data);
                                     }
                                 }
                             }

--- a/pgdog/src/backend/pool/connection/mod.rs
+++ b/pgdog/src/backend/pool/connection/mod.rs
@@ -162,10 +162,10 @@ impl Connection {
             let mut shards = vec![];
             let mut shard_indices = vec![];
             for (i, shard) in self.cluster()?.shards().iter().enumerate() {
-                if let Shard::Multi(numbers) = route.shard() {
-                    if !numbers.contains(&i) {
-                        continue;
-                    }
+                if let Shard::Multi(numbers) = route.shard()
+                    && !numbers.contains(&i)
+                {
+                    continue;
                 };
                 let mut server = if route.is_read() {
                     shard.replica(request).await?
@@ -325,14 +325,14 @@ impl Connection {
             // server. The injection has to follow the same route as the
             // request itself; sending it to extra shards would leave them
             // with a dangling Ignore expectation that hangs the read loop.
-            if let Some(ref parse) = client_request.last_parse {
-                if client_request.needs_parse_injection() {
-                    self.send_ignore(
-                        &ProtocolMessage::Parse(parse.clone()),
-                        client_request.route(),
-                    )
-                    .await?;
-                }
+            if let Some(ref parse) = client_request.last_parse
+                && client_request.needs_parse_injection()
+            {
+                self.send_ignore(
+                    &ProtocolMessage::Parse(parse.clone()),
+                    client_request.route(),
+                )
+                .await?;
             }
 
             // Send query to server.
@@ -366,27 +366,28 @@ impl Connection {
         // only load databases from the config. RELOAD effectively removes all passthrough
         // connection pools until a client needs to query it and we re-create it.
         //
-        if config.config.general.passthrough_auth() && databases().passwords(user).is_none() {
-            if let Some(ref cluster) = self.cluster {
-                let mut user = User {
-                    name: self.user.clone(),
-                    database: self.database.clone(),
-                    ..Default::default()
-                };
-                for pass in cluster.passwords() {
-                    match pass {
-                        PasswordKind::Hashed(hashed) => {
-                            user.password_hash = Some(hashed.clone());
-                        }
+        if config.config.general.passthrough_auth()
+            && databases().passwords(user).is_none()
+            && let Some(ref cluster) = self.cluster
+        {
+            let mut user = User {
+                name: self.user.clone(),
+                database: self.database.clone(),
+                ..Default::default()
+            };
+            for pass in cluster.passwords() {
+                match pass {
+                    PasswordKind::Hashed(hashed) => {
+                        user.password_hash = Some(hashed.clone());
+                    }
 
-                        PasswordKind::Plain(plain) => {
-                            user.passwords.push(plain.clone());
-                        }
+                    PasswordKind::Plain(plain) => {
+                        user.passwords.push(plain.clone());
                     }
                 }
-
-                databases::add(user)?;
             }
+
+            databases::add(user)?;
         }
 
         let databases = databases();

--- a/pgdog/src/backend/pool/connection/multi_shard/mod.rs
+++ b/pgdog/src/backend/pool/connection/multi_shard/mod.rs
@@ -344,14 +344,14 @@ impl MultiShard {
         let context = message.into();
         match context {
             Context::Bind(bind) => {
-                if self.decoder.rd().fields.is_empty() && !bind.anonymous() {
-                    if let Some(rd) = PreparedStatements::global()
+                if self.decoder.rd().fields.is_empty()
+                    && !bind.anonymous()
+                    && let Some(rd) = PreparedStatements::global()
                         .read()
                         .row_description(bind.statement())
-                    {
-                        self.decoder.row_description(&rd);
-                        self.validator.set_row_description(&rd);
-                    }
+                {
+                    self.decoder.row_description(&rd);
+                    self.validator.set_row_description(&rd);
                 }
                 self.decoder.bind(bind);
             }

--- a/pgdog/src/backend/pool/inner.rs
+++ b/pgdog/src/backend/pool/inner.rs
@@ -395,18 +395,18 @@ impl Inner {
     /// or the caller got cancelled.
     #[inline]
     pub(super) fn remove_waiter(&mut self, id: FrontendPid) {
-        if let Some(waiter) = self.waiting.pop_front() {
-            if waiter.request.id != id {
-                // Put me back.
-                self.waiting.push_front(waiter);
+        if let Some(waiter) = self.waiting.pop_front()
+            && waiter.request.id != id
+        {
+            // Put me back.
+            self.waiting.push_front(waiter);
 
-                // Slow search, but we should be somewhere towards the front
-                // if the runtime is doing scheduling correctly.
-                for (i, waiter) in self.waiting.iter().enumerate() {
-                    if waiter.request.id == id {
-                        self.waiting.remove(i);
-                        break;
-                    }
+            // Slow search, but we should be somewhere towards the front
+            // if the runtime is doing scheduling correctly.
+            for (i, waiter) in self.waiting.iter().enumerate() {
+                if waiter.request.id == id {
+                    self.waiting.remove(i);
+                    break;
                 }
             }
         }

--- a/pgdog/src/backend/pool/taken.rs
+++ b/pgdog/src/backend/pool/taken.rs
@@ -48,10 +48,10 @@ impl Taken {
         // backend. The deferred check-in from a prior `Server::drop` may fire
         // after the frontend has already taken a newer backend; in that case
         // the entry belongs to the newer backend and must not be touched.
-        if let Entry::Occupied(entry) = self.frontend_to_cancel.entry(frontend) {
-            if entry.get().backend == backend {
-                entry.remove();
-            }
+        if let Entry::Occupied(entry) = self.frontend_to_cancel.entry(frontend)
+            && entry.get().backend == backend
+        {
+            entry.remove();
         }
         Ok(())
     }

--- a/pgdog/src/backend/protocol/state.rs
+++ b/pgdog/src/backend/protocol/state.rs
@@ -136,13 +136,12 @@ impl ProtocolState {
     pub fn get_simulated(&mut self) -> Option<Message> {
         let code = self.queue.front();
         let message = self.simulated.front();
-        if let Some(ExecutionItem::Code(code)) = code {
-            if let Some(message) = message {
-                if code == &ExecutionCode::from(message.code()) {
-                    let _ = self.queue.pop_front();
-                    return self.simulated.pop_front();
-                }
-            }
+        if let Some(ExecutionItem::Code(code)) = code
+            && let Some(message) = message
+            && code == &ExecutionCode::from(message.code())
+        {
+            let _ = self.queue.pop_front();
+            return self.simulated.pop_front();
         }
         None
     }

--- a/pgdog/src/backend/replication/logical/error.rs
+++ b/pgdog/src/backend/replication/logical/error.rs
@@ -295,7 +295,10 @@ mod tests {
             }
         }
 
-        let wrappers: [(&str, fn(ErrorResponse) -> Error); 3] = [
+        type WrapperFn = fn(ErrorResponse) -> Error;
+        type WrapperCase = (&'static str, WrapperFn);
+
+        let wrappers: [WrapperCase; 3] = [
             ("PgError", |r| Error::PgError(Box::new(r))),
             ("Backend(ExecutionError)", |r| {
                 Error::Backend(BE::ExecutionError(Box::new(r)))

--- a/pgdog/src/backend/replication/logical/publisher/queries.rs
+++ b/pgdog/src/backend/replication/logical/publisher/queries.rs
@@ -197,6 +197,7 @@ impl From<DataRow> for PublicationTableColumn {
 ///   unique constraint) or every indexed attribute has `attnotnull = true` (NULLs impossible).
 ///   A plain nullable unique index allows two NULL-keyed rows to coexist during the copy–stream
 ///   overlap window, leaving the destination with more rows than the source.
+///
 /// Requires PostgreSQL 15+ when an `indnullsnotdistinct` index is present; the column does
 /// not exist on older servers and the query will return an error rather than silently accept.
 ///

--- a/pgdog/src/backend/replication/logical/publisher/slot.rs
+++ b/pgdog/src/backend/replication/logical/publisher/slot.rs
@@ -502,10 +502,10 @@ mod test {
                 if let Some(message) = message {
                     match message.clone() {
                         ReplicationData::CopyData(copy_data) => {
-                            if let Some(xlog_data) = copy_data.xlog_data() {
-                                if let Some(XLogPayload::Commit(_)) = xlog_data.payload() {
-                                    slot.stop_replication().await?;
-                                }
+                            if let Some(xlog_data) = copy_data.xlog_data()
+                                && let Some(XLogPayload::Commit(_)) = xlog_data.payload()
+                            {
+                                slot.stop_replication().await?;
                             }
                         }
                         ReplicationData::CopyDone => (),

--- a/pgdog/src/backend/replication/logical/subscriber/stream.rs
+++ b/pgdog/src/backend/replication/logical/subscriber/stream.rs
@@ -874,27 +874,27 @@ impl StreamSubscriber {
 
         let mut status_update = None;
 
-        if let Some(xlog) = data.xlog_data() {
-            if let Some(payload) = xlog.payload() {
-                match payload {
-                    XLogPayload::Insert(insert) => self.insert(insert).await?,
-                    XLogPayload::Update(update) => self.update(update).await?,
-                    XLogPayload::Delete(delete) => self.delete(delete).await?,
-                    XLogPayload::Commit(commit) => {
-                        self.commit(commit).await?;
-                        status_update = Some(self.status_update());
-                        self.in_transaction = false;
-                    }
-                    XLogPayload::Relation(relation) => self.relation(relation).await?,
-                    XLogPayload::Begin(begin) => {
-                        self.changed_tables.clear();
-                        self.set_working_lsn(begin.final_transaction_lsn);
-                        self.in_transaction = true;
-                    }
-                    _ => (),
+        if let Some(xlog) = data.xlog_data()
+            && let Some(payload) = xlog.payload()
+        {
+            match payload {
+                XLogPayload::Insert(insert) => self.insert(insert).await?,
+                XLogPayload::Update(update) => self.update(update).await?,
+                XLogPayload::Delete(delete) => self.delete(delete).await?,
+                XLogPayload::Commit(commit) => {
+                    self.commit(commit).await?;
+                    status_update = Some(self.status_update());
+                    self.in_transaction = false;
                 }
-                self.bytes_sharded += xlog.len();
+                XLogPayload::Relation(relation) => self.relation(relation).await?,
+                XLogPayload::Begin(begin) => {
+                    self.changed_tables.clear();
+                    self.set_working_lsn(begin.final_transaction_lsn);
+                    self.in_transaction = true;
+                }
+                _ => (),
             }
+            self.bytes_sharded += xlog.len();
         }
 
         Ok(status_update)

--- a/pgdog/src/backend/replication/sharded_schema.rs
+++ b/pgdog/src/backend/replication/sharded_schema.rs
@@ -42,10 +42,10 @@ impl Deref for ShardedSchemas {
 
 impl ShardedSchemas {
     pub fn get<'a>(&self, schema: Option<Schema<'a>>) -> Option<&ShardedSchema> {
-        if let Some(schema) = schema {
-            if let Some(schema) = self.inner.schemas.get(schema.name) {
-                return Some(schema);
-            }
+        if let Some(schema) = schema
+            && let Some(schema) = self.inner.schemas.get(schema.name)
+        {
+            return Some(schema);
         }
 
         self.inner.default_mapping.as_ref()

--- a/pgdog/src/backend/replication/sharded_tables.rs
+++ b/pgdog/src/backend/replication/sharded_tables.rs
@@ -137,18 +137,17 @@ impl ShardedTables {
         let table = column.table()?;
 
         for candidate in &self.inner.tables {
-            if let Some(table_name) = candidate.name.as_ref() {
-                if !table.name_match(table_name) {
-                    continue;
-                }
+            if let Some(table_name) = candidate.name.as_ref()
+                && !table.name_match(table_name)
+            {
+                continue;
             }
 
-            if let Some(schema_name) = candidate.schema.as_ref() {
-                if let Some(schema) = table.schema() {
-                    if schema.name != schema_name {
-                        continue;
-                    }
-                }
+            if let Some(schema_name) = candidate.schema.as_ref()
+                && let Some(schema) = table.schema()
+                && schema.name != schema_name
+            {
+                continue;
             }
 
             if column.name == candidate.column {
@@ -181,10 +180,10 @@ impl ShardedTables {
         };
 
         for sharded_table in with_names {
-            if Some(table) == sharded_table.name.as_deref() {
-                if let Some(column) = get_column(sharded_table, columns) {
-                    return Some(column);
-                }
+            if Some(table) == sharded_table.name.as_deref()
+                && let Some(column) = get_column(sharded_table, columns)
+            {
+                return Some(column);
             }
         }
 

--- a/pgdog/src/backend/schema/columns.rs
+++ b/pgdog/src/backend/schema/columns.rs
@@ -91,19 +91,18 @@ impl Column {
         let fk_rows: Vec<ForeignKeyRow> = server.fetch_all(FOREIGN_KEYS).await?;
         for fk_row in fk_rows {
             let key = (fk_row.source_schema.clone(), fk_row.source_table.clone());
-            if let Some(columns) = result.get_mut(&key) {
-                if let Some(column) = columns
+            if let Some(columns) = result.get_mut(&key)
+                && let Some(column) = columns
                     .iter_mut()
                     .find(|c| c.column_name == fk_row.source_column)
-                {
-                    column.foreign_keys.push(ForeignKey {
-                        schema: fk_row.ref_schema,
-                        table: fk_row.ref_table,
-                        column: fk_row.ref_column,
-                        on_delete: fk_row.on_delete,
-                        on_update: fk_row.on_update,
-                    });
-                }
+            {
+                column.foreign_keys.push(ForeignKey {
+                    schema: fk_row.ref_schema,
+                    table: fk_row.ref_table,
+                    column: fk_row.ref_column,
+                    on_delete: fk_row.on_delete,
+                    on_update: fk_row.on_update,
+                });
             }
         }
 

--- a/pgdog/src/backend/schema/sync/pg_dump.rs
+++ b/pgdog/src/backend/schema/sync/pg_dump.rs
@@ -485,10 +485,10 @@ impl PgDumpOutput {
             };
 
             // Tables with partspec are partitioned parent tables
-            if create_stmt.partspec.is_some() {
-                if let Some(ref relation) = create_stmt.relation {
-                    result.insert(Table::from(relation));
-                }
+            if create_stmt.partspec.is_some()
+                && let Some(ref relation) = create_stmt.relation
+            {
+                result.insert(Table::from(relation));
             }
         }
 
@@ -582,18 +582,17 @@ impl PgDumpOutput {
                     // Check if this column needs conversion
                     if columns_to_convert.contains(&col) {
                         result.insert((table, col_def.colname.as_str()), "int8");
-                    } else if let Some(ref type_name) = col_def.type_name {
-                        if let Some(last_name) = type_name.names.last() {
-                            if let Some(NodeEnum::String(PgString { sval })) = &last_name.node {
-                                // Store original type for non-converted columns
-                                let type_str: &'static str = match sval.as_str() {
-                                    "int4" => "int4",
-                                    "int8" => "int8",
-                                    _ => continue, // Only track integer types
-                                };
-                                result.insert((table, col_def.colname.as_str()), type_str);
-                            }
-                        }
+                    } else if let Some(ref type_name) = col_def.type_name
+                        && let Some(last_name) = type_name.names.last()
+                        && let Some(NodeEnum::String(PgString { sval })) = &last_name.node
+                    {
+                        // Store original type for non-converted columns
+                        let type_str: &'static str = match sval.as_str() {
+                            "int4" => "int4",
+                            "int8" => "int8",
+                            _ => continue, // Only track integer types
+                        };
+                        result.insert((table, col_def.colname.as_str()), type_str);
                     }
                 }
             }
@@ -622,21 +621,19 @@ impl PgDumpOutput {
             let table_name = relation.relname.as_str();
 
             for elt in &create_stmt.table_elts {
-                if let Some(NodeEnum::ColumnDef(col_def)) = &elt.node {
-                    if let Some(ref type_name) = col_def.type_name {
-                        if let Some(last_name) = type_name.names.last() {
-                            if let Some(NodeEnum::String(PgString { sval })) = &last_name.node {
-                                result.insert(
-                                    ColumnTypeKey {
-                                        schema,
-                                        table: table_name,
-                                        column: col_def.colname.as_str(),
-                                    },
-                                    sval.as_str(),
-                                );
-                            }
-                        }
-                    }
+                if let Some(NodeEnum::ColumnDef(col_def)) = &elt.node
+                    && let Some(ref type_name) = col_def.type_name
+                    && let Some(last_name) = type_name.names.last()
+                    && let Some(NodeEnum::String(PgString { sval })) = &last_name.node
+                {
+                    result.insert(
+                        ColumnTypeKey {
+                            schema,
+                            table: table_name,
+                            column: col_def.colname.as_str(),
+                        },
+                        sval.as_str(),
+                    );
                 }
             }
         }
@@ -669,356 +666,349 @@ impl PgDumpOutput {
                 .split_at_checked(stmt.stmt_len as usize)
                 .ok_or(Error::StmtOutOfBounds)?;
 
-            if let Some(ref node) = stmt.stmt {
-                if let Some(ref node) = node.node {
-                    match node {
-                        NodeEnum::CreateStmt(create_stmt) => {
-                            let mut stmt = create_stmt.clone();
-                            stmt.if_not_exists = true;
+            if let Some(ref node) = stmt.stmt
+                && let Some(ref node) = node.node
+            {
+                match node {
+                    NodeEnum::CreateStmt(create_stmt) => {
+                        let mut stmt = create_stmt.clone();
+                        stmt.if_not_exists = true;
 
-                            // Get table info
-                            let table = create_stmt
-                                .relation
-                                .as_ref()
-                                .map(Table::from)
-                                .unwrap_or_default();
-                            let schema = table.schema().map(|s| s.name).unwrap_or("public");
-                            let table_name = table.name;
+                        // Get table info
+                        let table = create_stmt
+                            .relation
+                            .as_ref()
+                            .map(Table::from)
+                            .unwrap_or_default();
+                        let schema = table.schema().map(|s| s.name).unwrap_or("public");
+                        let table_name = table.name;
 
-                            // Check if this table is a child partition
-                            let parent_table = partition_parents.get(&table);
+                        // Check if this table is a child partition
+                        let parent_table = partition_parents.get(&table);
 
-                            // Convert integer PK/FK columns to bigint
-                            for elt in &mut stmt.table_elts {
-                                if let Some(NodeEnum::ColumnDef(ref mut col_def)) = elt.node {
-                                    let col = Column {
-                                        name: col_def.colname.as_str(),
-                                        table: Some(table_name),
-                                        schema: Some(schema),
-                                    };
-
-                                    if should_convert_to_bigint(
-                                        &col,
-                                        col_def.type_name.as_ref(),
-                                        &columns_to_convert,
-                                        parent_table,
-                                        &parent_column_types,
-                                    ) {
-                                        if let Some(ref mut type_name) = col_def.type_name {
-                                            type_name.names = vec![
-                                                Node {
-                                                    node: Some(NodeEnum::String(PgString {
-                                                        sval: "pg_catalog".to_owned(),
-                                                    })),
-                                                },
-                                                Node {
-                                                    node: Some(NodeEnum::String(PgString {
-                                                        sval: "int8".to_owned(),
-                                                    })),
-                                                },
-                                            ];
-                                        }
-                                    }
-                                }
-                            }
-
-                            if state == SyncState::PreData {
-                                let sql = deparse_node(NodeEnum::CreateStmt(stmt))?;
-                                result.push(Statement::Table { table, sql });
-                            }
-                        }
-
-                        NodeEnum::CreateSeqStmt(stmt) => {
-                            let mut stmt = stmt.clone();
-                            stmt.if_not_exists = true;
-                            let sql = deparse_node(NodeEnum::CreateSeqStmt(stmt))?;
-                            if state == SyncState::PreData {
-                                // Bring sequences over.
-                                result.push(sql.into());
-                            }
-                        }
-
-                        NodeEnum::CreateExtensionStmt(stmt) => {
-                            let mut stmt = stmt.clone();
-                            stmt.if_not_exists = true;
-                            let sql = deparse_node(NodeEnum::CreateExtensionStmt(stmt))?;
-                            if state == SyncState::PreData {
-                                result.push(sql.into());
-                            }
-                        }
-
-                        NodeEnum::CreateSchemaStmt(stmt) => {
-                            let mut stmt = stmt.clone();
-                            stmt.if_not_exists = true;
-                            let sql = deparse_node(NodeEnum::CreateSchemaStmt(stmt))?;
-                            if state == SyncState::PreData {
-                                result.push(sql.into());
-                            }
-                        }
-
-                        NodeEnum::AlterTableStmt(stmt) => {
-                            for cmd in &stmt.cmds {
-                                if let Some(NodeEnum::AlterTableCmd(ref cmd)) = cmd.node {
-                                    match cmd.subtype() {
-                                        AlterTableType::AtAddConstraint => {
-                                            if let Some(ref def) = cmd.def {
-                                                if let Some(NodeEnum::Constraint(ref cons)) =
-                                                    def.node
-                                                {
-                                                    // Only allow primary key constraints.
-                                                    if matches!(
-                                                        cons.contype(),
-                                                        ConstrType::ConstrPrimary
-                                                            | ConstrType::ConstrNotnull
-                                                            | ConstrType::ConstrNull
-                                                    ) {
-                                                        // Integer PKs are already tracked and converted
-                                                        // to bigint in CreateStmt handler
-                                                        if state == SyncState::PreData {
-                                                            result.push(Statement::Other {
-                                                                sql: original.to_string(),
-                                                                idempotent: false,
-                                                            });
-                                                        }
-                                                    } else if cons.contype()
-                                                        == ConstrType::ConstrForeign
-                                                    {
-                                                        // FK columns referencing integer PKs are
-                                                        // computed from fk_columns at the end
-                                                        if state == SyncState::PostData {
-                                                            result.push(Statement::Other {
-                                                                sql: original.to_string(),
-                                                                idempotent: false,
-                                                            });
-                                                        }
-                                                    } else if state == SyncState::PostData {
-                                                        result.push(Statement::Other {
-                                                            sql: original.to_string(),
-                                                            idempotent: false,
-                                                        });
-                                                    }
-                                                }
-                                            }
-                                        }
-                                        AlterTableType::AtAttachPartition => {
-                                            match stmt.objtype() {
-                                                // Index partitions need to be attached to indexes,
-                                                // which we create in the post-data step.
-                                                ObjectType::ObjectIndex => {
-                                                    if state == SyncState::PostData {
-                                                        result.push(Statement::Other {
-                                                            sql: original.to_string(),
-                                                            idempotent: false,
-                                                        });
-                                                    }
-                                                }
-
-                                                // Table partitions are attached in pre-data
-                                                // after the partition tables are created.
-                                                ObjectType::ObjectTable => {
-                                                    if state == SyncState::PreData {
-                                                        result.push(Statement::Other {
-                                                            sql: original.to_string(),
-                                                            idempotent: false,
-                                                        });
-                                                    }
-                                                }
-
-                                                _ => {
-                                                    if state == SyncState::PreData {
-                                                        result.push(Statement::Other {
-                                                            sql: original.to_string(),
-                                                            idempotent: false,
-                                                        });
-                                                    }
-                                                }
-                                            }
-                                        }
-
-                                        AlterTableType::AtColumnDefault => {
-                                            if state == SyncState::PreData {
-                                                result.push(original.into())
-                                            }
-                                        }
-
-                                        AlterTableType::AtAddIdentity => (),
-                                        // AlterTableType::AtChangeOwner => {
-                                        //     continue; // Don't change owners, for now.
-                                        // }
-                                        _ => {
-                                            if state == SyncState::PreData {
-                                                result.push(original.into());
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-
-                        NodeEnum::CreateTrigStmt(stmt) => {
-                            let mut stmt = stmt.clone();
-                            stmt.replace = true;
-
-                            if state == SyncState::PreData {
-                                result.push(deparse_node(NodeEnum::CreateTrigStmt(stmt))?.into());
-                            }
-                        }
-
-                        NodeEnum::CreatePublicationStmt(stmt) => {
-                            if state == SyncState::PreData {
-                                // DROP first for idempotency
-                                result.push(Statement::Other {
-                                    sql: format!(
-                                        "DROP PUBLICATION IF EXISTS \"{}\"",
-                                        crate::util::escape_identifier(&stmt.pubname)
-                                    ),
-                                    idempotent: true,
-                                });
-                                result.push(Statement::Other {
-                                    sql: original.to_string(),
-                                    idempotent: false,
-                                });
-                            }
-                        }
-
-                        NodeEnum::AlterPublicationStmt(_) => {
-                            if state == SyncState::PreData {
-                                result.push(Statement::Other {
-                                    sql: original.to_string(),
-                                    idempotent: false,
-                                });
-                            }
-                        }
-
-                        // Skip these.
-                        NodeEnum::CreateSubscriptionStmt(_)
-                        | NodeEnum::AlterSubscriptionStmt(_) => (),
-
-                        NodeEnum::AlterSeqStmt(stmt) => {
-                            if matches!(state, SyncState::PreData | SyncState::Cutover) {
-                                let sequence = stmt
-                                    .sequence
-                                    .as_ref()
-                                    .map(Table::from)
-                                    .ok_or(Error::MissingEntity)?;
-                                let sequence = Sequence::from(sequence);
-                                let column = stmt.options.first().ok_or(Error::MissingEntity)?;
-                                let column =
-                                    Column::try_from(column).map_err(|_| Error::MissingEntity)?;
-
-                                if state == SyncState::PreData {
-                                    result.push(Statement::SequenceOwner {
-                                        column,
-                                        sequence,
-                                        sql: original,
-                                    });
-                                } else if state == SyncState::Cutover {
-                                    let sql = sequence
-                                        .setval_from_column(&column)
-                                        .map_err(|_| Error::MissingEntity)?;
-                                    result.push(Statement::SequenceSetMax { sequence, sql })
-                                }
-                            }
-                        }
-
-                        NodeEnum::IndexStmt(stmt) => {
-                            if state == SyncState::PostData {
-                                let sql = {
-                                    let mut stmt = stmt.clone();
-                                    stmt.concurrent = stmt
-                                        .relation
-                                        .as_ref()
-                                        .map(|relation| relation.inh) // ONLY used for partitioned tables, which can't be created concurrently.
-                                        .unwrap_or(false);
-                                    stmt.if_not_exists = true;
-                                    deparse_node(NodeEnum::IndexStmt(stmt))?
+                        // Convert integer PK/FK columns to bigint
+                        for elt in &mut stmt.table_elts {
+                            if let Some(NodeEnum::ColumnDef(ref mut col_def)) = elt.node {
+                                let col = Column {
+                                    name: col_def.colname.as_str(),
+                                    table: Some(table_name),
+                                    schema: Some(schema),
                                 };
 
-                                let table =
-                                    stmt.relation.as_ref().map(Table::from).unwrap_or_default();
-
-                                let index_schema =
-                                    stmt.relation.as_ref().map(schema_name).unwrap_or("public");
-                                result.push(Statement::Other {
-                                    sql: format!(
-                                        "DROP INDEX IF EXISTS \"{}\".\"{}\"",
-                                        index_schema, stmt.idxname
-                                    ),
-                                    idempotent: true,
-                                });
-
-                                result.push(Statement::Index {
-                                    table,
-                                    name: stmt.idxname.as_str(),
-                                    sql,
-                                });
+                                if should_convert_to_bigint(
+                                    &col,
+                                    col_def.type_name.as_ref(),
+                                    &columns_to_convert,
+                                    parent_table,
+                                    &parent_column_types,
+                                ) && let Some(ref mut type_name) = col_def.type_name
+                                {
+                                    type_name.names = vec![
+                                        Node {
+                                            node: Some(NodeEnum::String(PgString {
+                                                sval: "pg_catalog".to_owned(),
+                                            })),
+                                        },
+                                        Node {
+                                            node: Some(NodeEnum::String(PgString {
+                                                sval: "int8".to_owned(),
+                                            })),
+                                        },
+                                    ];
+                                }
                             }
                         }
 
-                        NodeEnum::ViewStmt(stmt) => {
-                            let mut stmt = stmt.clone();
-                            stmt.replace = true;
+                        if state == SyncState::PreData {
+                            let sql = deparse_node(NodeEnum::CreateStmt(stmt))?;
+                            result.push(Statement::Table { table, sql });
+                        }
+                    }
+
+                    NodeEnum::CreateSeqStmt(stmt) => {
+                        let mut stmt = stmt.clone();
+                        stmt.if_not_exists = true;
+                        let sql = deparse_node(NodeEnum::CreateSeqStmt(stmt))?;
+                        if state == SyncState::PreData {
+                            // Bring sequences over.
+                            result.push(sql.into());
+                        }
+                    }
+
+                    NodeEnum::CreateExtensionStmt(stmt) => {
+                        let mut stmt = stmt.clone();
+                        stmt.if_not_exists = true;
+                        let sql = deparse_node(NodeEnum::CreateExtensionStmt(stmt))?;
+                        if state == SyncState::PreData {
+                            result.push(sql.into());
+                        }
+                    }
+
+                    NodeEnum::CreateSchemaStmt(stmt) => {
+                        let mut stmt = stmt.clone();
+                        stmt.if_not_exists = true;
+                        let sql = deparse_node(NodeEnum::CreateSchemaStmt(stmt))?;
+                        if state == SyncState::PreData {
+                            result.push(sql.into());
+                        }
+                    }
+
+                    NodeEnum::AlterTableStmt(stmt) => {
+                        for cmd in &stmt.cmds {
+                            if let Some(NodeEnum::AlterTableCmd(ref cmd)) = cmd.node {
+                                match cmd.subtype() {
+                                    AlterTableType::AtAddConstraint => {
+                                        if let Some(ref def) = cmd.def
+                                            && let Some(NodeEnum::Constraint(ref cons)) = def.node
+                                        {
+                                            // Only allow primary key constraints.
+                                            if matches!(
+                                                cons.contype(),
+                                                ConstrType::ConstrPrimary
+                                                    | ConstrType::ConstrNotnull
+                                                    | ConstrType::ConstrNull
+                                            ) {
+                                                // Integer PKs are already tracked and converted
+                                                // to bigint in CreateStmt handler
+                                                if state == SyncState::PreData {
+                                                    result.push(Statement::Other {
+                                                        sql: original.to_string(),
+                                                        idempotent: false,
+                                                    });
+                                                }
+                                            } else if cons.contype() == ConstrType::ConstrForeign {
+                                                // FK columns referencing integer PKs are
+                                                // computed from fk_columns at the end
+                                                if state == SyncState::PostData {
+                                                    result.push(Statement::Other {
+                                                        sql: original.to_string(),
+                                                        idempotent: false,
+                                                    });
+                                                }
+                                            } else if state == SyncState::PostData {
+                                                result.push(Statement::Other {
+                                                    sql: original.to_string(),
+                                                    idempotent: false,
+                                                });
+                                            }
+                                        }
+                                    }
+                                    AlterTableType::AtAttachPartition => {
+                                        match stmt.objtype() {
+                                            // Index partitions need to be attached to indexes,
+                                            // which we create in the post-data step.
+                                            ObjectType::ObjectIndex => {
+                                                if state == SyncState::PostData {
+                                                    result.push(Statement::Other {
+                                                        sql: original.to_string(),
+                                                        idempotent: false,
+                                                    });
+                                                }
+                                            }
+
+                                            // Table partitions are attached in pre-data
+                                            // after the partition tables are created.
+                                            ObjectType::ObjectTable => {
+                                                if state == SyncState::PreData {
+                                                    result.push(Statement::Other {
+                                                        sql: original.to_string(),
+                                                        idempotent: false,
+                                                    });
+                                                }
+                                            }
+
+                                            _ => {
+                                                if state == SyncState::PreData {
+                                                    result.push(Statement::Other {
+                                                        sql: original.to_string(),
+                                                        idempotent: false,
+                                                    });
+                                                }
+                                            }
+                                        }
+                                    }
+
+                                    AlterTableType::AtColumnDefault => {
+                                        if state == SyncState::PreData {
+                                            result.push(original.into())
+                                        }
+                                    }
+
+                                    AlterTableType::AtAddIdentity => (),
+                                    // AlterTableType::AtChangeOwner => {
+                                    //     continue; // Don't change owners, for now.
+                                    // }
+                                    _ => {
+                                        if state == SyncState::PreData {
+                                            result.push(original.into());
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    NodeEnum::CreateTrigStmt(stmt) => {
+                        let mut stmt = stmt.clone();
+                        stmt.replace = true;
+
+                        if state == SyncState::PreData {
+                            result.push(deparse_node(NodeEnum::CreateTrigStmt(stmt))?.into());
+                        }
+                    }
+
+                    NodeEnum::CreatePublicationStmt(stmt) => {
+                        if state == SyncState::PreData {
+                            // DROP first for idempotency
+                            result.push(Statement::Other {
+                                sql: format!(
+                                    "DROP PUBLICATION IF EXISTS \"{}\"",
+                                    crate::util::escape_identifier(&stmt.pubname)
+                                ),
+                                idempotent: true,
+                            });
+                            result.push(Statement::Other {
+                                sql: original.to_string(),
+                                idempotent: false,
+                            });
+                        }
+                    }
+
+                    NodeEnum::AlterPublicationStmt(_) => {
+                        if state == SyncState::PreData {
+                            result.push(Statement::Other {
+                                sql: original.to_string(),
+                                idempotent: false,
+                            });
+                        }
+                    }
+
+                    // Skip these.
+                    NodeEnum::CreateSubscriptionStmt(_) | NodeEnum::AlterSubscriptionStmt(_) => (),
+
+                    NodeEnum::AlterSeqStmt(stmt) => {
+                        if matches!(state, SyncState::PreData | SyncState::Cutover) {
+                            let sequence = stmt
+                                .sequence
+                                .as_ref()
+                                .map(Table::from)
+                                .ok_or(Error::MissingEntity)?;
+                            let sequence = Sequence::from(sequence);
+                            let column = stmt.options.first().ok_or(Error::MissingEntity)?;
+                            let column =
+                                Column::try_from(column).map_err(|_| Error::MissingEntity)?;
 
                             if state == SyncState::PreData {
-                                result.push(Statement::Other {
-                                    sql: deparse_node(NodeEnum::ViewStmt(stmt))?,
-                                    idempotent: true,
+                                result.push(Statement::SequenceOwner {
+                                    column,
+                                    sequence,
+                                    sql: original,
                                 });
+                            } else if state == SyncState::Cutover {
+                                let sql = sequence
+                                    .setval_from_column(&column)
+                                    .map_err(|_| Error::MissingEntity)?;
+                                result.push(Statement::SequenceSetMax { sequence, sql })
                             }
                         }
+                    }
 
-                        NodeEnum::CreateTableAsStmt(stmt) => {
-                            let mut stmt = stmt.clone();
-                            stmt.if_not_exists = true;
+                    NodeEnum::IndexStmt(stmt) => {
+                        if state == SyncState::PostData {
+                            let sql = {
+                                let mut stmt = stmt.clone();
+                                stmt.concurrent = stmt
+                                    .relation
+                                    .as_ref()
+                                    .map(|relation| relation.inh) // ONLY used for partitioned tables, which can't be created concurrently.
+                                    .unwrap_or(false);
+                                stmt.if_not_exists = true;
+                                deparse_node(NodeEnum::IndexStmt(stmt))?
+                            };
 
-                            if state == SyncState::PreData {
-                                result.push(Statement::Other {
-                                    sql: deparse_node(NodeEnum::CreateTableAsStmt(stmt))?,
-                                    idempotent: true,
-                                });
-                            }
+                            let table = stmt.relation.as_ref().map(Table::from).unwrap_or_default();
+
+                            let index_schema =
+                                stmt.relation.as_ref().map(schema_name).unwrap_or("public");
+                            result.push(Statement::Other {
+                                sql: format!(
+                                    "DROP INDEX IF EXISTS \"{}\".\"{}\"",
+                                    index_schema, stmt.idxname
+                                ),
+                                idempotent: true,
+                            });
+
+                            result.push(Statement::Index {
+                                table,
+                                name: stmt.idxname.as_str(),
+                                sql,
+                            });
                         }
+                    }
 
-                        NodeEnum::CreateFunctionStmt(stmt) => {
-                            let mut stmt = stmt.clone();
-                            stmt.replace = true;
+                    NodeEnum::ViewStmt(stmt) => {
+                        let mut stmt = stmt.clone();
+                        stmt.replace = true;
 
-                            if state == SyncState::PreData {
-                                result.push(Statement::Other {
-                                    sql: deparse_node(NodeEnum::CreateFunctionStmt(stmt))?,
-                                    idempotent: true,
-                                });
-                            }
+                        if state == SyncState::PreData {
+                            result.push(Statement::Other {
+                                sql: deparse_node(NodeEnum::ViewStmt(stmt))?,
+                                idempotent: true,
+                            });
                         }
+                    }
 
-                        NodeEnum::AlterOwnerStmt(stmt) => {
-                            if stmt.object_type() != ObjectType::ObjectPublication
-                                && state == SyncState::PreData
-                            {
-                                result.push(Statement::Other {
-                                    sql: original.to_string(),
-                                    idempotent: true,
-                                });
-                            }
+                    NodeEnum::CreateTableAsStmt(stmt) => {
+                        let mut stmt = stmt.clone();
+                        stmt.if_not_exists = true;
+
+                        if state == SyncState::PreData {
+                            result.push(Statement::Other {
+                                sql: deparse_node(NodeEnum::CreateTableAsStmt(stmt))?,
+                                idempotent: true,
+                            });
                         }
+                    }
 
-                        NodeEnum::CreateEnumStmt(_)
-                        | NodeEnum::CreateDomainStmt(_)
-                        | NodeEnum::CompositeTypeStmt(_) => {
-                            if state == SyncState::PreData {
-                                result.push(Statement::Other {
-                                    sql: original.to_owned(),
-                                    idempotent: false,
-                                });
-                            }
+                    NodeEnum::CreateFunctionStmt(stmt) => {
+                        let mut stmt = stmt.clone();
+                        stmt.replace = true;
+
+                        if state == SyncState::PreData {
+                            result.push(Statement::Other {
+                                sql: deparse_node(NodeEnum::CreateFunctionStmt(stmt))?,
+                                idempotent: true,
+                            });
                         }
+                    }
 
-                        NodeEnum::VariableSetStmt(_) => continue,
-                        NodeEnum::SelectStmt(_) => continue,
-                        _ => {
-                            if state == SyncState::PreData {
-                                result.push(original.into());
-                            }
+                    NodeEnum::AlterOwnerStmt(stmt) => {
+                        if stmt.object_type() != ObjectType::ObjectPublication
+                            && state == SyncState::PreData
+                        {
+                            result.push(Statement::Other {
+                                sql: original.to_string(),
+                                idempotent: true,
+                            });
+                        }
+                    }
+
+                    NodeEnum::CreateEnumStmt(_)
+                    | NodeEnum::CreateDomainStmt(_)
+                    | NodeEnum::CompositeTypeStmt(_) => {
+                        if state == SyncState::PreData {
+                            result.push(Statement::Other {
+                                sql: original.to_owned(),
+                                idempotent: false,
+                            });
+                        }
+                    }
+
+                    NodeEnum::VariableSetStmt(_) => continue,
+                    NodeEnum::SelectStmt(_) => continue,
+                    _ => {
+                        if state == SyncState::PreData {
+                            result.push(original.into());
                         }
                     }
                 }
@@ -1087,24 +1077,21 @@ impl PgDumpOutput {
                         if let backend::Error::ExecutionError(ref err) = err {
                             let code = &err.code;
 
-                            if let Statement::Other { idempotent, .. } = stmt {
-                                if !idempotent {
-                                    if matches!(
-                                        code.as_str(),
-                                        "42P16" | "42710" | "42809" | "42P07"
-                                    ) {
-                                        warn!("entity already exists, skipping");
-                                        continue;
-                                    } else if !ignore_errors {
-                                        if let Some(ref mut tracker) = tracker {
-                                            tracker.error(err);
-                                        }
-                                        return Err(Error::Backend(
-                                            backend::Error::ExecutionError(err.clone()),
-                                        ));
-                                    } else {
-                                        warn!("skipping: {}", err);
+                            if let Statement::Other { idempotent, .. } = stmt
+                                && !idempotent
+                            {
+                                if matches!(code.as_str(), "42P16" | "42710" | "42809" | "42P07") {
+                                    warn!("entity already exists, skipping");
+                                    continue;
+                                } else if !ignore_errors {
+                                    if let Some(ref mut tracker) = tracker {
+                                        tracker.error(err);
                                     }
+                                    return Err(Error::Backend(backend::Error::ExecutionError(
+                                        err.clone(),
+                                    )));
+                                } else {
+                                    warn!("skipping: {}", err);
                                 }
                             }
                         } else {

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -105,7 +105,7 @@ impl Client {
     /// - `addr`: TCP IP.
     /// - `config`: Currently loaded `pgdog.toml` and `users.toml`.
     /// - `protocol_version`: The version of the PostgreSQL protocol used by the client. This is typically 3.0, but can be 3.2
-    ///                       for more modern clients.
+    ///   for more modern clients.
     ///
     pub async fn spawn(
         stream: Stream,

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -520,13 +520,14 @@ impl Client {
     /// Handle client messages.
     async fn client_messages(&mut self, query_engine: &mut QueryEngine) -> Result<(), Error> {
         // Check maintenance mode.
-        if !self.in_transaction() && !self.admin {
-            if let Some(waiter) = maintenance_mode::waiter(&self.database) {
-                let state = query_engine.get_state();
-                query_engine.set_state(State::Waiting);
-                waiter.await;
-                query_engine.set_state(state);
-            }
+        if !self.in_transaction()
+            && !self.admin
+            && let Some(waiter) = maintenance_mode::waiter(&self.database)
+        {
+            let state = query_engine.get_state();
+            query_engine.set_state(State::Waiting);
+            waiter.await;
+            query_engine.set_state(state);
         }
 
         // If client sent multiple requests, split them up and execute individually.

--- a/pgdog/src/frontend/client/query_engine/advisory_lock.rs
+++ b/pgdog/src/frontend/client/query_engine/advisory_lock.rs
@@ -18,10 +18,10 @@ impl AdvisoryLocks {
                     // pg_advisory_unlock_all() clears every advisory lock.
                     self.locks.clear();
                 }
-            } else if let Some(id) = lock.id {
-                if lock.scope == LockScope::Session {
-                    self.locks.insert(id);
-                }
+            } else if let Some(id) = lock.id
+                && lock.scope == LockScope::Session
+            {
+                self.locks.insert(id);
             }
         }
     }

--- a/pgdog/src/frontend/client/query_engine/mod.rs
+++ b/pgdog/src/frontend/client/query_engine/mod.rs
@@ -153,10 +153,9 @@ impl QueryEngine {
             .route // Admin commands don't have a route.
             .as_mut()
             .and_then(|route| route.take_explain())
+            && config().config.general.expanded_explain
         {
-            if config().config.general.expanded_explain {
-                self.pending_explain = Some(ExplainResponseState::new(trace));
-            }
+            self.pending_explain = Some(ExplainResponseState::new(trace));
         }
 
         match command {

--- a/pgdog/src/frontend/client/query_engine/query.rs
+++ b/pgdog/src/frontend/client/query_engine/query.rs
@@ -130,15 +130,15 @@ impl QueryEngine {
         };
         let has_more_messages = self.backend.has_more_messages();
 
-        if let Some(bytes) = payload {
-            if let Some(state) = self.pending_explain.as_mut() {
-                match RowDescription::from_bytes(bytes) {
-                    Ok(row_description) => {
-                        state.capture_row_description(row_description);
-                    }
-                    _ => {
-                        state.annotated = true;
-                    }
+        if let Some(bytes) = payload
+            && let Some(state) = self.pending_explain.as_mut()
+        {
+            match RowDescription::from_bytes(bytes) {
+                Ok(row_description) => {
+                    state.capture_row_description(row_description);
+                }
+                _ => {
+                    state.annotated = true;
                 }
             }
         }

--- a/pgdog/src/frontend/client/query_engine/two_pc/manager.rs
+++ b/pgdog/src/frontend/client/query_engine/two_pc/manager.rs
@@ -303,10 +303,10 @@ impl Manager {
 
     async fn remove(&self, transaction: &TwoPcTransaction) {
         self.inner.lock().transactions.remove(transaction);
-        if let Some(wal) = self.wal.load_full() {
-            if let Err(err) = wal.append_end(*transaction).await {
-                warn!("[2pc] wal end record failed for {}: {}", transaction, err);
-            }
+        if let Some(wal) = self.wal.load_full()
+            && let Err(err) = wal.append_end(*transaction).await
+        {
+            warn!("[2pc] wal end record failed for {}: {}", transaction, err);
         }
     }
 

--- a/pgdog/src/frontend/client_request.rs
+++ b/pgdog/src/frontend/client_request.rs
@@ -330,10 +330,10 @@ impl ClientRequest {
                 // it if we haven't already. We also don't want to send requests
                 // that contain Flush only since they will get stuck.
                 'H' => {
-                    if let Some(last_message) = current_request.last() {
-                        if last_message.code() != 'H' {
-                            current_request.push(message.clone());
-                        }
+                    if let Some(last_message) = current_request.last()
+                        && last_message.code() != 'H'
+                    {
+                        current_request.push(message.clone());
                     }
                 }
 

--- a/pgdog/src/frontend/error.rs
+++ b/pgdog/src/frontend/error.rs
@@ -101,10 +101,10 @@ impl Error {
     }
 
     pub(crate) fn disconnect(&self) -> bool {
-        if let Error::Net(crate::net::Error::Io(err)) = self {
-            if err.kind() == ErrorKind::UnexpectedEof {
-                return true;
-            }
+        if let Error::Net(crate::net::Error::Io(err)) = self
+            && err.kind() == ErrorKind::UnexpectedEof
+        {
+            return true;
         }
 
         false

--- a/pgdog/src/frontend/logical_transaction.rs
+++ b/pgdog/src/frontend/logical_transaction.rs
@@ -194,10 +194,10 @@ impl LogicalTransaction {
         }
 
         // if we already touched a different shard, error
-        if let Some(d) = &self.dirty_shard {
-            if *d != shard {
-                return Err(TransactionError::ShardConflict);
-            }
+        if let Some(d) = &self.dirty_shard
+            && *d != shard
+        {
+            return Err(TransactionError::ShardConflict);
         }
 
         self.manual_shard = Some(shard);
@@ -218,17 +218,17 @@ impl LogicalTransaction {
         }
 
         // Already pinned to a manual shard → forbid drift.
-        if let Some(hint) = &self.manual_shard {
-            if *hint != shard {
-                return Err(TransactionError::ShardConflict);
-            }
+        if let Some(hint) = &self.manual_shard
+            && *hint != shard
+        {
+            return Err(TransactionError::ShardConflict);
         }
 
         // Already dirtied another shard → forbid drift.
-        if let Some(dirty) = &self.dirty_shard {
-            if *dirty != shard {
-                return Err(TransactionError::ShardConflict);
-            }
+        if let Some(dirty) = &self.dirty_shard
+            && *dirty != shard
+        {
+            return Err(TransactionError::ShardConflict);
         }
 
         // Nothing in conflict; mark the shard.

--- a/pgdog/src/frontend/prepared_statements/global_cache.rs
+++ b/pgdog/src/frontend/prepared_statements/global_cache.rs
@@ -225,10 +225,10 @@ impl GlobalCache {
     /// Client sent a Describe for a prepared statement and received a RowDescription.
     /// We record the RowDescription for later use by the results decoder.
     pub fn insert_row_description(&mut self, name: &str, row_description: &RowDescription) {
-        if let Some(ref mut entry) = self.names.get_mut(name) {
-            if entry.row_description.is_none() {
-                entry.row_description = Some(row_description.clone());
-            }
+        if let Some(ref mut entry) = self.names.get_mut(name)
+            && entry.row_description.is_none()
+        {
+            entry.row_description = Some(row_description.clone());
         }
     }
 
@@ -338,12 +338,12 @@ impl GlobalCache {
 
     /// Decrement usage of prepared statement without removing it.
     pub fn decrement(&mut self, name: &str) {
-        if let Some(stmt) = self.names.get(name) {
-            if let Some(stmt) = self.statements.get_mut(&stmt.cache_key()) {
-                stmt.used = stmt.used.saturating_sub(1);
-                if stmt.used == 0 {
-                    self.unused.insert(stmt.counter);
-                }
+        if let Some(stmt) = self.names.get(name)
+            && let Some(stmt) = self.statements.get_mut(&stmt.cache_key())
+        {
+            stmt.used = stmt.used.saturating_sub(1);
+            if stmt.used == 0 {
+                self.unused.insert(stmt.counter);
             }
         }
     }

--- a/pgdog/src/frontend/query_logger.rs
+++ b/pgdog/src/frontend/query_logger.rs
@@ -23,16 +23,16 @@ impl<'a> QueryLogger<'a> {
     pub async fn log(&self) -> Result<(), Error> {
         let path = &config().config.general.query_log;
 
-        if let Some(path) = path {
-            if let Some(query) = self.buffer.query()? {
-                let mut file = OpenOptions::new()
-                    .append(true)
-                    .create(true)
-                    .open(path)
-                    .await?;
-                let line = format!("{}\n", query.trim());
-                file.write_all(line.as_bytes()).await?;
-            }
+        if let Some(path) = path
+            && let Some(query) = self.buffer.query()?
+        {
+            let mut file = OpenOptions::new()
+                .append(true)
+                .create(true)
+                .open(path)
+                .await?;
+            let line = format!("{}\n", query.trim());
+            file.write_all(line.as_bytes()).await?;
         }
 
         Ok(())

--- a/pgdog/src/frontend/regex_parser.rs
+++ b/pgdog/src/frontend/regex_parser.rs
@@ -67,14 +67,14 @@ impl RegexParser {
         let session_control =
             self.level == QueryParserLevel::SessionControl || self.level == QueryParserLevel::Auto;
 
-        if with_locks || session_control {
-            if let Ok(Some(query)) = request.query() {
-                let prefix = scan_prefix(query.query(), self.limit);
-                if with_locks {
-                    return CMD_RE_ADVISORY.is_match(prefix);
-                } else {
-                    return CMD_RE.is_match(prefix);
-                }
+        if (with_locks || session_control)
+            && let Ok(Some(query)) = request.query()
+        {
+            let prefix = scan_prefix(query.query(), self.limit);
+            if with_locks {
+                return CMD_RE_ADVISORY.is_match(prefix);
+            } else {
+                return CMD_RE.is_match(prefix);
             }
         }
 

--- a/pgdog/src/frontend/router/mod.rs
+++ b/pgdog/src/frontend/router/mod.rs
@@ -63,10 +63,10 @@ impl Router {
         let command = self.query_parser.parse(context)?;
         self.latest_command = command;
 
-        if let Command::Query(ref route) = self.latest_command {
-            if route.is_schema_changed() {
-                self.schema_changed = true;
-            }
+        if let Command::Query(ref route) = self.latest_command
+            && route.is_schema_changed()
+        {
+            self.schema_changed = true;
         }
 
         Ok(&self.latest_command)

--- a/pgdog/src/frontend/router/parameter_hints.rs
+++ b/pgdog/src/frontend/router/parameter_hints.rs
@@ -45,12 +45,12 @@ impl ParameterHints<'_> {
             self.hooks.record_set_shard(&shard);
             shards.push(ShardWithPriority::new_set(shard));
         }
-        if let Some(ParameterValue::String(val)) = self.pgdog_shard {
-            if let Ok(shard) = val.parse() {
-                let shard = Shard::Direct(shard);
-                self.hooks.record_set_shard(&shard);
-                shards.push(ShardWithPriority::new_set(shard));
-            }
+        if let Some(ParameterValue::String(val)) = self.pgdog_shard
+            && let Ok(shard) = val.parse()
+        {
+            let shard = Shard::Direct(shard);
+            self.hooks.record_set_shard(&shard);
+            shards.push(ShardWithPriority::new_set(shard));
         }
         if let Some(ParameterValue::String(val)) = self.pgdog_sharding_key {
             if sharding_schema.schemas.is_empty() {

--- a/pgdog/src/frontend/router/parser/aggregate.rs
+++ b/pgdog/src/frontend/router/parser/aggregate.rs
@@ -58,7 +58,7 @@ impl fmt::Display for AggregateFunction {
             AggregateFunction::StddevSamp => write!(f, "stddev_samp"),
             AggregateFunction::VarPop => write!(f, "var_pop"),
             AggregateFunction::VarSamp => write!(f, "var_samp"),
-            AggregateFunction::Unrecognized(s) => f.write_str(&*s),
+            AggregateFunction::Unrecognized(s) => f.write_str(s),
         }
     }
 }
@@ -73,33 +73,33 @@ fn target_list_to_index(stmt: &SelectStmt, column_names: Vec<&String>) -> Option
     for (idx, node) in stmt.target_list.iter().enumerate() {
         if let Some(NodeEnum::ResTarget(res_target_box)) = node.node.as_ref() {
             let res_target = res_target_box.as_ref();
-            if let Some(node_box) = res_target.val.as_ref() {
-                if let Some(NodeEnum::ColumnRef(column_ref)) = node_box.node.as_ref() {
-                    let select_names: Vec<&String> = column_ref
-                        .fields
-                        .iter()
-                        .filter_map(|field_node| {
-                            if let Some(node_box) = field_node.node.as_ref() {
-                                match node_box {
-                                    NodeEnum::String(PgQueryString {
-                                        sval: found_column_name,
-                                        ..
-                                    }) => Some(found_column_name),
-                                    _ => None,
-                                }
-                            } else {
-                                None
+            if let Some(node_box) = res_target.val.as_ref()
+                && let Some(NodeEnum::ColumnRef(column_ref)) = node_box.node.as_ref()
+            {
+                let select_names: Vec<&String> = column_ref
+                    .fields
+                    .iter()
+                    .filter_map(|field_node| {
+                        if let Some(node_box) = field_node.node.as_ref() {
+                            match node_box {
+                                NodeEnum::String(PgQueryString {
+                                    sval: found_column_name,
+                                    ..
+                                }) => Some(found_column_name),
+                                _ => None,
                             }
-                        })
-                        .collect();
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
 
-                    if select_names.is_empty() {
-                        continue;
-                    }
+                if select_names.is_empty() {
+                    continue;
+                }
 
-                    if columns_match(&column_names, &select_names) {
-                        return Some(idx);
-                    }
+                if columns_match(&column_names, &select_names) {
+                    return Some(idx);
                 }
             }
         }
@@ -159,49 +159,48 @@ impl Aggregate {
             .collect::<Vec<_>>();
 
         for (idx, node) in stmt.target_list.iter().enumerate() {
-            if let Some(NodeEnum::ResTarget(res)) = &node.node {
-                if let Some(node) = &res.val {
-                    if let Ok(func) = Function::try_from(node.as_ref()) {
-                        let function = match func.name {
-                            "count" => Some(AggregateFunction::Count),
-                            "max" => Some(AggregateFunction::Max),
-                            "min" => Some(AggregateFunction::Min),
-                            "sum" => Some(AggregateFunction::Sum),
-                            "avg" => Some(AggregateFunction::Avg),
-                            "stddev" | "stddev_samp" => Some(AggregateFunction::StddevSamp),
-                            "stddev_pop" => Some(AggregateFunction::StddevPop),
-                            "variance" | "var_samp" => Some(AggregateFunction::VarSamp),
-                            "var_pop" => Some(AggregateFunction::VarPop),
-                            fname => {
-                                if schema.aggregate_functions.contains(fname) {
-                                    Some(AggregateFunction::Unrecognized(fname.to_owned()))
-                                } else {
-                                    None
-                                }
-                            }
-                        };
-
-                        if let Some(function) = function {
-                            let (expr_id, distinct) = match node.node.as_ref() {
-                                Some(NodeEnum::FuncCall(func)) => {
-                                    let arg_id = func
-                                        .args
-                                        .first()
-                                        .map(|arg| registry.intern(arg))
-                                        .unwrap_or_else(|| registry.intern(node.as_ref()));
-                                    (arg_id, func.agg_distinct)
-                                }
-                                _ => (registry.intern(node.as_ref()), false),
-                            };
-
-                            targets.push(AggregateTarget {
-                                column: idx,
-                                function,
-                                expr_id,
-                                distinct,
-                            });
+            if let Some(NodeEnum::ResTarget(res)) = &node.node
+                && let Some(node) = &res.val
+                && let Ok(func) = Function::try_from(node.as_ref())
+            {
+                let function = match func.name {
+                    "count" => Some(AggregateFunction::Count),
+                    "max" => Some(AggregateFunction::Max),
+                    "min" => Some(AggregateFunction::Min),
+                    "sum" => Some(AggregateFunction::Sum),
+                    "avg" => Some(AggregateFunction::Avg),
+                    "stddev" | "stddev_samp" => Some(AggregateFunction::StddevSamp),
+                    "stddev_pop" => Some(AggregateFunction::StddevPop),
+                    "variance" | "var_samp" => Some(AggregateFunction::VarSamp),
+                    "var_pop" => Some(AggregateFunction::VarPop),
+                    fname => {
+                        if schema.aggregate_functions.contains(fname) {
+                            Some(AggregateFunction::Unrecognized(fname.to_owned()))
+                        } else {
+                            None
                         }
                     }
+                };
+
+                if let Some(function) = function {
+                    let (expr_id, distinct) = match node.node.as_ref() {
+                        Some(NodeEnum::FuncCall(func)) => {
+                            let arg_id = func
+                                .args
+                                .first()
+                                .map(|arg| registry.intern(arg))
+                                .unwrap_or_else(|| registry.intern(node.as_ref()));
+                            (arg_id, func.agg_distinct)
+                        }
+                        _ => (registry.intern(node.as_ref()), false),
+                    };
+
+                    targets.push(AggregateTarget {
+                        column: idx,
+                        function,
+                        expr_id,
+                        distinct,
+                    });
                 }
             }
         }

--- a/pgdog/src/frontend/router/parser/cache/ast.rs
+++ b/pgdog/src/frontend/router/parser/cache/ast.rs
@@ -106,14 +106,14 @@ impl Ast {
         let mut stats = Stats::new();
         stats.parse_time += elapsed;
 
-        if let Some(threshold) = schema.log_min_duration_parse {
-            if elapsed >= threshold {
-                warn!(
-                    "[slow_query_parse] parse_time_in_ms={}ms truncated_query=\"{}\"",
-                    elapsed.as_millis(),
-                    query.truncated_query(schema.log_query_sample_length),
-                );
-            }
+        if let Some(threshold) = schema.log_min_duration_parse
+            && elapsed >= threshold
+        {
+            warn!(
+                "[slow_query_parse] parse_time_in_ms={}ms truncated_query=\"{}\"",
+                elapsed.as_millis(),
+                query.truncated_query(schema.log_query_sample_length),
+            );
         }
 
         Ok(Self {
@@ -203,10 +203,10 @@ impl Ast {
 
                 NodeRef::DropStmt(stmt) if stmt.remove_type() == ObjectType::ObjectTable => {
                     for object in &stmt.objects {
-                        if let Some(NodeEnum::List(ref list)) = object.node {
-                            if let Ok(table) = Table::try_from(list) {
-                                tables.insert(table);
-                            }
+                        if let Some(NodeEnum::List(ref list)) = object.node
+                            && let Ok(table) = Table::try_from(list)
+                        {
+                            tables.insert(table);
                         }
                     }
                 }

--- a/pgdog/src/frontend/router/parser/comment/directive.rs
+++ b/pgdog/src/frontend/router/parser/comment/directive.rs
@@ -29,40 +29,40 @@ pub(super) fn shard_role_from_comment(
 ) -> Result<(Option<Shard>, Option<Role>), Error> {
     let mut role = None;
 
-    if let Some(cap) = ROLE.captures(comment) {
-        if let Some(r) = cap.get(1) {
-            match r.as_str() {
-                "primary" => role = Some(Role::Primary),
-                "replica" => role = Some(Role::Replica),
-                _ => return Err(Error::RegexError),
-            }
+    if let Some(cap) = ROLE.captures(comment)
+        && let Some(r) = cap.get(1)
+    {
+        match r.as_str() {
+            "primary" => role = Some(Role::Primary),
+            "replica" => role = Some(Role::Replica),
+            _ => return Err(Error::RegexError),
         }
     }
-    if let Some(cap) = SHARDING_KEY.captures(comment) {
-        if let Some(sharding_key) = get_matched_value(&cap) {
-            if let Some(schema) = schema.schemas.get(Some(sharding_key.into())) {
-                return Ok((Some(schema.shard().into()), role));
-            }
-            let ctx = ContextBuilder::infer_from_from_and_config(sharding_key, schema)?
-                .shards(schema.shards)
-                .build()?;
-            return Ok((Some(ctx.apply()?), role));
+    if let Some(cap) = SHARDING_KEY.captures(comment)
+        && let Some(sharding_key) = get_matched_value(&cap)
+    {
+        if let Some(schema) = schema.schemas.get(Some(sharding_key.into())) {
+            return Ok((Some(schema.shard().into()), role));
         }
+        let ctx = ContextBuilder::infer_from_from_and_config(sharding_key, schema)?
+            .shards(schema.shards)
+            .build()?;
+        return Ok((Some(ctx.apply()?), role));
     }
-    if let Some(cap) = SHARD.captures(comment) {
-        if let Some(shard) = cap.get(1) {
-            return Ok((
-                Some(
-                    shard
-                        .as_str()
-                        .parse::<usize>()
-                        .ok()
-                        .map(Shard::Direct)
-                        .unwrap_or(Shard::All),
-                ),
-                role,
-            ));
-        }
+    if let Some(cap) = SHARD.captures(comment)
+        && let Some(shard) = cap.get(1)
+    {
+        return Ok((
+            Some(
+                shard
+                    .as_str()
+                    .parse::<usize>()
+                    .ok()
+                    .map(Shard::Direct)
+                    .unwrap_or(Shard::All),
+            ),
+            role,
+        ));
     }
 
     Ok((None, role))

--- a/pgdog/src/frontend/router/parser/comment/strip.rs
+++ b/pgdog/src/frontend/router/parser/comment/strip.rs
@@ -63,7 +63,7 @@ pub(super) fn trailing_block_comment(q: &str) -> Option<(&str, &str)> {
         };
         // If the body contains `*/`, the trailing `*/` pairs with an earlier
         // `/*` we can't see from here — stop.
-        if memmem::find(inner[s + start.len()..].as_bytes(), end.as_bytes()).is_some() {
+        if memmem::find(&inner.as_bytes()[s + start.len()..], end.as_bytes()).is_some() {
             break;
         }
         first_start = Some(s);

--- a/pgdog/src/frontend/router/parser/copy.rs
+++ b/pgdog/src/frontend/router/parser/copy.rs
@@ -133,31 +133,30 @@ impl CopyParser {
                 if let Some(NodeEnum::DefElem(ref elem)) = option.node {
                     match elem.defname.to_lowercase().as_str() {
                         "format" => {
-                            if let Some(ref arg) = elem.arg {
-                                if let Some(NodeEnum::String(ref string)) = arg.node {
-                                    match string.sval.to_lowercase().as_str() {
-                                        "binary" => {
-                                            parser.headers = true;
-                                            format = CopyFormat::Binary;
-                                        }
-                                        "csv" => {
-                                            if parser.delimiter.is_none() {
-                                                parser.delimiter = Some(',');
-                                            }
-                                            format = CopyFormat::Csv;
-                                        }
-                                        _ => (),
+                            if let Some(ref arg) = elem.arg
+                                && let Some(NodeEnum::String(ref string)) = arg.node
+                            {
+                                match string.sval.to_lowercase().as_str() {
+                                    "binary" => {
+                                        parser.headers = true;
+                                        format = CopyFormat::Binary;
                                     }
+                                    "csv" => {
+                                        if parser.delimiter.is_none() {
+                                            parser.delimiter = Some(',');
+                                        }
+                                        format = CopyFormat::Csv;
+                                    }
+                                    _ => (),
                                 }
                             }
                         }
 
                         "delimiter" => {
-                            if let Some(ref arg) = elem.arg {
-                                if let Some(NodeEnum::String(ref string)) = arg.node {
-                                    parser.delimiter =
-                                        Some(string.sval.chars().next().unwrap_or(','));
-                                }
+                            if let Some(ref arg) = elem.arg
+                                && let Some(NodeEnum::String(ref string)) = arg.node
+                            {
+                                parser.delimiter = Some(string.sval.chars().next().unwrap_or(','));
                             }
                         }
 
@@ -166,10 +165,10 @@ impl CopyParser {
                         }
 
                         "null" => {
-                            if let Some(ref arg) = elem.arg {
-                                if let Some(NodeEnum::String(ref string)) = arg.node {
-                                    null_string = string.sval.clone();
-                                }
+                            if let Some(ref arg) = elem.arg
+                                && let Some(NodeEnum::String(ref string)) = arg.node
+                            {
+                                null_string = string.sval.clone();
                             }
                         }
 
@@ -259,14 +258,14 @@ impl CopyParser {
                 }
 
                 CopyStream::Binary(stream) => {
-                    if self.headers {
-                        if let Some(header) = stream.header()? {
-                            rows.push(CopyRow::new(
-                                &header.to_bytes(),
-                                self.schema_shard.clone().unwrap_or(Shard::All),
-                            ));
-                            self.headers = false;
-                        }
+                    if self.headers
+                        && let Some(header) = stream.header()?
+                    {
+                        rows.push(CopyRow::new(
+                            &header.to_bytes(),
+                            self.schema_shard.clone().unwrap_or(Shard::All),
+                        ));
+                        self.headers = false;
                     }
 
                     for tuple in stream.tuples() {

--- a/pgdog/src/frontend/router/parser/from_clause.rs
+++ b/pgdog/src/frontend/router/parser/from_clause.rs
@@ -18,10 +18,10 @@ impl<'a> FromClause<'a> {
     /// If no alias is specified, the table name is returned as-is.
     pub fn resolve_alias(&'a self, name: &'a str) -> Option<&'a str> {
         for node in self.nodes {
-            if let Some(ref node) = node.node {
-                if let Some(name) = Self::resolve(name, node) {
-                    return Some(name);
-                }
+            if let Some(ref node) = node.node
+                && let Some(name) = Self::resolve(name, node)
+            {
+                return Some(name);
             }
         }
 
@@ -32,10 +32,10 @@ impl<'a> FromClause<'a> {
         match node {
             NodeEnum::JoinExpr(join) => {
                 for arg in [&join.larg, &join.rarg].into_iter().flatten() {
-                    if let Some(ref node) = arg.node {
-                        if let Some(name) = Self::resolve(name, node) {
-                            return Some(name);
-                        }
+                    if let Some(ref node) = arg.node
+                        && let Some(name) = Self::resolve(name, node)
+                    {
+                        return Some(name);
                     }
                 }
             }
@@ -55,11 +55,11 @@ impl<'a> FromClause<'a> {
 
     /// Get table name if the FROM clause contains only one table.
     pub fn table_name(&'a self) -> Option<&'a str> {
-        if let Some(node) = self.nodes.first() {
-            if let Some(NodeEnum::RangeVar(ref range_var)) = node.node {
-                let table = Table::from(range_var);
-                return Some(table.name);
-            }
+        if let Some(node) = self.nodes.first()
+            && let Some(NodeEnum::RangeVar(ref range_var)) = node.node
+        {
+            let table = Table::from(range_var);
+            return Some(table.name);
         }
 
         None

--- a/pgdog/src/frontend/router/parser/query/ddl.rs
+++ b/pgdog/src/frontend/router/parser/query/ddl.rs
@@ -268,7 +268,7 @@ mod test {
     }
 
     fn parse_stmt(query: &str) -> Option<NodeEnum> {
-        let root = parse(query)
+        parse(query)
             .unwrap()
             .protobuf
             .stmts
@@ -277,8 +277,7 @@ mod test {
             .clone()
             .stmt
             .unwrap()
-            .node;
-        root
+            .node
     }
 
     #[test]

--- a/pgdog/src/frontend/router/parser/query/ddl.rs
+++ b/pgdog/src/frontend/router/parser/query/ddl.rs
@@ -42,10 +42,10 @@ impl QueryParser {
                 | ObjectType::ObjectView
                 | ObjectType::ObjectSequence => {
                     let table = Table::try_from(&stmt.objects).ok();
-                    if let Some(table) = table {
-                        if let Some(schema) = schema.schemas.get(table.schema()) {
-                            shard = schema.shard().into();
-                        }
+                    if let Some(table) = table
+                        && let Some(schema) = schema.schemas.get(table.schema())
+                    {
+                        shard = schema.shard().into();
                     }
                     schema_changed = true;
                 }
@@ -54,11 +54,9 @@ impl QueryParser {
                     if let Some(Node {
                         node: Some(NodeEnum::String(string)),
                     }) = stmt.objects.first()
+                        && let Some(schema) = schema.schemas.get(Some(string.sval.as_str().into()))
                     {
-                        if let Some(schema) = schema.schemas.get(Some(string.sval.as_str().into()))
-                        {
-                            shard = schema.shard().into();
-                        }
+                        shard = schema.shard().into();
                     }
                 }
 
@@ -127,15 +125,15 @@ impl QueryParser {
             }
 
             Some(NodeEnum::LockStmt(stmt)) => {
-                if let Some(node) = stmt.relations.first() {
-                    if let Some(NodeEnum::RangeVar(ref table)) = node.node {
-                        let table = Table::from(table);
-                        shard = schema
-                            .schemas
-                            .get(table.schema())
-                            .map(|schema| schema.shard().into())
-                            .unwrap_or(Shard::All);
-                    }
+                if let Some(node) = stmt.relations.first()
+                    && let Some(NodeEnum::RangeVar(ref table)) = node.node
+                {
+                    let table = Table::from(table);
+                    shard = schema
+                        .schemas
+                        .get(table.schema())
+                        .map(|schema| schema.shard().into())
+                        .unwrap_or(Shard::All);
                 }
             }
 
@@ -154,43 +152,36 @@ impl QueryParser {
 
             // DO $$ BEGIN ... END
             Some(NodeEnum::DoStmt(stmt)) => {
-                if let Some(inner) = stmt.args.first() {
-                    if let Some(NodeEnum::DefElem(ref elem)) = inner.node {
-                        if let Some(ref arg) = elem.arg {
-                            if let Some(NodeEnum::String(ref string)) = arg.node {
-                                // Parse each statement individually.
-                                // The first DDL statement to return a direct shard will be used.
-                                // TODO: handle non-DDL statements in here as well,
-                                // need a full recursive call back to QueryParser::query basically, but that requires a refactor.
-                                for stmt in string.sval.lines() {
-                                    if let Ok(stmt) = parse(stmt) {
-                                        if let Some(node) = stmt
-                                            .protobuf
-                                            .stmts
-                                            .first()
-                                            .map(|stmt| &stmt.stmt)
-                                            .cloned()
-                                            .flatten()
-                                        {
-                                            // Use a fresh calculator for each inner statement
-                                            // to avoid pollution from statements that don't match
-                                            // any DDL pattern (like BEGIN, END, etc.)
-                                            let mut inner_calculator =
-                                                ShardsWithPriority::default();
-                                            let command = Self::shard_ddl(
-                                                &node.node,
-                                                schema,
-                                                &mut inner_calculator,
-                                            )?;
-                                            if let Command::Query(query) = command {
-                                                if !query.is_cross_shard() {
-                                                    shard = query.shard().clone();
-                                                    break;
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
+                if let Some(inner) = stmt.args.first()
+                    && let Some(NodeEnum::DefElem(ref elem)) = inner.node
+                    && let Some(ref arg) = elem.arg
+                    && let Some(NodeEnum::String(ref string)) = arg.node
+                {
+                    // Parse each statement individually.
+                    // The first DDL statement to return a direct shard will be used.
+                    // TODO: handle non-DDL statements in here as well,
+                    // need a full recursive call back to QueryParser::query basically, but that requires a refactor.
+                    for stmt in string.sval.lines() {
+                        if let Ok(stmt) = parse(stmt)
+                            && let Some(node) = stmt
+                                .protobuf
+                                .stmts
+                                .first()
+                                .map(|stmt| &stmt.stmt)
+                                .cloned()
+                                .flatten()
+                        {
+                            // Use a fresh calculator for each inner statement
+                            // to avoid pollution from statements that don't match
+                            // any DDL pattern (like BEGIN, END, etc.)
+                            let mut inner_calculator = ShardsWithPriority::default();
+                            let command =
+                                Self::shard_ddl(&node.node, schema, &mut inner_calculator)?;
+                            if let Command::Query(query) = command
+                                && !query.is_cross_shard()
+                            {
+                                shard = query.shard().clone();
+                                break;
                             }
                         }
                     }
@@ -234,10 +225,10 @@ impl QueryParser {
         schema: &ShardingSchema,
     ) -> Result<Option<Shard>, Error> {
         let table = range_var.as_ref().map(Table::from);
-        if let Some(table) = table {
-            if let Some(sharded_schema) = schema.schemas.get(table.schema()) {
-                return Ok(Some(sharded_schema.shard().into()));
-            }
+        if let Some(table) = table
+            && let Some(sharded_schema) = schema.schemas.get(table.schema())
+        {
+            return Ok(Some(sharded_schema.shard().into()));
         }
 
         Ok(None)

--- a/pgdog/src/frontend/router/parser/query/mod.rs
+++ b/pgdog/src/frontend/router/parser/query/mod.rs
@@ -77,12 +77,11 @@ impl QueryParser {
             return;
         }
 
-        if let Some(root) = ast.protobuf.stmts.first() {
-            if let Some(node) = root.stmt.as_ref().and_then(|stmt| stmt.node.as_ref()) {
-                if matches!(node, NodeEnum::ExplainStmt(_)) {
-                    self.explain_recorder = Some(ExplainRecorder::new());
-                }
-            }
+        if let Some(root) = ast.protobuf.stmts.first()
+            && let Some(node) = root.stmt.as_ref().and_then(|stmt| stmt.node.as_ref())
+            && matches!(node, NodeEnum::ExplainStmt(_))
+        {
+            self.explain_recorder = Some(ExplainRecorder::new());
         }
     }
 
@@ -254,10 +253,10 @@ impl QueryParser {
         let stmts = &statement.parse_result().protobuf.stmts;
 
         // Handle multi-statement SET commands (e.g. "SET x TO 1; SET y TO 2").
-        if stmts.len() > 1 {
-            if let Some(command) = self.try_multi_set(stmts, context)? {
-                return Ok(command);
-            }
+        if stmts.len() > 1
+            && let Some(command) = self.try_multi_set(stmts, context)?
+        {
+            return Ok(command);
         }
 
         //
@@ -350,24 +349,24 @@ impl QueryParser {
         }?;
 
         // e.g. Parse, Describe, Flush-style flow.
-        if !context.router_context.executable {
-            if let Command::Query(ref query) = command {
-                if query.is_cross_shard() && statement.rewrite_plan.insert_split.is_empty() {
-                    context
-                        .shards_calculator
-                        .push(ShardWithPriority::new_rr_not_executable(Shard::Direct(
-                            round_robin::next() % context.shards,
-                        )));
+        if !context.router_context.executable
+            && let Command::Query(ref query) = command
+            && query.is_cross_shard()
+            && statement.rewrite_plan.insert_split.is_empty()
+        {
+            context
+                .shards_calculator
+                .push(ShardWithPriority::new_rr_not_executable(Shard::Direct(
+                    round_robin::next() % context.shards,
+                )));
 
-                    // Since this query isn't executable and we decided
-                    // to route it to any shard, we can early return here.
-                    return Ok(Command::Query(
-                        query
-                            .clone()
-                            .with_shard(context.shards_calculator.shard().clone()),
-                    ));
-                }
-            }
+            // Since this query isn't executable and we decided
+            // to route it to any shard, we can early return here.
+            return Ok(Command::Query(
+                query
+                    .clone()
+                    .with_shard(context.shards_calculator.shard().clone()),
+            ));
         }
 
         // Run plugins, if any.
@@ -409,15 +408,16 @@ impl QueryParser {
         // there is no point of doing a multi-shard query with only one shard
         // in the set.
         //
-        if context.shards == 1 && !context.dry_run {
-            if let Command::Query(ref mut route) = command {
-                context
-                    .shards_calculator
-                    .push(ShardWithPriority::new_override_only_one_shard(
-                        Shard::Direct(0),
-                    ));
-                route.set_shard_mut(context.shards_calculator.shard());
-            }
+        if context.shards == 1
+            && !context.dry_run
+            && let Command::Query(ref mut route) = command
+        {
+            context
+                .shards_calculator
+                .push(ShardWithPriority::new_override_only_one_shard(
+                    Shard::Direct(0),
+                ));
+            route.set_shard_mut(context.shards_calculator.shard());
         }
 
         if let Command::Query(ref mut route) = command {
@@ -478,21 +478,21 @@ impl QueryParser {
         // phase of data-sync.
         //
         let table = stmt.relation.as_ref().map(Table::from);
-        if let Some(table) = table {
-            if let Some(schema) = context.sharding_schema.schemas.get(table.schema()) {
-                let shard: Shard = schema.shard().into();
-                context
-                    .shards_calculator
-                    .push(ShardWithPriority::new_table(shard));
-                if !stmt.is_from {
-                    return Ok(Command::Query(Route::read(
-                        context.shards_calculator.shard(),
-                    )));
-                } else {
-                    return Ok(Command::Query(Route::write(
-                        context.shards_calculator.shard(),
-                    )));
-                }
+        if let Some(table) = table
+            && let Some(schema) = context.sharding_schema.schemas.get(table.schema())
+        {
+            let shard: Shard = schema.shard().into();
+            context
+                .shards_calculator
+                .push(ShardWithPriority::new_table(shard));
+            if !stmt.is_from {
+                return Ok(Command::Query(Route::read(
+                    context.shards_calculator.shard(),
+                )));
+            } else {
+                return Ok(Command::Query(Route::write(
+                    context.shards_calculator.shard(),
+                )));
             }
         }
 

--- a/pgdog/src/frontend/router/parser/query/select.rs
+++ b/pgdog/src/frontend/router/parser/query/select.rs
@@ -277,49 +277,43 @@ impl QueryParser {
                     }
 
                     NodeEnum::AExpr(expr) => {
-                        if expr.kind() == AExprKind::AexprOp {
-                            if let Some(node) = expr.name.first() {
-                                if let Some(NodeEnum::String(String { sval })) = &node.node {
-                                    match sval.as_str() {
-                                        "<->" => {
-                                            let mut vector: Option<Vector> = None;
-                                            let mut column: Option<std::string::String> = None;
+                        if expr.kind() == AExprKind::AexprOp
+                            && let Some(node) = expr.name.first()
+                            && let Some(NodeEnum::String(String { sval })) = &node.node
+                        {
+                            match sval.as_str() {
+                                "<->" => {
+                                    let mut vector: Option<Vector> = None;
+                                    let mut column: Option<std::string::String> = None;
 
-                                            for e in
-                                                [&expr.lexpr, &expr.rexpr].iter().copied().flatten()
-                                            {
-                                                if let Ok(vec) = Value::try_from(&e.node) {
-                                                    match vec {
-                                                        Value::Placeholder(p) => {
-                                                            if let Some(bind) = params {
-                                                                if let Ok(Some(param)) =
-                                                                    bind.parameter((p - 1) as usize)
-                                                                {
-                                                                    vector = param.vector();
-                                                                }
-                                                            }
-                                                        }
-                                                        Value::Vector(vec) => vector = Some(vec),
-                                                        _ => (),
+                                    for e in [&expr.lexpr, &expr.rexpr].iter().copied().flatten() {
+                                        if let Ok(vec) = Value::try_from(&e.node) {
+                                            match vec {
+                                                Value::Placeholder(p) => {
+                                                    if let Some(bind) = params
+                                                        && let Ok(Some(param)) =
+                                                            bind.parameter((p - 1) as usize)
+                                                    {
+                                                        vector = param.vector();
                                                     }
                                                 }
-
-                                                if let Ok(col) = Column::try_from(&e.node) {
-                                                    column = Some(col.name.to_owned());
-                                                }
-                                            }
-
-                                            if let Some(vector) = vector {
-                                                if let Some(column) = column {
-                                                    order_by.push(OrderBy::AscVectorL2Column(
-                                                        column, vector,
-                                                    ));
-                                                }
+                                                Value::Vector(vec) => vector = Some(vec),
+                                                _ => (),
                                             }
                                         }
-                                        _ => continue,
+
+                                        if let Ok(col) = Column::try_from(&e.node) {
+                                            column = Some(col.name.to_owned());
+                                        }
+                                    }
+
+                                    if let Some(vector) = vector
+                                        && let Some(column) = column
+                                    {
+                                        order_by.push(OrderBy::AscVectorL2Column(column, vector));
                                     }
                                 }
+                                _ => continue,
                             }
                         }
                     }
@@ -349,14 +343,13 @@ impl QueryParser {
         // nested inside a WITH clause still routes to the primary.
         if let Some(ref with_clause) = stmt.with_clause {
             for cte in &with_clause.ctes {
-                if let Some(NodeEnum::CommonTableExpr(ref expr)) = cte.node {
-                    if let Some(ref query) = expr.ctequery {
-                        if let Some(NodeEnum::SelectStmt(ref inner)) = query.node {
-                            let behavior = Self::functions(inner)?;
-                            if behavior.writes {
-                                return Ok(behavior);
-                            }
-                        }
+                if let Some(NodeEnum::CommonTableExpr(ref expr)) = cte.node
+                    && let Some(ref query) = expr.ctequery
+                    && let Some(NodeEnum::SelectStmt(ref inner)) = query.node
+                {
+                    let behavior = Self::functions(inner)?;
+                    if behavior.writes {
+                        return Ok(behavior);
                     }
                 }
             }
@@ -374,14 +367,12 @@ impl QueryParser {
 
         if let Some(ref with_clause) = stmt.with_clause {
             for cte in &with_clause.ctes {
-                if let Some(NodeEnum::CommonTableExpr(ref expr)) = cte.node {
-                    if let Some(ref query) = expr.ctequery {
-                        if let Some(NodeEnum::SelectStmt(ref inner)) = query.node {
-                            if Self::has_locking_clause(inner) {
-                                return true;
-                            }
-                        }
-                    }
+                if let Some(NodeEnum::CommonTableExpr(ref expr)) = cte.node
+                    && let Some(ref query) = expr.ctequery
+                    && let Some(NodeEnum::SelectStmt(ref inner)) = query.node
+                    && Self::has_locking_clause(inner)
+                {
+                    return true;
                 }
             }
         }
@@ -398,20 +389,19 @@ impl QueryParser {
     fn cte_writes(stmt: &SelectStmt) -> bool {
         if let Some(ref with_clause) = stmt.with_clause {
             for cte in &with_clause.ctes {
-                if let Some(NodeEnum::CommonTableExpr(ref expr)) = cte.node {
-                    if let Some(ref query) = expr.ctequery {
-                        if let Some(ref node) = query.node {
-                            match node {
-                                NodeEnum::SelectStmt(stmt) => {
-                                    if Self::cte_writes(stmt) {
-                                        return true;
-                                    }
-                                }
-
-                                _ => {
-                                    return true;
-                                }
+                if let Some(NodeEnum::CommonTableExpr(ref expr)) = cte.node
+                    && let Some(ref query) = expr.ctequery
+                    && let Some(ref node) = query.node
+                {
+                    match node {
+                        NodeEnum::SelectStmt(stmt) => {
+                            if Self::cte_writes(stmt) {
+                                return true;
                             }
+                        }
+
+                        _ => {
+                            return true;
                         }
                     }
                 }

--- a/pgdog/src/frontend/router/parser/query/set.rs
+++ b/pgdog/src/frontend/router/parser/query/set.rs
@@ -120,14 +120,13 @@ impl QueryParser {
                 },
                 // e.g. SET TIME ZONE INTERVAL '+00:00' HOUR TO MINUTE
                 Some(NodeEnum::TypeCast(tc)) => {
-                    if let Some(ref arg) = tc.arg {
-                        if let Some(NodeEnum::AConst(AConst {
+                    if let Some(ref arg) = tc.arg
+                        && let Some(NodeEnum::AConst(AConst {
                             val: Some(Val::Sval(String { ref sval })),
                             ..
                         })) = arg.node
-                        {
-                            value.push(sval.to_string());
-                        }
+                    {
+                        value.push(sval.to_string());
                     }
                 }
                 _ => (),

--- a/pgdog/src/frontend/router/parser/query/shared.rs
+++ b/pgdog/src/frontend/router/parser/query/shared.rs
@@ -14,7 +14,7 @@ pub(super) enum ConvergeAlgorithm {
 impl QueryParser {
     /// Converge to a single route given multiple shards.
     pub(super) fn converge(shards: &HashSet<Shard>, algorithm: ConvergeAlgorithm) -> Option<Shard> {
-        let shard = if shards.is_empty() {
+        if shards.is_empty() {
             None
         } else if shards.len() == 1 {
             shards.iter().next().cloned()
@@ -46,9 +46,7 @@ impl QueryParser {
             } else {
                 Shard::Multi(multi.into_iter().collect())
             })
-        };
-
-        shard
+        }
     }
 }
 

--- a/pgdog/src/frontend/router/parser/query/test/setup.rs
+++ b/pgdog/src/frontend/router/parser/query/test/setup.rs
@@ -134,16 +134,16 @@ impl QueryParserTest {
                 self.last_parse = Some(name);
             }
 
-            if let ProtocolMessage::Bind(bind) = message {
-                if let Some(ref name) = self.last_parse {
-                    bind.rename(name);
-                }
+            if let ProtocolMessage::Bind(bind) = message
+                && let Some(ref name) = self.last_parse
+            {
+                bind.rename(name);
             }
 
-            if let ProtocolMessage::Describe(desc) = message {
-                if let Some(ref name) = self.last_parse {
-                    desc.rename(name);
-                }
+            if let ProtocolMessage::Describe(desc) = message
+                && let Some(ref name) = self.last_parse
+            {
+                desc.rename(name);
             }
         }
 

--- a/pgdog/src/frontend/router/parser/query/transaction.rs
+++ b/pgdog/src/frontend/router/parser/query/transaction.rs
@@ -64,16 +64,16 @@ impl QueryParser {
     fn transaction_type(options: &[Node]) -> Option<TransactionType> {
         for option_node in options {
             let node_enum = option_node.node.as_ref()?;
-            if let NodeEnum::DefElem(def_elem) = node_enum {
-                if def_elem.defname == "transaction_read_only" {
-                    let arg_node = def_elem.arg.as_ref()?.node.as_ref()?;
-                    if let NodeEnum::AConst(ac) = arg_node {
-                        // 1 => read-only, 0 => read-write
-                        if let Some(a_const::Val::Ival(i)) = ac.val.as_ref() {
-                            if i.ival != 0 {
-                                return Some(TransactionType::ReadOnly);
-                            }
-                        }
+            if let NodeEnum::DefElem(def_elem) = node_enum
+                && def_elem.defname == "transaction_read_only"
+            {
+                let arg_node = def_elem.arg.as_ref()?.node.as_ref()?;
+                if let NodeEnum::AConst(ac) = arg_node {
+                    // 1 => read-only, 0 => read-write
+                    if let Some(a_const::Val::Ival(i)) = ac.val.as_ref()
+                        && i.ival != 0
+                    {
+                        return Some(TransactionType::ReadOnly);
                     }
                 }
             }

--- a/pgdog/src/frontend/router/parser/query/update.rs
+++ b/pgdog/src/frontend/router/parser/query/update.rs
@@ -80,20 +80,20 @@ mod tests {
         let mut found_string = false;
 
         for target in &update.target_list {
-            if let Some(NodeEnum::ResTarget(res)) = &target.node {
-                if let Some(val) = &res.val {
-                    let value = Value::try_from(&val.node).unwrap();
-                    match value {
-                        Value::Float(f) => {
-                            assert_eq!(f, 50.0);
-                            found_decimal = true;
-                        }
-                        Value::String(s) => {
-                            assert_eq!(s, "completed");
-                            found_string = true;
-                        }
-                        _ => {}
+            if let Some(NodeEnum::ResTarget(res)) = &target.node
+                && let Some(val) = &res.val
+            {
+                let value = Value::try_from(&val.node).unwrap();
+                match value {
+                    Value::Float(f) => {
+                        assert_eq!(f, 50.0);
+                        found_decimal = true;
                     }
+                    Value::String(s) => {
+                        assert_eq!(s, "completed");
+                        found_string = true;
+                    }
+                    _ => {}
                 }
             }
         }
@@ -123,13 +123,13 @@ mod tests {
         // Quoted decimals should be treated as strings
         let mut found_string = false;
         for target in &update.target_list {
-            if let Some(NodeEnum::ResTarget(res)) = &target.node {
-                if let Some(val) = &res.val {
-                    let value = Value::try_from(&val.node).unwrap();
-                    if let Value::String(s) = value {
-                        assert_eq!(s, "50.00");
-                        found_string = true;
-                    }
+            if let Some(NodeEnum::ResTarget(res)) = &target.node
+                && let Some(val) = &res.val
+            {
+                let value = Value::try_from(&val.node).unwrap();
+                if let Value::String(s) = value {
+                    assert_eq!(s, "50.00");
+                    found_string = true;
                 }
             }
         }

--- a/pgdog/src/frontend/router/parser/rewrite/statement/auto_id.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/auto_id.rs
@@ -125,10 +125,10 @@ impl StatementRewrite<'_> {
             .cols
             .iter()
             .filter_map(|col| {
-                if let Some(NodeEnum::ResTarget(res)) = &col.node {
-                    if !res.name.is_empty() {
-                        return Some(res.name.as_str());
-                    }
+                if let Some(NodeEnum::ResTarget(res)) = &col.node
+                    && !res.name.is_empty()
+                {
+                    return Some(res.name.as_str());
                 }
                 None
             })
@@ -159,11 +159,11 @@ impl StatementRewrite<'_> {
         for values_node in &mut select_stmt.values_lists {
             if let Some(NodeEnum::List(list)) = &mut values_node.node {
                 for &pos in positions {
-                    if pos < list.items.len() {
-                        if let Some(NodeEnum::SetToDefault(_)) = &list.items[pos].node {
-                            list.items[pos] = unique_id_call.clone();
-                            replaced += 1;
-                        }
+                    if pos < list.items.len()
+                        && let Some(NodeEnum::SetToDefault(_)) = &list.items[pos].node
+                    {
+                        list.items[pos] = unique_id_call.clone();
+                        replaced += 1;
                     }
                 }
             }

--- a/pgdog/src/frontend/router/parser/rewrite/statement/insert.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/insert.rs
@@ -88,15 +88,13 @@ impl InsertSplit {
         // single-tuple statement so the backend prepares the right one;
         // otherwise it would still hold the original multi-tuple statement and
         // reject the Bind's parameter count.
-        if !has_parse {
-            if let Some(parse) = &request.last_parse {
-                let mut split_parse = parse.clone();
-                split_parse.set_query(&self.stmt);
-                if let Some(name) = self.statement_name() {
-                    split_parse.rename_fast(name);
-                }
-                new_request.last_parse = Some(split_parse);
+        if !has_parse && let Some(parse) = &request.last_parse {
+            let mut split_parse = parse.clone();
+            split_parse.set_query(&self.stmt);
+            if let Some(name) = self.statement_name() {
+                split_parse.rename_fast(name);
             }
+            new_request.last_parse = Some(split_parse);
         }
 
         new_request
@@ -220,10 +218,10 @@ impl StatementRewrite<'_> {
 
         if let NodeEnum::InsertStmt(insert) = node.node.as_ref()? {
             let select = insert.select_stmt.as_ref()?;
-            if let NodeEnum::SelectStmt(select_stmt) = select.node.as_ref()? {
-                if !select_stmt.values_lists.is_empty() {
-                    return Some(&select_stmt.values_lists);
-                }
+            if let NodeEnum::SelectStmt(select_stmt) = select.node.as_ref()?
+                && !select_stmt.values_lists.is_empty()
+            {
+                return Some(&select_stmt.values_lists);
             }
         }
         None
@@ -243,16 +241,13 @@ impl StatementRewrite<'_> {
         Self::renumber_params(&mut new_values_list, &params);
 
         // Replace the values_lists with just this one tuple
-        if let Some(stmt) = ast.stmts.first_mut() {
-            if let Some(node) = stmt.stmt.as_mut() {
-                if let Some(NodeEnum::InsertStmt(insert)) = node.node.as_mut() {
-                    if let Some(select) = insert.select_stmt.as_mut() {
-                        if let Some(NodeEnum::SelectStmt(select_stmt)) = select.node.as_mut() {
-                            select_stmt.values_lists = vec![new_values_list];
-                        }
-                    }
-                }
-            }
+        if let Some(stmt) = ast.stmts.first_mut()
+            && let Some(node) = stmt.stmt.as_mut()
+            && let Some(NodeEnum::InsertStmt(insert)) = node.node.as_mut()
+            && let Some(select) = insert.select_stmt.as_mut()
+            && let Some(NodeEnum::SelectStmt(select_stmt)) = select.node.as_mut()
+        {
+            select_stmt.values_lists = vec![new_values_list];
         }
 
         let stmt = match self.schema.query_parser_engine {

--- a/pgdog/src/frontend/router/parser/rewrite/statement/plan.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/plan.rs
@@ -147,12 +147,12 @@ impl RewritePlan {
             return Ok(RewriteResult::InsertSplit(requests));
         }
 
-        if let Some(sharding_key_update) = &self.sharding_key_update {
-            if request.is_executable() {
-                return Ok(RewriteResult::ShardingKeyUpdate(
-                    sharding_key_update.clone(),
-                ));
-            }
+        if let Some(sharding_key_update) = &self.sharding_key_update
+            && request.is_executable()
+        {
+            return Ok(RewriteResult::ShardingKeyUpdate(
+                sharding_key_update.clone(),
+            ));
         }
 
         Ok(RewriteResult::InPlace {

--- a/pgdog/src/frontend/router/parser/rewrite/statement/simple_prepared.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/simple_prepared.rs
@@ -47,18 +47,18 @@ impl StatementRewrite<'_> {
         }
 
         for stmt in &mut self.stmt.stmts {
-            if let Some(ref mut node) = stmt.stmt {
-                if let Some(ref mut inner) = node.node {
-                    match rewrite_single_prepared(inner, self.prepared_statements, self.schema)? {
-                        SimplePreparedRewrite::Prepared => {
-                            result.rewritten = true;
-                        }
-                        SimplePreparedRewrite::Executed { name, statement } => {
-                            result.prepares.push((name, statement));
-                            result.rewritten = true;
-                        }
-                        SimplePreparedRewrite::None => {}
+            if let Some(ref mut node) = stmt.stmt
+                && let Some(ref mut inner) = node.node
+            {
+                match rewrite_single_prepared(inner, self.prepared_statements, self.schema)? {
+                    SimplePreparedRewrite::Prepared => {
+                        result.rewritten = true;
                     }
+                    SimplePreparedRewrite::Executed { name, statement } => {
+                        result.prepares.push((name, statement));
+                        result.rewritten = true;
+                    }
+                    SimplePreparedRewrite::None => {}
                 }
             }
         }

--- a/pgdog/src/frontend/router/parser/statement.rs
+++ b/pgdog/src/frontend/router/parser/statement.rs
@@ -74,21 +74,20 @@ pub(super) fn advisory_locks_from_func_call(
 
     // Slow path: `SELECT pg_advisory_lock(value) FROM (VALUES (1),(2)) AS t(value)`.
     // The function is called once per row, so we emit one lock per resolved value.
-    if let Some(NodeEnum::ColumnRef(cref)) = arg.node.as_ref() {
-        if let Some(col) = last_column_name(&cref.fields) {
-            if let Some(rows) = values_columns.and_then(|m| m.get(col)) {
-                return rows
-                    .iter()
-                    // Skip unresolvable param refs when there is no Bind.
-                    .filter(|v| bind.is_some() || !is_param_ref(v))
-                    .map(|v| AdvisoryLock {
-                        id: integer_arg(v, bind),
-                        unlock,
-                        scope,
-                    })
-                    .collect();
-            }
-        }
+    if let Some(NodeEnum::ColumnRef(cref)) = arg.node.as_ref()
+        && let Some(col) = last_column_name(&cref.fields)
+        && let Some(rows) = values_columns.and_then(|m| m.get(col))
+    {
+        return rows
+            .iter()
+            // Skip unresolvable param refs when there is no Bind.
+            .filter(|v| bind.is_some() || !is_param_ref(v))
+            .map(|v| AdvisoryLock {
+                id: integer_arg(v, bind),
+                unlock,
+                scope,
+            })
+            .collect();
     }
 
     vec![AdvisoryLock {
@@ -278,10 +277,10 @@ impl<'a> SearchContext<'a> {
         ctx.extract_aliases(nodes);
 
         // Try to get the primary table for simple queries
-        if nodes.len() == 1 {
-            if let Some(table) = nodes.first().and_then(|n| Table::try_from(n).ok()) {
-                ctx.table = Some(table);
-            }
+        if nodes.len() == 1
+            && let Some(table) = nodes.first().and_then(|n| Table::try_from(n).ok())
+        {
+            ctx.table = Some(table);
         }
 
         ctx
@@ -627,27 +626,27 @@ impl<'a, 'b, 'c> StatementParser<'a, 'b, 'c> {
         for table in self.tables() {
             // Check named sharded table configs (fast path, no schema lookup needed)
             for config in &named {
-                if let Some(ref name) = config.name {
-                    if table.name == name {
-                        // Also check schema match if specified in config
-                        if let Some(ref config_schema) = config.schema {
-                            if table.schema != Some(config_schema.as_str()) {
-                                continue;
-                            }
-                        }
-                        return true;
+                if let Some(ref name) = config.name
+                    && table.name == name
+                {
+                    // Also check schema match if specified in config
+                    if let Some(ref config_schema) = config.schema
+                        && table.schema != Some(config_schema.as_str())
+                    {
+                        continue;
                     }
+                    return true;
                 }
             }
 
             // Check nameless configs by looking up the table in the db schema
             // to see if it has the sharding column
-            if !nameless.is_empty() {
-                if let Some(relation) = db_schema.table(*table, user, search_path) {
-                    for config in &nameless {
-                        if relation.has_column(&config.column) {
-                            return true;
-                        }
+            if !nameless.is_empty()
+                && let Some(relation) = db_schema.table(*table, user, search_path)
+            {
+                for config in &nameless {
+                    if relation.has_column(&config.column) {
+                        return true;
                     }
                 }
             }
@@ -711,12 +710,11 @@ impl<'a, 'b, 'c> StatementParser<'a, 'b, 'c> {
         // WITH clause (CTEs)
         if let Some(ref with_clause) = stmt.with_clause {
             for cte in &with_clause.ctes {
-                if let Some(NodeEnum::CommonTableExpr(ref cte_expr)) = cte.node {
-                    if let Some(ref ctequery) = cte_expr.ctequery {
-                        if let Some(NodeEnum::SelectStmt(ref inner_select)) = ctequery.node {
-                            self.walk_select(inner_select, walk);
-                        }
-                    }
+                if let Some(NodeEnum::CommonTableExpr(ref cte_expr)) = cte.node
+                    && let Some(ref ctequery) = cte_expr.ctequery
+                    && let Some(NodeEnum::SelectStmt(ref inner_select)) = ctequery.node
+                {
+                    self.walk_select(inner_select, walk);
                 }
             }
         }
@@ -738,12 +736,11 @@ impl<'a, 'b, 'c> StatementParser<'a, 'b, 'c> {
 
         if let Some(ref with_clause) = stmt.with_clause {
             for cte in &with_clause.ctes {
-                if let Some(NodeEnum::CommonTableExpr(ref cte_expr)) = cte.node {
-                    if let Some(ref ctequery) = cte_expr.ctequery {
-                        if let Some(NodeEnum::SelectStmt(ref inner_select)) = ctequery.node {
-                            self.walk_select(inner_select, walk);
-                        }
-                    }
+                if let Some(NodeEnum::CommonTableExpr(ref cte_expr)) = cte.node
+                    && let Some(ref ctequery) = cte_expr.ctequery
+                    && let Some(NodeEnum::SelectStmt(ref inner_select)) = ctequery.node
+                {
+                    self.walk_select(inner_select, walk);
                 }
             }
         }
@@ -764,12 +761,11 @@ impl<'a, 'b, 'c> StatementParser<'a, 'b, 'c> {
 
         if let Some(ref with_clause) = stmt.with_clause {
             for cte in &with_clause.ctes {
-                if let Some(NodeEnum::CommonTableExpr(ref cte_expr)) = cte.node {
-                    if let Some(ref ctequery) = cte_expr.ctequery {
-                        if let Some(NodeEnum::SelectStmt(ref inner_select)) = ctequery.node {
-                            self.walk_select(inner_select, walk);
-                        }
-                    }
+                if let Some(NodeEnum::CommonTableExpr(ref cte_expr)) = cte.node
+                    && let Some(ref ctequery) = cte_expr.ctequery
+                    && let Some(NodeEnum::SelectStmt(ref inner_select)) = ctequery.node
+                {
+                    self.walk_select(inner_select, walk);
                 }
             }
         }
@@ -786,20 +782,19 @@ impl<'a, 'b, 'c> StatementParser<'a, 'b, 'c> {
 
         if let Some(ref with_clause) = stmt.with_clause {
             for cte in &with_clause.ctes {
-                if let Some(NodeEnum::CommonTableExpr(ref cte_expr)) = cte.node {
-                    if let Some(ref ctequery) = cte_expr.ctequery {
-                        if let Some(NodeEnum::SelectStmt(ref inner_select)) = ctequery.node {
-                            self.walk_select(inner_select, walk);
-                        }
-                    }
+                if let Some(NodeEnum::CommonTableExpr(ref cte_expr)) = cte.node
+                    && let Some(ref ctequery) = cte_expr.ctequery
+                    && let Some(NodeEnum::SelectStmt(ref inner_select)) = ctequery.node
+                {
+                    self.walk_select(inner_select, walk);
                 }
             }
         }
 
-        if let Some(ref select_stmt) = stmt.select_stmt {
-            if let Some(NodeEnum::SelectStmt(ref inner_select)) = select_stmt.node {
-                self.walk_select(inner_select, walk);
-            }
+        if let Some(ref select_stmt) = stmt.select_stmt
+            && let Some(NodeEnum::SelectStmt(ref inner_select)) = select_stmt.node
+        {
+            self.walk_select(inner_select, walk);
         }
     }
 
@@ -817,17 +812,17 @@ impl<'a, 'b, 'c> StatementParser<'a, 'b, 'c> {
                 }
             }
             Some(NodeEnum::RangeSubselect(subselect)) => {
-                if let Some(ref subquery) = subselect.subquery {
-                    if let Some(NodeEnum::SelectStmt(ref inner_select)) = subquery.node {
-                        self.walk_select(inner_select, walk);
-                    }
+                if let Some(ref subquery) = subselect.subquery
+                    && let Some(NodeEnum::SelectStmt(ref inner_select)) = subquery.node
+                {
+                    self.walk_select(inner_select, walk);
                 }
             }
             Some(NodeEnum::SubLink(sublink)) => {
-                if let Some(ref subselect) = sublink.subselect {
-                    if let Some(NodeEnum::SelectStmt(ref inner_select)) = subselect.node {
-                        self.walk_select(inner_select, walk);
-                    }
+                if let Some(ref subselect) = sublink.subselect
+                    && let Some(NodeEnum::SelectStmt(ref inner_select)) = subselect.node
+                {
+                    self.walk_select(inner_select, walk);
                 }
             }
             Some(NodeEnum::SelectStmt(inner_select)) => {
@@ -974,10 +969,10 @@ impl<'a, 'b, 'c> StatementParser<'a, 'b, 'c> {
                 table: Some(table_name),
                 schema,
             };
-            if let Some(sharded_table) = self.schema.tables().get_table(column) {
-                if sharded_table.name.is_some() {
-                    return Some(sharded_table);
-                }
+            if let Some(sharded_table) = self.schema.tables().get_table(column)
+                && sharded_table.name.is_some()
+            {
+                return Some(sharded_table);
             }
         }
 
@@ -1099,10 +1094,10 @@ impl<'a, 'b, 'c> StatementParser<'a, 'b, 'c> {
                 let mut column = Column::try_from(&node.node)?;
 
                 // If column has no table, qualify with context table
-                if column.table().is_none() {
-                    if let Some(ref table) = ctx.table {
-                        column.qualify(*table);
-                    }
+                if column.table().is_none()
+                    && let Some(ref table) = ctx.table
+                {
+                    column.qualify(*table);
                 }
 
                 Ok(SearchResult::Column(column))
@@ -1432,14 +1427,13 @@ impl<'a, 'b, 'c> StatementParser<'a, 'b, 'c> {
         }
 
         // No columns specified in INSERT, try to look them up from schema
-        if let (Some(table), Some(schema_lookup)) = (ctx.table, &self.schema_lookup) {
-            if let Some(relation) =
+        if let (Some(table), Some(schema_lookup)) = (ctx.table, &self.schema_lookup)
+            && let Some(relation) =
                 schema_lookup
                     .db_schema
                     .table(table, schema_lookup.user, schema_lookup.search_path)
-            {
-                return relation.column_names().map(String::from).collect();
-            }
+        {
+            return relation.column_names().map(String::from).collect();
         }
 
         vec![]
@@ -1452,10 +1446,10 @@ impl<'a, 'b, 'c> StatementParser<'a, 'b, 'c> {
         ctx: &SearchContext<'a>,
     ) -> Result<SearchResult<'a>, Error> {
         // Schema-based routing takes priority for INSERTs
-        if let Some(table) = ctx.table {
-            if let Some(schema) = self.schema.schemas.get(table.schema()) {
-                return Ok(SearchResult::Match(schema.shard().into()));
-            }
+        if let Some(table) = ctx.table
+            && let Some(schema) = self.schema.schemas.get(table.schema())
+        {
+            return Ok(SearchResult::Match(schema.shard().into()));
         }
 
         // Get the column names from INSERT INTO table (col1, col2, ...) or from schema
@@ -1474,27 +1468,24 @@ impl<'a, 'b, 'c> StatementParser<'a, 'b, 'c> {
                     // Try to extract constants from SELECT target list
                     if !select_stmt.target_list.is_empty() {
                         for (pos, target_node) in select_stmt.target_list.iter().enumerate() {
-                            if let Some(NodeEnum::ResTarget(ref target)) = target_node.node {
-                                if let Some(column_name) = columns.get(pos) {
-                                    let table_name = ctx.table.map(|t| t.name);
-                                    let table_schema = ctx.table.and_then(|t| t.schema);
-                                    let sharded_table = self.get_sharded_table_by_name(
-                                        column_name.as_str(),
-                                        table_name,
-                                        table_schema,
-                                    );
+                            if let Some(NodeEnum::ResTarget(ref target)) = target_node.node
+                                && let Some(column_name) = columns.get(pos)
+                            {
+                                let table_name = ctx.table.map(|t| t.name);
+                                let table_schema = ctx.table.and_then(|t| t.schema);
+                                let sharded_table = self.get_sharded_table_by_name(
+                                    column_name.as_str(),
+                                    table_name,
+                                    table_schema,
+                                );
 
-                                    if sharded_table.is_some() {
-                                        if let Some(ref val) = target.val {
-                                            if let Ok(value) = Value::try_from(val.as_ref()) {
-                                                if let Some(shard) = self
-                                                    .compute_shard_for_table(sharded_table, value)?
-                                                {
-                                                    return Ok(SearchResult::Match(shard));
-                                                }
-                                            }
-                                        }
-                                    }
+                                if sharded_table.is_some()
+                                    && let Some(ref val) = target.val
+                                    && let Ok(value) = Value::try_from(val.as_ref())
+                                    && let Some(shard) =
+                                        self.compute_shard_for_table(sharded_table, value)?
+                                {
+                                    return Ok(SearchResult::Match(shard));
                                 }
                             }
                         }
@@ -1520,41 +1511,40 @@ impl<'a, 'b, 'c> StatementParser<'a, 'b, 'c> {
         }
 
         // The select_stmt field contains either VALUES or a SELECT subquery
-        if let Some(ref select_node) = stmt.select_stmt {
-            if let Some(NodeEnum::SelectStmt(ref select_stmt)) = select_node.node {
-                // Check if this is VALUES (has values_lists) - need special handling
-                // to match column positions with sharding keys
-                if !select_stmt.values_lists.is_empty() {
-                    for values_list in &select_stmt.values_lists {
-                        if let Some(NodeEnum::List(ref list)) = values_list.node {
-                            for (pos, value_node) in list.items.iter().enumerate() {
-                                // Check if this position corresponds to a sharding key column
-                                if let Some(column_name) = columns.get(pos) {
-                                    let table_name = ctx.table.map(|t| t.name);
-                                    let table_schema = ctx.table.and_then(|t| t.schema);
-                                    let sharded_table = self.get_sharded_table_by_name(
-                                        column_name.as_str(),
-                                        table_name,
-                                        table_schema,
-                                    );
+        if let Some(ref select_node) = stmt.select_stmt
+            && let Some(NodeEnum::SelectStmt(ref select_stmt)) = select_node.node
+        {
+            // Check if this is VALUES (has values_lists) - need special handling
+            // to match column positions with sharding keys
+            if !select_stmt.values_lists.is_empty() {
+                for values_list in &select_stmt.values_lists {
+                    if let Some(NodeEnum::List(ref list)) = values_list.node {
+                        for (pos, value_node) in list.items.iter().enumerate() {
+                            // Check if this position corresponds to a sharding key column
+                            if let Some(column_name) = columns.get(pos) {
+                                let table_name = ctx.table.map(|t| t.name);
+                                let table_schema = ctx.table.and_then(|t| t.schema);
+                                let sharded_table = self.get_sharded_table_by_name(
+                                    column_name.as_str(),
+                                    table_name,
+                                    table_schema,
+                                );
 
-                                    if sharded_table.is_some() {
-                                        // Try to extract the value directly
-                                        if let Ok(value) = Value::try_from(value_node) {
-                                            if let Some(shard) =
-                                                self.compute_shard_for_table(sharded_table, value)?
-                                            {
-                                                return Ok(SearchResult::Match(shard));
-                                            }
-                                        }
+                                if sharded_table.is_some() {
+                                    // Try to extract the value directly
+                                    if let Ok(value) = Value::try_from(value_node)
+                                        && let Some(shard) =
+                                            self.compute_shard_for_table(sharded_table, value)?
+                                    {
+                                        return Ok(SearchResult::Match(shard));
                                     }
                                 }
+                            }
 
-                                // Search subqueries in values recursively
-                                let result = self.select_search(value_node, ctx)?;
-                                if result.is_match() {
-                                    return Ok(result);
-                                }
+                            // Search subqueries in values recursively
+                            let result = self.select_search(value_node, ctx)?;
+                            if result.is_match() {
+                                return Ok(result);
                             }
                         }
                     }

--- a/pgdog/src/frontend/router/parser/table.rs
+++ b/pgdog/src/frontend/router/parser/table.rs
@@ -135,14 +135,14 @@ impl<'a> TryFrom<&'a Vec<Node>> for Table<'a> {
                         None
                     }
                 });
-                if let Some(schema) = schema {
-                    if let Some(table) = table {
-                        return Ok(Table {
-                            name: table,
-                            schema: Some(schema),
-                            alias: None,
-                        });
-                    }
+                if let Some(schema) = schema
+                    && let Some(table) = table
+                {
+                    return Ok(Table {
+                        name: table,
+                        schema: Some(schema),
+                        alias: None,
+                    });
                 }
             }
 

--- a/pgdog/src/frontend/router/parser/value.rs
+++ b/pgdog/src/frontend/router/parser/value.rs
@@ -119,19 +119,16 @@ impl<'a> TryFrom<&'a Option<NodeEnum>> for Value<'a> {
             }
 
             Some(NodeEnum::AExpr(expr)) => {
-                if expr.kind() == AExprKind::AexprOp {
-                    if let Some(Node {
+                if expr.kind() == AExprKind::AexprOp
+                    && let Some(Node {
                         node: Some(NodeEnum::String(pg_query::protobuf::String { sval })),
                     }) = expr.name.first()
-                    {
-                        if sval == "-" {
-                            if let Some(ref node) = expr.rexpr {
-                                let value = Value::try_from(&node.node)?;
-                                if let Value::Float(float) = value {
-                                    return Ok(Value::Float(-float));
-                                }
-                            }
-                        }
+                    && sval == "-"
+                    && let Some(ref node) = expr.rexpr
+                {
+                    let value = Value::try_from(&node.node)?;
+                    if let Value::Float(float) = value {
+                        return Ok(Value::Float(-float));
                     }
                 }
 

--- a/pgdog/src/frontend/router/parser/where_clause.rs
+++ b/pgdog/src/frontend/router/parser/where_clause.rs
@@ -113,10 +113,10 @@ impl<'a> WhereClause<'a> {
     }
 
     fn column_match(column: &Column, table: Option<&str>, name: &str) -> bool {
-        if let (Some(table), Some(other_table)) = (table, &column.table) {
-            if &table != other_table {
-                return false;
-            }
+        if let (Some(table), Some(other_table)) = (table, &column.table)
+            && &table != other_table
+        {
+            return false;
         };
 
         column.name == name
@@ -181,20 +181,21 @@ impl<'a> WhereClause<'a> {
             }
         }
 
-        if let Output::NullCheck(c) = output {
-            if c.name == column_name && c.table == table_name {
-                keys.push(Key::Null);
-            }
+        if let Output::NullCheck(c) = output
+            && c.name == column_name
+            && c.table == table_name
+        {
+            keys.push(Key::Null);
         }
 
         keys
     }
 
     fn string(node: Option<&Node>) -> Option<&str> {
-        if let Some(node) = node {
-            if let Some(NodeEnum::String(ref string)) = node.node {
-                return Some(string.sval.as_str());
-            }
+        if let Some(node) = node
+            && let Some(NodeEnum::String(ref string)) = node.node
+        {
+            return Some(string.sval.as_str());
         }
 
         None
@@ -237,21 +238,19 @@ impl<'a> WhereClause<'a> {
                     AExprKind::AexprOp | AExprKind::AexprIn | AExprKind::AexprOpAny
                 ) {
                     let op = Self::string(expr.name.first());
-                    if let Some(op) = op {
-                        if op != "=" {
+                    if let Some(op) = op
+                        && op != "=" {
                             return keys;
                         }
-                    }
                 }
                 let array = matches!(kind, AExprKind::AexprOpAny);
-                if let Some(ref left) = expr.lexpr {
-                    if let Some(ref right) = expr.rexpr {
+                if let Some(ref left) = expr.lexpr
+                    && let Some(ref right) = expr.rexpr {
                         let left = Self::parse(source, left, array);
                         let right = Self::parse(source, right, array);
 
                         keys.push(Output::Filter(left, right));
                     }
-                }
             }
 
             Some(NodeEnum::AConst(ref value)) => {

--- a/pgdog/src/frontend/router/sharding/range.rs
+++ b/pgdog/src/frontend/router/sharding/range.rs
@@ -67,16 +67,16 @@ impl<'a> Ranges<'a> {
             .filter(|m| m.kind == ShardedMappingKind::Range)
         {
             let range = Range::new(mapping);
-            if let Some(integer) = &integer {
-                if range.integer(integer) {
-                    return Ok(Shard::Direct(range.shard));
-                }
+            if let Some(integer) = &integer
+                && range.integer(integer)
+            {
+                return Ok(Shard::Direct(range.shard));
             }
 
-            if let Some(varchar) = &varchar {
-                if range.varchar(varchar) {
-                    return Ok(Shard::Direct(range.shard));
-                }
+            if let Some(varchar) = &varchar
+                && range.varchar(varchar)
+            {
+                return Ok(Shard::Direct(range.shard));
             }
         }
 

--- a/pgdog/src/frontend/router/sharding/schema.rs
+++ b/pgdog/src/frontend/router/sharding/schema.rs
@@ -55,10 +55,10 @@ impl SchemaSharder {
     }
 
     pub fn get(&self) -> Option<(Shard, &str)> {
-        if let Some(current) = self.current.as_ref() {
-            if let Some(schema) = self.schema.as_ref() {
-                return Some((current.clone(), schema.as_str()));
-            }
+        if let Some(current) = self.current.as_ref()
+            && let Some(schema) = self.schema.as_ref()
+        {
+            return Some((current.clone(), schema.as_str()));
         }
 
         None

--- a/pgdog/src/frontend/router/sharding/tables.rs
+++ b/pgdog/src/frontend/router/sharding/tables.rs
@@ -22,12 +22,10 @@ impl<'a> Tables<'a> {
     pub(crate) fn sharded(&'a self, table: Table) -> Option<&'a ShardedTable> {
         let tables = self.schema.tables().tables();
 
-        let sharded = tables
+        tables
             .iter()
             .filter(|table| table.name.is_some())
-            .find(|t| t.name.as_deref() == Some(table.name));
-
-        sharded
+            .find(|t| t.name.as_deref() == Some(table.name))
     }
 
     pub(crate) fn key(&'a self, table: Table, columns: &'a [Column]) -> Option<Key<'a>> {
@@ -39,13 +37,13 @@ impl<'a> Tables<'a> {
             .filter(|table| table.name.is_some())
             .find(|t| t.name.as_deref() == Some(table.name));
 
-        if let Some(sharded) = sharded {
-            if let Some(position) = columns.iter().position(|col| col.name == sharded.column) {
-                return Some(Key {
-                    table: sharded,
-                    position,
-                });
-            }
+        if let Some(sharded) = sharded
+            && let Some(position) = columns.iter().position(|col| col.name == sharded.column)
+        {
+            return Some(Key {
+                table: sharded,
+                position,
+            });
         }
 
         // Check tables without name.
@@ -54,13 +52,13 @@ impl<'a> Tables<'a> {
             .filter(|table| table.name.is_none())
             .map(|t| (t, columns.iter().position(|col| col.name == t.column)))
             .find(|t| t.1.is_some());
-        if let Some(key) = key {
-            if let Some(position) = key.1 {
-                return Some(Key {
-                    table: key.0,
-                    position,
-                });
-            }
+        if let Some(key) = key
+            && let Some(position) = key.1
+        {
+            return Some(Key {
+                table: key.0,
+                position,
+            });
         }
 
         None

--- a/pgdog/src/main.rs
+++ b/pgdog/src/main.rs
@@ -189,11 +189,11 @@ async fn pgdog(command: Option<Commands>) -> Result<(), Box<dyn std::error::Erro
                 cli::replicate_and_cutover(command.clone()).await?;
             }
 
-            if let Commands::Route { .. } = command {
-                if let Err(err) = cli::route(command.clone()).await {
-                    error!("{}", err);
-                    return Err(err);
-                }
+            if let Commands::Route { .. } = command
+                && let Err(err) = cli::route(command.clone()).await
+            {
+                error!("{}", err);
+                return Err(err);
             }
         }
     }

--- a/pgdog/src/net/decoder.rs
+++ b/pgdog/src/net/decoder.rs
@@ -38,13 +38,12 @@ impl Decoder {
             self.formats = bind.codes().to_vec();
         }
 
-        if self.rd.is_empty() {
-            if let Some(rd) = PreparedStatements::global()
+        if self.rd.is_empty()
+            && let Some(rd) = PreparedStatements::global()
                 .read()
                 .row_description(bind.statement())
-            {
-                self.rd = rd;
-            }
+        {
+            self.rd = rd;
         }
     }
 

--- a/pgdog/src/net/messages/data_row.rs
+++ b/pgdog/src/net/messages/data_row.rs
@@ -120,18 +120,18 @@ impl DataRow {
         index: usize,
         decoder: &'a Decoder,
     ) -> Result<Option<Column<'a>>, Error> {
-        if let Some(field) = decoder.rd().field(index) {
-            if let Some(data) = self.columns.get(index) {
-                return Ok(Some(Column {
-                    name: field.name.as_str(),
-                    value: Datum::new(
-                        &data.data,
-                        field.data_type(),
-                        decoder.format(index),
-                        data.is_null,
-                    )?,
-                }));
-            }
+        if let Some(field) = decoder.rd().field(index)
+            && let Some(data) = self.columns.get(index)
+        {
+            return Ok(Some(Column {
+                name: field.name.as_str(),
+                value: Datum::new(
+                    &data.data,
+                    field.data_type(),
+                    decoder.format(index),
+                    data.is_null,
+                )?,
+            }));
         }
 
         Ok(None)

--- a/pgdog/src/net/messages/hello.rs
+++ b/pgdog/src/net/messages/hello.rs
@@ -99,18 +99,18 @@ impl Startup {
                             let name = nvs.next();
                             let value = nvs.next();
 
-                            if let Some(name) = name {
-                                if let Some(value) = value {
-                                    let name = name.trim().to_string();
-                                    let value = value.trim().to_string();
-                                    if !name.is_empty() && !value.is_empty() {
-                                        let value = if name == "search_path" {
-                                            search_path(&value)
-                                        } else {
-                                            ParameterValue::from(value)
-                                        };
-                                        params.insert(name, value);
-                                    }
+                            if let Some(name) = name
+                                && let Some(value) = value
+                            {
+                                let name = name.trim().to_string();
+                                let value = value.trim().to_string();
+                                if !name.is_empty() && !value.is_empty() {
+                                    let value = if name == "search_path" {
+                                        search_path(&value)
+                                    } else {
+                                        ParameterValue::from(value)
+                                    };
+                                    params.insert(name, value);
                                 }
                             }
                         }

--- a/pgdog/src/net/tls.rs
+++ b/pgdog/src/net/tls.rs
@@ -103,13 +103,11 @@ pub(crate) fn identity_from_certs(certs: &[CertificateDer<'_>]) -> Option<String
         }
     }
 
-    let cn = cert
-        .subject()
+    cert.subject()
         .iter_common_name()
         .next()
         .and_then(|cn| cn.as_str().ok())
-        .map(String::from);
-    cn
+        .map(String::from)
 }
 
 /// Create new TLS connector using the current configuration.
@@ -408,10 +406,10 @@ pub fn connector_with_verify_mode(
 ) -> Result<TlsConnector, Error> {
     let config_key = ConnectorConfigKey::new(mode, ca_cert_path);
 
-    if let Some(entry) = CONNECTOR.load_full() {
-        if entry.key == config_key {
-            return Ok(entry.connector());
-        }
+    if let Some(entry) = CONNECTOR.load_full()
+        && entry.key == config_key
+    {
+        return Ok(entry.connector());
     }
 
     let client_config = build_connector(&config_key)?;

--- a/pgdog/src/stats/otel.rs
+++ b/pgdog/src/stats/otel.rs
@@ -178,11 +178,11 @@ fn percent_decode(s: &str) -> String {
             let lo = chars.next();
             if let (Some(hi), Some(lo)) = (hi, lo) {
                 let hex = [hi, lo];
-                if let Ok(s) = std::str::from_utf8(&hex) {
-                    if let Ok(byte) = u8::from_str_radix(s, 16) {
-                        result.push(byte as char);
-                        continue;
-                    }
+                if let Ok(s) = std::str::from_utf8(&hex)
+                    && let Ok(byte) = u8::from_str_radix(s, 16)
+                {
+                    result.push(byte as char);
+                    continue;
                 }
             }
             // Malformed sequence — pass through as-is.


### PR DESCRIPTION
Fix many (not all) clippy warnings in the code. Only those clippy warnings were fixed which were deemed safe and risk free, these included:

* Those performed by `cargo clippy --fix`.
* Some others which cargo clippy couldn't fix but were manually found to be safe to edit. These are pointed out with comments in the PR.

Clippy warnings which needed bigger refactors or could have performance impact, like large Err variant warnings, were not fixed. Vast majority of fixes were the [collapsible_if](https://rust-lang.github.io/rust-clippy/rust-1.96.0/index.html#collapsible_if) warnings due to which the diffs look bigger than the actual changes.