### PR TITLE
feat: log warning when lsn_check_delay is misconfigured

### DIFF
--- a/pgdog-config/src/core.rs
+++ b/pgdog-config/src/core.rs
@@ -415,6 +415,8 @@ impl Config {
             parser_warned: bool,
             mirror_parser_warned: bool,
             have_replicas: bool,
+            have_primary: bool,
+            have_auto: bool,
             sharded: bool,
         }
 
@@ -439,11 +441,17 @@ impl Config {
                 if !existing.have_replicas {
                     existing.have_replicas = database.role == Role::Replica;
                 }
+                if !existing.have_primary {
+                    existing.have_primary = database.role == Role::Primary;
+                }
+                if !existing.have_auto {
+                    existing.have_auto = database.role == Role::Auto;
+                }
                 if !existing.sharded {
                     existing.sharded = database.shard > 0;
                 }
 
-                if (existing.sharded || existing.have_replicas)
+                if (existing.sharded || (existing.have_replicas && existing.have_primary))
                     && self.general.query_parser == QueryParserLevel::Off
                     && !existing.parser_warned
                 {
@@ -462,7 +470,9 @@ impl Config {
                         role_warned: false,
                         parser_warned: false,
                         mirror_parser_warned: false,
+                        have_primary: database.role == Role::Primary,
                         have_replicas: database.role == Role::Replica,
+                        have_auto: database.role == Role::Auto,
                         sharded: database.shard > 0,
                     },
                 );
@@ -540,6 +550,20 @@ impl Config {
                 warn!(
                     r#"database "{}" has no replicas and "read_write_split" is set to "{}": read queries will be rejected"#,
                     database, self.general.read_write_split
+                );
+            }
+
+            if self.general.lsn_checks_enabled() && !check.have_auto && !check.have_replicas {
+                warn!(
+                    r#"database "{}" has no replicas and LSN checks are enabled: PgDog will query databases for their LSNs unnecessarily"#,
+                    database
+                )
+            }
+
+            if !self.general.lsn_checks_enabled() && check.have_auto {
+                warn!(
+                    r#"database "{}" has a role set to "auto" but LSN checks are disabled: this disables automatic role detection"#,
+                    database
                 );
             }
         }

--- a/pgdog-config/src/general.rs
+++ b/pgdog-config/src/general.rs
@@ -1191,6 +1191,10 @@ impl General {
         )
     }
 
+    pub fn lsn_checks_enabled(&self) -> bool {
+        self.lsn_check_delay < crate::MAX_DURATION.as_millis() as u64
+    }
+
     fn read_write_strategy() -> ReadWriteStrategy {
         Self::env_enum_or_default("PGDOG_READ_WRITE_STRATEGY")
     }
@@ -1562,6 +1566,21 @@ mod tests {
 
         assert_eq!(General::host(), "0.0.0.0");
         assert_eq!(General::port(), 6432);
+    }
+
+    #[test]
+    fn test_lsn_checks_enabled() {
+        let mut general = General::default();
+        assert!(!general.lsn_checks_enabled());
+
+        general.lsn_check_delay = 0;
+        assert!(general.lsn_checks_enabled());
+
+        general.lsn_check_delay = 5_000;
+        assert!(general.lsn_checks_enabled());
+
+        general.lsn_check_delay = crate::MAX_DURATION.as_millis() as u64;
+        assert!(!general.lsn_checks_enabled());
     }
 
     #[test]


### PR DESCRIPTION
Log a warning on configuration load if `lsn_check_delay` is configured incorrectly.