### PR TITLE
Handle the special case of `SELECT set_config(...)`

### DIFF
--- a/integration/rust/tests/integration/mod.rs
+++ b/integration/rust/tests/integration/mod.rs
@@ -27,6 +27,7 @@ pub mod reset;
 pub mod rewrite;
 pub mod rewrite_omni;
 pub mod savepoint;
+pub mod set_config;
 pub mod set_in_transaction;
 pub mod set_sharding_key;
 pub mod shard_consistency;

--- a/integration/rust/tests/integration/set_config.rs
+++ b/integration/rust/tests/integration/set_config.rs
@@ -1,0 +1,57 @@
+use rust::setup::connections_sqlx;
+use sqlx::query_scalar;
+use std::assert_matches;
+
+#[tokio::test]
+async fn test_set_config_behaves_like_set() {
+    let pool = connections_sqlx().await.pop().unwrap();
+    let mut conn = pool.acquire().await.unwrap();
+    let set_config: String = query_scalar("SELECT set_config('lock_timeout', '1000s', false);")
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+    assert_eq!(set_config, "1000s");
+    let lock_timeout: String = query_scalar("SHOW lock_timeout")
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+    assert_eq!(lock_timeout, "1000s");
+
+    let set_config: String = query_scalar("SELECT set_config('lock_timeout', '500s', false);")
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+    assert_eq!(set_config, "500s");
+    let lock_timeout: String = query_scalar("SHOW lock_timeout")
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+    assert_eq!(lock_timeout, "500s");
+
+    let set_config: Option<String> =
+        query_scalar("SELECT set_config('lock_timeout', NULL, false);")
+            .fetch_one(&mut *conn)
+            .await
+            .unwrap();
+    assert_eq!(set_config, None);
+
+    let lock_timeout: String = query_scalar("SHOW lock_timeout")
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+    assert_eq!(lock_timeout, "0");
+}
+
+#[tokio::test]
+// We can't handle every possible invocation yet, but we at least shouldn't
+// error
+async fn test_set_config_does_something_when_unable_to_resolve_args() {
+    let pool = connections_sqlx().await.pop().unwrap();
+    let mut conn = pool.acquire().await.unwrap();
+
+    let set_config: Result<String, _> =
+        query_scalar("SELECT set_config('lock_timeout', (SELECT '1'), false);")
+            .fetch_one(&mut *conn)
+            .await;
+    assert_matches!(set_config, Ok(_));
+}

--- a/pgdog/src/frontend/client/query_engine/fake.rs
+++ b/pgdog/src/frontend/client/query_engine/fake.rs
@@ -1,8 +1,8 @@
 use tokio::io::AsyncWriteExt;
 
 use crate::net::{
-    BindComplete, CloseComplete, CommandComplete, NoData, ParameterDescription, ParseComplete,
-    ProtocolMessage, ReadyForQuery, RowDescription,
+    BindComplete, CloseComplete, CommandComplete, DataRow, Field, NoData, ParameterDescription,
+    ParseComplete, ProtocolMessage, ReadyForQuery, RowDescription, parameter::ParameterValue,
 };
 
 use super::*;
@@ -14,8 +14,23 @@ impl QueryEngine {
         &mut self,
         context: &mut QueryEngineContext<'_>,
         command: &str,
+        return_value: Option<impl IntoIterator<Item = Option<&'_ ParameterValue>> + Clone>,
     ) -> Result<(), Error> {
         let mut sent = 0;
+        let return_fields = return_value
+            .clone()
+            .into_iter()
+            .flatten()
+            .map(|_| Field::text(""))
+            .collect::<Vec<_>>();
+        let row_description = RowDescription::new(&return_fields);
+        let data_row = return_value.map(|return_value| {
+            let mut row = DataRow::new();
+            for val in return_value {
+                row.add(val);
+            }
+            row
+        });
         for message in context.client_request.iter() {
             sent += match message {
                 ProtocolMessage::Parse(_) => context.stream.send(&ParseComplete).await?,
@@ -26,13 +41,17 @@ impl QueryEngine {
                             .stream
                             .send(&ParameterDescription::default())
                             .await?
-                            + context.stream.send(&RowDescription::default()).await?
+                            + context.stream.send(&row_description).await?
                     } else {
                         context.stream.send(&NoData).await?
                     }
                 }
                 ProtocolMessage::Execute(_) => {
-                    context.stream.send(&CommandComplete::new(command)).await?
+                    (if let Some(row) = data_row.as_ref() {
+                        context.stream.send(row).await?
+                    } else {
+                        0
+                    }) + context.stream.send(&CommandComplete::new(command)).await?
                 }
                 ProtocolMessage::Sync(_) => {
                     context
@@ -41,7 +60,12 @@ impl QueryEngine {
                         .await?
                 }
                 ProtocolMessage::Query(_) => {
-                    context.stream.send(&CommandComplete::new(command)).await?
+                    (if let Some(row) = data_row.as_ref() {
+                        context.stream.send(&row_description).await?
+                            + context.stream.send(row).await?
+                    } else {
+                        0
+                    }) + context.stream.send(&CommandComplete::new(command)).await?
                         + context
                             .stream
                             .send(&ReadyForQuery::in_transaction(context.in_transaction()))

--- a/pgdog/src/frontend/client/query_engine/fake.rs
+++ b/pgdog/src/frontend/client/query_engine/fake.rs
@@ -21,7 +21,8 @@ impl QueryEngine {
             .clone()
             .into_iter()
             .flatten()
-            .map(|_| Field::text(""))
+            // FIXME(sage): Don't assume `set_config` is the only consumer
+            .map(|_| Field::text("set_config"))
             .collect::<Vec<_>>();
         let row_description = RowDescription::new(&return_fields);
         let data_row = return_value.map(|return_value| {

--- a/pgdog/src/frontend/client/query_engine/mod.rs
+++ b/pgdog/src/frontend/client/query_engine/mod.rs
@@ -228,9 +228,13 @@ impl QueryEngine {
                     .await?
             }
             Command::Unlisten(channel) => self.unlisten(context, &channel.clone()).await?,
-            Command::Set { params, .. } => {
+            Command::Set {
+                params,
+                behave_like_select,
+                ..
+            } => {
                 let params = params.clone();
-                self.set(context, &params).await?;
+                self.set(context, &params, *behave_like_select).await?;
             }
             Command::ResetAll => {
                 self.reset_all(context).await?;

--- a/pgdog/src/frontend/client/query_engine/multi_step/update.rs
+++ b/pgdog/src/frontend/client/query_engine/multi_step/update.rs
@@ -86,7 +86,7 @@ impl<'a> UpdateMulti<'a> {
             // This happens, but the UPDATE's WHERE clause
             // doesn't match any rows, so this whole thing is a no-op.
             self.engine
-                .fake_command_response(context, "UPDATE 0")
+                .fake_command_response(context, "UPDATE 0", None::<Option<_>>)
                 .await?;
         }
 

--- a/pgdog/src/frontend/client/query_engine/set.rs
+++ b/pgdog/src/frontend/client/query_engine/set.rs
@@ -7,18 +7,21 @@ impl QueryEngine {
         &mut self,
         context: &mut QueryEngineContext<'_>,
         params: &[SetParam],
+        behave_like_select: bool,
     ) -> Result<(), Error> {
         let mut fake_command = "SET";
         for param in params {
-            if param.reset {
-                context.params.reset(&param.name);
-                fake_command = "RESET";
-            } else if context.in_transaction() {
-                context
-                    .params
-                    .insert_transaction(&param.name, param.value.clone(), param.local);
+            if let Some(value) = param.value.clone() {
+                if context.in_transaction() {
+                    context
+                        .params
+                        .insert_transaction(&param.name, value, param.local);
+                } else {
+                    context.params.insert(&param.name, value);
+                }
             } else {
-                context.params.insert(&param.name, param.value.clone());
+                fake_command = "RESET";
+                context.params.reset(&param.name);
             }
         }
 
@@ -29,7 +32,10 @@ impl QueryEngine {
         if self.backend.connected() {
             self.execute(context).await?;
         } else {
-            self.fake_command_response(context, fake_command).await?;
+            let values_to_return =
+                behave_like_select.then(|| params.iter().map(|p| p.value.as_ref()));
+            self.fake_command_response(context, fake_command, values_to_return)
+                .await?;
         }
 
         Ok(())
@@ -44,7 +50,8 @@ impl QueryEngine {
         if self.backend.connected() {
             self.execute(context).await?;
         } else {
-            self.fake_command_response(context, "RESET").await?;
+            self.fake_command_response(context, "RESET", None::<Option<_>>)
+                .await?;
         }
 
         Ok(())

--- a/pgdog/src/frontend/router/parser/command.rs
+++ b/pgdog/src/frontend/router/parser/command.rs
@@ -8,9 +8,8 @@ use lazy_static::lazy_static;
 #[derive(Debug, Clone, PartialEq)]
 pub struct SetParam {
     pub name: String,
-    pub value: ParameterValue,
+    pub value: Option<ParameterValue>,
     pub local: bool,
-    pub reset: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -33,6 +32,7 @@ pub enum Command {
     Set {
         params: Vec<SetParam>,
         route: Route,
+        behave_like_select: bool,
     },
     ResetAll,
     PreparedStatement(Prepare),

--- a/pgdog/src/frontend/router/parser/mod.rs
+++ b/pgdog/src/frontend/router/parser/mod.rs
@@ -29,6 +29,7 @@ pub mod sequence;
 pub mod statement;
 pub mod table;
 pub mod tuple;
+pub(crate) mod util;
 pub mod value;
 pub mod where_clause;
 

--- a/pgdog/src/frontend/router/parser/query/mod.rs
+++ b/pgdog/src/frontend/router/parser/query/mod.rs
@@ -6,7 +6,10 @@ use crate::{
     config::Role,
     frontend::router::{
         context::RouterContext,
-        parser::{OrderBy, Shard},
+        parser::{
+            OrderBy, Shard,
+            util::{PgStr, pg_str},
+        },
         round_robin,
         sharding::{Centroids, ContextBuilder},
     },
@@ -28,6 +31,7 @@ mod plugins;
 mod schema_sharding;
 mod select;
 mod set;
+mod set_config;
 mod shared;
 mod show;
 mod transaction;
@@ -284,6 +288,14 @@ impl QueryParser {
         let mut command = match root.node {
             // SET statements -> return immediately.
             Some(NodeEnum::VariableSetStmt(ref stmt)) => return self.set(stmt, context),
+
+            // SELECT set_config(...) -> treat as SET and return
+            Some(NodeEnum::SelectStmt(ref stmt))
+                if let Some(set_config) = extract_set_config(stmt) =>
+            {
+                return Ok(self.set_config(set_config, context));
+            }
+
             // SHOW statements -> return immediately.
             Some(NodeEnum::VariableShowStmt(ref stmt)) => return self.show(stmt, context),
             // DEALLOCATE statements -> return immediately.
@@ -563,6 +575,29 @@ impl QueryParser {
         }
 
         Ok(Command::Query(Route::write(shard)))
+    }
+}
+
+fn extract_set_config(stmt: &SelectStmt) -> Option<&FuncCall> {
+    static SET_CONFIG: &[&[PgStr<'static>]] = &[
+        &[pg_str("pg_catalog"), pg_str("set_config")],
+        &[pg_str("set_config")],
+    ];
+    // FIXME(sage): Dear god we need some pattern macros for this
+    if let [
+        Node {
+            node: Some(NodeEnum::ResTarget(r)),
+        },
+    ] = &*stmt.target_list
+        && let ResTarget { val: Some(n), .. } = &**r
+        && let Node {
+            node: Some(NodeEnum::FuncCall(f)),
+        } = &**n
+        && SET_CONFIG.iter().any(|&n| n == f.funcname)
+    {
+        Some(f)
+    } else {
+        None
     }
 }
 

--- a/pgdog/src/frontend/router/parser/query/set.rs
+++ b/pgdog/src/frontend/router/parser/query/set.rs
@@ -21,6 +21,7 @@ impl QueryParser {
             return Ok(Command::Set {
                 params: vec![param],
                 route: Route::write(context.shards_calculator.shard()),
+                behave_like_select: false,
             });
         }
 
@@ -40,17 +41,15 @@ impl QueryParser {
         let value = Self::parse_set_value(stmt)?;
 
         match value {
-            Some(value) => Ok(Some(SetParam {
+            value @ Some(_) => Ok(Some(SetParam {
                 name: stmt.name.to_string(),
                 value,
                 local: stmt.is_local,
-                reset: is_reset,
             })),
             None if is_reset => Ok(Some(SetParam {
                 name: stmt.name.to_string(),
-                value: ParameterValue::String(std::string::String::new()),
+                value: None,
                 local: false,
-                reset: true,
             })),
             None => Ok(None),
         }
@@ -103,6 +102,7 @@ impl QueryParser {
         Ok(Some(Command::Set {
             params,
             route: Route::write(context.shards_calculator.shard()),
+            behave_like_select: false,
         }))
     }
 

--- a/pgdog/src/frontend/router/parser/query/set_config.rs
+++ b/pgdog/src/frontend/router/parser/query/set_config.rs
@@ -1,0 +1,69 @@
+use super::{String as PgString, *};
+use std::string::String;
+
+impl QueryParser {
+    /// Handle SELECT set_config('key', 'value', is_local)
+    ///
+    /// If the function arguments are a form we cannot handle, we warn and
+    /// pass through
+    pub(super) fn set_config(&mut self, fcall: &FuncCall, context: &QueryParserContext) -> Command {
+        if let Some(param) = parse_args(fcall) {
+            Command::Set {
+                params: vec![param],
+                route: Route::write(context.shards_calculator.shard()),
+                behave_like_select: true,
+            }
+        } else {
+            Command::Query(
+                Route::write(context.shards_calculator.shard()).with_read(context.read_only),
+            )
+        }
+    }
+}
+
+/// Returns None if the arguments could not be parsed
+fn parse_args(fcall: &FuncCall) -> Option<SetParam> {
+    let name = parse_config_name(fcall.args.first()?)?;
+    let value = parse_config_value(fcall.args.get(1)?)?;
+    let local = parse_is_local(fcall.args.get(2)?)?;
+    Some(SetParam { name, value, local })
+}
+
+/// Returns None if the name could not be parsed
+fn parse_config_name(arg: &Node) -> Option<String> {
+    match &arg.node {
+        Some(NodeEnum::AConst(AConst {
+            val: Some(Val::Sval(PgString { sval })),
+            ..
+        })) => Some(sval.clone()),
+        // Only constant strings can be handled for now
+        _ => None,
+    }
+}
+
+/// Returns None if the value could not be parsed, Some(None) if the value
+/// is NULL, and Some if the value was successfully parsed
+fn parse_config_value(arg: &Node) -> Option<Option<ParameterValue>> {
+    match &arg.node {
+        Some(NodeEnum::AConst(AConst {
+            val: Some(Val::Sval(PgString { sval })),
+            ..
+        })) => Some(Some(ParameterValue::String(sval.clone()))),
+        Some(NodeEnum::AConst(AConst { isnull: true, .. })) => Some(None),
+        // FIXME(sage): The function only takes text. Do we need to deal with
+        // other literals?
+        _ => None,
+    }
+}
+
+/// Returns None if the node was not a constant boolean
+fn parse_is_local(arg: &Node) -> Option<bool> {
+    match &arg.node {
+        Some(NodeEnum::AConst(AConst {
+            val: Some(Val::Boolval(Boolean { boolval })),
+            ..
+        })) => Some(*boolval),
+        // Only constant strings can be handled for now
+        _ => None,
+    }
+}

--- a/pgdog/src/frontend/router/parser/query/test/mod.rs
+++ b/pgdog/src/frontend/router/parser/query/test/mod.rs
@@ -384,7 +384,7 @@ fn test_set() {
         match command {
             Command::Set { params, .. } => {
                 assert_eq!(params[0].name, "timezone");
-                assert_eq!(params[0].value, ParameterValue::from("UTC"));
+                assert_eq!(params[0].value, Some(ParameterValue::from("UTC")));
             }
             _ => panic!("not a set"),
         };
@@ -394,7 +394,7 @@ fn test_set() {
     match command {
         Command::Set { params, .. } => {
             assert_eq!(params[0].name, "statement_timeout");
-            assert_eq!(params[0].value, ParameterValue::from("3000"));
+            assert_eq!(params[0].value, Some(ParameterValue::from("3000")));
         }
         _ => panic!("not a set"),
     };
@@ -405,7 +405,7 @@ fn test_set() {
     match command {
         Command::Set { params, .. } => {
             assert_eq!(params[0].name, "is_superuser");
-            assert_eq!(params[0].value, ParameterValue::from("true"));
+            assert_eq!(params[0].value, Some(ParameterValue::from("true")));
         }
         _ => panic!("not a set"),
     };
@@ -424,7 +424,11 @@ fn test_set() {
             assert_eq!(params[0].name, "search_path");
             assert_eq!(
                 params[0].value,
-                ParameterValue::Tuple(vec!["$user".into(), "public".into(), "APPLES".into()])
+                Some(ParameterValue::Tuple(vec![
+                    "$user".into(),
+                    "public".into(),
+                    "APPLES".into()
+                ]))
             )
         }
         _ => panic!("search path"),
@@ -500,9 +504,11 @@ fn test_transaction() {
     match route {
         Command::Set { params, .. } => {
             assert_eq!(params[0].name, "application_name");
-            assert_eq!(params[0].value.as_str().unwrap(), "test");
+            assert_eq!(
+                params[0].value.as_ref().and_then(|s| s.as_str()),
+                Some("test")
+            );
             assert!(!cluster.read_only());
-            assert!(!params[0].local);
         }
 
         _ => panic!("not a query"),

--- a/pgdog/src/frontend/router/parser/query/test/test_set.rs
+++ b/pgdog/src/frontend/router/parser/query/test/test_set.rs
@@ -21,7 +21,7 @@ fn test_set_comment() {
     ]);
 
     assert!(
-        matches!(command.clone(), Command::Set { ref params, ref route } if params.len() == 1 && params[0].name == "statement_timeout" && !params[0].local && params[0].value == ParameterValue::String("1".into()) && route.shard().is_direct()),
+        matches!(command.clone(), Command::Set { ref params, ref route, ..} if params.len() == 1 && params[0].name == "statement_timeout" && !params[0].local && params[0].value == ParameterValue::String("1".into()) && route.shard().is_direct()),
         "expected Command::Set, got {:#?}",
         command,
     );

--- a/pgdog/src/frontend/router/parser/query/test/test_set.rs
+++ b/pgdog/src/frontend/router/parser/query/test/test_set.rs
@@ -21,7 +21,7 @@ fn test_set_comment() {
     ]);
 
     assert!(
-        matches!(command.clone(), Command::Set { ref params, ref route, ..} if params.len() == 1 && params[0].name == "statement_timeout" && !params[0].local && params[0].value == ParameterValue::String("1".into()) && route.shard().is_direct()),
+        matches!(command.clone(), Command::Set { ref params, ref route, ..} if params.len() == 1 && params[0].name == "statement_timeout" && !params[0].local && params[0].value == Some(ParameterValue::String("1".into())) && route.shard().is_direct()),
         "expected Command::Set, got {:#?}",
         command,
     );
@@ -39,10 +39,10 @@ fn test_set_multi_statement() {
         Command::Set { ref params, .. } => {
             assert_eq!(params.len(), 2);
             assert_eq!(params[0].name, "statement_timeout");
-            assert_eq!(params[0].value, ParameterValue::String("1".into()));
+            assert_eq!(params[0].value, Some(ParameterValue::String("1".into())));
             assert!(!params[0].local);
             assert_eq!(params[1].name, "work_mem");
-            assert_eq!(params[1].value, ParameterValue::String("64MB".into()));
+            assert_eq!(params[1].value, Some(ParameterValue::String("64MB".into())));
             assert!(!params[1].local);
         }
         _ => panic!("expected Command::Set, got {command:#?}"),
@@ -103,9 +103,15 @@ fn test_set_multi_statement_with_timezone_interval() {
         Command::Set { ref params, .. } => {
             assert_eq!(params.len(), 2);
             assert_eq!(params[0].name, "client_min_messages");
-            assert_eq!(params[0].value, ParameterValue::String("warning".into()));
+            assert_eq!(
+                params[0].value,
+                Some(ParameterValue::String("warning".into()))
+            );
             assert_eq!(params[1].name, "timezone");
-            assert_eq!(params[1].value, ParameterValue::String("+00:00".into()));
+            assert_eq!(
+                params[1].value,
+                Some(ParameterValue::String("+00:00".into()))
+            );
         }
         _ => panic!("expected Command::Set, got {command:#?}"),
     }
@@ -151,7 +157,7 @@ fn test_reset() {
         Command::Set { params, .. } => {
             assert_eq!(params.len(), 1);
             assert_eq!(params[0].name, "statement_timeout");
-            assert!(params[0].reset);
+            assert_eq!(params[0].value, None);
         }
         _ => panic!("expected Command::Set, got {command:#?}"),
     }

--- a/pgdog/src/frontend/router/parser/query/test/test_transaction.rs
+++ b/pgdog/src/frontend/router/parser/query/test/test_transaction.rs
@@ -65,7 +65,7 @@ fn test_set_in_transaction() {
     match command {
         Command::Set { params, .. } => {
             assert_eq!(params[0].name, "statement_timeout");
-            assert_eq!(params[0].value, ParameterValue::from("3000"));
+            assert_eq!(params[0].value, Some(ParameterValue::from("3000")));
         }
         _ => panic!("expected Set, got {command:?}"),
     }
@@ -80,9 +80,12 @@ fn test_set_application_name_in_transaction() {
     let command = test.execute(vec![Query::new("SET application_name TO 'test'").into()]);
 
     match command.clone() {
-        Command::Set { params, route } => {
+        Command::Set { params, route, .. } => {
             assert_eq!(params[0].name, "application_name");
-            assert_eq!(params[0].value.as_str().unwrap(), "test");
+            assert_eq!(
+                params[0].value.as_ref().and_then(|s| s.as_str()),
+                Some("test")
+            );
             assert!(!params[0].local);
             assert!(!test.cluster().read_only());
             assert!(route.is_write());

--- a/pgdog/src/frontend/router/parser/rewrite/statement/aggregate/engine.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/aggregate/engine.rs
@@ -1,8 +1,10 @@
-use crate::frontend::router::parser::aggregate::{Aggregate, AggregateFunction};
+use crate::frontend::router::parser::{
+    aggregate::{Aggregate, AggregateFunction},
+    util::pg_string,
+};
 use pg_query::NodeEnum;
 use pg_query::protobuf::{
-    AConst, FuncCall, Integer, Node, ResTarget, SelectStmt, String as PgString, TypeCast, TypeName,
-    a_const::Val,
+    AConst, FuncCall, Integer, Node, ResTarget, SelectStmt, TypeCast, TypeName, a_const::Val,
 };
 
 use super::{AggregateRewritePlan, HelperKind, HelperMapping, RewriteOutput};
@@ -246,12 +248,6 @@ impl AggregatesRewrite {
             }
             _ => vec![],
         }
-    }
-}
-
-fn pg_string(s: impl Into<String>) -> Node {
-    Node {
-        node: Some(NodeEnum::String(PgString { sval: s.into() })),
     }
 }
 

--- a/pgdog/src/frontend/router/parser/util.rs
+++ b/pgdog/src/frontend/router/parser/util.rs
@@ -1,0 +1,28 @@
+use pg_query::NodeEnum;
+use pg_query::protobuf::{Node, String as PgString};
+use std::cmp::PartialEq;
+
+pub(crate) fn pg_string(s: impl Into<String>) -> Node {
+    node(NodeEnum::String(PgString { sval: s.into() }))
+}
+
+pub(crate) fn node(n: NodeEnum) -> Node {
+    Node { node: Some(n) }
+}
+
+/// A const type that can be compared with Node for equality
+pub(crate) const fn pg_str(s: &str) -> PgStr<'_> {
+    PgStr(s)
+}
+
+#[derive(Debug)]
+pub(crate) struct PgStr<'a>(&'a str);
+
+impl PartialEq<Node> for PgStr<'_> {
+    fn eq(&self, rhs: &Node) -> bool {
+        match &rhs.node {
+            Some(NodeEnum::String(PgString { sval })) => sval == self.0,
+            _ => false,
+        }
+    }
+}

--- a/pgdog/src/net/parameter.rs
+++ b/pgdog/src/net/parameter.rs
@@ -11,7 +11,11 @@ use std::{
 
 use once_cell::sync::Lazy;
 
-use crate::{net::ToBytes, stats::memory::MemoryUsage};
+use crate::{
+    net::{ToBytes, ToDataRowColumn},
+    stats::memory::MemoryUsage,
+};
+use pgdog_postgres_types::Data;
 
 use super::{Error, messages::Query};
 
@@ -85,6 +89,22 @@ impl ToBytes for ParameterValue {
         bytes.put_u8(0);
 
         bytes.freeze()
+    }
+}
+
+impl ToDataRowColumn for ParameterValue {
+    fn to_data_row_column(&self) -> Data {
+        match self {
+            Self::String(s) => s.to_data_row_column(),
+            Self::Tuple(_) => self.to_bytes().to_data_row_column(),
+            Self::Integer(i) => i.to_data_row_column(),
+        }
+    }
+}
+
+impl ToDataRowColumn for &'_ ParameterValue {
+    fn to_data_row_column(&self) -> Data {
+        (*self).to_data_row_column()
     }
 }
 


### PR DESCRIPTION
This intercepts queries that are in the simplest form of `set_config`, where it is a select statement containing exactly one call to that function, and all arguments are literals. Any queries like this could have easily been written using `SET` instead, but this is a form that is emitted by pg_dump, which results in sessions being left in a bad state if we don't handle it explicitly. So we have to handle it.

I took great care to avoid any allocations when we're checking if the select statement is in a form that we can handle, which was slightly more painful than I'd like since we need to check for both qualified an unqualified function names.

Eventually we need to handle this more broadly. `set_config` can appear anywhere in expression context (with undefined execution order, dear god), and can take any expression as an argument including cross-shard queries. When we have a cheaper and more walkable AST, we should at least warn when we encounter this function in any cases where we don't handle.

We can't *just* treat it exactly as `SET`, since the function does return a value and so the client may be expecting rows. I've left the implementation of this somewhat extensible so that we can at least handle selections with multiple calls to `set_config` down the road. Realistically, long term, we need to go through the whole AST and replace any calls to this with their value, while figuring out which config settings to apply when... somehow.

If we encounter a form that we can't parse (non-literals)

Ultimately the very existence of this function is something of an abomination, and I suspect we'll be avoiding dealing with more complex forms for as long as we possibly can.

Fixes #1055