### PR TITLE
fix: replica lag evalution in load balancer

### DIFF
--- a/pgdog/src/admin/ban.rs
+++ b/pgdog/src/admin/ban.rs
@@ -53,7 +53,7 @@ impl Command for Ban {
                     }
 
                     if self.unban {
-                        ban.unban(false);
+                        ban.unban(false, pool::lb::UnbanReason::Manual);
                     } else {
                         ban.ban(pool::Error::ManualBan, Duration::MAX);
                     }

--- a/pgdog/src/backend/pool/lb/ban.rs
+++ b/pgdog/src/backend/pool/lb/ban.rs
@@ -1,6 +1,6 @@
 use super::*;
 use parking_lot::RwLock;
-use std::time::Instant;
+use std::{fmt::Display, time::Instant};
 
 use tracing::{error, warn};
 
@@ -9,6 +9,24 @@ use tracing::{error, warn};
 pub struct Ban {
     inner: Arc<RwLock<BanInner>>,
     pool: Pool,
+}
+
+#[derive(Debug, Default, Copy, Clone)]
+pub enum UnbanReason {
+    #[default]
+    AllTargetsBanned,
+    Expired,
+    Manual,
+}
+
+impl Display for UnbanReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AllTargetsBanned => write!(f, "all targets banned"),
+            Self::Expired => write!(f, "expired"),
+            Self::Manual => write!(f, "manual"),
+        }
+    }
 }
 
 impl Ban {
@@ -48,7 +66,7 @@ impl Ban {
     }
 
     /// Unban the database.
-    pub fn unban(&self, manual_check: bool) {
+    pub fn unban(&self, manual_check: bool, reason: UnbanReason) {
         let mut guard = self.inner.upgradable_read();
         if let Some(ref ban) = guard.ban {
             if ban.error != Error::ManualBan || !manual_check {
@@ -56,7 +74,7 @@ impl Ban {
                     guard.ban = None;
                 });
             }
-            warn!("resuming read queries [{}]", self.pool.addr());
+            warn!("resuming read queries: {} [{}]", reason, self.pool.addr());
         }
     }
 
@@ -114,7 +132,11 @@ impl Ban {
         };
         drop(guard);
         if unbanned {
-            warn!("resuming read queries [{}]", self.pool.addr());
+            warn!(
+                "resuming read queries: {} [{}]",
+                UnbanReason::Expired,
+                self.pool.addr()
+            );
         }
         unbanned
     }
@@ -185,7 +207,7 @@ mod tests {
         let pool = Pool::new_test();
         let ban = Ban::new(&pool);
         ban.ban(Error::ServerError, Duration::from_secs(1));
-        ban.unban(false);
+        ban.unban(false, UnbanReason::Expired);
         assert!(!ban.banned());
         assert!(ban.error().is_none());
     }
@@ -195,7 +217,7 @@ mod tests {
         let pool = Pool::new_test();
         let ban = Ban::new(&pool);
         ban.ban(Error::ManualBan, Duration::from_secs(1));
-        ban.unban(true);
+        ban.unban(true, UnbanReason::Expired);
         assert!(ban.banned());
         assert_eq!(ban.error(), Some(Error::ManualBan));
     }
@@ -205,7 +227,7 @@ mod tests {
         let pool = Pool::new_test();
         let ban = Ban::new(&pool);
         ban.ban(Error::ServerError, Duration::from_secs(1));
-        ban.unban(true);
+        ban.unban(true, UnbanReason::Manual);
         assert!(!ban.banned());
         assert!(ban.error().is_none());
     }
@@ -303,7 +325,7 @@ mod tests {
 
         for _ in 0..100 {
             ban.ban(Error::ServerError, Duration::from_secs(1));
-            ban.unban(false);
+            ban.unban(false, UnbanReason::Expired);
         }
 
         h1.join().unwrap();
@@ -374,7 +396,7 @@ mod tests {
         for _ in 0..10 {
             assert!(ban.ban(Error::ServerError, Duration::from_secs(1)));
             assert!(ban.banned());
-            ban.unban(false);
+            ban.unban(false, UnbanReason::default());
             assert!(!ban.banned());
         }
     }

--- a/pgdog/src/backend/pool/lb/ban.rs
+++ b/pgdog/src/backend/pool/lb/ban.rs
@@ -11,9 +11,8 @@ pub struct Ban {
     pool: Pool,
 }
 
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub enum UnbanReason {
-    #[default]
     AllTargetsBanned,
     Expired,
     Manual,
@@ -66,15 +65,25 @@ impl Ban {
     }
 
     /// Unban the database.
+    ///
+    /// FIXME(lev): `reason` seems like it should be
+    /// used as an operand but it's only used for logging.
+    /// We should unify methods and provide one public interface to this.
+    ///
     pub fn unban(&self, manual_check: bool, reason: UnbanReason) {
         let mut guard = self.inner.upgradable_read();
         if let Some(ref ban) = guard.ban {
+            let mut unbanned = false;
             if ban.error != Error::ManualBan || !manual_check {
                 guard.with_upgraded(|guard| {
                     guard.ban = None;
                 });
+                unbanned = true;
             }
-            warn!("resuming read queries: {} [{}]", reason, self.pool.addr());
+
+            if unbanned {
+                warn!("resuming read queries: {} [{}]", reason, self.pool.addr());
+            }
         }
     }
 
@@ -396,7 +405,7 @@ mod tests {
         for _ in 0..10 {
             assert!(ban.ban(Error::ServerError, Duration::from_secs(1)));
             assert!(ban.banned());
-            ban.unban(false, UnbanReason::default());
+            ban.unban(false, UnbanReason::AllTargetsBanned);
             assert!(!ban.banned());
         }
     }

--- a/pgdog/src/backend/pool/lb/mod.rs
+++ b/pgdog/src/backend/pool/lb/mod.rs
@@ -350,12 +350,17 @@ impl LoadBalancer {
         let primary_reads = match self.rw_split {
             IncludePrimary => true,
             IncludePrimaryIfReplicaBanned => candidates.iter().any(|target| target.ban.banned()),
-            // Under PreferPrimary, default queries already route to the primary as writes;
-            // a read only reaches here when it explicitly opted into replicas, so honor it
-            // like ExcludePrimary and fall back to the primary only if there are no replicas.
-            ExcludePrimary | PreferPrimary => !candidates
+            // we read from the primary if we have no replicas
+            ExcludePrimary => !candidates
                 .iter()
                 .any(|target| matches!(target.role(), Role::Replica | Role::Auto)),
+            // Under PreferPrimary, default queries already route to the primary as writes;
+            // a read only reaches here when it explicitly opted into replicas, so fall back to
+            // the primary only when no replica is actually usable (none configured, or every
+            // one currently banned) — otherwise honor the opt-in and stick to the replica.
+            PreferPrimary => !candidates.iter().any(|target| {
+                matches!(target.role(), Role::Replica | Role::Auto) && !target.ban.banned()
+            }),
         };
 
         if !primary_reads {

--- a/pgdog/src/backend/pool/lb/mod.rs
+++ b/pgdog/src/backend/pool/lb/mod.rs
@@ -25,6 +25,7 @@ pub mod monitor;
 pub mod target_health;
 
 use ban::Ban;
+pub use ban::UnbanReason;
 use monitor::*;
 pub use target_health::*;
 
@@ -427,7 +428,9 @@ impl LoadBalancer {
             }
         }
 
-        candidates.iter().for_each(|target| target.ban.unban(true));
+        candidates
+            .iter()
+            .for_each(|target| target.ban.unban(true, UnbanReason::AllTargetsBanned));
 
         Err(Error::AllReplicasDown)
     }

--- a/pgdog/src/backend/pool/lb/mod.rs
+++ b/pgdog/src/backend/pool/lb/mod.rs
@@ -354,10 +354,9 @@ impl LoadBalancer {
             ExcludePrimary => !candidates
                 .iter()
                 .any(|target| matches!(target.role(), Role::Replica | Role::Auto)),
-            // Under PreferPrimary, default queries already route to the primary as writes;
-            // a read only reaches here when it explicitly opted into replicas, so fall back to
-            // the primary only when no replica is actually usable (none configured, or every
-            // one currently banned) — otherwise honor the opt-in and stick to the replica.
+            // PreferPrimary makes all queries writes. If a query lands here,
+            // it's because of pgdog.role=replica. Let it use the primary only if
+            // no replicas are available.
             PreferPrimary => !candidates.iter().any(|target| {
                 matches!(target.role(), Role::Replica | Role::Auto) && !target.ban.banned()
             }),

--- a/pgdog/src/backend/pool/lb/monitor.rs
+++ b/pgdog/src/backend/pool/lb/monitor.rs
@@ -128,7 +128,7 @@ impl Monitor {
         // intent.
         if targets.len() == unavailable {
             targets.iter().for_each(|target| {
-                target.ban.unban(true);
+                target.ban.unban(true, UnbanReason::AllTargetsBanned);
             });
         } else {
             for (i, reason) in ban_targets {

--- a/pgdog/src/backend/pool/lb/test.rs
+++ b/pgdog/src/backend/pool/lb/test.rs
@@ -635,6 +635,41 @@ async fn test_read_write_split_with_banned_replicas() {
 }
 
 #[tokio::test]
+async fn test_prefer_primary_with_banned_replicas_falls_back_to_primary() {
+    let primary_config = create_test_pool_config("127.0.0.1", 5432);
+    let primary_pool = Pool::new(&primary_config);
+    primary_pool.launch();
+
+    let replica_configs = [create_test_pool_config("localhost", 5432)];
+
+    let replicas = LoadBalancer::new(
+        &Some(primary_pool),
+        &replica_configs,
+        LoadBalancingStrategy::Random,
+        ReadWriteSplit::PreferPrimary,
+    );
+    replicas.launch();
+
+    let replica_ban = &replicas.targets[0].ban;
+    replica_ban.ban(Error::ServerError, Duration::from_millis(1000));
+
+    let request = Request::default();
+
+    let mut used_pool_ids = HashSet::new();
+    for _ in 0..10 {
+        let conn = replicas.get(&request).await.unwrap();
+        used_pool_ids.insert(conn.pool.id());
+    }
+
+    assert_eq!(used_pool_ids.len(), 1);
+
+    let primary_id = replicas.primary().unwrap().id();
+    assert!(used_pool_ids.contains(&primary_id));
+
+    replicas.shutdown();
+}
+
+#[tokio::test]
 async fn test_read_write_split_exclude_primary_with_round_robin() {
     let primary_config = create_test_pool_config("127.0.0.1", 5432);
     let primary_pool = Pool::new(&primary_config);

--- a/pgdog/src/backend/pool/lb/test.rs
+++ b/pgdog/src/backend/pool/lb/test.rs
@@ -79,7 +79,7 @@ async fn test_replica_manual_unban() {
     assert!(ban.banned());
 
     // Manually unban
-    ban.unban(false);
+    ban.unban(false, UnbanReason::default());
 
     assert!(!ban.banned());
 

--- a/pgdog/src/backend/pool/lb/test.rs
+++ b/pgdog/src/backend/pool/lb/test.rs
@@ -79,7 +79,7 @@ async fn test_replica_manual_unban() {
     assert!(ban.banned());
 
     // Manually unban
-    ban.unban(false, UnbanReason::default());
+    ban.unban(false, UnbanReason::Manual);
 
     assert!(!ban.banned());
 

--- a/pgdog/src/backend/pool/lsn_monitor.rs
+++ b/pgdog/src/backend/pool/lsn_monitor.rs
@@ -290,7 +290,7 @@ impl DerefMut for LsnConnection {
 mod test {
     use super::*;
 
-    use pgdog_postgres_types::{Format, FromDataType, TimestampTz};
+    use pgdog_postgres_types::TimestampTz;
     use pgdog_stats::Lsn;
     use tokio::time::timeout;
 
@@ -479,48 +479,6 @@ mod test {
         assert!(monitor.run_query(&mut conn, LSN_QUERY).await.is_some());
 
         pool.shutdown();
-    }
-
-    fn make_stats(replica: bool, lsn: i64, ts: &str) -> LsnStats {
-        StatsLsnStats {
-            replica,
-            lsn: Lsn::from_i64(lsn),
-            offset_bytes: lsn,
-            timestamp: TimestampTz::decode(ts.as_bytes(), Format::Text).unwrap(),
-            fetched: SystemTime::now(),
-            aurora: false,
-        }
-        .into()
-    }
-
-    // Regression test: the shard monitor used to call `replica_lag` with
-    // `self` and `primary` swapped, which inverted both subtractions inside
-    // (`primary.lsn - self.lsn`, `primary.timestamp - self.timestamp`). The
-    // result was negative bytes and a duration clamped to 0, so the replica
-    // always reported zero lag and `ban_replica_lag` could never trigger.
-    #[test]
-    fn test_replica_lag_direction() {
-        let replica = make_stats(true, 100, "2026-07-01 13:33:00.000000+00");
-        let primary = make_stats(false, 200, "2026-07-01 13:33:10.000000+00");
-
-        // Correct direction: replica lags primary by 100 bytes / 10 seconds.
-        let lag = replica.replica_lag(&primary);
-        assert_eq!(lag.bytes, 100, "bytes should be primary.lsn - replica.lsn");
-        assert_eq!(
-            lag.duration.as_secs(),
-            10,
-            "duration should be primary.timestamp - replica.timestamp"
-        );
-
-        // Swapped (buggy) direction: negative bytes, duration clamped to 0,
-        // neither can ever exceed a positive ban threshold.
-        let swapped = primary.replica_lag(&replica);
-        assert_eq!(swapped.bytes, -100, "swapped args invert bytes");
-        assert_eq!(
-            swapped.duration.as_secs(),
-            0,
-            "swapped args clamp the negative duration to 0"
-        );
     }
 
     #[test]

--- a/pgdog/src/backend/pool/lsn_monitor.rs
+++ b/pgdog/src/backend/pool/lsn_monitor.rs
@@ -290,7 +290,7 @@ impl DerefMut for LsnConnection {
 mod test {
     use super::*;
 
-    use pgdog_postgres_types::TimestampTz;
+    use pgdog_postgres_types::{Format, FromDataType, TimestampTz};
     use pgdog_stats::Lsn;
     use tokio::time::timeout;
 
@@ -479,6 +479,48 @@ mod test {
         assert!(monitor.run_query(&mut conn, LSN_QUERY).await.is_some());
 
         pool.shutdown();
+    }
+
+    fn make_stats(replica: bool, lsn: i64, ts: &str) -> LsnStats {
+        StatsLsnStats {
+            replica,
+            lsn: Lsn::from_i64(lsn),
+            offset_bytes: lsn,
+            timestamp: TimestampTz::decode(ts.as_bytes(), Format::Text).unwrap(),
+            fetched: SystemTime::now(),
+            aurora: false,
+        }
+        .into()
+    }
+
+    // Regression test: the shard monitor used to call `replica_lag` with
+    // `self` and `primary` swapped, which inverted both subtractions inside
+    // (`primary.lsn - self.lsn`, `primary.timestamp - self.timestamp`). The
+    // result was negative bytes and a duration clamped to 0, so the replica
+    // always reported zero lag and `ban_replica_lag` could never trigger.
+    #[test]
+    fn test_replica_lag_direction() {
+        let replica = make_stats(true, 100, "2026-07-01 13:33:00.000000+00");
+        let primary = make_stats(false, 200, "2026-07-01 13:33:10.000000+00");
+
+        // Correct direction: replica lags primary by 100 bytes / 10 seconds.
+        let lag = replica.replica_lag(&primary);
+        assert_eq!(lag.bytes, 100, "bytes should be primary.lsn - replica.lsn");
+        assert_eq!(
+            lag.duration.as_secs(),
+            10,
+            "duration should be primary.timestamp - replica.timestamp"
+        );
+
+        // Swapped (buggy) direction: negative bytes, duration clamped to 0,
+        // neither can ever exceed a positive ban threshold.
+        let swapped = primary.replica_lag(&replica);
+        assert_eq!(swapped.bytes, -100, "swapped args invert bytes");
+        assert_eq!(
+            swapped.duration.as_secs(),
+            0,
+            "swapped args clamp the negative duration to 0"
+        );
     }
 
     #[test]

--- a/pgdog/src/backend/pool/shard/monitor.rs
+++ b/pgdog/src/backend/pool/shard/monitor.rs
@@ -1,4 +1,4 @@
-use crate::backend::pool::lsn_monitor::ReplicaLag;
+use crate::backend::pool::lsn_monitor::{LsnStats, ReplicaLag};
 
 use super::*;
 
@@ -92,30 +92,7 @@ impl ShardMonitor {
                 );
             }
 
-            let pool_with_stats = self
-                .shard
-                .pools()
-                .iter()
-                .map(|pool| (pool.clone(), pool.lsn_stats()))
-                .collect::<Vec<_>>();
-
-            let primary = pool_with_stats.iter().find(|pair| !pair.1.replica);
-
-            // There is a primary. If not, replica lag cannot be
-            // calculated.
-            if let Some(primary) = primary {
-                let replicas = pool_with_stats.iter().filter(|pair| pair.1.replica);
-                for replica in replicas {
-                    // Primary is ahead, there is replica lag.
-                    let lag = if primary.1.lsn.lsn > replica.1.lsn.lsn {
-                        replica.1.replica_lag(&primary.1)
-                    } else {
-                        ReplicaLag::default()
-                    };
-                    replica.0.lock().replica_lag = lag;
-                }
-                primary.0.lock().replica_lag = ReplicaLag::default();
-            }
+            update_replica_lag(&self.shard.pools());
         }
 
         debug!(
@@ -123,6 +100,53 @@ impl ShardMonitor {
             self.shard.number(),
             self.shard.identifier()
         );
+    }
+}
+
+fn update_replica_lag(pools: &[Pool]) {
+    let primary = pools
+        .iter()
+        .map(|pool| (pool, pool.lsn_stats()))
+        .find(|(_, stats)| !stats.replica);
+
+    // There is a primary. If not, replica lag cannot be calculated.
+    if let Some((primary_pool, primary_stats)) = primary {
+        for replica_pool in pools {
+            let replica_stats = replica_pool.lsn_stats();
+            if !replica_stats.replica {
+                continue;
+            }
+
+            let lag = calculate_replica_lag(&primary_stats, &replica_stats);
+            replica_pool.lock().replica_lag = lag;
+        }
+        primary_pool.lock().replica_lag = ReplicaLag::default();
+    }
+}
+
+fn calculate_replica_lag(primary: &LsnStats, replica: &LsnStats) -> ReplicaLag {
+    debug_assert!(
+        !primary.replica,
+        "primary stats must come from the primary pool"
+    );
+    debug_assert!(
+        replica.replica,
+        "replica stats must come from the replica pool"
+    );
+
+    // Replica lag is how far the replica trails the primary.
+    let bytes = primary.lsn.lsn - replica.lsn.lsn;
+    if bytes <= 0 {
+        return ReplicaLag::default();
+    }
+
+    let lag_ms = (primary.timestamp.to_naive_datetime() - replica.timestamp.to_naive_datetime())
+        .num_milliseconds()
+        .clamp(0, i64::MAX);
+
+    ReplicaLag {
+        bytes,
+        duration: Duration::from_millis(lag_ms as u64),
     }
 }
 
@@ -136,6 +160,7 @@ mod test {
     use crate::backend::pool::{Address, Config, PoolConfig};
     use crate::backend::replication::publisher::Lsn;
     use crate::config::{LoadBalancingStrategy, ReadWriteSplit, Role};
+    use pgdog_postgres_types::{Format, FromDataType, TimestampTz};
     use pgdog_stats::LsnStats as StatsLsnStats;
     use tokio::time::sleep;
 
@@ -166,6 +191,84 @@ mod test {
         }
         .into();
         *pools[index].inner().lsn_stats.write() = stats;
+    }
+
+    fn set_pool_lsn_stats(pool: &Pool, replica: bool, lsn: i64, timestamp: &str) {
+        *pool.inner().lsn_stats.write() = lsn_stats(replica, lsn, timestamp);
+    }
+
+    fn lsn_stats(replica: bool, lsn: i64, timestamp: &str) -> LsnStats {
+        StatsLsnStats {
+            replica,
+            lsn: Lsn::from_i64(lsn),
+            offset_bytes: lsn,
+            timestamp: TimestampTz::decode(timestamp.as_bytes(), Format::Text).unwrap(),
+            fetched: SystemTime::now(),
+            aurora: false,
+        }
+        .into()
+    }
+
+    // Regression test for the shard monitor lag calculation. The broken monitor
+    // called `primary.replica_lag(replica)`, which inverted bytes and clamped the
+    // duration to zero, preventing replica-lag bans from triggering.
+    #[test]
+    fn test_calculate_replica_lag_uses_replica_against_primary() {
+        let primary = lsn_stats(false, 200, "2026-07-01 13:33:10.000000+00");
+        let replica = lsn_stats(true, 100, "2026-07-01 13:33:00.000000+00");
+
+        let lag = calculate_replica_lag(&primary, &replica);
+
+        assert_eq!(lag.bytes, 100);
+        assert_eq!(lag.duration.as_secs(), 10);
+    }
+
+    #[test]
+    fn test_calculate_replica_lag_is_zero_when_replica_is_not_behind() {
+        let primary = lsn_stats(false, 100, "2026-07-01 13:33:00.000000+00");
+        let replica = lsn_stats(true, 200, "2026-07-01 13:33:10.000000+00");
+
+        let lag = calculate_replica_lag(&primary, &replica);
+
+        assert_eq!(lag.bytes, 0);
+        assert_eq!(lag.duration, Duration::default());
+    }
+
+    #[test]
+    #[should_panic(expected = "primary stats must come from the primary pool")]
+    fn test_calculate_replica_lag_rejects_swapped_stats() {
+        let primary = lsn_stats(false, 200, "2026-07-01 13:33:10.000000+00");
+        let replica = lsn_stats(true, 100, "2026-07-01 13:33:00.000000+00");
+
+        let _ = calculate_replica_lag(&replica, &primary);
+    }
+
+    #[test]
+    fn test_update_replica_lag_assigns_primary_minus_replica_to_replica_pool() {
+        let primary = Pool::new(&PoolConfig {
+            address: Address::new_test(),
+            config: Config::default(),
+        });
+        let replica = Pool::new(&PoolConfig {
+            address: Address {
+                configured_role: Role::Replica,
+                ..Address::new_test()
+            },
+            config: Config::default(),
+        });
+
+        set_pool_lsn_stats(&primary, false, 200, "2026-07-01 13:33:10.000000+00");
+        set_pool_lsn_stats(&replica, true, 100, "2026-07-01 13:33:00.000000+00");
+
+        update_replica_lag(&[replica.clone(), primary.clone()]);
+
+        let replica_lag = replica.replica_lag();
+        assert_eq!(replica_lag.bytes, 100);
+        assert_eq!(replica_lag.duration.as_secs(), 10);
+
+        let primary_lag = primary.replica_lag();
+        assert_eq!(primary_lag.bytes, 0);
+        assert_eq!(primary_lag.duration, Duration::default());
     }
 
     // The shard monitor reacts to an `lsn_role_change` notification by

--- a/pgdog/src/backend/pool/shard/monitor.rs
+++ b/pgdog/src/backend/pool/shard/monitor.rs
@@ -108,7 +108,7 @@ impl ShardMonitor {
                 for replica in replicas {
                     // Primary is ahead, there is replica lag.
                     let lag = if primary.1.lsn.lsn > replica.1.lsn.lsn {
-                        primary.1.replica_lag(&replica.1)
+                        replica.1.replica_lag(&primary.1)
                     } else {
                         ReplicaLag::default()
                     };


### PR DESCRIPTION
- fix: the primary/replica evaluation order was inverted, so the replica ban never triggered
- fix: `prefer_primary` incorrectly excluded primary when all replicas were banned @stewart-glabs :pray: 
- feat: show the reason why pools are unbanned (helps debugging)