### PR TITLE
feat: improve reload to preserve replica connection and paused state

### DIFF
--- a/pgdog/src/backend/pool/lb/mod.rs
+++ b/pgdog/src/backend/pool/lb/mod.rs
@@ -224,29 +224,42 @@ impl LoadBalancer {
     }
 
     /// Move connections from this replica set to another.
+    ///
+    /// Uses address-based matching so existing pools survive replica additions or
+    /// removals: each old target is paired with the new target that shares its
+    /// address. New targets with no matching old target start empty; old targets
+    /// with no match in the new config have their connections dropped.
     pub fn move_conns_to(&self, destination: &LoadBalancer) -> Result<(), Error> {
-        assert_eq!(self.targets.len(), destination.targets.len());
+        for from in &self.targets {
+            if let Some(to) = destination
+                .targets
+                .iter()
+                .find(|to| from.pool.can_move_conns_to(&to.pool))
+            {
+                from.pool.move_conns_to(&to.pool)?;
 
-        for (from, to) in self.targets.iter().zip(destination.targets.iter()) {
-            from.pool.move_conns_to(&to.pool)?;
-
-            // Carry over detected roles and LSN stats so the new load balancer
-            // doesn't briefly appear read-only before the role detector runs.
-            to.set_role(from.role());
-            *to.pool.inner().lsn_stats.write() = from.pool.lsn_stats();
+                // Carry over detected roles and LSN stats so the new load balancer
+                // doesn't briefly appear read-only before the role detector runs.
+                to.set_role(from.role());
+                *to.pool.inner().lsn_stats.write() = from.pool.lsn_stats();
+            }
         }
 
         Ok(())
     }
 
     /// The two replica sets are referring to the same databases.
+    ///
+    /// Returns `true` when every target in `self` has a matching address in
+    /// `destination`. This allows replica additions (new targets start empty)
+    /// while still preserving connections to unchanged replicas.
     pub fn can_move_conns_to(&self, destination: &LoadBalancer) -> bool {
-        self.targets.len() == destination.targets.len()
-            && self
+        self.targets.iter().all(|from| {
+            destination
                 .targets
                 .iter()
-                .zip(destination.targets.iter())
-                .all(|(a, b)| a.pool.can_move_conns_to(&b.pool))
+                .any(|to| from.pool.can_move_conns_to(&to.pool))
+        })
     }
 
     /// True if the LB has any target that can serve replica reads.

--- a/pgdog/src/backend/pool/lb/test.rs
+++ b/pgdog/src/backend/pool/lb/test.rs
@@ -1031,7 +1031,7 @@ async fn test_can_move_conns_to_with_added_replica() {
 
     let lb_old = LoadBalancer::new(
         &None,
-        &[pool_config1.clone()],
+        std::slice::from_ref(&pool_config1),
         LoadBalancingStrategy::Random,
         ReadWriteSplit::IncludePrimary,
     );
@@ -1057,7 +1057,7 @@ async fn test_move_conns_to_with_added_replica_matches_by_address() {
 
     let lb_old = LoadBalancer::new(
         &None,
-        &[pool_config1.clone()],
+        std::slice::from_ref(&pool_config1),
         LoadBalancingStrategy::Random,
         ReadWriteSplit::IncludePrimary,
     );

--- a/pgdog/src/backend/pool/lb/test.rs
+++ b/pgdog/src/backend/pool/lb/test.rs
@@ -999,7 +999,9 @@ async fn test_can_move_conns_to_same_config() {
 }
 
 #[tokio::test]
-async fn test_can_move_conns_to_different_count() {
+async fn test_can_move_conns_to_with_removed_replica() {
+    // Old LB has 2 replicas; new LB dropped one. The old replica with no
+    // matching address in the new LB makes this return false.
     let pool_config1 = create_test_pool_config("127.0.0.1", 5432);
     let pool_config2 = create_test_pool_config("localhost", 5432);
 
@@ -1018,6 +1020,80 @@ async fn test_can_move_conns_to_different_count() {
     );
 
     assert!(!lb1.can_move_conns_to(&lb2));
+}
+
+#[tokio::test]
+async fn test_can_move_conns_to_with_added_replica() {
+    // Old LB has 1 replica; new LB gained an extra one. Every old address
+    // still exists in the new LB, so connections can be preserved.
+    let pool_config1 = create_test_pool_config("127.0.0.1", 5432);
+    let pool_config2 = create_test_pool_config("localhost", 5432);
+
+    let lb_old = LoadBalancer::new(
+        &None,
+        &[pool_config1.clone()],
+        LoadBalancingStrategy::Random,
+        ReadWriteSplit::IncludePrimary,
+    );
+
+    let lb_new = LoadBalancer::new(
+        &None,
+        &[pool_config1, pool_config2],
+        LoadBalancingStrategy::Random,
+        ReadWriteSplit::IncludePrimary,
+    );
+
+    assert!(lb_old.can_move_conns_to(&lb_new));
+}
+
+#[tokio::test]
+async fn test_move_conns_to_with_added_replica_matches_by_address() {
+    // Old LB: one replica at 127.0.0.1.
+    // New LB: same replica plus a brand-new one at localhost.
+    // After the move the existing pool's connections land in the correct new
+    // pool (address match), and the new pool starts empty.
+    let pool_config1 = create_test_pool_config("127.0.0.1", 5432);
+    let pool_config2 = create_test_pool_config("localhost", 5432);
+
+    let lb_old = LoadBalancer::new(
+        &None,
+        &[pool_config1.clone()],
+        LoadBalancingStrategy::Random,
+        ReadWriteSplit::IncludePrimary,
+    );
+    lb_old.launch();
+
+    let lb_new = LoadBalancer::new(
+        &None,
+        &[pool_config1.clone(), pool_config2.clone()],
+        LoadBalancingStrategy::Random,
+        ReadWriteSplit::IncludePrimary,
+    );
+    lb_new.launch();
+
+    // Record the role on the old target so we can verify it was carried over.
+    lb_old.targets[0].set_role(Role::Primary);
+
+    assert!(lb_old.can_move_conns_to(&lb_new));
+    lb_old.move_conns_to(&lb_new).unwrap();
+
+    // The matching new target (same address) should have inherited the role.
+    let new_target_for_existing = lb_new
+        .targets
+        .iter()
+        .find(|t| t.pool.addr().host == "127.0.0.1")
+        .expect("should have target for 127.0.0.1");
+    assert_eq!(new_target_for_existing.role(), Role::Primary);
+
+    // The brand-new target (localhost) should not have been touched.
+    let new_target_for_added = lb_new
+        .targets
+        .iter()
+        .find(|t| t.pool.addr().host == "localhost")
+        .expect("should have target for localhost");
+    assert_eq!(new_target_for_added.role(), Role::Replica);
+
+    lb_new.shutdown();
 }
 
 #[tokio::test]

--- a/pgdog/src/backend/pool/pool_impl.rs
+++ b/pgdog/src/backend/pool/pool_impl.rs
@@ -302,6 +302,11 @@ impl Pool {
             let mut from_guard = self.lock();
             let mut to_guard = destination.lock();
 
+            // Propagate pause state so a paused database stays paused after reload.
+            if from_guard.paused {
+                to_guard.paused = true;
+            }
+
             from_guard.online = false;
             let (idle, taken) = from_guard.move_conns_to(destination);
             for server in idle {

--- a/pgdog/src/backend/pool/test/mod.rs
+++ b/pgdog/src/backend/pool/test/mod.rs
@@ -1205,3 +1205,51 @@ async fn test_token_refresh_loop_stops_on_shutdown() {
         "refresh loop must not write to cache after pool shutdown"
     );
 }
+
+#[tokio::test]
+async fn test_move_conns_to_propagates_pause_state() {
+    // When the source pool is paused, the destination pool should also
+    // start paused so the database stays paused across a RELOAD.
+    let source = Pool::new_test();
+    let destination = Pool::new_test();
+
+    source.launch();
+    destination.launch();
+
+    // Pause the source pool.
+    source.pause();
+    assert!(source.lock().paused);
+    assert!(!destination.lock().paused);
+
+    source.move_conns_to(&destination).unwrap();
+
+    assert!(
+        destination.lock().paused,
+        "destination should be paused after move from a paused source"
+    );
+
+    destination.shutdown();
+}
+
+#[tokio::test]
+async fn test_move_conns_to_does_not_pause_destination_when_source_is_not_paused() {
+    // When the source pool is NOT paused, the destination should also
+    // remain unpaused after the move.
+    let source = Pool::new_test();
+    let destination = Pool::new_test();
+
+    source.launch();
+    destination.launch();
+
+    assert!(!source.lock().paused);
+    assert!(!destination.lock().paused);
+
+    source.move_conns_to(&destination).unwrap();
+
+    assert!(
+        !destination.lock().paused,
+        "destination should remain unpaused when source is not paused"
+    );
+
+    destination.shutdown();
+}


### PR DESCRIPTION
## Description

When adding new replicas to a cluster, `RELOAD` previously dropped all existing backend connections because the target count changed. Connection preservation now uses address-based matching instead of requiring identical replica counts. Existing replicas keep their connections, and new replicas start with empty pools.

If a database was paused via `PAUSE` before a `RELOAD`, the new pools now inherit the `paused` state so the database stays paused.

## Testing

replica test
```
cargo nextest run --profile dev -E 'test(test_can_move_conns_to_with_added_replica) or test(test_can_move_conns_to_with_removed_replica) or test(test_move_conns_to_with_added_replica_matches_by_address)'
```
pause test
```
cargo nextest run --profile dev -E 'test(test_move_conns_to_propagates_pause_state) or test(test_move_conns_to_does_not_pause_destination_when_source_is_not_paused)'
```

## Related Issues/Comments

closes: #356 