### PR TITLE
fix chunked copying of large csv rows

### DIFF
--- a/integration/rust/tests/integration/copy.rs
+++ b/integration/rust/tests/integration/copy.rs
@@ -1,0 +1,69 @@
+use rust::setup::{connections_sqlx, connections_tokio};
+
+#[tokio::test]
+async fn copy_from_csv() -> Result<(), Box<dyn std::error::Error>> {
+    let conns = connections_tokio().await;
+    let client = &conns[0];
+
+    client
+        .execute("DROP TABLE IF EXISTS copy_csv_test", &[])
+        .await?;
+    client
+        .execute("CREATE TABLE copy_csv_test (id BIGINT, name TEXT)", &[])
+        .await?;
+
+    let pools = connections_sqlx().await;
+    let pool = &pools[0];
+    let mut conn = pool.acquire().await?;
+
+    let mut copy = conn
+        .copy_in_raw("COPY copy_csv_test (id, name) FROM STDIN (FORMAT CSV)")
+        .await?;
+    copy.send(b"1,Alice\n2,Bob\n3,Charlie\n".as_ref()).await?;
+    copy.finish().await?;
+
+    client.execute("DROP TABLE copy_csv_test", &[]).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn copy_from_csv_with_chunked_buffer() -> Result<(), Box<dyn std::error::Error>> {
+    let conns = connections_tokio().await;
+    let client = &conns[0];
+
+    client
+        .execute("DROP TABLE IF EXISTS copy_csv_large_test", &[])
+        .await?;
+    client
+        .execute(
+            "CREATE TABLE copy_csv_large_test (id BIGINT, data JSONB)",
+            &[],
+        )
+        .await?;
+
+    let pools = connections_sqlx().await;
+    let pool = &pools[0];
+    let mut conn = pool.acquire().await?;
+
+    // Single row with a large JSONB value sent as n 4k CopyData chunks.
+    let chunk_size = 4096;
+    let n_chunks = 4;
+    let json = format!("{{\"value\":\"{}\"}}", "e".repeat(chunk_size * n_chunks));
+    let csv = format!("1,{}\n", json);
+
+    let mut copy = conn
+        .copy_in_raw("COPY copy_csv_large_test (id, data) FROM STDIN (FORMAT CSV)")
+        .await?;
+    for chunk in csv.as_bytes().chunks(chunk_size) {
+        copy.send(chunk).await?;
+    }
+    let rows_inserted = copy.finish().await?;
+    assert_eq!(rows_inserted, 1);
+
+    client
+        .execute("DROP TABLE copy_csv_large_test", &[])
+        .await?;
+
+    Ok(())
+}

--- a/integration/rust/tests/integration/mod.rs
+++ b/integration/rust/tests/integration/mod.rs
@@ -6,6 +6,7 @@ pub mod ban;
 pub mod cancel;
 pub mod client_ids;
 pub mod connection_recovery;
+pub mod copy;
 pub mod cross_shard_disabled;
 pub mod distinct;
 pub mod explain;

--- a/pgdog/src/backend/pool/connection/mod.rs
+++ b/pgdog/src/backend/pool/connection/mod.rs
@@ -307,10 +307,8 @@ impl Connection {
                 .map_err(|e| Error::Router(e.to_string()))?;
             if !rows.is_empty() {
                 self.send_copy(rows).await?;
-                self.send(&client_request.without_copy_data()).await?;
-            } else {
-                self.send(client_request).await?;
             }
+            self.send(&client_request.without_copy_data()).await?;
         } else {
             // We split up the extended protocol exhange as soon as we see
             // a Flush or Sync that doesn't actually execute anything. This


### PR DESCRIPTION
I ran into this issue when importing data using psql from a csv for a table with a relatively big jsonb config column.

```sql
\copy public.table from 'table.csv' WITH NULL 'CSV_NONE_SENTINEL' CSV HEADER;
```

For large rows a partial message seems to be forwarded to the postgres backend resulting in an error like this. I'm not sure if this patch is the best approach to handle this case but so far it seems to be working for my usecase.

```
[88115] ERROR:  unterminated CSV quoted field
[88115] CONTEXT:  COPY copy_csv_large_test, line 1: "1,{"value":"eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee..."
[88115] STATEMENT:  COPY copy_csv_large_test (id, data) FROM STDIN (FORMAT CSV)
```