### PR TITLE
fix: handle comments in SET in regex detector

### DIFF
--- a/pgdog/src/frontend/regex_parser.rs
+++ b/pgdog/src/frontend/regex_parser.rs
@@ -205,6 +205,53 @@ mod test {
     }
 
     #[test]
+    fn test_leading_whitespace() {
+        assert!(matches("   /* comment */ SET statement_timeout TO 1"));
+        assert!(matches("\t/* comment */\tBEGIN"));
+        assert!(matches("\n\n-- comment\nCOMMIT"));
+        assert!(matches(" \t\n SET statement_timeout TO 1"));
+        assert!(matches("/* comment */\n\n   ROLLBACK"));
+        assert!(matches("  -- one\n  -- two\n  begin"));
+    }
+
+    #[test]
+    fn test_comment_edge_cases() {
+        // Empty and minimal comments.
+        assert!(matches("/**/SET statement_timeout TO 1"));
+        assert!(matches("/* */BEGIN"));
+        assert!(matches("--\nCOMMIT"));
+
+        // Stars and slashes inside block comments.
+        assert!(matches("/* a * b */ SET statement_timeout TO 1"));
+        assert!(matches("/* a / b ** c */ BEGIN"));
+
+        // Non-greedy: comment ends at the first `*/`.
+        assert!(matches("/* a */ SET application_name TO '/* b */'"));
+
+        // Windows line endings in line comments.
+        assert!(matches("-- comment\r\nSET statement_timeout TO 1"));
+
+        // Comment-lookalikes inside the comment body.
+        assert!(matches("/* -- not a line comment */ ROLLBACK"));
+        assert!(matches("-- /* not a block comment\nBEGIN"));
+
+        // Unterminated block comment never reaches a statement.
+        assert!(!matches("/* unterminated SET statement_timeout TO 1"));
+
+        // Line comment swallows the rest of the line; next line decides.
+        assert!(matches("-- SET commented out\nSET statement_timeout TO 1"));
+        assert!(!matches("/* a */ -- SET commented out\nSELECT 1"));
+    }
+
+    #[test]
+    fn test_advisory_lock_with_comments() {
+        let l = QueryParserLevel::SessionControlAndLocks;
+        assert!(matches_at("/* comment */ SELECT pg_advisory_lock(1)", l));
+        assert!(matches_at("-- comment\nSELECT pg_advisory_unlock(1)", l));
+        assert!(matches_at("SELECT /* inline */ pg_try_advisory_lock(1)", l));
+    }
+
+    #[test]
     fn test_no_match() {
         assert!(!matches("SELECT 1"));
         assert!(!matches("INSERT INTO users VALUES (1)"));

--- a/pgdog/src/frontend/regex_parser.rs
+++ b/pgdog/src/frontend/regex_parser.rs
@@ -4,12 +4,11 @@ use regex::RegexSet;
 
 use crate::frontend::ClientRequest;
 
-static CMD_BASE: &[&str] = &[
-    "(?i)^ *(RE)?SET",
-    "(?i)^ *BEGIN",
-    "(?i)^ *COMMIT",
-    "(?i)^ *ROLLBACK",
-];
+/// Whitespace and inline SQL comments (`-- line` and `/* block */`)
+/// allowed before a statement keyword.
+static COMMENT_PREFIX: &str = r"(?i)^\s*(?:(?:--[^\n]*\n|/\*[\s\S]*?\*/)\s*)*";
+
+static CMD_BASE: &[&str] = &["(RE)?SET", "BEGIN", "COMMIT", "ROLLBACK"];
 
 static CMD_ADVISORY: &[&str] = &[
     r"(?i)\bpg_advisory_lock\b",
@@ -25,9 +24,16 @@ static CMD_ADVISORY: &[&str] = &[
     r"(?i)\bpg_try_advisory_xact_lock_shared\b",
 ];
 
-static CMD_RE: Lazy<RegexSet> = Lazy::new(|| RegexSet::new(CMD_BASE).unwrap());
-static CMD_RE_ADVISORY: Lazy<RegexSet> =
-    Lazy::new(|| RegexSet::new(CMD_BASE.iter().chain(CMD_ADVISORY.iter())).unwrap());
+fn cmd_base_patterns() -> impl Iterator<Item = String> {
+    CMD_BASE
+        .iter()
+        .map(|cmd| format!("{}{}", COMMENT_PREFIX, cmd))
+}
+
+static CMD_RE: Lazy<RegexSet> = Lazy::new(|| RegexSet::new(cmd_base_patterns()).unwrap());
+static CMD_RE_ADVISORY: Lazy<RegexSet> = Lazy::new(|| {
+    RegexSet::new(cmd_base_patterns().chain(CMD_ADVISORY.iter().map(|s| s.to_string()))).unwrap()
+});
 
 fn scan_prefix(query: &str, limit: usize) -> &str {
     if query.len() <= limit {
@@ -179,6 +185,23 @@ mod test {
 
         let short = format!("{}pg_advisory_lock(1)", " ".repeat(900));
         assert!(matches_at(&short, l));
+    }
+
+    #[test]
+    fn test_inline_comments() {
+        assert!(matches("/* comment */ SET statement_timeout TO 1"));
+        assert!(matches("/* comment */SET statement_timeout TO 1"));
+        assert!(matches("-- comment\nSET statement_timeout TO 1"));
+        assert!(matches("--comment\n  RESET ALL"));
+        assert!(matches("/* one */ /* two */ BEGIN"));
+        assert!(matches("/* multi\nline\ncomment */ COMMIT"));
+        assert!(matches("-- first\n-- second\nROLLBACK"));
+        assert!(matches("/* block */ -- line\nbegin read only"));
+
+        // Comment-only or commented-out statements don't match.
+        assert!(!matches("-- SET statement_timeout TO 1"));
+        assert!(!matches("/* SET statement_timeout TO 1 */ SELECT 1"));
+        assert!(!matches("/* comment */ SELECT 1"));
     }
 
     #[test]

--- a/pgdog/src/frontend/regex_parser.rs
+++ b/pgdog/src/frontend/regex_parser.rs
@@ -188,6 +188,23 @@ mod test {
     }
 
     #[test]
+    fn test_limit_longer_than_query() {
+        let query = "SET statement_timeout TO 1";
+
+        for limit in [query.len(), query.len() + 1, 10_000, usize::MAX] {
+            let req = ClientRequest::from(vec![ProtocolMessage::from(Query::new(query))]);
+            let parser = RegexParser::new(limit, QueryParserLevel::SessionControl);
+            assert!(parser.use_parser(&req), "limit {} should match", limit);
+        }
+
+        // Multi-byte characters at the end don't trip the boundary scan.
+        let multibyte = "SET application_name TO 'héllo'";
+        let req = ClientRequest::from(vec![ProtocolMessage::from(Query::new(multibyte))]);
+        let parser = RegexParser::new(usize::MAX, QueryParserLevel::SessionControl);
+        assert!(parser.use_parser(&req));
+    }
+
+    #[test]
     fn test_inline_comments() {
         assert!(matches("/* comment */ SET statement_timeout TO 1"));
         assert!(matches("/* comment */SET statement_timeout TO 1"));


### PR DESCRIPTION
This makes sure that statements like:

```sql
/*line:(name):2:in '<main>'*/ SET statement_timeout = '8s'
```

are correctly detected and parsed with `pg_query`.