### PR TITLE
Port Value::try_from to the new parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3268,7 +3268,7 @@ dependencies = [
 [[package]]
 name = "pg_raw_parse"
 version = "0.1.0"
-source = "git+https://github.com/pgdogdev/pg_raw_parse.git?rev=922d89c#922d89c7d3239c64a5b07014c0f80d0bb39223aa"
+source = "git+https://github.com/pgdogdev/pg_raw_parse.git?rev=b94e4cf#b94e4cf77de42cf1a99505e6a153fd0ef7a2cb53"
 dependencies = [
  "bindgen 0.72.1",
  "cc",

--- a/pgdog/Cargo.toml
+++ b/pgdog/Cargo.toml
@@ -79,7 +79,7 @@ smallvec = "1"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-webpki-roots-no-provider", "json"] }
 hex = "0.4"
 x509-parser = "0.18"
-pg_raw_parse = { git = "https://github.com/pgdogdev/pg_raw_parse.git", rev = "922d89c", optional = true }
+pg_raw_parse = { git = "https://github.com/pgdogdev/pg_raw_parse.git", rev = "b94e4cf", optional = true }
 itertools = "0.15.0"
 
 [target.'cfg(unix)'.dependencies]

--- a/pgdog/src/frontend/router/parser/value.rs
+++ b/pgdog/src/frontend/router/parser/value.rs
@@ -2,10 +2,14 @@
 
 use std::fmt::Display;
 
+#[cfg(feature = "new_parser")]
+use itertools::*;
 use pg_query::{
     NodeEnum,
-    protobuf::{a_const::Val, *},
+    protobuf::{Node as PgNode, a_const::Val, *},
 };
+#[cfg(feature = "new_parser")]
+use pg_raw_parse::{Node, nodes};
 
 use crate::net::{messages::Vector, vector::str_to_vector};
 
@@ -14,6 +18,7 @@ use crate::net::{messages::Vector, vector::str_to_vector};
 pub enum Value<'a> {
     String(&'a str),
     Integer(i64),
+    // FIXME(sage): This will lose precision on numeric
     Float(f64),
     Boolean(bool),
     Null,
@@ -45,10 +50,39 @@ impl Display for Value<'_> {
 impl Value<'_> {
     /// Get vector if it's a vector.
     #[cfg(test)]
-    pub(crate) fn vector(self) -> Option<Vector> {
+    fn vector(self) -> Option<Vector> {
         match self {
             Self::Vector(vector) => Some(vector),
             _ => None,
+        }
+    }
+}
+
+#[cfg(feature = "new_parser")]
+impl<'a> From<&'a nodes::A_Const> for Value<'a> {
+    fn from(node: &'a nodes::A_Const) -> Self {
+        use pg_raw_parse::const_val::ConstValue;
+        match node.val() {
+            Some(ConstValue::String(s)) if s.starts_with('[') && s.ends_with(']') => {
+                str_to_vector(s)
+                    .map(Value::Vector)
+                    .unwrap_or(Value::String(s))
+            }
+            Some(ConstValue::String(s)) => {
+                s.parse().map(Value::Integer).unwrap_or(Value::String(s))
+            }
+
+            Some(ConstValue::Boolean(b)) => Value::Boolean(b),
+            Some(ConstValue::Integer(i)) => Value::Integer(i.into()),
+            Some(ConstValue::Float(f)) if f.contains('.') => {
+                f.parse().map(Value::Float).unwrap_or(Value::String(f))
+            }
+            Some(c @ ConstValue::Float(f)) => c
+                .numeric_value()
+                .map(Value::Integer)
+                .unwrap_or(Value::String(f)),
+            Some(ConstValue::BitString(bs)) => Value::String(bs),
+            _ => Value::Null,
         }
     }
 }
@@ -95,11 +129,34 @@ impl<'a> From<&'a AConst> for Value<'a> {
     }
 }
 
-impl<'a> TryFrom<&'a Node> for Value<'a> {
+impl<'a> TryFrom<&'a PgNode> for Value<'a> {
     type Error = ();
 
-    fn try_from(value: &'a Node) -> Result<Self, Self::Error> {
+    fn try_from(value: &'a PgNode) -> Result<Self, Self::Error> {
         Value::try_from(&value.node)
+    }
+}
+
+#[cfg(feature = "new_parser")]
+impl<'a> TryFrom<Node<'a>> for Value<'a> {
+    type Error = ();
+
+    fn try_from(value: Node<'a>) -> Result<Self, Self::Error> {
+        use pg_raw_parse::nodes::A_Expr_Kind::AEXPR_OP;
+
+        match value {
+            Node::A_Const(c) => Ok(Self::from(c)),
+            Node::ParamRef(pr) => Ok(Self::Placeholder(pr.number)),
+            Node::TypeCast(c) => Self::try_from(c.arg()),
+            Node::A_Expr(expr @ nodes::A_Expr { kind: AEXPR_OP, .. })
+                if let Ok(n) = expr.name().into_iter().exactly_one()
+                    && n.as_str() == Some("-")
+                    && let Ok(Self::Float(float)) = expr.rexpr().try_into() =>
+            {
+                Ok(Self::Float(-float))
+            }
+            _ => Err(()),
+        }
     }
 }
 
@@ -120,7 +177,7 @@ impl<'a> TryFrom<&'a Option<NodeEnum>> for Value<'a> {
 
             Some(NodeEnum::AExpr(expr)) => {
                 if expr.kind() == AExprKind::AexprOp
-                    && let Some(Node {
+                    && let Some(PgNode {
                         node: Some(NodeEnum::String(pg_query::protobuf::String { sval })),
                     }) = expr.name.first()
                     && sval == "-"
@@ -145,6 +202,23 @@ mod test {
     use super::*;
 
     #[test]
+    #[cfg(feature = "new_parser")]
+    fn test_vector_value() {
+        use pgdog_vector::Float;
+
+        let result = pg_raw_parse::parse("SELECT '[1,2,3]'").unwrap();
+        let node = selected_expr(&result);
+        let vector = Value::try_from(node).unwrap();
+        assert_eq!(
+            vector.vector().unwrap(),
+            Vector {
+                values: vec![Float(1.0), Float(2.0), Float(3.0)]
+            }
+        );
+    }
+
+    #[test]
+    #[cfg(not(feature = "new_parser"))]
     fn test_vector_value() {
         let a_cosnt = AConst {
             val: Some(Val::Sval(String {
@@ -153,7 +227,7 @@ mod test {
             isnull: false,
             location: 0,
         };
-        let node = Node {
+        let node = PgNode {
             node: Some(NodeEnum::AConst(a_cosnt)),
         };
         let vector = Value::try_from(&node).unwrap();
@@ -161,6 +235,19 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "new_parser")]
+    fn test_negative_numeric_with_cast() {
+        // This will be parsed as a unary negation on a cast node, not a cast on
+        // a negative numeric constant
+        let result = pg_raw_parse::parse("SELECT -987654321.123456789::NUMERIC").unwrap();
+        let neg_numeric_node = selected_expr(&result);
+
+        let value = Value::try_from(neg_numeric_node).unwrap();
+        assert_eq!(value, Value::Float(-987_654_321.123_456_8));
+    }
+
+    #[test]
+    #[cfg(not(feature = "new_parser"))]
     fn test_negative_numeric_with_cast() {
         let stmt =
             pg_query::parse("INSERT INTO t (id, val) VALUES (2, -987654321.123456789::NUMERIC)")
@@ -188,5 +275,14 @@ mod test {
         let value = Value::try_from(&neg_numeric_node.node).unwrap();
 
         assert_eq!(value, Value::Float(-987_654_321.123_456_8));
+    }
+
+    #[cfg(feature = "new_parser")]
+    fn selected_expr(result: &pg_raw_parse::ParseResult) -> Node<'_> {
+        let stmt = result.stmts().exactly_one().ok().unwrap();
+        match stmt {
+            Node::SelectStmt(s) => s.targetList().into_iter().exactly_one().unwrap().val(),
+            _ => unreachable!(),
+        }
     }
 }


### PR DESCRIPTION
This port diverges from the old implementation in that it doesn't try to stick any int looking ConstValue::String into an integer, as there wasn't any clear reason for us to be doing so.