### PR TITLE
chore: normalize configs for nextest and rust integration tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,7 +1,12 @@
-[profile.dev]
-fail-fast = true
-test-threads = 1
-default-filter = "not package(rust)"
-
 [profile.default]
-slow-timeout = "15s"
+slow-timeout = { period = "15s" }
+fail-fast = true
+# ignore integration tests since they require a running pgdog instance
+default-filter = "not package(rust)"
+test-threads = 1
+
+[profile.dev]
+inherits = "default"
+
+[profile.integration]
+default-filter = "package(rust)"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -2,11 +2,11 @@
 slow-timeout = { period = "15s" }
 fail-fast = true
 # ignore integration tests since they require a running pgdog instance
-default-filter = "not package(rust)"
+default-filter = "not package(integration_tests_rust)"
 test-threads = 1
 
 [profile.dev]
 inherits = "default"
 
 [profile.integration]
-default-filter = "package(rust)"
+default-filter = "package(integration_tests_rust)"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,8 @@ Contributions are welcome. If you see a bug, feel free to submit a PR with a fix
 4. Run the setup script `bash integration/setup.sh`. It configures required PostgreSQL
    settings and creates the test databases. If any settings were changed, the script
    will exit with a notice — restart PostgreSQL and re-run the script before continuing.
-5. Run the tests `cargo nextest run --profile dev`. If a test fails, try running it directly.
-6. Run the integration tests `bash integration/run.sh` or exact integration test with `bash integration/go/run.sh`.
+5. Run the unit tests with `cargo nextest run`. If some test fails, try running it directly.
+6. Run the integration tests `bash integration/run.sh` or exact integration test e.g. `bash integration/go/run.sh`.
 
 ## Coding
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,9 +654,9 @@ dependencies = [
 
 [[package]]
 name = "azure_core"
-version = "0.34.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688882dc4a96b0ea158299d590fad91c471eced6403fd9a9ea1992c14397f25f"
+checksum = "fe6a26a7d374b440015cbbcbf2d9d8be5a133aa940599f5e5dc569504baa262e"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -675,9 +675,9 @@ dependencies = [
 
 [[package]]
 name = "azure_core_macros"
-version = "0.8.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70066e34b8db2c3f0b852c56a99333bd25fdedfb8850cd95dddf930928b47b80"
+checksum = "b9b52dba6a345f3ad2d42ff8d0d63df9d0994cfa29657bf18ffdbf149f78a4f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -687,9 +687,9 @@ dependencies = [
 
 [[package]]
 name = "azure_identity"
-version = "0.34.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8392bbf0028c43df2f69422825721614f47e12fd601f9056df2c18d35c57e0"
+checksum = "32edf96b356ca7c51d7590c4925cc36efc3947a5da4468e8e0b25c56ecbb3de5"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -1110,6 +1110,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -1989,8 +1999,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2000,9 +2012,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2308,23 +2322,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
 ]
 
 [[package]]
@@ -2537,7 +2534,7 @@ dependencies = [
  "ordered-float",
  "parking_lot",
  "rand 0.9.4",
- "reqwest 0.12.28",
+ "reqwest",
  "rust_decimal",
  "serde_json",
  "serial_test",
@@ -2614,6 +2611,55 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "jobserver"
@@ -2763,6 +2809,12 @@ checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac_address"
@@ -3309,7 +3361,7 @@ dependencies = [
  "rand 0.9.4",
  "ratatui",
  "regex",
- "reqwest 0.12.28",
+ "reqwest",
  "rmp-serde",
  "rust_decimal",
  "rustls-native-certs",
@@ -3749,6 +3801,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.6.3",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.3",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4020,72 +4128,36 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "encoding_rs",
- "futures-core",
- "h2",
- "http 1.4.1",
- "http-body 1.0.1",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-tls",
- "hyper-util",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "percent-encoding",
- "pin-project-lite",
- "rustls",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-native-tls",
- "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2",
  "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper",
- "hyper-tls",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
- "native-tls",
+ "mime",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -4284,8 +4356,36 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -4310,6 +4410,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scc"
@@ -4613,6 +4722,16 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
 
 [[package]]
 name = "simdutf8"
@@ -5249,16 +5368,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-postgres"
 version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5551,9 +5660,9 @@ checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "typespec"
-version = "0.14.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "247afbeabe0c383f630d0fdcb4fb92818c31cd3fe5d293335daff8cac79d4e0f"
+checksum = "21666a31293beab8f41d38c2849ddbc342cd9c7cb4d71a9818868287a8934e53"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5565,9 +5674,9 @@ dependencies = [
 
 [[package]]
 name = "typespec_client_core"
-version = "0.13.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66166c78ee5b5a03b665a639899414a468f645f58dba3c8154b82d64847d227b"
+checksum = "924f0c734e0ac3b881ab99d032bd28fcc969d2bb73ef1b8dd4772fd8e518a382"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5576,7 +5685,7 @@ dependencies = [
  "futures",
  "pin-project",
  "rand 0.10.1",
- "reqwest 0.13.4",
+ "reqwest",
  "serde",
  "serde_json",
  "time",
@@ -5590,9 +5699,9 @@ dependencies = [
 
 [[package]]
 name = "typespec_macros"
-version = "0.13.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d17153fde258b3c862cecffad95e185c0eb83e619e76542c4b3ed9828af840f0"
+checksum = "2c608f4427943f8adb211abc95c87672b1b98847152783507d54e3246e502f60"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5754,6 +5863,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
 dependencies = [
  "utf8parse",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -5927,10 +6046,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "1.0.7"
+name = "web-time"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6063,6 +6192,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,16 +1113,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "combine"
-version = "4.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
-dependencies = [
- "bytes",
- "memchr",
-]
-
-[[package]]
 name = "compact_str"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1999,10 +1989,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2012,11 +2000,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2541,6 +2527,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "integration_tests_rust"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "chrono",
+ "futures-util",
+ "libc",
+ "ordered-float",
+ "parking_lot",
+ "rand 0.9.4",
+ "reqwest 0.12.28",
+ "rust_decimal",
+ "serde_json",
+ "serial_test",
+ "sqlx",
+ "tokio",
+ "tokio-postgres",
+ "tokio-rustls",
+ "uuid",
+]
+
+[[package]]
 name = "ipconfig"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2606,55 +2614,6 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
-name = "jni"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
-dependencies = [
- "cfg-if",
- "combine",
- "jni-macros",
- "jni-sys",
- "log",
- "simd_cesu8",
- "thiserror 2.0.18",
- "walkdir",
- "windows-link",
-]
-
-[[package]]
-name = "jni-macros"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
-dependencies = [
- "proc-macro2",
- "quote",
- "rustc_version",
- "simd_cesu8",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
-dependencies = [
- "jni-sys-macros",
-]
-
-[[package]]
-name = "jni-sys-macros"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
-dependencies = [
- "quote",
- "syn 2.0.118",
-]
 
 [[package]]
 name = "jobserver"
@@ -2804,12 +2763,6 @@ checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
 ]
-
-[[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac_address"
@@ -3796,62 +3749,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quinn"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2 0.6.3",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
-dependencies = [
- "aws-lc-rs",
- "bytes",
- "getrandom 0.3.4",
- "lru-slab",
- "rand 0.9.4",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.18",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2 0.6.3",
- "tracing",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4129,15 +4026,20 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-core",
+ "h2",
  "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "rustls",
@@ -4147,6 +4049,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tower",
  "tower-http",
@@ -4166,31 +4069,23 @@ checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
  "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper",
- "hyper-rustls",
  "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
- "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier",
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -4288,28 +4183,6 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rust"
-version = "0.1.0"
-dependencies = [
- "bytes",
- "chrono",
- "futures-util",
- "libc",
- "ordered-float",
- "parking_lot",
- "rand 0.9.4",
- "reqwest 0.13.4",
- "rust_decimal",
- "serde_json",
- "serial_test",
- "sqlx",
- "tokio",
- "tokio-postgres",
- "tokio-rustls",
- "uuid",
 ]
 
 [[package]]
@@ -4411,36 +4284,8 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
- "web-time",
  "zeroize",
 ]
-
-[[package]]
-name = "rustls-platform-verifier"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
-dependencies = [
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "jni",
- "log",
- "once_cell",
- "rustls",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework",
- "security-framework-sys",
- "webpki-root-certs",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls-platform-verifier-android"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -4465,15 +4310,6 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
 
 [[package]]
 name = "scc"
@@ -4777,16 +4613,6 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
-
-[[package]]
-name = "simd_cesu8"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
-dependencies = [
- "rustc_version",
- "simdutf8",
-]
 
 [[package]]
 name = "simdutf8"
@@ -5931,16 +5757,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
-
-[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6111,25 +5927,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-root-certs"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "webpki-roots"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6268,15 +6065,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
-name = "winapi-util"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6372,15 +6160,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -6412,28 +6191,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -6449,12 +6211,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6465,12 +6221,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6485,22 +6235,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6515,12 +6253,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6531,12 +6263,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6551,12 +6277,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6567,12 +6287,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,11 @@ bon = "3.9"
 schemars = { version = "1.2.1", features = ["uuid1"] }
 serde_json = "1.0"
 indexmap = { version = "2.14", features = ["serde"] }
+reqwest = { version = "0.13", features = ["json"] }
+bytes = "1"
+uuid = { version = "1", features = ["v4", "serde"] }
+parking_lot = "0.12"
+futures-util = "0.3.32"
 
 # [patch.crates-io]
 # tokio = { path = "../tokio/tokio" }

--- a/integration/rust/Cargo.toml
+++ b/integration/rust/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rust"
+name = "integration_tests_rust"
 version = "0.1.0"
 edition = "2024"
 

--- a/integration/rust/Cargo.toml
+++ b/integration/rust/Cargo.toml
@@ -10,16 +10,16 @@ test = true
 tokio-postgres = {version = "0.7.13", features = ["with-uuid-1"]}
 sqlx = { version = "0.8.6", features = ["postgres", "runtime-tokio", "tls-native-tls", "bigdecimal", "chrono", "json", "rust_decimal"]}
 tokio = { version = "1", features = ["full"]}
-futures-util = "*"
-uuid  = "*"
+futures-util.workspace = true
+uuid.workspace = true
 serial_test = "3"
 chrono = "0.4"
-parking_lot = "*"
-reqwest = "*"
-serde_json = "*"
+parking_lot.workspace = true
+reqwest.workspace = true
+serde_json.workspace = true
 ordered-float = "4.2"
 tokio-rustls = "0.26"
 libc = "0.2"
 rand = "0.9"
-bytes = "*"
+bytes.workspace = true
 rust_decimal = { version = "1.42.0", features = ["macros"] }

--- a/integration/rust/dev.sh
+++ b/integration/rust/dev.sh
@@ -3,5 +3,5 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 set -e
 
 pushd ${SCRIPT_DIR}
-cargo nextest run --no-fail-fast --test-threads=1
+cargo nextest run --profile integration
 popd

--- a/integration/rust/tests/integration/admin/show_config.rs
+++ b/integration/rust/tests/integration/admin/show_config.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use rust::setup::admin_sqlx;
+use crate::setup::admin_sqlx;
 use sqlx::{Executor, Row};
 
 use super::assert_layout;

--- a/integration/rust/tests/integration/admin/show_version.rs
+++ b/integration/rust/tests/integration/admin/show_version.rs
@@ -1,4 +1,4 @@
-use rust::setup::admin_sqlx;
+use crate::setup::admin_sqlx;
 use sqlx::{Executor, Row};
 
 use super::assert_layout;

--- a/integration/rust/tests/integration/admin/tasks.rs
+++ b/integration/rust/tests/integration/admin/tasks.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use rust::setup::{admin_sqlx, connection_sqlx_direct, connection_sqlx_direct_db};
+use crate::setup::{admin_sqlx, connection_sqlx_direct, connection_sqlx_direct_db};
 use sqlx::{Executor, Pool, Postgres, Row};
 use tokio::time::{sleep, timeout};
 

--- a/integration/rust/tests/integration/admin_termination.rs
+++ b/integration/rust/tests/integration/admin_termination.rs
@@ -1,4 +1,4 @@
-use rust::setup::{admin_sqlx, connection_sqlx_direct, connections_sqlx};
+use crate::setup::{admin_sqlx, connection_sqlx_direct, connections_sqlx};
 use sqlx::{Executor, Row};
 
 /// Test that PgDog gracefully handles connections terminated by administrator command.
@@ -38,8 +38,8 @@ async fn test_admin_termination_retry() {
     // The pooler passes through the client's application_name, which is "sqlx"
     let pids: Vec<i32> = admin_pool
         .fetch_all(
-            "SELECT pid FROM pg_stat_activity 
-             WHERE datname = 'pgdog' 
+            "SELECT pid FROM pg_stat_activity
+             WHERE datname = 'pgdog'
              AND application_name = 'sqlx'
              AND state = 'idle'
              AND pid != pg_backend_pid()",

--- a/integration/rust/tests/integration/auth.rs
+++ b/integration/rust/tests/integration/auth.rs
@@ -1,5 +1,5 @@
-use rust::setup::admin_sqlx;
-use rust::utils::assert_setting_str;
+use crate::setup::admin_sqlx;
+use crate::utils::assert_setting_str;
 use serial_test::serial;
 use sqlx::{Connection, Executor, PgConnection};
 

--- a/integration/rust/tests/integration/auto_id.rs
+++ b/integration/rust/tests/integration/auto_id.rs
@@ -1,6 +1,6 @@
 //! Integration tests for auto_id injection of pgdog.unique_id()
 
-use rust::setup::{admin_sqlx, connections_sqlx};
+use crate::setup::{admin_sqlx, connections_sqlx};
 use sqlx::{Executor, Pool, Postgres};
 
 const AUTO_ID_TABLE: &str = "auto_id_test";

--- a/integration/rust/tests/integration/avg.rs
+++ b/integration/rust/tests/integration/avg.rs
@@ -1,4 +1,4 @@
-use rust::setup::{admin_sqlx, connections_sqlx};
+use crate::setup::{admin_sqlx, connections_sqlx};
 use sqlx::{Connection, Executor, PgConnection, Row};
 
 #[tokio::test]

--- a/integration/rust/tests/integration/ban.rs
+++ b/integration/rust/tests/integration/ban.rs
@@ -1,4 +1,4 @@
-use rust::setup::{admin_sqlx, connections_sqlx};
+use crate::setup::{admin_sqlx, connections_sqlx};
 use sqlx::Executor;
 use sqlx::Row;
 

--- a/integration/rust/tests/integration/cancel.rs
+++ b/integration/rust/tests/integration/cancel.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
+use crate::setup::{admin_tokio, connection_sqlx_direct};
 use bytes::{BufMut, BytesMut};
-use rust::setup::{admin_tokio, connection_sqlx_direct};
 use sqlx::PgPool;
 use tokio::{io::AsyncWriteExt, net::TcpStream, task::JoinHandle, time::timeout};
 use tokio_postgres::{CancelToken, Error as PgError, NoTls, SimpleQueryMessage};

--- a/integration/rust/tests/integration/client_ids.rs
+++ b/integration/rust/tests/integration/client_ids.rs
@@ -1,5 +1,5 @@
+use crate::setup::admin_sqlx;
 use futures_util::future::join_all;
-use rust::setup::admin_sqlx;
 use serial_test::serial;
 use sqlx::{Executor, Row};
 use std::collections::HashSet;

--- a/integration/rust/tests/integration/connection_recovery.rs
+++ b/integration/rust/tests/integration/connection_recovery.rs
@@ -1,4 +1,4 @@
-use rust::setup::{admin_sqlx, admin_tokio};
+use crate::setup::{admin_sqlx, admin_tokio};
 use serial_test::serial;
 use sqlx::{Executor, Row};
 use std::time::Duration;

--- a/integration/rust/tests/integration/copy.rs
+++ b/integration/rust/tests/integration/copy.rs
@@ -1,4 +1,4 @@
-use rust::setup::{connections_sqlx, connections_tokio};
+use crate::setup::{connections_sqlx, connections_tokio};
 
 #[tokio::test]
 async fn copy_from_csv() -> Result<(), Box<dyn std::error::Error>> {

--- a/integration/rust/tests/integration/cross_shard_disabled.rs
+++ b/integration/rust/tests/integration/cross_shard_disabled.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use rust::setup::{admin_sqlx, connections_sqlx};
+use crate::setup::{admin_sqlx, connections_sqlx};
 use sqlx::Executor;
 use tokio::time::sleep;
 

--- a/integration/rust/tests/integration/distinct.rs
+++ b/integration/rust/tests/integration/distinct.rs
@@ -1,4 +1,4 @@
-use rust::setup::connections_sqlx;
+use crate::setup::connections_sqlx;
 use sqlx::{Executor, Row};
 
 #[tokio::test]

--- a/integration/rust/tests/integration/explain.rs
+++ b/integration/rust/tests/integration/explain.rs
@@ -1,4 +1,4 @@
-use rust::setup::{admin_sqlx, connections_tokio};
+use crate::setup::{admin_sqlx, connections_tokio};
 use sqlx::Executor;
 use tokio_postgres::SimpleQueryMessage;
 

--- a/integration/rust/tests/integration/fake_transactions.rs
+++ b/integration/rust/tests/integration/fake_transactions.rs
@@ -1,4 +1,4 @@
-use rust::setup::{admin_sqlx, connections_sqlx};
+use crate::setup::{admin_sqlx, connections_sqlx};
 use serial_test::serial;
 use sqlx::{Executor, Pool, Postgres, Row};
 

--- a/integration/rust/tests/integration/idle_in_transaction.rs
+++ b/integration/rust/tests/integration/idle_in_transaction.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use rust::setup::{admin_sqlx, connection_sqlx_direct, connections_sqlx};
+use crate::setup::{admin_sqlx, connection_sqlx_direct, connections_sqlx};
 use sqlx::{Executor, Row};
 use tokio::time::sleep;
 

--- a/integration/rust/tests/integration/limit.rs
+++ b/integration/rust/tests/integration/limit.rs
@@ -1,5 +1,5 @@
-use rust::setup::admin_sqlx;
-use rust::setup::connections_sqlx;
+use crate::setup::admin_sqlx;
+use crate::setup::connections_sqlx;
 use sqlx::{Executor, Row, postgres::PgPool};
 
 #[tokio::test]

--- a/integration/rust/tests/integration/maintenance_mode.rs
+++ b/integration/rust/tests/integration/maintenance_mode.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use rust::setup::{admin_sqlx, admin_tokio, connection_failover, connections_sqlx};
+use crate::setup::{admin_sqlx, admin_tokio, connection_failover, connections_sqlx};
 use serial_test::serial;
 use sqlx::Executor;
 use tokio::time::sleep;

--- a/integration/rust/tests/integration/max.rs
+++ b/integration/rust/tests/integration/max.rs
@@ -1,5 +1,5 @@
+use crate::setup::{admin_sqlx, connections_sqlx};
 use chrono::{DateTime, NaiveDateTime, Utc};
-use rust::setup::{admin_sqlx, connections_sqlx};
 use sqlx::{Connection, Executor, PgConnection, Row, postgres::PgPool};
 
 const SHARD_URLS: [&str; 2] = [

--- a/integration/rust/tests/integration/multi_set.rs
+++ b/integration/rust/tests/integration/multi_set.rs
@@ -1,4 +1,4 @@
-use rust::setup::connections_tokio;
+use crate::setup::connections_tokio;
 
 fn extract_simple_query_value(msgs: &[tokio_postgres::SimpleQueryMessage]) -> String {
     for msg in msgs {

--- a/integration/rust/tests/integration/notify.rs
+++ b/integration/rust/tests/integration/notify.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use crate::setup::admin_sqlx;
 use parking_lot::Mutex;
-use rust::setup::admin_sqlx;
 use rust_decimal::prelude::ToPrimitive;
 use sqlx::{Connection, Executor, PgConnection, Pool, Postgres, Row, postgres::PgListener};
 use tokio::{

--- a/integration/rust/tests/integration/offset.rs
+++ b/integration/rust/tests/integration/offset.rs
@@ -1,4 +1,4 @@
-use rust::setup::{admin_sqlx, connections_sqlx};
+use crate::setup::{admin_sqlx, connections_sqlx};
 use sqlx::{Executor, Row, postgres::PgPool};
 
 const TABLE: &str = "offset_test";

--- a/integration/rust/tests/integration/partial_req.rs
+++ b/integration/rust/tests/integration/partial_req.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use rust::{
+use crate::{
     setup::{admin_sqlx, connection_sqlx_direct},
     utils::{Message, connect},
 };

--- a/integration/rust/tests/integration/per_stmt_routing.rs
+++ b/integration/rust/tests/integration/per_stmt_routing.rs
@@ -1,4 +1,4 @@
-use rust::setup::{admin_sqlx, connections_sqlx};
+use crate::setup::{admin_sqlx, connections_sqlx};
 use sqlx::{Acquire, Executor, Row};
 
 #[tokio::test]

--- a/integration/rust/tests/integration/prepared.rs
+++ b/integration/rust/tests/integration/prepared.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use rust::setup::*;
+use crate::setup::*;
 use sqlx::{Executor, Row, postgres::PgPoolOptions, types::BigDecimal};
 use tokio::{spawn, time::sleep};
 

--- a/integration/rust/tests/integration/protocol_version.rs
+++ b/integration/rust/tests/integration/protocol_version.rs
@@ -1,8 +1,8 @@
-use bytes::{Buf, Bytes};
-use rust::{
+use crate::{
     setup::admin_sqlx,
     utils::{Message, startup_with_version},
 };
+use bytes::{Buf, Bytes};
 use serial_test::serial;
 use sqlx::Executor;
 use tokio::{io::AsyncWriteExt, net::TcpStream};

--- a/integration/rust/tests/integration/reload.rs
+++ b/integration/rust/tests/integration/reload.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use rust::setup::{admin_tokio, backends, connection_failover, connection_sqlx_direct};
+use crate::setup::{admin_tokio, backends, connection_failover, connection_sqlx_direct};
 use serial_test::serial;
 use sqlx::{Executor, Row, postgres::PgPoolOptions};
 use tokio::time::sleep;

--- a/integration/rust/tests/integration/reset.rs
+++ b/integration/rust/tests/integration/reset.rs
@@ -1,4 +1,4 @@
-use rust::setup::{admin_sqlx, connections_sqlx};
+use crate::setup::{admin_sqlx, connections_sqlx};
 use sqlx::Executor;
 
 async fn run_reset_single_param() {

--- a/integration/rust/tests/integration/rewrite.rs
+++ b/integration/rust/tests/integration/rewrite.rs
@@ -1,4 +1,4 @@
-use rust::setup::{admin_sqlx, connections_sqlx};
+use crate::setup::{admin_sqlx, connections_sqlx};
 use sqlx::{Executor, Pool, Postgres};
 
 const TEST_TABLE: &str = "sharded_list";

--- a/integration/rust/tests/integration/rewrite_omni.rs
+++ b/integration/rust/tests/integration/rewrite_omni.rs
@@ -1,4 +1,4 @@
-use rust::setup::*;
+use crate::setup::*;
 use sqlx::Executor;
 
 #[tokio::test]

--- a/integration/rust/tests/integration/savepoint.rs
+++ b/integration/rust/tests/integration/savepoint.rs
@@ -1,4 +1,4 @@
-use rust::setup::connections_sqlx;
+use crate::setup::connections_sqlx;
 use sqlx::Executor;
 
 #[tokio::test]

--- a/integration/rust/tests/integration/set_config.rs
+++ b/integration/rust/tests/integration/set_config.rs
@@ -1,4 +1,4 @@
-use rust::setup::connections_sqlx;
+use crate::setup::connections_sqlx;
 use sqlx::query_scalar;
 use std::assert_matches;
 

--- a/integration/rust/tests/integration/set_in_transaction.rs
+++ b/integration/rust/tests/integration/set_in_transaction.rs
@@ -1,4 +1,4 @@
-use rust::setup::{admin_sqlx, connections_sqlx};
+use crate::setup::{admin_sqlx, connections_sqlx};
 use sqlx::Executor;
 
 async fn run_set_in_transaction_reset_after_commit() {

--- a/integration/rust/tests/integration/set_sharding_key.rs
+++ b/integration/rust/tests/integration/set_sharding_key.rs
@@ -1,6 +1,6 @@
 //! Test cluster with just one sharding function.
 
-use rust::setup::connections_sqlx;
+use crate::setup::connections_sqlx;
 use sqlx::Connection;
 use sqlx::prelude::*;
 

--- a/integration/rust/tests/integration/shard_consistency.rs
+++ b/integration/rust/tests/integration/shard_consistency.rs
@@ -1,4 +1,4 @@
-use rust::setup::{admin_sqlx, connections_sqlx};
+use crate::setup::{admin_sqlx, connections_sqlx};
 use sqlx::{Executor, Row};
 
 #[tokio::test]

--- a/integration/rust/tests/integration/stddev.rs
+++ b/integration/rust/tests/integration/stddev.rs
@@ -1,4 +1,4 @@
-use rust::setup::{admin_sqlx, connections_sqlx};
+use crate::setup::{admin_sqlx, connections_sqlx};
 use rust_decimal::prelude::*;
 use sqlx::{Executor, Pool, Postgres, Row};
 

--- a/integration/rust/tests/integration/sum.rs
+++ b/integration/rust/tests/integration/sum.rs
@@ -1,4 +1,4 @@
-use rust::setup::{admin_sqlx, connections_sqlx};
+use crate::setup::{admin_sqlx, connections_sqlx};
 use sqlx::{Connection, Executor, PgConnection, Row, postgres::PgPool};
 
 const SHARD_URLS: [&str; 2] = [

--- a/integration/rust/tests/integration/syntax_error.rs
+++ b/integration/rust/tests/integration/syntax_error.rs
@@ -1,4 +1,4 @@
-use rust::setup::connections_sqlx;
+use crate::setup::connections_sqlx;
 use sqlx::Executor;
 
 /// Make sure we don't get disconnected on syntax error.

--- a/integration/rust/tests/integration/timestamp_sorting.rs
+++ b/integration/rust/tests/integration/timestamp_sorting.rs
@@ -1,5 +1,5 @@
+use crate::setup::connections_sqlx;
 use chrono::{Duration, Utc};
-use rust::setup::connections_sqlx;
 use sqlx::{Executor, Row};
 
 #[tokio::test]
@@ -41,7 +41,7 @@ async fn test_timestamp_sorting_across_shards() {
 
     for (id, name, timestamp) in &test_data {
         sqlx::query(
-            "INSERT INTO timestamp_test (id, name, created_at, updated_at) 
+            "INSERT INTO timestamp_test (id, name, created_at, updated_at)
              VALUES ($1, $2, $3, $3)",
         )
         .bind(id)
@@ -138,7 +138,7 @@ async fn test_timestamp_sorting_across_shards() {
     );
 
     sqlx::query(
-        "INSERT INTO timestamp_test (id, name, created_at, special_ts) 
+        "INSERT INTO timestamp_test (id, name, created_at, special_ts)
          VALUES ($1, $2, $3, 'infinity'::timestamp)",
     )
     .bind(301i64)
@@ -149,7 +149,7 @@ async fn test_timestamp_sorting_across_shards() {
     .unwrap();
 
     sqlx::query(
-        "INSERT INTO timestamp_test (id, name, created_at, special_ts) 
+        "INSERT INTO timestamp_test (id, name, created_at, special_ts)
          VALUES ($1, $2, $3, '-infinity'::timestamp)",
     )
     .bind(302i64)

--- a/integration/rust/tests/integration/tls_enforced.rs
+++ b/integration/rust/tests/integration/tls_enforced.rs
@@ -1,5 +1,5 @@
-use rust::setup::admin_sqlx;
-use rust::utils::assert_setting_str;
+use crate::setup::admin_sqlx;
+use crate::utils::assert_setting_str;
 use sqlx::{ConnectOptions, Connection, Executor, postgres::PgSslMode};
 
 #[tokio::test]

--- a/integration/rust/tests/integration/tls_reload.rs
+++ b/integration/rust/tests/integration/tls_reload.rs
@@ -9,7 +9,7 @@ use std::{
     time::Duration,
 };
 
-use rust::setup::admin_tokio;
+use crate::setup::admin_tokio;
 use serial_test::serial;
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},

--- a/integration/rust/tests/integration/transaction_state.rs
+++ b/integration/rust/tests/integration/transaction_state.rs
@@ -1,4 +1,4 @@
-use rust::setup::admin_sqlx;
+use crate::setup::admin_sqlx;
 use serial_test::serial;
 use sqlx::{Executor, Pool, Postgres, Row};
 use tokio::time::{Duration, Instant, sleep};

--- a/integration/rust/tests/integration/unrecognized_aggregate.rs
+++ b/integration/rust/tests/integration/unrecognized_aggregate.rs
@@ -1,4 +1,4 @@
-use rust::setup::{admin_sqlx, connections_sqlx};
+use crate::setup::{admin_sqlx, connections_sqlx};
 use sqlx::Executor;
 use std::assert_matches;
 

--- a/integration/rust/tests/mod.rs
+++ b/integration/rust/tests/mod.rs
@@ -5,3 +5,5 @@ pub mod stats;
 pub mod tokio_postgres;
 
 pub use stats::get_stat;
+
+use integration_tests_rust::*;

--- a/integration/rust/tests/sqlx/bad_auth.rs
+++ b/integration/rust/tests/sqlx/bad_auth.rs
@@ -1,4 +1,4 @@
-use rust::setup::admin_sqlx;
+use crate::setup::admin_sqlx;
 use serial_test::serial;
 use sqlx::{Connection, Executor, PgConnection};
 

--- a/integration/rust/tests/sqlx/multi_set.rs
+++ b/integration/rust/tests/sqlx/multi_set.rs
@@ -1,4 +1,4 @@
-use rust::setup::connections_sqlx;
+use crate::setup::connections_sqlx;
 use sqlx::Executor;
 
 #[tokio::test]

--- a/integration/rust/tests/sqlx/select.rs
+++ b/integration/rust/tests/sqlx/select.rs
@@ -1,4 +1,4 @@
-use rust::setup::connections_sqlx;
+use crate::setup::connections_sqlx;
 use tokio::task::JoinSet;
 
 use crate::get_stat;

--- a/integration/rust/tests/sqlx/unique_id.rs
+++ b/integration/rust/tests/sqlx/unique_id.rs
@@ -1,4 +1,4 @@
-use rust::setup::connection_sqlx_direct;
+use crate::setup::connection_sqlx_direct;
 use sqlx::{Executor, Postgres, pool::Pool, postgres::PgPoolOptions};
 
 async fn sharded_pool() -> Pool<Postgres> {

--- a/integration/rust/tests/tokio_postgres/copy.rs
+++ b/integration/rust/tests/tokio_postgres/copy.rs
@@ -2,7 +2,7 @@
 // use tokio_postgres::binary_copy::{BinaryCopyInWriter, BinaryCopyOutStream};
 // use tokio_postgres::types::Type;
 
-// use rust::setup::connections;
+// use crate::setup::connections;
 
 // #[tokio::test]
 // async fn test_copy() {

--- a/integration/rust/tests/tokio_postgres/nulls.rs
+++ b/integration/rust/tests/tokio_postgres/nulls.rs
@@ -1,4 +1,4 @@
-use rust::setup::connections_tokio;
+use crate::setup::connections_tokio;
 
 #[tokio::test]
 async fn test_nulls() {

--- a/integration/rust/tests/tokio_postgres/prepared.rs
+++ b/integration/rust/tests/tokio_postgres/prepared.rs
@@ -1,4 +1,4 @@
-use rust::setup::*;
+use crate::setup::*;
 
 #[tokio::test]
 async fn test_prepared() {

--- a/integration/rust/tests/tokio_postgres/select.rs
+++ b/integration/rust/tests/tokio_postgres/select.rs
@@ -1,4 +1,4 @@
-use rust::setup::connections_tokio;
+use crate::setup::connections_tokio;
 
 #[tokio::test]
 async fn select_one() {

--- a/nextest.toml
+++ b/nextest.toml
@@ -1,2 +1,0 @@
-[profile.default]
-slow-timeout = { period = "60s", terminate-after = 2 }

--- a/pgdog-config/Cargo.toml
+++ b/pgdog-config/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2024"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde_json.workspace = true
 tracing = "0.1"
 thiserror = "2"
 toml = "0.8"
 url = "2"
-uuid = { version = "1", features = ["v4", "serde"] }
+uuid.workspace = true
 rand = "*"
 pgdog-vector = { path = "../pgdog-vector" }
 once_cell = "*"

--- a/pgdog-postgres-types/Cargo.toml
+++ b/pgdog-postgres-types/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2024"
 
 [dependencies]
 chrono = "0.4"
-bytes = "*"
+bytes.workspace = true
 thiserror = "*"
-uuid = "*"
+uuid.workspace = true
 serde = { version = "*", features = ["derive"]}
 schemars.workspace = true
 pgdog-vector = { path = "../pgdog-vector" }

--- a/pgdog-stats/Cargo.toml
+++ b/pgdog-stats/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2024"
 serde = {version = "*", features = ["derive", "rc"]}
 pgdog-config = { path = "../pgdog-config" }
 pgdog-postgres-types = { path = "../pgdog-postgres-types" }
-bytes = "*"
-indexmap = { version = "*", features = ["serde"] }
+bytes.workspace = true
+indexmap.workspace = true
 schemars.workspace = true

--- a/pgdog-vector/Cargo.toml
+++ b/pgdog-vector/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2024"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde_json.workspace = true
 schemars.workspace = true

--- a/pgdog/Cargo.toml
+++ b/pgdog/Cargo.toml
@@ -21,13 +21,13 @@ tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "std"] }
 tracing-throttle = "0.4"
-parking_lot = "0.12"
+parking_lot.workspace = true
 thiserror = "2"
 derive_more = { version = "2", features = ["display", "debug", "error", "from", "from_str"] }
-bytes = "1"
+bytes.workspace = true
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde_json.workspace = true
 async-trait = "0.1"
 rand = "0.9.2"
 once_cell = "1"
@@ -49,7 +49,7 @@ pg_query = { git = "https://github.com/pgdogdev/pg_query.rs.git", rev = "97019d0
 regex = "1"
 memchr = "2"
 semver = "1"
-uuid = { version = "1", features = ["v4", "serde"] }
+uuid.workspace = true
 url = "2"
 ratatui = { version = "0.30.0-alpha.1", optional = true }
 rmp-serde = "1"
@@ -72,12 +72,12 @@ pgdog-config = { path = "../pgdog-config" }
 pgdog-vector = { path = "../pgdog-vector" }
 pgdog-stats = { path = "../pgdog-stats" }
 pgdog-postgres-types = { path = "../pgdog-postgres-types"}
-azure_identity = "0.34.0"
-azure_core = "0.34.0"
+azure_identity = "1.0.0"
+azure_core = "1.0.0"
 crc32c = "0.6.8"
 bit-vec = "0.8"
 smallvec = "1"
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-webpki-roots-no-provider", "json"] }
+reqwest.workspace = true
 hex = "0.4"
 x509-parser = "0.18"
 pg_raw_parse = { git = "https://github.com/pgdogdev/pg_raw_parse.git", rev = "b94e4cf", optional = true }

--- a/pgdog/src/backend/databases.rs
+++ b/pgdog/src/backend/databases.rs
@@ -1869,13 +1869,13 @@ mod tests {
         let original_config = r#"
 [[databases]]
 name = "source_db"
-host = "source-host"
+host = "127.0.0.1"
 port = 5432
 role = "primary"
 
 [[databases]]
 name = "destination_db"
-host = "destination-host"
+host = "127.0.0.2"
 port = 5433
 role = "primary"
 "#;
@@ -1899,54 +1899,54 @@ password = "testpass"
         cutover("source_db", "destination_db").await.unwrap();
 
         // Verify backup files contain original content
-        let backup_config_str = fs::read_to_string(config_path.with_extension("bak.toml"))
+        let backup_config = fs::read_to_string(config_path.with_extension("bak.toml"))
             .await
             .unwrap();
-        let backup_config: crate::config::Config = toml::from_str(&backup_config_str).unwrap();
+        let backup_config: crate::config::Config = toml::from_str(&backup_config).unwrap();
         let backup_source = backup_config
             .databases
             .iter()
             .find(|d| d.name == "source_db")
             .unwrap();
-        assert_eq!(backup_source.host, "source-host");
+        assert_eq!(backup_source.host, "127.0.0.1");
         assert_eq!(backup_source.port, 5432);
         let backup_dest = backup_config
             .databases
             .iter()
             .find(|d| d.name == "destination_db")
             .unwrap();
-        assert_eq!(backup_dest.host, "destination-host");
+        assert_eq!(backup_dest.host, "127.0.0.2");
         assert_eq!(backup_dest.port, 5433);
 
-        let backup_users_str = fs::read_to_string(users_path.with_extension("bak.toml"))
+        let backup_users = fs::read_to_string(users_path.with_extension("bak.toml"))
             .await
             .unwrap();
-        let backup_users: crate::config::Users = toml::from_str(&backup_users_str).unwrap();
+        let backup_users: crate::config::Users = toml::from_str(&backup_users).unwrap();
         assert_eq!(backup_users.users.len(), 1);
         assert_eq!(backup_users.users[0].name, "testuser");
         assert_eq!(backup_users.users[0].database, "source_db");
 
         // Verify new config files have swapped values
-        let new_config_str = fs::read_to_string(&config_path).await.unwrap();
-        let new_config: crate::config::Config = toml::from_str(&new_config_str).unwrap();
+        let new_config = fs::read_to_string(&config_path).await.unwrap();
+        let new_config: crate::config::Config = toml::from_str(&new_config).unwrap();
         let new_source = new_config
             .databases
             .iter()
             .find(|d| d.name == "source_db")
             .unwrap();
-        assert_eq!(new_source.host, "destination-host");
+        assert_eq!(new_source.host, "127.0.0.2");
         assert_eq!(new_source.port, 5433);
         let new_dest = new_config
             .databases
             .iter()
             .find(|d| d.name == "destination_db")
             .unwrap();
-        assert_eq!(new_dest.host, "source-host");
+        assert_eq!(new_dest.host, "127.0.0.1");
         assert_eq!(new_dest.port, 5432);
 
         // Verify users were swapped
-        let new_users_str = fs::read_to_string(&users_path).await.unwrap();
-        let new_users: crate::config::Users = toml::from_str(&new_users_str).unwrap();
+        let new_users = fs::read_to_string(&users_path).await.unwrap();
+        let new_users: crate::config::Users = toml::from_str(&new_users).unwrap();
         assert_eq!(new_users.users.len(), 1);
         assert_eq!(new_users.users[0].name, "testuser");
         assert_eq!(new_users.users[0].database, "destination_db");


### PR DESCRIPTION
- more explicit nextest config with profile for integration tests
- fix slow unit test (slow on wsl)
- rename integration tests package rust -> integration_tests_rust
- dedupe some dependencies and make lock file smaller