### PR TITLE
feat: block cross-shard sharding key updates with ON DELETE

### DIFF
--- a/pgdog-stats/src/schema.rs
+++ b/pgdog-stats/src/schema.rs
@@ -32,6 +32,10 @@ impl ForeignKeyAction {
             _ => Self::NoAction,
         }
     }
+
+    pub fn is_destructive_on_delete(&self) -> bool {
+        matches!(self, Self::Cascade | Self::SetNull | Self::SetDefault)
+    }
 }
 
 /// A foreign key reference to another table's column.
@@ -182,6 +186,27 @@ impl Schema {
             .relations
             .get(schema)
             .and_then(|tables| tables.get(name))
+    }
+
+    /// Returns true if a column is referenced by a foreign key whose ON DELETE
+    /// action would be unsafe during a sharding-key row move.
+    pub fn has_destructive_on_delete_reference(
+        &self,
+        schema: &str,
+        table: &str,
+        column: &str,
+    ) -> bool {
+        self.relations
+            .values()
+            .flat_map(|tables| tables.values())
+            .flat_map(|relation| relation.columns.values())
+            .flat_map(|column| column.foreign_keys.iter())
+            .any(|foreign_key| {
+                foreign_key.schema == schema
+                    && foreign_key.table == table
+                    && foreign_key.column == column
+                    && foreign_key.on_delete.is_destructive_on_delete()
+            })
     }
 }
 

--- a/pgdog/src/frontend/client/query_engine/multi_step/error.rs
+++ b/pgdog/src/frontend/client/query_engine/multi_step/error.rs
@@ -39,6 +39,9 @@ pub enum UpdateError {
 
     #[error("sharding key update changes more than one row ({0})")]
     TooManyRows(usize),
+
+    #[error("sharding key update would move a row referenced by an ON DELETE foreign key")]
+    ForeignKeyOnDelete,
 }
 
 impl From<crate::frontend::Error> for Error {

--- a/pgdog/src/frontend/client/query_engine/multi_step/test/update.rs
+++ b/pgdog/src/frontend/client/query_engine/multi_step/test/update.rs
@@ -18,6 +18,47 @@ use crate::{
 
 use super::super::super::Error;
 
+const FK_CHILD_TABLE: &str = "shard_key_update_fk_child";
+
+async fn ensure_sharded_table(client: &mut TestClient) {
+    client
+        .send(Query::new(
+            "CREATE TABLE IF NOT EXISTS sharded (id BIGINT PRIMARY KEY, value TEXT)",
+        ))
+        .await;
+    client.try_process().await.unwrap();
+    client.read_until('Z').await.unwrap();
+}
+
+async fn setup_fk_child(client: &mut TestClient, on_delete: &str) {
+    ensure_sharded_table(client).await;
+
+    client
+        .send(Query::new(format!("DROP TABLE IF EXISTS {FK_CHILD_TABLE}")))
+        .await;
+    client.try_process().await.unwrap();
+    client.read_until('Z').await.unwrap();
+
+    client
+        .send(Query::new(format!(
+            "CREATE TABLE {FK_CHILD_TABLE} (
+                id BIGINT PRIMARY KEY,
+                parent_id BIGINT NOT NULL REFERENCES sharded(id) ON DELETE {on_delete}
+            )"
+        )))
+        .await;
+    client.try_process().await.unwrap();
+    client.read_until('Z').await.unwrap();
+}
+
+async fn cleanup_fk_child(client: &mut TestClient) {
+    client
+        .send(Query::new(format!("DROP TABLE IF EXISTS {FK_CHILD_TABLE}")))
+        .await;
+    client.try_process().await.unwrap();
+    client.read_until('Z').await.unwrap();
+}
+
 async fn same_shard_check(request: ClientRequest) -> Result<(), Error> {
     let mut client = TestClient::new_rewrites(Parameters::default()).await;
     client.client().client_request.extend(request.messages);
@@ -570,4 +611,109 @@ async fn test_update_with_expr() {
     let dr = DataRow::try_from(data_row.clone()).unwrap();
     assert_eq!(dr.column(0).unwrap(), shard_1_id_str.as_bytes());
     assert_eq!(dr.column(1).unwrap(), "prefix_suffix".as_bytes());
+}
+
+#[tokio::test]
+async fn test_foreign_key_on_delete_sharding_key_update() {
+    let mut client = TestClient::new_rewrites(Parameters::default()).await;
+
+    setup_fk_child(&mut client, "CASCADE").await;
+
+    let shard_0_id = client.random_id_for_shard(0);
+    let shard_0_other_id = client.random_id_for_shard(0);
+    let shard_1_id = client.random_id_for_shard(1);
+
+    client
+        .send_simple(Query::new(format!(
+            "INSERT INTO sharded (id) VALUES ({}) ON CONFLICT(id) DO NOTHING",
+            shard_0_id
+        )))
+        .await;
+    client.read_until('Z').await.unwrap();
+
+    // Same-shard sharding key updates are still allowed with destructive FKs.
+    client
+        .try_send_simple(Query::new(format!(
+            "UPDATE sharded SET id = {} WHERE id = {}",
+            shard_0_other_id, shard_0_id
+        )))
+        .await
+        .unwrap();
+    let cmd = client.read().await;
+    assert_eq!(
+        CommandComplete::try_from(cmd).unwrap().command(),
+        "UPDATE 1"
+    );
+    expect_message!(client.read().await, ReadyForQuery);
+
+    // Cross-shard move with ON DELETE CASCADE is blocked before delete/insert.
+    client.send_simple(Query::new("BEGIN")).await;
+    client.read_until('Z').await.unwrap();
+
+    client
+        .send_simple(Query::new(format!(
+            "UPDATE sharded SET id = {} WHERE id = {}",
+            shard_1_id, shard_0_other_id
+        )))
+        .await;
+    let err = ErrorResponse::try_from(client.read().await).expect("expected error");
+    assert!(
+        err.message.contains(
+            "sharding key update would move a row referenced by an ON DELETE foreign key"
+        ),
+        "unexpected error message: {}",
+        err.message
+    );
+    client.read_until('Z').await.unwrap();
+    client.send_simple(Query::new("ROLLBACK")).await;
+    client.read_until('Z').await.unwrap();
+
+    client.send_simple(Query::new("SELECT 1")).await;
+    client.read_until('Z').await.unwrap();
+
+    // ON DELETE RESTRICT does not trigger the PgDog block.
+    setup_fk_child(&mut client, "RESTRICT").await;
+
+    client
+        .send_simple(Query::new(format!(
+            "INSERT INTO sharded (id) VALUES ({}) ON CONFLICT(id) DO NOTHING",
+            shard_0_other_id
+        )))
+        .await;
+    client.read_until('Z').await.unwrap();
+
+    client.send_simple(Query::new("BEGIN")).await;
+    client.read_until('Z').await.unwrap();
+
+    client
+        .try_send_simple(Query::new(format!(
+            "UPDATE sharded SET id = {} WHERE id = {}",
+            shard_1_id, shard_0_other_id
+        )))
+        .await
+        .unwrap();
+
+    let reply = client.read_until('Z').await.unwrap();
+    reply
+        .into_iter()
+        .zip(['C', 'Z'])
+        .for_each(|(message, code)| {
+            assert_eq!(message.code(), code);
+            match code {
+                'C' => assert_eq!(
+                    CommandComplete::try_from(message).unwrap().command(),
+                    "UPDATE 1"
+                ),
+                'Z' => assert_eq!(
+                    ReadyForQuery::try_from(message).unwrap().state().unwrap(),
+                    TransactionState::InTrasaction
+                ),
+                _ => unreachable!(),
+            }
+        });
+
+    client.send_simple(Query::new("COMMIT")).await;
+    client.read_until('Z').await.unwrap();
+
+    cleanup_fk_child(&mut client).await;
 }

--- a/pgdog/src/frontend/client/query_engine/multi_step/test/update.rs
+++ b/pgdog/src/frontend/client/query_engine/multi_step/test/update.rs
@@ -20,12 +20,19 @@ use super::super::super::Error;
 
 const FK_CHILD_TABLE: &str = "shard_key_update_fk_child";
 
+const SHARDED_TABLE_DDL: &str = "CREATE TABLE IF NOT EXISTS sharded (
+    id BIGINT PRIMARY KEY,
+    value TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    enabled BOOLEAN DEFAULT false,
+    user_id BIGINT,
+    region_id INTEGER DEFAULT 10,
+    country_id SMALLINT DEFAULT 5,
+    options JSONB DEFAULT '{}'::jsonb
+)";
+
 async fn ensure_sharded_table(client: &mut TestClient) {
-    client
-        .send(Query::new(
-            "CREATE TABLE IF NOT EXISTS sharded (id BIGINT PRIMARY KEY, value TEXT)",
-        ))
-        .await;
+    client.send(Query::new(SHARDED_TABLE_DDL)).await;
     client.try_process().await.unwrap();
     client.read_until('Z').await.unwrap();
 }

--- a/pgdog/src/frontend/client/query_engine/multi_step/update.rs
+++ b/pgdog/src/frontend/client/query_engine/multi_step/update.rs
@@ -135,6 +135,10 @@ impl<'a> UpdateMulti<'a> {
                 return Err(UpdateError::TransactionRequired.into());
             }
 
+            if self.has_destructive_on_delete_reference(context)? {
+                return Err(UpdateError::ForeignKeyOnDelete.into());
+            }
+
             self.delete_row(context).await?;
             self.execute_request_internal(
                 context,
@@ -155,6 +159,31 @@ impl<'a> UpdateMulti<'a> {
 
             Ok(())
         }
+    }
+
+    fn has_destructive_on_delete_reference(
+        &self,
+        context: &QueryEngineContext<'_>,
+    ) -> Result<bool, Error> {
+        let cluster = self.engine.backend.cluster()?;
+        let schema = cluster.schema();
+        let Some(table) = self.rewrite.target_table() else {
+            return Ok(false);
+        };
+
+        let Some(relation) = schema.table(table, cluster.user(), context.params.search_path())
+        else {
+            return Ok(false);
+        };
+        let Some(sharded_table) = self.rewrite.sharded_table(cluster.sharded_tables()) else {
+            return Ok(false);
+        };
+
+        Ok(schema.has_destructive_on_delete_reference(
+            relation.schema(),
+            &relation.name,
+            &sharded_table.column,
+        ))
     }
 
     /// Execute request and return messages to the client if forward_reply is true.

--- a/pgdog/src/frontend/router/parser/rewrite/statement/update.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/update.rs
@@ -16,6 +16,7 @@ use crate::{
         router::{
             Ast,
             parser::{Column, Table, Value, rewrite::statement::visitor::visit_and_mutate_nodes},
+            sharding::ShardedTable,
         },
     },
     net::{
@@ -93,6 +94,36 @@ impl Deref for ShardingKeyUpdate {
 
     fn deref(&self) -> &Self::Target {
         &self.inner
+    }
+}
+
+impl ShardingKeyUpdate {
+    pub(crate) fn target_table(&self) -> Option<Table<'_>> {
+        self.insert.table.as_ref().map(Table::from)
+    }
+
+    pub(crate) fn sharded_table<'a>(
+        &self,
+        sharded_tables: &'a [ShardedTable],
+    ) -> Option<&'a ShardedTable> {
+        let table = self.target_table()?;
+
+        sharded_tables.iter().find(|sharded| {
+            if let Some(name) = sharded.name.as_ref()
+                && !table.name_match(name)
+            {
+                return false;
+            }
+
+            if let Some(schema) = sharded.schema.as_ref()
+                && let Some(table_schema) = table.schema
+                && table_schema != schema
+            {
+                return false;
+            }
+
+            self.insert.mapping.contains_key(&sharded.column)
+        })
     }
 }
 
@@ -716,6 +747,11 @@ mod test {
         // SELECT should have WHERE clause with param renumbered to $1
         assert_eq!(result.select.stmt, "SELECT * FROM sharded WHERE email = $1");
         assert_eq!(result.select.params, vec![2]);
+
+        let schema = default_schema();
+        let tables = schema.tables.tables();
+        assert_eq!(result.target_table().unwrap().name, "sharded");
+        assert_eq!(result.sharded_table(tables).unwrap().column, "id");
     }
 
     #[test]
@@ -765,6 +801,26 @@ mod test {
             .unwrap();
 
         assert_eq!(result.delete.stmt, "DELETE FROM sharded WHERE email = $1");
+
+        assert!(result.sharded_table(&[]).is_none());
+        assert!(
+            result
+                .sharded_table(&[ShardedTable {
+                    name: Some("other".into()),
+                    column: "id".into(),
+                    ..Default::default()
+                }])
+                .is_none()
+        );
+        assert!(
+            result
+                .sharded_table(&[ShardedTable {
+                    name: Some("sharded".into()),
+                    column: "user_id".into(),
+                    ..Default::default()
+                }])
+                .is_none()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description 

Block cross-shard sharding key updates when the row is referenced by a foreign key with a destructive `ON DELETE` action (`CASCADE`, `SET NULL`, or `SET DEFAULT`). Those moves are implemented as `DELETE + INSERT`, so the delete step could silently affect related rows. PgDog now checks loaded schema metadata before the delete/insert and returns a recoverable error; same-shard updates and `ON DELETE RESTRICT / NO ACTION` are unchanged.

## Testing

```
cargo nextest run --profile dev test_foreign_key_on_delete_sharding_key_update

 cargo nextest run --profile dev 'frontend::router::parser::rewrite::statement::update::test'

 cargo nextest run --profile dev 'frontend::client::query_engine::multi_step::test'
```

## Related issues/comments

closes #899 