### PR TITLE
~BUG: support kubernetes/docker native signals

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,9 @@ COPY --from=builder /build/target/release/pgdog /usr/local/bin/pgdog
 COPY --from=builder /build/target/release/libpgdog_primary_only_tables.so /usr/lib/libpgdog_primary_only_tables.so
 
 WORKDIR /pgdog
+# PgDog drains gracefully on both SIGINT and SIGTERM, so the STOPSIGNAL value no
+# longer affects shutdown behavior. Keep SIGINT to preserve the historical
+# `docker stop` signal; SIGTERM (Kubernetes default, systemd, manual kill) is
+# handled the same way regardless.
 STOPSIGNAL SIGINT
 CMD ["/usr/local/bin/pgdog"]

--- a/pgdog/src/cli.rs
+++ b/pgdog/src/cli.rs
@@ -5,8 +5,8 @@ use std::time::Duration;
 use clap::{Parser, Subcommand};
 use std::fs::read_to_string;
 use thiserror::Error;
+use tokio::select;
 use tokio::time::sleep;
-use tokio::{select, signal::ctrl_c};
 use tracing::{info, warn};
 
 use crate::backend::databases::databases;
@@ -15,6 +15,7 @@ use crate::backend::schema::sync::config::ShardConfig;
 use crate::backend::schema::sync::pg_dump::SyncState;
 use crate::config::{Config, Users};
 use crate::frontend::router::cli::RouterCli;
+use crate::signals::Shutdown;
 
 /// PgDog is a PostgreSQL pooler, proxy, load balancer and query router.
 #[derive(Parser, Debug)]
@@ -322,6 +323,9 @@ pub async fn data_sync(commands: Commands) -> Result<(), Box<dyn std::error::Err
         )?;
         orchestrator.load_schema().await?;
 
+        // Drain cleanly on Ctrl-C / SIGINT and on SIGTERM (Kubernetes, systemd, ...).
+        let mut signals = Shutdown::new()?;
+
         if !skip_schema_sync {
             orchestrator.schema_sync_pre(true).await?;
         }
@@ -332,7 +336,7 @@ pub async fn data_sync(commands: Commands) -> Result<(), Box<dyn std::error::Err
                     result?;
                 }
 
-                _ = ctrl_c() => {
+                _ = signals.listen() => {
                     warn!("abort signal received, waiting 5 seconds and performing cleanup");
                     sleep(Duration::from_secs(5)).await;
 
@@ -351,7 +355,7 @@ pub async fn data_sync(commands: Commands) -> Result<(), Box<dyn std::error::Err
                     result?;
                 }
 
-                _ = ctrl_c() => {
+                _ = signals.listen() => {
                     warn!("abort signal received");
 
                     orchestrator.request_stop().await;

--- a/pgdog/src/frontend/listener.rs
+++ b/pgdog/src/frontend/listener.rs
@@ -11,8 +11,8 @@ use crate::net::messages::{FrontendPid, NegotiateProtocolVersion, Startup, hello
 use crate::net::tls::{acceptor, peer_identity};
 use crate::net::{self, Stream, tweak};
 use crate::sighup::Sighup;
+use crate::signals::Shutdown;
 use tokio::net::{TcpListener, TcpStream};
-use tokio::signal::ctrl_c;
 use tokio::sync::Notify;
 use tokio::time::timeout;
 use tokio::{select, spawn};
@@ -43,6 +43,7 @@ impl Listener {
         let listener = TcpListener::bind(&self.addr).await?;
         let shutdown_signal = comms().shutting_down();
         let mut sighup = Sighup::new()?;
+        let mut signals = Shutdown::new()?;
 
         loop {
             select! {
@@ -71,7 +72,7 @@ impl Listener {
                     self.start_shutdown();
                 }
 
-                _ = ctrl_c() => {
+                _ = signals.listen() => {
                     self.start_shutdown();
                 }
 

--- a/pgdog/src/lib.rs
+++ b/pgdog/src/lib.rs
@@ -12,6 +12,7 @@ pub mod healthcheck;
 pub mod net;
 pub mod plugin;
 pub mod sighup;
+pub mod signals;
 pub mod state;
 pub mod stats;
 #[cfg(test)]

--- a/pgdog/src/signals.rs
+++ b/pgdog/src/signals.rs
@@ -1,0 +1,89 @@
+//! Listen for OS signals that request a graceful shutdown.
+//!
+//! PgDog drains client connections on `Ctrl-C` / `SIGINT` *and* on `SIGTERM`.
+//! `SIGTERM` is what Kubernetes' kubelet, systemd and `docker stop` send by
+//! default, so handling it is what lets pods terminate cleanly instead of
+//! being abruptly killed.
+
+#[cfg(target_family = "unix")]
+use tokio::signal::unix::{Signal, SignalKind, signal};
+
+#[cfg(not(target_family = "unix"))]
+use tokio::signal::ctrl_c;
+
+#[cfg(target_family = "unix")]
+use tokio::select;
+
+/// Listener for shutdown signals (`SIGINT` and `SIGTERM`).
+///
+/// Construct this once and hold it for the lifetime of the loop that awaits
+/// [`Shutdown::listen`]. The underlying signal streams are kept registered the
+/// whole time, so a signal delivered between `listen` calls is still observed
+/// on the next poll — recreating the streams on every iteration could drop a
+/// `SIGTERM`, which is never redelivered by the kernel.
+pub struct Shutdown {
+    #[cfg(target_family = "unix")]
+    interrupt: Signal,
+    #[cfg(target_family = "unix")]
+    terminate: Signal,
+}
+
+impl Shutdown {
+    #[cfg(target_family = "unix")]
+    pub(crate) fn new() -> std::io::Result<Self> {
+        Ok(Self {
+            interrupt: signal(SignalKind::interrupt())?,
+            terminate: signal(SignalKind::terminate())?,
+        })
+    }
+
+    #[cfg(not(target_family = "unix"))]
+    pub(crate) fn new() -> std::io::Result<Self> {
+        Ok(Self {})
+    }
+
+    /// Wait for the next shutdown signal (`SIGINT` or `SIGTERM`).
+    pub(crate) async fn listen(&mut self) {
+        #[cfg(target_family = "unix")]
+        select! {
+            _ = self.interrupt.recv() => {},
+            _ = self.terminate.recv() => {},
+        }
+
+        #[cfg(not(target_family = "unix"))]
+        let _ = ctrl_c().await;
+    }
+}
+
+#[cfg(all(test, target_family = "unix"))]
+mod test {
+    use super::*;
+    use std::time::Duration;
+    use tokio::time::timeout;
+
+    // Each test runs in its own process under nextest, so raising a real
+    // signal here is isolated and safe.
+    async fn assert_resolves_on(kind: libc::c_int) {
+        let mut shutdown = Shutdown::new().unwrap();
+
+        // SAFETY: sending a signal to our own process; a handler is already
+        // installed by `Shutdown::new` above.
+        unsafe {
+            assert_eq!(libc::raise(kind), 0);
+        }
+
+        timeout(Duration::from_secs(5), shutdown.listen())
+            .await
+            .expect("shutdown.listen() should resolve after the signal");
+    }
+
+    #[tokio::test]
+    async fn resolves_on_sigterm() {
+        assert_resolves_on(libc::SIGTERM).await;
+    }
+
+    #[tokio::test]
+    async fn resolves_on_sigint() {
+        assert_resolves_on(libc::SIGINT).await;
+    }
+}


### PR DESCRIPTION
```
support kubernetes/docker native SIGTERM
kubernetes/docker default to sigterm so support is better than
relying on any version of kubelet out there to respect the custom signal
this adds support for sigterm through the same pathway as ctrl_c/SIGINT
```

thanks for your consideration!