### PR TITLE
Begin porting the codebase to use the new parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -163,7 +163,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -197,7 +197,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -581,7 +581,7 @@ checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -671,7 +671,7 @@ checksum = "70066e34b8db2c3f0b852c56a99333bd25fdedfb8850cd95dddf930928b47b80"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "tracing",
 ]
 
@@ -750,8 +750,8 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex",
- "syn 2.0.117",
+ "shlex 1.3.0",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -770,8 +770,8 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex",
- "syn 2.0.117",
+ "shlex 1.3.0",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -861,7 +861,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -941,14 +941,14 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -1038,7 +1038,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1375,7 +1375,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1388,7 +1388,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1399,7 +1399,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1410,7 +1410,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1501,7 +1501,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1511,7 +1511,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1533,7 +1533,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn 2.0.118",
  "unicode-xid",
 ]
 
@@ -1569,7 +1569,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1626,7 +1626,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1891,7 +1891,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2478,7 +2478,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2534,6 +2534,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2566,7 +2575,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2585,7 +2594,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2955,7 +2964,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3062,7 +3071,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3172,7 +3181,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3213,6 +3222,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "pg_raw_parse"
+version = "0.1.0"
+source = "git+https://github.com/pgdogdev/pg_raw_parse.git?rev=a5b12f3#a5b12f330f10ecf309c5621624fc8ee2063e63aa"
+dependencies = [
+ "bindgen 0.72.1",
+ "cc",
+ "glob",
+ "libc",
+ "prettyplease",
+ "regex",
+ "syn 2.0.118",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "pgdog"
 version = "0.1.45"
 dependencies = [
@@ -3243,6 +3267,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "indexmap",
+ "itertools 0.15.0",
  "lazy_static",
  "libc",
  "lru",
@@ -3251,6 +3276,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "pg_query",
+ "pg_raw_parse",
  "pgdog-config",
  "pgdog-plugin",
  "pgdog-postgres-types",
@@ -3336,7 +3362,7 @@ dependencies = [
  "futures",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "tokio",
 ]
 
@@ -3452,7 +3478,7 @@ dependencies = [
  "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3490,7 +3516,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3605,7 +3631,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3652,7 +3678,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.117",
+ "syn 2.0.118",
  "tempfile",
 ]
 
@@ -3666,7 +3692,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3977,14 +4003,14 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4011,9 +4037,9 @@ checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rend"
@@ -4241,7 +4267,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74a5a6f027e892c7a035c6fddb50435a1fbf5a734ffc0c2a9fed4d0221440519"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4419,7 +4445,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4506,7 +4532,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4517,7 +4543,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4577,7 +4603,7 @@ checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4627,6 +4653,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -4812,7 +4844,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4835,7 +4867,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.117",
+ "syn 2.0.118",
  "tokio",
  "url",
 ]
@@ -5004,7 +5036,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5026,9 +5058,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5052,7 +5084,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5190,7 +5222,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5201,7 +5233,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5316,7 +5348,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5531,7 +5563,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5668,7 +5700,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5937,7 +5969,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -6200,7 +6232,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6211,7 +6243,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6531,7 +6563,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -6547,7 +6579,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -6655,7 +6687,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -6676,7 +6708,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6696,7 +6728,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -6736,7 +6768,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/pgdog/Cargo.toml
+++ b/pgdog/Cargo.toml
@@ -12,6 +12,7 @@ default-run = "pgdog"
 
 [features]
 tui = ["ratatui"]
+new_parser = ["pg_raw_parse"]
 
 [dependencies]
 pin-project = "1"
@@ -78,6 +79,8 @@ smallvec = "1"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-webpki-roots-no-provider"] }
 hex = "0.4"
 x509-parser = "0.18"
+pg_raw_parse = { git = "https://github.com/pgdogdev/pg_raw_parse.git", rev = "a5b12f3", optional = true }
+itertools = "0.15.0"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/pgdog/src/frontend/router/parser/cache/ast.rs
+++ b/pgdog/src/frontend/router/parser/cache/ast.rs
@@ -38,6 +38,9 @@ pub struct Ast {
 pub struct AstInner {
     /// Cached AST.
     pub ast: ParseResult,
+    // FIXME(sage): Rename to ast when parser port is done
+    #[cfg(feature = "new_parser")]
+    pub new_ast: pg_raw_parse::ParseResult,
     /// AST stats.
     pub stats: Mutex<Stats>,
     /// Rewrite plan.
@@ -52,6 +55,8 @@ impl AstInner {
     /// Create new AST record, with no rewrite or comment routing.
     pub fn new(ast: ParseResult) -> Self {
         Self {
+            #[cfg(feature = "new_parser")]
+            new_ast: pg_raw_parse::parse(&ast.deparse().unwrap()).unwrap(),
             ast,
             stats: Mutex::new(Stats::new()),
             rewrite_plan: RewritePlan::default(),
@@ -85,6 +90,8 @@ impl Ast {
             QueryParserEngine::PgQueryRaw => parse_raw(query.query_without_comment),
         }
         .map_err(Error::PgQuery)?;
+        #[cfg(feature = "new_parser")]
+        let new_ast = pg_raw_parse::parse(query.query_without_comment).map_err(Error::Parse)?;
 
         // Run the rewrite unconditionally. Even when a shard comment will
         // route the query to a specific shard, we need to know whether the
@@ -92,6 +99,8 @@ impl Ast {
         // `Cache::query` can decide whether this entry is safe to cache.
         let rewrite_plan = StatementRewrite::new(StatementRewriteContext {
             stmt: &mut ast.protobuf,
+            #[cfg(feature = "new_parser")]
+            new_stmt: Some(&new_ast),
             extended: query.original_query.extended(),
             prepared: query.original_query.prepared(),
             prepared_statements,
@@ -123,6 +132,8 @@ impl Ast {
             query_parser_engine: schema.query_parser_engine,
             inner: Arc::new(AstInner {
                 stats: Mutex::new(stats),
+                #[cfg(feature = "new_parser")]
+                new_ast: pg_raw_parse::parse(&ast.deparse().unwrap()).unwrap(),
                 ast,
                 rewrite_plan,
                 fingerprint: OnceCell::new(),

--- a/pgdog/src/frontend/router/parser/error.rs
+++ b/pgdog/src/frontend/router/parser/error.rs
@@ -10,6 +10,10 @@ pub enum Error {
     #[error("{0}")]
     PgQuery(pg_query::Error),
 
+    #[cfg(feature = "new_parser")]
+    #[error("Error parsing query: {0}")]
+    Parse(pg_raw_parse::Error),
+
     #[error("only CSV is supported for sharded copy")]
     OnlyCsv,
 

--- a/pgdog/src/frontend/router/parser/query/delete.rs
+++ b/pgdog/src/frontend/router/parser/query/delete.rs
@@ -4,10 +4,13 @@ impl QueryParser {
     pub(super) fn delete(
         &mut self,
         stmt: &DeleteStmt,
+        #[cfg(feature = "new_parser")] new_stmt: pg_raw_parse::Node<'_>,
         context: &mut QueryParserContext,
     ) -> Result<Command, Error> {
         let mut parser = StatementParser::from_delete(
             stmt,
+            #[cfg(feature = "new_parser")]
+            new_stmt,
             context.router_context.bind,
             &context.sharding_schema,
             self.recorder_mut(),

--- a/pgdog/src/frontend/router/parser/query/explain.rs
+++ b/pgdog/src/frontend/router/parser/query/explain.rs
@@ -9,6 +9,14 @@ impl QueryParser {
     ) -> Result<Command, Error> {
         let query = stmt.query.as_ref().ok_or(Error::EmptyQuery)?;
         let node = query.node.as_ref().ok_or(Error::EmptyQuery)?;
+        #[cfg(feature = "new_parser")]
+        let new_stmt = {
+            let stmt = cached_ast.new_ast.stmts().next().unwrap();
+            let pg_raw_parse::Node::ExplainStmt(query) = stmt else {
+                unreachable!()
+            };
+            query.query()
+        };
 
         if context.expanded_explain() {
             if self.explain_recorder.is_none() {
@@ -19,10 +27,31 @@ impl QueryParser {
         }
 
         let result = match node {
-            NodeEnum::SelectStmt(stmt) => self.select(cached_ast, stmt, context),
-            NodeEnum::InsertStmt(stmt) => self.insert(stmt, context),
-            NodeEnum::UpdateStmt(stmt) => self.update(stmt, context),
-            NodeEnum::DeleteStmt(stmt) => self.delete(stmt, context),
+            NodeEnum::SelectStmt(stmt) => self.select(
+                cached_ast,
+                stmt,
+                #[cfg(feature = "new_parser")]
+                new_stmt,
+                context,
+            ),
+            NodeEnum::InsertStmt(stmt) => self.insert(
+                stmt,
+                #[cfg(feature = "new_parser")]
+                new_stmt,
+                context,
+            ),
+            NodeEnum::UpdateStmt(stmt) => self.update(
+                stmt,
+                #[cfg(feature = "new_parser")]
+                new_stmt,
+                context,
+            ),
+            NodeEnum::DeleteStmt(stmt) => self.delete(
+                stmt,
+                #[cfg(feature = "new_parser")]
+                new_stmt,
+                context,
+            ),
 
             _ => {
                 // For other statement types, route to all shards

--- a/pgdog/src/frontend/router/parser/query/mod.rs
+++ b/pgdog/src/frontend/router/parser/query/mod.rs
@@ -283,6 +283,8 @@ impl QueryParser {
                 context.shards_calculator.shard(),
             )));
         };
+        #[cfg(feature = "new_parser")]
+        let new_root = statement.new_ast.stmts().next().unwrap();
 
         let mut command = match root.node {
             // SET statements -> return immediately.
@@ -302,15 +304,36 @@ impl QueryParser {
                 return Ok(Command::Deallocate);
             }
             // SELECT statements.
-            Some(NodeEnum::SelectStmt(ref stmt)) => self.select(&statement, stmt, context),
+            Some(NodeEnum::SelectStmt(ref stmt)) => self.select(
+                &statement,
+                stmt,
+                #[cfg(feature = "new_parser")]
+                new_root,
+                context,
+            ),
             // COPY statements.
             Some(NodeEnum::CopyStmt(ref stmt)) => Self::copy(stmt, context),
             // INSERT statements.
-            Some(NodeEnum::InsertStmt(ref stmt)) => self.insert(stmt, context),
+            Some(NodeEnum::InsertStmt(ref stmt)) => self.insert(
+                stmt,
+                #[cfg(feature = "new_parser")]
+                new_root,
+                context,
+            ),
             // UPDATE statements.
-            Some(NodeEnum::UpdateStmt(ref stmt)) => self.update(stmt, context),
+            Some(NodeEnum::UpdateStmt(ref stmt)) => self.update(
+                stmt,
+                #[cfg(feature = "new_parser")]
+                new_root,
+                context,
+            ),
             // DELETE statements.
-            Some(NodeEnum::DeleteStmt(ref stmt)) => self.delete(stmt, context),
+            Some(NodeEnum::DeleteStmt(ref stmt)) => self.delete(
+                stmt,
+                #[cfg(feature = "new_parser")]
+                new_root,
+                context,
+            ),
             // Transaction control statements,
             // e.g. BEGIN, COMMIT, etc.
             Some(NodeEnum::TransactionStmt(ref stmt)) => match self.transaction(stmt, context)? {
@@ -530,6 +553,7 @@ impl QueryParser {
     fn insert(
         &mut self,
         stmt: &InsertStmt,
+        #[cfg(feature = "new_parser")] new_stmt: pg_raw_parse::Node<'_>,
         context: &mut QueryParserContext,
     ) -> Result<Command, Error> {
         let schema_lookup = SchemaLookupContext {
@@ -539,6 +563,8 @@ impl QueryParser {
         };
         let mut parser = StatementParser::from_insert(
             stmt,
+            #[cfg(feature = "new_parser")]
+            new_stmt,
             context.router_context.bind,
             &context.sharding_schema,
             self.recorder_mut(),

--- a/pgdog/src/frontend/router/parser/query/select.rs
+++ b/pgdog/src/frontend/router/parser/query/select.rs
@@ -18,6 +18,7 @@ impl QueryParser {
         &mut self,
         cached_ast: &Ast,
         stmt: &SelectStmt,
+        #[cfg(feature = "new_parser")] new_stmt: pg_raw_parse::Node<'_>,
         context: &mut QueryParserContext,
     ) -> Result<Command, Error> {
         let cte_writes = Self::cte_writes(stmt);
@@ -42,6 +43,8 @@ impl QueryParser {
         let (advisory_locks, mut omnisharded) = {
             let mut parser = StatementParser::from_select(
                 stmt,
+                #[cfg(feature = "new_parser")]
+                new_stmt,
                 context.router_context.bind,
                 &context.sharding_schema,
                 None,
@@ -65,6 +68,8 @@ impl QueryParser {
         let (shard, is_sharded, tables) = {
             let mut statement_parser = StatementParser::from_select(
                 stmt,
+                #[cfg(feature = "new_parser")]
+                new_stmt,
                 context.router_context.bind,
                 &context.sharding_schema,
                 self.recorder_mut(),

--- a/pgdog/src/frontend/router/parser/query/update.rs
+++ b/pgdog/src/frontend/router/parser/query/update.rs
@@ -4,10 +4,13 @@ impl QueryParser {
     pub(super) fn update(
         &mut self,
         stmt: &UpdateStmt,
+        #[cfg(feature = "new_parser")] new_stmt: pg_raw_parse::Node<'_>,
         context: &mut QueryParserContext,
     ) -> Result<Command, Error> {
         let mut parser = StatementParser::from_update(
             stmt,
+            #[cfg(feature = "new_parser")]
+            new_stmt,
             context.router_context.bind,
             &context.sharding_schema,
             self.recorder_mut(),

--- a/pgdog/src/frontend/router/parser/rewrite/statement/auto_id.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/auto_id.rs
@@ -97,11 +97,24 @@ impl StatementRewrite<'_> {
     fn get_insert_table(&self) -> Option<(Table<'_>, bool)> {
         let stmt = self.stmt.stmts.first()?;
         let node = stmt.stmt.as_ref()?;
+        #[cfg(feature = "new_parser")]
+        // FIXME(sage): Propagate Nones when port is finished
+        let new_stmt = self
+            .new_stmt
+            .and_then(|r| r.stmts().next())
+            .unwrap_or(pg_raw_parse::Node::None);
 
         if let NodeEnum::InsertStmt(insert) = node.node.as_ref()? {
             let relation = insert.relation.as_ref()?;
-            let is_sharded = StatementParser::from_insert(insert, None, self.schema, None)
-                .is_sharded(self.db_schema, self.user, self.search_path);
+            let is_sharded = StatementParser::from_insert(
+                insert,
+                #[cfg(feature = "new_parser")]
+                new_stmt,
+                None,
+                self.schema,
+                None,
+            )
+            .is_sharded(self.db_schema, self.user, self.search_path);
 
             return Some((Table::from(relation), is_sharded));
         }
@@ -358,6 +371,8 @@ mod tests {
         let schema = sharding_schema_with_mode(mode);
         let mut rewriter = StatementRewrite::new(StatementRewriteContext {
             stmt: &mut ast,
+            #[cfg(feature = "new_parser")]
+            new_stmt: None,
             extended: false,
             prepared: false,
             prepared_statements: &mut prepared,
@@ -565,9 +580,13 @@ mod tests {
     ) -> Result<(String, RewritePlan), Error> {
         let _guard = set_env_var("NODE_ID", "pgdog-1");
         let mut ast = pg_query::parse(sql).unwrap().protobuf;
+        #[cfg(feature = "new_parser")]
+        let new_ast = pg_raw_parse::parse(sql).unwrap();
         let mut prepared = PreparedStatements::default();
         let mut rewriter = StatementRewrite::new(StatementRewriteContext {
             stmt: &mut ast,
+            #[cfg(feature = "new_parser")]
+            new_stmt: Some(&new_ast),
             extended: false,
             prepared: false,
             prepared_statements: &mut prepared,

--- a/pgdog/src/frontend/router/parser/rewrite/statement/insert.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/insert.rs
@@ -339,6 +339,8 @@ mod tests {
         let db_schema = default_db_schema();
         let mut rewriter = StatementRewrite::new(StatementRewriteContext {
             stmt: &mut ast,
+            #[cfg(feature = "new_parser")]
+            new_stmt: None,
             extended: false,
             prepared: false,
             prepared_statements: &mut prepared,

--- a/pgdog/src/frontend/router/parser/rewrite/statement/mod.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/mod.rs
@@ -32,6 +32,8 @@ pub(crate) use update::*;
 pub struct StatementRewriteContext<'a> {
     /// The AST of the statement we are rewriting.
     pub stmt: &'a mut ParseResult,
+    #[cfg(feature = "new_parser")]
+    pub(crate) new_stmt: Option<&'a pg_raw_parse::ParseResult>,
     /// The statement is using the extended protocol with placeholders.
     pub extended: bool,
     /// The statement is named, so we need to save any derivatives into the global
@@ -53,6 +55,8 @@ pub struct StatementRewriteContext<'a> {
 pub struct StatementRewrite<'a> {
     /// SQL statement.
     stmt: &'a mut ParseResult,
+    #[cfg(feature = "new_parser")]
+    new_stmt: Option<&'a pg_raw_parse::ParseResult>,
     /// The statement was rewritten.
     rewritten: bool,
     /// Statement is using the extended protocol, so
@@ -82,6 +86,8 @@ impl<'a> StatementRewrite<'a> {
     pub fn new(ctx: StatementRewriteContext<'a>) -> Self {
         Self {
             stmt: ctx.stmt,
+            #[cfg(feature = "new_parser")]
+            new_stmt: ctx.new_stmt,
             rewritten: false,
             extended: ctx.extended,
             prepared: ctx.prepared,

--- a/pgdog/src/frontend/router/parser/rewrite/statement/offset.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/offset.rs
@@ -285,6 +285,8 @@ mod tests {
         let mut ps = PreparedStatements::default();
         let mut rewrite = StatementRewrite::new(StatementRewriteContext {
             stmt: &mut ast.protobuf,
+            #[cfg(feature = "new_parser")]
+            new_stmt: None,
             extended: false,
             prepared: false,
             prepared_statements: &mut ps,

--- a/pgdog/src/frontend/router/parser/rewrite/statement/simple_prepared.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/simple_prepared.rs
@@ -156,6 +156,8 @@ mod tests {
             let mut ast = parse(sql).unwrap().protobuf;
             let mut rewrite = StatementRewrite::new(StatementRewriteContext {
                 stmt: &mut ast,
+                #[cfg(feature = "new_parser")]
+                new_stmt: None,
                 extended: false,
                 prepared: false,
                 prepared_statements: &mut self.ps,

--- a/pgdog/src/frontend/router/parser/rewrite/statement/unique_id.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/unique_id.rs
@@ -192,6 +192,8 @@ mod tests {
         let db_schema = default_db_schema();
         let mut rewrite = StatementRewrite::new(StatementRewriteContext {
             stmt: &mut ast,
+            #[cfg(feature = "new_parser")]
+            new_stmt: None,
             extended: true,
             prepared: false,
             prepared_statements: &mut ps,
@@ -218,6 +220,8 @@ mod tests {
         let db_schema = default_db_schema();
         let mut rewrite = StatementRewrite::new(StatementRewriteContext {
             stmt: &mut ast,
+            #[cfg(feature = "new_parser")]
+            new_stmt: None,
             extended: true,
             prepared: false,
             prepared_statements: &mut ps,
@@ -244,6 +248,8 @@ mod tests {
         let db_schema = default_db_schema();
         let mut rewrite = StatementRewrite::new(StatementRewriteContext {
             stmt: &mut ast,
+            #[cfg(feature = "new_parser")]
+            new_stmt: None,
             extended: true,
             prepared: false,
             prepared_statements: &mut ps,
@@ -271,6 +277,8 @@ mod tests {
         let db_schema = default_db_schema();
         let mut rewrite = StatementRewrite::new(StatementRewriteContext {
             stmt: &mut ast,
+            #[cfg(feature = "new_parser")]
+            new_stmt: None,
             extended: false,
             prepared: false,
             prepared_statements: &mut ps,
@@ -306,6 +314,8 @@ mod tests {
         let db_schema = default_db_schema();
         let mut rewrite = StatementRewrite::new(StatementRewriteContext {
             stmt: &mut ast,
+            #[cfg(feature = "new_parser")]
+            new_stmt: None,
             extended: false,
             prepared: false,
             prepared_statements: &mut ps,
@@ -333,6 +343,8 @@ mod tests {
         let db_schema = default_db_schema();
         let mut rewrite = StatementRewrite::new(StatementRewriteContext {
             stmt: &mut ast,
+            #[cfg(feature = "new_parser")]
+            new_stmt: None,
             extended: true,
             prepared: false,
             prepared_statements: &mut ps,
@@ -359,6 +371,8 @@ mod tests {
         let db_schema = default_db_schema();
         let mut rewrite = StatementRewrite::new(StatementRewriteContext {
             stmt: &mut ast,
+            #[cfg(feature = "new_parser")]
+            new_stmt: None,
             extended: true,
             prepared: false,
             prepared_statements: &mut ps,
@@ -385,6 +399,8 @@ mod tests {
         let db_schema = default_db_schema();
         let mut rewrite = StatementRewrite::new(StatementRewriteContext {
             stmt: &mut ast,
+            #[cfg(feature = "new_parser")]
+            new_stmt: None,
             extended: true,
             prepared: false,
             prepared_statements: &mut ps,
@@ -410,6 +426,8 @@ mod tests {
         let db_schema = default_db_schema();
         let mut rewrite = StatementRewrite::new(StatementRewriteContext {
             stmt: &mut ast,
+            #[cfg(feature = "new_parser")]
+            new_stmt: None,
             extended: true,
             prepared: false,
             prepared_statements: &mut ps,
@@ -435,6 +453,8 @@ mod tests {
         let db_schema = default_db_schema();
         let mut rewrite = StatementRewrite::new(StatementRewriteContext {
             stmt: &mut ast,
+            #[cfg(feature = "new_parser")]
+            new_stmt: None,
             extended: true,
             prepared: false,
             prepared_statements: &mut ps,
@@ -460,6 +480,8 @@ mod tests {
         let db_schema = default_db_schema();
         let mut rewrite = StatementRewrite::new(StatementRewriteContext {
             stmt: &mut ast,
+            #[cfg(feature = "new_parser")]
+            new_stmt: None,
             extended: true,
             prepared: false,
             prepared_statements: &mut ps,
@@ -485,6 +507,8 @@ mod tests {
         let db_schema = default_db_schema();
         let mut rewrite = StatementRewrite::new(StatementRewriteContext {
             stmt: &mut ast,
+            #[cfg(feature = "new_parser")]
+            new_stmt: None,
             extended: true,
             prepared: false,
             prepared_statements: &mut ps,
@@ -512,6 +536,8 @@ mod tests {
         let db_schema = default_db_schema();
         let mut rewrite = StatementRewrite::new(StatementRewriteContext {
             stmt: &mut ast,
+            #[cfg(feature = "new_parser")]
+            new_stmt: None,
             extended: true,
             prepared: false,
             prepared_statements: &mut ps,
@@ -540,6 +566,8 @@ mod tests {
         let db_schema = default_db_schema();
         let mut rewrite = StatementRewrite::new(StatementRewriteContext {
             stmt: &mut ast,
+            #[cfg(feature = "new_parser")]
+            new_stmt: None,
             extended: true,
             prepared: false,
             prepared_statements: &mut ps,
@@ -565,6 +593,8 @@ mod tests {
         let db_schema = default_db_schema();
         let mut rewrite = StatementRewrite::new(StatementRewriteContext {
             stmt: &mut ast,
+            #[cfg(feature = "new_parser")]
+            new_stmt: None,
             extended: true,
             prepared: false,
             prepared_statements: &mut ps,

--- a/pgdog/src/frontend/router/parser/rewrite/statement/update.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/update.rs
@@ -694,6 +694,8 @@ mod test {
 
         let ctx = StatementRewriteContext {
             stmt: &mut stmt.protobuf,
+            #[cfg(feature = "new_parser")]
+            new_stmt: None,
             schema: &schema,
             db_schema: &db_schema,
             extended: true,

--- a/pgdog/src/frontend/router/parser/statement.rs
+++ b/pgdog/src/frontend/router/parser/statement.rs
@@ -1,14 +1,115 @@
+#[cfg(feature = "new_parser")]
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 
+#[cfg(feature = "new_parser")]
+use itertools::*;
+use pg_query::Node as PgNode;
+#[cfg(not(feature = "new_parser"))]
+use pg_query::Node;
+#[cfg(test)]
+use pg_query::protobuf::RawStmt;
+#[cfg_attr(feature = "new_parser", allow(unused))]
 use pg_query::{
-    Node, NodeEnum,
+    NodeEnum,
     protobuf::{
         self, AConst, AExprKind, BoolExprType, DeleteStmt, FuncCall, InsertStmt, Integer, RangeVar,
-        RawStmt, SelectStmt, UpdateStmt, a_const::Val,
+        SelectStmt, UpdateStmt, a_const::Val,
     },
 };
+#[cfg(feature = "new_parser")]
+use pg_raw_parse::{Node, nodes, walk};
 
-pub(super) fn advisory_locks_from_func_call(
+#[cfg(feature = "new_parser")]
+fn advisory_locks_from_func_call(
+    func: &nodes::FuncCall,
+    bind: Option<&Bind>,
+    values_columns: Option<&ValuesColumns<'_>>,
+) -> Vec<AdvisoryLock> {
+    let mut name_parts = func.funcname().filter_map(|node| match node {
+        Node::String(s) => s.sval(),
+        _ => None,
+    });
+
+    if func.funcname().len() != 1 {
+        return Vec::new();
+    }
+    let name = name_parts.next().unwrap();
+
+    let (unlock, scope) = match name {
+        "pg_advisory_lock"
+        | "pg_advisory_lock_shared"
+        | "pg_try_advisory_lock"
+        | "pg_try_advisory_lock_shared" => (false, LockScope::Session),
+        "pg_advisory_xact_lock"
+        | "pg_advisory_xact_lock_shared"
+        | "pg_try_advisory_xact_lock"
+        | "pg_try_advisory_xact_lock_shared" => (false, LockScope::Transaction),
+        // Session-scoped unlocks. xact locks can't be released by name;
+        // Postgres drops them automatically at COMMIT/ROLLBACK.
+        "pg_advisory_unlock" => (true, LockScope::Session),
+        "pg_advisory_unlock_all" => {
+            return vec![AdvisoryLock {
+                id: None,
+                unlock: true,
+                scope: LockScope::Session,
+            }];
+        }
+        _ => return Vec::new(),
+    };
+
+    let Some(arg) = func.args().next() else {
+        return vec![AdvisoryLock {
+            id: None,
+            unlock,
+            scope,
+        }];
+    };
+
+    // Fast path: the key is a literal / param / cast we can resolve directly.
+    if let Some(id) = integer_arg(arg, bind) {
+        return vec![AdvisoryLock {
+            id: Some(id),
+            unlock,
+            scope,
+        }];
+    }
+
+    // If the argument is a parameter placeholder ($1) and we have no Bind message,
+    // this is just a prepared statement being parsed — the lock isn't actually
+    // being taken yet. Return empty so we don't route as if a lock is held.
+    if bind.is_none() && is_param_ref(arg) {
+        return Vec::new();
+    }
+
+    // Slow path: `SELECT pg_advisory_lock(value) FROM (VALUES (1),(2)) AS t(value)`.
+    // The function is called once per row, so we emit one lock per resolved value.
+    if let Node::ColumnRef(cref) = arg
+        // FIXME: Don't assume the name is unqualified
+        && let Some(col) = last_column_name(cref.fields())
+        && let Some(rows) = values_columns.and_then(|m| m.get(col))
+    {
+        return rows
+            .iter()
+            // Skip unresolvable param refs when there is no Bind.
+            .filter(|v| bind.is_some() || !is_param_ref(**v))
+            .map(|v| AdvisoryLock {
+                id: integer_arg(*v, bind),
+                unlock,
+                scope,
+            })
+            .collect();
+    }
+
+    vec![AdvisoryLock {
+        id: None,
+        unlock,
+        scope,
+    }]
+}
+
+#[cfg(not(feature = "new_parser"))]
+fn advisory_locks_from_func_call(
     func: &FuncCall,
     bind: Option<&Bind>,
     values_columns: Option<&ValuesColumns<'_>>,
@@ -97,6 +198,15 @@ pub(super) fn advisory_locks_from_func_call(
     }]
 }
 
+#[cfg(feature = "new_parser")]
+fn last_column_name<'a>(fields: impl Iterator<Item = Node<'a>>) -> Option<&'a str> {
+    fields.last().and_then(|node| match node {
+        Node::String(s) => s.sval(),
+        _ => None,
+    })
+}
+
+#[cfg(not(feature = "new_parser"))]
 fn last_column_name(fields: &[Node]) -> Option<&str> {
     match fields.last()?.node.as_ref()? {
         NodeEnum::String(protobuf::String { sval }) => Some(sval.as_str()),
@@ -104,12 +214,54 @@ fn last_column_name(fields: &[Node]) -> Option<&str> {
     }
 }
 
+#[cfg(feature = "new_parser")]
+type ValuesColumns<'a> = std::collections::HashMap<Cow<'a, str>, Vec<Node<'a>>>;
+
 /// Map from unqualified VALUES column alias to the list of value nodes — one
 /// per row — introduced by a `FROM (VALUES (...), ...) AS t(col, ...)` in the
 /// current SELECT's FROM clause.
-pub(super) type ValuesColumns<'a> = std::collections::HashMap<&'a str, Vec<&'a Node>>;
+#[cfg(not(feature = "new_parser"))]
+type ValuesColumns<'a> = std::collections::HashMap<&'a str, Vec<&'a PgNode>>;
 
-pub(super) fn collect_values_columns(stmt: &SelectStmt) -> ValuesColumns<'_> {
+#[cfg(feature = "new_parser")]
+fn collect_values_columns(stmt: &nodes::SelectStmt) -> Option<ValuesColumns<'_>> {
+    let Node::RangeSubselect(rs) = stmt.fromClause().exactly_one().ok()? else {
+        return None;
+    };
+    let alias = rs.alias();
+    let Node::SelectStmt(s) = rs.subquery() else {
+        return None;
+    };
+    if s.valuesLists().len() == 0 {
+        return None;
+    }
+    let colnames = alias
+        .map(|a| {
+            a.colnames()
+                .filter_map(|n| match n {
+                    Node::String(s) => s.sval(),
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let values = s
+        .valuesLists()
+        .filter_map(|values| values.as_list())
+        .flat_map(|row| row.enumerate())
+        .map(|(i, v)| {
+            let colname = colnames
+                .get(i)
+                .map(|&s| Cow::Borrowed(s))
+                .unwrap_or_else(|| format!("column{}", i + 1).into());
+            (colname, v)
+        })
+        .into_group_map();
+    Some(values)
+}
+
+#[cfg(not(feature = "new_parser"))]
+fn collect_values_columns(stmt: &SelectStmt) -> ValuesColumns<'_> {
     let mut out: ValuesColumns<'_> = ValuesColumns::default();
     for node in &stmt.from_clause {
         let Some(NodeEnum::RangeSubselect(rs)) = node.node.as_ref() else {
@@ -149,6 +301,7 @@ pub(super) fn collect_values_columns(stmt: &SelectStmt) -> ValuesColumns<'_> {
     out
 }
 
+#[cfg(not(feature = "new_parser"))]
 fn name_of_string_node(node: &Node) -> Option<&str> {
     match node.node.as_ref()? {
         NodeEnum::String(protobuf::String { sval }) => Some(sval.as_str()),
@@ -156,6 +309,21 @@ fn name_of_string_node(node: &Node) -> Option<&str> {
     }
 }
 
+#[cfg(feature = "new_parser")]
+fn integer_arg(node: Node<'_>, bind: Option<&Bind>) -> Option<i64> {
+    match node {
+        Node::A_Const(a) => a.val()?.numeric_value(),
+        Node::TypeCast(c) => integer_arg(c.arg(), bind),
+        Node::ParamRef(param_ref) => {
+            let index = (param_ref.number as usize).checked_sub(1)?;
+            let param = bind?.parameter(index).ok()??;
+            param.decode::<i64>()
+        }
+        _ => None,
+    }
+}
+
+#[cfg(not(feature = "new_parser"))]
 fn integer_arg(node: &Node, bind: Option<&Bind>) -> Option<i64> {
     match node.node.as_ref()? {
         NodeEnum::AConst(AConst { val: Some(val), .. }) => match val {
@@ -178,6 +346,17 @@ fn integer_arg(node: &Node, bind: Option<&Bind>) -> Option<i64> {
 }
 
 /// Check whether a node is (or wraps) a parameter placeholder (`$N`).
+#[cfg(feature = "new_parser")]
+fn is_param_ref(node: Node<'_>) -> bool {
+    match node {
+        Node::ParamRef(_) => true,
+        Node::TypeCast(cast) => is_param_ref(cast.arg()),
+        _ => false,
+    }
+}
+
+/// Check whether a node is (or wraps) a parameter placeholder (`$N`).
+#[cfg(not(feature = "new_parser"))]
 fn is_param_ref(node: &Node) -> bool {
     match node.node.as_ref() {
         Some(NodeEnum::ParamRef(_)) => true,
@@ -271,7 +450,7 @@ struct SearchContext<'a> {
 
 impl<'a> SearchContext<'a> {
     /// Build context from a FROM clause, extracting table aliases.
-    fn from_from_clause(nodes: &'a [Node]) -> Self {
+    fn from_from_clause(nodes: &'a [PgNode]) -> Self {
         let mut ctx = Self::default();
         ctx.extract_aliases(nodes);
 
@@ -285,13 +464,13 @@ impl<'a> SearchContext<'a> {
         ctx
     }
 
-    fn extract_aliases(&mut self, nodes: &'a [Node]) {
+    fn extract_aliases(&mut self, nodes: &'a [PgNode]) {
         for node in nodes {
             self.extract_alias_from_node(node);
         }
     }
 
-    fn extract_alias_from_node(&mut self, node: &'a Node) {
+    fn extract_alias_from_node(&mut self, node: &'a PgNode) {
         match &node.node {
             Some(NodeEnum::RangeVar(range_var)) => {
                 if let Some(ref alias) = range_var.alias {
@@ -418,6 +597,8 @@ pub struct SchemaLookupContext<'a> {
 
 pub struct StatementParser<'a, 'b, 'c> {
     stmt: Statement<'a>,
+    #[cfg(feature = "new_parser")]
+    new_stmt: pg_raw_parse::Node<'a>,
     bind: Option<&'b Bind>,
     schema: &'b ShardingSchema,
     recorder: Option<&'c mut ExplainRecorder>,
@@ -433,12 +614,15 @@ pub struct StatementParser<'a, 'b, 'c> {
 impl<'a, 'b, 'c> StatementParser<'a, 'b, 'c> {
     fn new(
         stmt: Statement<'a>,
+        #[cfg(feature = "new_parser")] new_stmt: Node<'a>,
         bind: Option<&'b Bind>,
         schema: &'b ShardingSchema,
         recorder: Option<&'c mut ExplainRecorder>,
     ) -> Self {
         Self {
             stmt,
+            #[cfg(feature = "new_parser")]
+            new_stmt,
             bind,
             schema,
             recorder,
@@ -489,38 +673,70 @@ impl<'a, 'b, 'c> StatementParser<'a, 'b, 'c> {
 
     pub fn from_select(
         stmt: &'a SelectStmt,
+        #[cfg(feature = "new_parser")] new_stmt: Node<'a>,
         bind: Option<&'b Bind>,
         schema: &'b ShardingSchema,
         recorder: Option<&'c mut ExplainRecorder>,
     ) -> Self {
-        Self::new(Statement::Select(stmt), bind, schema, recorder)
+        Self::new(
+            Statement::Select(stmt),
+            #[cfg(feature = "new_parser")]
+            new_stmt,
+            bind,
+            schema,
+            recorder,
+        )
     }
 
     pub fn from_update(
         stmt: &'a UpdateStmt,
+        #[cfg(feature = "new_parser")] new_stmt: Node<'a>,
         bind: Option<&'b Bind>,
         schema: &'b ShardingSchema,
         recorder: Option<&'c mut ExplainRecorder>,
     ) -> Self {
-        Self::new(Statement::Update(stmt), bind, schema, recorder)
+        Self::new(
+            Statement::Update(stmt),
+            #[cfg(feature = "new_parser")]
+            new_stmt,
+            bind,
+            schema,
+            recorder,
+        )
     }
 
     pub fn from_delete(
         stmt: &'a DeleteStmt,
+        #[cfg(feature = "new_parser")] new_stmt: Node<'a>,
         bind: Option<&'b Bind>,
         schema: &'b ShardingSchema,
         recorder: Option<&'c mut ExplainRecorder>,
     ) -> Self {
-        Self::new(Statement::Delete(stmt), bind, schema, recorder)
+        Self::new(
+            Statement::Delete(stmt),
+            #[cfg(feature = "new_parser")]
+            new_stmt,
+            bind,
+            schema,
+            recorder,
+        )
     }
 
     pub fn from_insert(
         stmt: &'a InsertStmt,
+        #[cfg(feature = "new_parser")] new_stmt: Node<'a>,
         bind: Option<&'b Bind>,
         schema: &'b ShardingSchema,
         recorder: Option<&'c mut ExplainRecorder>,
     ) -> Self {
-        Self::new(Statement::Insert(stmt), bind, schema, recorder)
+        Self::new(
+            Statement::Insert(stmt),
+            #[cfg(feature = "new_parser")]
+            new_stmt,
+            bind,
+            schema,
+            recorder,
+        )
     }
 
     /// Record a sharding key match.
@@ -544,17 +760,47 @@ impl<'a, 'b, 'c> StatementParser<'a, 'b, 'c> {
         }
     }
 
-    pub fn from_raw(
+    #[cfg(test)]
+    fn from_raw(
         raw: &'a RawStmt,
+        #[cfg(feature = "new_parser")] new_stmt: Node<'a>,
         bind: Option<&'b Bind>,
         schema: &'b ShardingSchema,
         recorder: Option<&'c mut ExplainRecorder>,
     ) -> Result<Self, Error> {
         match raw.stmt.as_ref().and_then(|n| n.node.as_ref()) {
-            Some(NodeEnum::SelectStmt(stmt)) => Ok(Self::from_select(stmt, bind, schema, recorder)),
-            Some(NodeEnum::UpdateStmt(stmt)) => Ok(Self::from_update(stmt, bind, schema, recorder)),
-            Some(NodeEnum::DeleteStmt(stmt)) => Ok(Self::from_delete(stmt, bind, schema, recorder)),
-            Some(NodeEnum::InsertStmt(stmt)) => Ok(Self::from_insert(stmt, bind, schema, recorder)),
+            Some(NodeEnum::SelectStmt(stmt)) => Ok(Self::from_select(
+                stmt,
+                #[cfg(feature = "new_parser")]
+                new_stmt,
+                bind,
+                schema,
+                recorder,
+            )),
+            Some(NodeEnum::UpdateStmt(stmt)) => Ok(Self::from_update(
+                stmt,
+                #[cfg(feature = "new_parser")]
+                new_stmt,
+                bind,
+                schema,
+                recorder,
+            )),
+            Some(NodeEnum::DeleteStmt(stmt)) => Ok(Self::from_delete(
+                stmt,
+                #[cfg(feature = "new_parser")]
+                new_stmt,
+                bind,
+                schema,
+                recorder,
+            )),
+            Some(NodeEnum::InsertStmt(stmt)) => Ok(Self::from_insert(
+                stmt,
+                #[cfg(feature = "new_parser")]
+                new_stmt,
+                bind,
+                schema,
+                recorder,
+            )),
             _ => Err(Error::NotASelect),
         }
     }
@@ -666,6 +912,47 @@ impl<'a, 'b, 'c> StatementParser<'a, 'b, 'c> {
         }
     }
 
+    // Are we running? Or walking? MAKE UP YOUR MIND DAMMIT
+    #[cfg(feature = "new_parser")]
+    fn run_walk(&self) -> Walk<'a> {
+        use pg_raw_parse::walk::Recurse;
+        use std::ops::ControlFlow;
+        use std::ptr;
+
+        let mut walk = Walk::default();
+        walk::walk(self.new_stmt, |node| match node {
+            Node::SelectStmt(s) => {
+                let values_columns = collect_values_columns(s);
+
+                // Extract any advisory locks that exist in this, and only
+                // this select statement, using the values columns that appear
+                // in its FROM clause if any
+                walk::walk_manual::<()>(node, |node| match node {
+                    Node::FuncCall(func) => {
+                        walk.advisory_locks.extend(advisory_locks_from_func_call(
+                            func,
+                            self.bind,
+                            values_columns.as_ref(),
+                        ));
+                        ControlFlow::Continue(Recurse::No)
+                    }
+                    // Don't recurse into subselects, otherwise we'll resolve
+                    // advisory locks with the wrong set of values columns
+                    Node::SelectStmt(s2) => Recurse::recurse_if(ptr::eq(s, s2)),
+                    _ => ControlFlow::Continue(Recurse::Yes),
+                })
+                .expect("PG received an unrecognized node");
+            }
+
+            Node::RangeVar(r) => walk.tables.push(Table::from(r)),
+            _ => (),
+        })
+        .expect("PG received an unrecognized node");
+
+        walk
+    }
+
+    #[cfg(not(feature = "new_parser"))]
     fn run_walk(&self) -> Walk<'a> {
         let mut walk = Walk::default();
         match self.stmt {
@@ -677,6 +964,7 @@ impl<'a, 'b, 'c> StatementParser<'a, 'b, 'c> {
         walk
     }
 
+    #[cfg(not(feature = "new_parser"))]
     fn walk_select(&self, stmt: &'a SelectStmt, walk: &mut Walk<'a>) {
         // Build a VALUES-column lookup for the current SELECT scope so a call
         // like `pg_advisory_lock(value) FROM (VALUES (1),(2)) AS t(value)`
@@ -724,6 +1012,7 @@ impl<'a, 'b, 'c> StatementParser<'a, 'b, 'c> {
         }
     }
 
+    #[cfg(not(feature = "new_parser"))]
     fn walk_update(&self, stmt: &'a UpdateStmt, walk: &mut Walk<'a>) {
         if let Some(ref relation) = stmt.relation {
             walk.tables.push(Table::from(relation));
@@ -749,6 +1038,7 @@ impl<'a, 'b, 'c> StatementParser<'a, 'b, 'c> {
         }
     }
 
+    #[cfg(not(feature = "new_parser"))]
     fn walk_delete(&self, stmt: &'a DeleteStmt, walk: &mut Walk<'a>) {
         if let Some(ref relation) = stmt.relation {
             walk.tables.push(Table::from(relation));
@@ -774,6 +1064,7 @@ impl<'a, 'b, 'c> StatementParser<'a, 'b, 'c> {
         }
     }
 
+    #[cfg(not(feature = "new_parser"))]
     fn walk_insert(&self, stmt: &'a InsertStmt, walk: &mut Walk<'a>) {
         if let Some(ref relation) = stmt.relation {
             walk.tables.push(Table::from(relation));
@@ -797,6 +1088,7 @@ impl<'a, 'b, 'c> StatementParser<'a, 'b, 'c> {
         }
     }
 
+    #[cfg(not(feature = "new_parser"))]
     fn walk_node(&self, node: &'a Node, walk: &mut Walk<'a>, values: Option<&ValuesColumns<'a>>) {
         match &node.node {
             Some(NodeEnum::RangeVar(range_var)) => {
@@ -1054,7 +1346,7 @@ impl<'a, 'b, 'c> StatementParser<'a, 'b, 'c> {
 
     fn select_search(
         &mut self,
-        node: &'a Node,
+        node: &'a pg_query::Node,
         ctx: &SearchContext<'a>,
     ) -> Result<SearchResult<'a>, Error> {
         match node.node {
@@ -1623,7 +1915,18 @@ mod test {
             .first()
             .cloned()
             .unwrap();
-        let mut parser = StatementParser::from_raw(&raw, bind, &schema, None)?;
+        #[cfg(feature = "new_parser")]
+        let new_raw = pg_raw_parse::parse(stmt).unwrap();
+        #[cfg(feature = "new_parser")]
+        let new_stmt = new_raw.stmts().next().unwrap();
+        let mut parser = StatementParser::from_raw(
+            &raw,
+            #[cfg(feature = "new_parser")]
+            new_stmt,
+            bind,
+            &schema,
+            None,
+        )?;
         parser.shard()
     }
 
@@ -2445,7 +2748,18 @@ mod test {
             .first()
             .cloned()
             .unwrap();
-        let mut parser = StatementParser::from_raw(&raw, bind, &schema, None)?;
+        #[cfg(feature = "new_parser")]
+        let new_raw = pg_raw_parse::parse(stmt).unwrap();
+        #[cfg(feature = "new_parser")]
+        let new_stmt = new_raw.stmts().next().unwrap();
+        let mut parser = StatementParser::from_raw(
+            &raw,
+            #[cfg(feature = "new_parser")]
+            new_stmt,
+            bind,
+            &schema,
+            None,
+        )?;
         parser.shard()
     }
 
@@ -2562,7 +2876,18 @@ mod test {
             .first()
             .cloned()
             .unwrap();
-        let mut parser = StatementParser::from_raw(&raw, bind, &schema, None)?;
+        #[cfg(feature = "new_parser")]
+        let new_raw = pg_raw_parse::parse(stmt).unwrap();
+        #[cfg(feature = "new_parser")]
+        let new_stmt = new_raw.stmts().next().unwrap();
+        let mut parser = StatementParser::from_raw(
+            &raw,
+            #[cfg(feature = "new_parser")]
+            new_stmt,
+            bind,
+            &schema,
+            None,
+        )?;
         parser.shard()
     }
 
@@ -2723,8 +3048,19 @@ mod test {
             .first()
             .cloned()
             .unwrap();
-        let mut parser = StatementParser::from_raw(&raw, bind, &sharding_schema, None)?
-            .with_schema_lookup(schema_lookup);
+        #[cfg(feature = "new_parser")]
+        let new_raw = pg_raw_parse::parse(stmt).unwrap();
+        #[cfg(feature = "new_parser")]
+        let new_stmt = new_raw.stmts().next().unwrap();
+        let mut parser = StatementParser::from_raw(
+            &raw,
+            #[cfg(feature = "new_parser")]
+            new_stmt,
+            bind,
+            &sharding_schema,
+            None,
+        )?
+        .with_schema_lookup(schema_lookup);
         parser.shard()
     }
 
@@ -2848,7 +3184,19 @@ mod test {
             .first()
             .cloned()
             .unwrap();
-        let mut parser = StatementParser::from_raw(&raw, None, &schema, None).unwrap();
+        #[cfg(feature = "new_parser")]
+        let new_raw = pg_raw_parse::parse(stmt).unwrap();
+        #[cfg(feature = "new_parser")]
+        let new_stmt = new_raw.stmts().next().unwrap();
+        let mut parser = StatementParser::from_raw(
+            &raw,
+            #[cfg(feature = "new_parser")]
+            new_stmt,
+            None,
+            &schema,
+            None,
+        )
+        .unwrap();
         parser.is_sharded(&db_schema, "test", None)
     }
 
@@ -2932,7 +3280,19 @@ mod test {
             let ast = parse(query).unwrap().protobuf;
             let schema = ShardingSchema::default();
             let raw = ast.stmts.first().unwrap();
-            let mut parser = StatementParser::from_raw(raw, bind, &schema, None).unwrap();
+            #[cfg(feature = "new_parser")]
+            let new_ast = pg_raw_parse::parse(query).unwrap();
+            #[cfg(feature = "new_parser")]
+            let new_stmt = new_ast.stmts().next().unwrap();
+            let mut parser = StatementParser::from_raw(
+                raw,
+                #[cfg(feature = "new_parser")]
+                new_stmt,
+                bind,
+                &schema,
+                None,
+            )
+            .unwrap();
             let mut v: Vec<_> = parser.extract_advisory_locks().iter().copied().collect();
             v.sort_by_key(|l| (l.id, l.unlock));
             v
@@ -3140,6 +3500,34 @@ mod test {
             // called once per row, so the parser should emit one lock per row.
             assert_eq!(
                 locks("SELECT pg_advisory_lock(value) FROM (VALUES (10), (20), (30)) AS t(value)",),
+                vec![
+                    session(Some(10), false),
+                    session(Some(20), false),
+                    session(Some(30), false),
+                ],
+            );
+        }
+
+        #[test]
+        #[cfg(feature = "new_parser")]
+        fn advisory_lock_from_values_without_explicit_column_name() {
+            assert_eq!(
+                locks("SELECT pg_advisory_lock(column1) FROM (VALUES (10), (20), (30))",),
+                vec![
+                    session(Some(10), false),
+                    session(Some(20), false),
+                    session(Some(30), false),
+                ],
+            );
+        }
+
+        #[test]
+        #[cfg(feature = "new_parser")]
+        fn advisory_lock_when_client_is_sadistic() {
+            assert_eq!(
+                locks(
+                    "SELECT pg_advisory_lock(column1), (SELECT pg_advisory_lock(c) FROM (VALUES (20), (30)) AS t(c)) FROM (VALUES (10))",
+                ),
                 vec![
                     session(Some(10), false),
                     session(Some(20), false),

--- a/pgdog/src/frontend/router/parser/table.rs
+++ b/pgdog/src/frontend/router/parser/table.rs
@@ -153,6 +153,20 @@ impl<'a> TryFrom<&'a Vec<Node>> for Table<'a> {
     }
 }
 
+#[cfg(feature = "new_parser")]
+impl<'a> From<&'a pg_raw_parse::nodes::RangeVar> for Table<'a> {
+    fn from(range_var: &'a pg_raw_parse::nodes::RangeVar) -> Self {
+        let name = range_var.relname().unwrap_or_default();
+        let alias = range_var.alias().and_then(|a| a.aliasname());
+        let schema = range_var.schemaname();
+        Self {
+            name,
+            alias,
+            schema,
+        }
+    }
+}
+
 impl<'a> From<&'a RangeVar> for Table<'a> {
     fn from(range_var: &'a RangeVar) -> Self {
         let (name, alias) = if let Some(ref alias) = range_var.alias {


### PR DESCRIPTION
This is the first in a series of (hopefully smaller from this point)
commits that port the codebase over to use the new parser. The function
this commit focuses on is StatementParser::run_walk.

This commit leaks *way* outside that function, since it required most of
the glue code to pass the new AST around. The parsed AST must live at
the cache layer, since `pg_raw_parse::ParseResult` is what holds the
`MemoryContext`, and all nodes contain a lifetime referring to that
struct.

We're doing a funky thing where we parse once at the same time as the
old parser runs, but then later we unparse and reparse and start passing
that around. The reason for this is that the rewriter hasn't been ported
yet, so it only operates on the old parser's AST. If we didn't
deparse/reparse at that point, code after that which gets ported would
be based on the untransformed query.

The actual porting code is relatively straightforward. It's mostly 1:1
changes with fewer layers of indirection, but I did clean up some edge
cases in advisory locks while I was at it. The new code can handle
advisory locks coming from values clauses without an explicit column
name given, and also correctly handles completely silly cases where the
advisory lock comes form a subselect.

These edge cases are unlikely to ever show up in the wild, but it's
imporant that if we ever do encounter them, we do something sensible
instead of silently doing the wrong thing. And handling the tricky edge
cases also gave me an opportunity to stress test the capability of the
new parser's AST walking API.
