### PR TITLE
fix(replication): update the processed lsn on keep-alive messages

### DIFF
--- a/docs/issues/replication.md
+++ b/docs/issues/replication.md
@@ -2,7 +2,22 @@
 
 ---
 
-## 🚧 Issue 1 — Lag inflation when source databases share a PostgreSQL instance
+## ✅ Issue 1 — Lag inflation when source databases share a PostgreSQL instance (resolved)
+
+> **Resolved.** On a keepalive received **between transactions**
+> (`StreamSubscriber::in_transaction() == false`), the streaming loop advances
+> the subscriber's confirmed position to the keepalive's `wal_end`
+> (`stream.set_current_lsn(ka.wal_end)`), so the next standby status update
+> reports `flush_lsn = wal_end`. PostgreSQL then advances `confirmed_flush_lsn`
+> to `wal_end` and the lag query returns ~0
+> ([`publisher_impl.rs`](../../pgdog/src/backend/replication/logical/publisher/publisher_impl.rs)).
+> The `in_transaction` guard preserves the existing invariant
+> ([`stream.rs:122`](../../pgdog/src/backend/replication/logical/subscriber/stream.rs)) —
+> `committed_lsn` never advances mid-transaction — so a reply can't confirm past
+> an unapplied commit, even for a large transaction that triggers a
+> mid-stream keepalive. This is the realized form of the `data_since_keepalive`
+> sketch below: the "no data since the last keepalive" condition is read
+> directly off the subscriber's transaction state instead of a separate flag.
 
 ### Description
 
@@ -42,21 +57,37 @@ their publication-scoped `confirmed_flush_lsn` from the same instance-wide
 |---|---|
 | `ReplicationSlot::replication_lag()` — the lag query | [`pgdog/src/backend/replication/logical/publisher/slot.rs`](../../pgdog/src/backend/replication/logical/publisher/slot.rs) |
 | `ReplicationWaiter::wait_for_replication()` — the cutover gate | [`pgdog/src/backend/replication/logical/orchestrator.rs`](../../pgdog/src/backend/replication/logical/orchestrator.rs) |
-| Keepalive handler / `flush_lsn` reply (proposed `data_since_keepalive` flag) | [`pgdog/src/backend/replication/logical/publisher/publisher_impl.rs`](../../pgdog/src/backend/replication/logical/publisher/publisher_impl.rs) |
+| Keepalive handler — `set_current_lsn(wal_end)` guarded by `in_transaction` | [`pgdog/src/backend/replication/logical/publisher/publisher_impl.rs`](../../pgdog/src/backend/replication/logical/publisher/publisher_impl.rs) |
+| `StreamSubscriber::in_transaction()` / `set_current_lsn()` / `status_update()` | [`pgdog/src/backend/replication/logical/subscriber/stream.rs`](../../pgdog/src/backend/replication/logical/subscriber/stream.rs) |
 ### Fix
 
-The PostgreSQL walsender sends a keepalive message after exhausting all decoded changes available for the publication. The keepalive carries `wal_end` — the server's current WAL write position. When a keepalive arrives and no xlog data was received since the previous keepalive, the slot has drained: there is nothing for the publication between `committed_lsn` and `wal_end`, so that gap consists entirely of other databases' WAL.
+The PostgreSQL walsender sends a keepalive carrying `wal_end` — the server's current WAL write position — once it has exhausted the decoded changes for the publication. When the slot has drained, the gap between the last published commit and `wal_end` is entirely other databases' WAL, so the client can safely confirm `wal_end`.
 
-In this state the client can safely reply with `flush_lsn = wal_end`. PostgreSQL sets `confirmed_flush_lsn` on the slot to `wal_end`, and the lag query returns ~0.
+The streaming loop does this in the keepalive branch:
 
-Reporting `wal_end` is only valid when the slot is caught up. During active streaming — where the server is sending transactions and keepalives may arrive between commits — `flush_lsn` must remain at `committed_lsn`. Reporting `wal_end` prematurely would advance `confirmed_flush_lsn` past unapplied commits; if the connection dropped, the server would restart from `wal_end` and those commits would be lost.
+```rust
+if let Some(ReplicationMeta::KeepAlive(ka)) = data.replication_meta() {
+    // Only between transactions: advance the confirmed position to wal_end.
+    if !stream.in_transaction() {
+        stream.set_current_lsn(ka.wal_end);
+    }
+    if ka.reply() {
+        slot.status_update(stream.status_update()).await?;
+    }
+    // ...
+}
+```
 
-The proposed guard: a `data_since_keepalive` flag. Set to `true` when any xlog data message arrives; cleared to `false` when a keepalive arrives. A keepalive is the catch-up signal only when this flag is `false` — meaning no data arrived between the last keepalive and this one.
+`set_current_lsn` moves `committed_lsn` to `wal_end`; `status_update()` reports `flush_lsn = committed_lsn`, so the reply advances the slot's `confirmed_flush_lsn` to `wal_end` and the lag query returns ~0.
+
+The `in_transaction` guard is what keeps this safe. Reporting `wal_end` mid-transaction would advance `confirmed_flush_lsn` past changes received but not yet applied to the destination; on a dropped connection the server would restart from `wal_end` and those changes would be lost. Even in non-streaming logical replication (pgdog uses `proto_version '4'` without `streaming`), a large transaction whose send time exceeds `wal_sender_timeout/2` triggers a mid-stream keepalive — so the guard is load-bearing, not just defensive. While `in_transaction` is true the confirmed position holds at the last commit (`committed_lsn`), matching the invariant in [`stream.rs:122`](../../pgdog/src/backend/replication/logical/subscriber/stream.rs).
+
+This is the `data_since_keepalive` idea, with "no data since the last keepalive" read directly off the subscriber's transaction state:
 
 ```
 keepalive received
-  data_since_keepalive = true  -> reply flush_lsn = committed_lsn  (active, mid-stream)
-  data_since_keepalive = false -> reply flush_lsn = wal_end         (caught up)
+  in_transaction == true  -> reply flush_lsn = committed_lsn  (active, mid-stream)
+  in_transaction == false -> confirm wal_end                  (caught up)
 ```
 
 ### PostgreSQL references

--- a/pgdog/src/backend/replication/logical/orchestrator.rs
+++ b/pgdog/src/backend/replication/logical/orchestrator.rs
@@ -310,8 +310,8 @@ impl ReplicationWaiter {
                 info!("[cutover] replication lag is not calculated for all shards, yet");
                 continue;
             };
-            cutover_state(CutoverState::WaitingForReplication { lag });
 
+            cutover_state(CutoverState::WaitingForReplication { lag });
             info!("[cutover] replication lag: {}", format_bytes(lag));
 
             // Time to go.
@@ -551,13 +551,20 @@ mod tests {
     impl Orchestrator {
         fn new_test(config: &ConfigAndUsers) -> Self {
             let cluster = Cluster::new_test(config);
+            let publication = "test_pub".to_owned();
+            let replication_slot = "test_slot".to_owned();
+            let publisher = Publisher::new(
+                &publication,
+                config.config.general.query_parser_engine,
+                replication_slot.clone(),
+            );
             Self {
                 source: cluster.clone(),
                 destination: cluster,
-                publication: "test_pub".to_owned(),
+                publication,
                 schema: None,
-                publisher: Arc::new(Mutex::new(Publisher::default())),
-                replication_slot: "test_slot".to_owned(),
+                publisher: Arc::new(Mutex::new(publisher)),
+                replication_slot,
             }
         }
     }
@@ -760,11 +767,8 @@ mod tests {
         assert!(matches!(result, CutoverAction::NoGo { .. }));
     }
 
-    /// `replication_lag` returns `None` (so the decision stays `NoGo`) until
-    /// every source shard has reported a measurement:
-    ///   1. an empty map (no shard reported) → `None`, and
-    ///   2. a partial map (some shards reported, others missing) → `None`.
-    /// Only when every shard has a real, below-threshold measurement does it Go.
+    /// Cutover holds off until every shard has reported a lag measurement; an
+    /// unreported shard reads as unknown (`None`), not zero.
     #[tokio::test]
     async fn should_not_cutover_before_every_shard_reports() {
         let mut config = ConfigAndUsers::default();
@@ -772,10 +776,9 @@ mod tests {
         config.config.general.cutover_replication_lag_threshold = 1000;
         config.config.general.cutover_last_transaction_delay = 500;
 
-        // Fresh orchestrator: the publisher's lag map has no entries yet.
+        // No shard has reported a lag yet.
         let orchestrator = Orchestrator::new_test(&config);
-        // Recent transaction so the last-transaction arm never forces a cutover;
-        // this isolates the lag check.
+        // Recent transaction so only the lag arm decides the outcome.
         orchestrator
             .publisher
             .lock()
@@ -793,9 +796,7 @@ mod tests {
             CutoverAction::NoGo { .. }
         );
 
-        // Only shard 0 reports; shard 1 is still missing from the map, so the
-        // lag stays unknown (None) and the decision remains NoGo — the gate waits
-        // for every shard, not just the first to report.
+        // Only shard 0 reported; shard 1 is missing, so the lag stays unknown.
         {
             let publisher = orchestrator.publisher.lock().await;
             publisher.set_replication_lag(0, 500);
@@ -815,6 +816,123 @@ mod tests {
         assert_eq!(
             waiter.should_cutover(elapsed).await,
             CutoverAction::Go(CutoverReason::Lag)
+        );
+    }
+
+    /// Writes to a table outside the publication must not block cutover.
+    /// Unrelated WAL advances the instance's LSN but not the publication's
+    /// `confirmed_flush_lsn`; keepalives advance it to `wal_end` between
+    /// transactions, so the drained slot reports ~0 lag and
+    /// `wait_for_replication` completes.
+    ///
+    /// Runs against the live `pgdog` database (integration/setup.sh).
+    #[tokio::test]
+    async fn wait_for_replication_finishes_with_unrelated_writes() {
+        use crate::backend::server::test::test_server;
+        use tokio::time::{sleep, timeout};
+
+        crate::logger();
+        maintenance_mode::stop(None);
+
+        const TRAFFIC_STOP: u64 = 1_000;
+
+        let mut config = ConfigAndUsers::default();
+        config.config.general.cutover_traffic_stop_threshold = TRAFFIC_STOP;
+        config.config.general.cutover_timeout = 120_000;
+
+        let orchestrator = Orchestrator::new_test(&config);
+        let publication = orchestrator.publication.clone();
+        let slot = orchestrator.replication_slot().to_owned();
+        let shards = orchestrator.source.shards().len();
+
+        // Publication covers only `issue1_main`; `issue1_noise` is never published.
+        let mut source = test_server().await;
+        let _ = source
+            .execute(format!("DROP PUBLICATION IF EXISTS {publication}"))
+            .await;
+        for shard in 0..shards {
+            let _ = source
+                .execute(format!("SELECT pg_drop_replication_slot('{slot}_{shard}')"))
+                .await;
+        }
+        source
+            .execute("DROP TABLE IF EXISTS issue1_main, issue1_noise")
+            .await
+            .unwrap();
+        source
+            .execute("CREATE TABLE issue1_main (id BIGINT PRIMARY KEY)")
+            .await
+            .unwrap();
+        source
+            .execute("CREATE TABLE issue1_noise (id BIGINT, payload TEXT)")
+            .await
+            .unwrap();
+        source
+            .execute(format!(
+                "CREATE PUBLICATION {publication} FOR TABLE issue1_main"
+            ))
+            .await
+            .unwrap();
+
+        orchestrator.source.launch();
+
+        let stream = orchestrator
+            .publisher
+            .lock()
+            .await
+            .replicate(&orchestrator.source, &orchestrator.destination)
+            .await
+            .unwrap();
+
+        let config = Arc::new(config);
+        let mut waiter = ReplicationWaiter {
+            orchestrator: orchestrator.clone(),
+            waiter: stream,
+            config,
+        };
+
+        // ~10MB of incompressible WAL into the unpublished table: the slot
+        // decodes none of it, but the instance LSN advances, inflating lag.
+        source
+            .execute(
+                "INSERT INTO issue1_noise \
+                 SELECT g, (SELECT string_agg(md5(random()::text), '') FROM generate_series(1, 64)) \
+                 FROM generate_series(1, 5000) g",
+            )
+            .await
+            .unwrap();
+
+        // Let one check_lag tick (1s) refresh the lag cache with the post-write
+        // value before sampling the gate.
+        sleep(Duration::from_secs(1)).await;
+
+        // 30s margin: keepalive cadence (wal_sender_timeout) is not bounded by
+        // the 1s sleep, so give confirmed_flush_lsn room to advance.
+        let result = timeout(Duration::from_secs(30), waiter.wait_for_replication()).await;
+        let maintenance_on = maintenance_mode::is_on("");
+
+        // Clean up before asserting so a failure can't leak slots or maintenance mode.
+        waiter.stop();
+        maintenance_mode::stop(None);
+        for shard in 0..shards {
+            let _ = source
+                .execute(format!("SELECT pg_drop_replication_slot('{slot}_{shard}')"))
+                .await;
+        }
+        let _ = source
+            .execute(format!("DROP PUBLICATION IF EXISTS {publication}"))
+            .await;
+        let _ = source
+            .execute("DROP TABLE IF EXISTS issue1_main, issue1_noise")
+            .await;
+
+        let waited = result
+            .expect("wait_for_replication never finished: lag stays inflated by unrelated WAL");
+        waited.expect("wait_for_replication returned an error");
+        // Cutover fired: once the lag fell below the threshold, traffic stopped.
+        assert!(
+            maintenance_on,
+            "wait_for_replication returned without stopping traffic (cutover did not fire)"
         );
     }
 }

--- a/pgdog/src/backend/replication/logical/publisher/publisher_impl.rs
+++ b/pgdog/src/backend/replication/logical/publisher/publisher_impl.rs
@@ -260,6 +260,17 @@ impl Publisher {
                                         if let Some(ReplicationMeta::KeepAlive(ka)) =
                                             data.replication_meta()
                                         {
+                                            // Between transactions, advance the
+                                            // confirmed position to the keepalive's
+                                            // wal_end: the slot has drained and the
+                                            // gap to wal_end is unrelated WAL the
+                                            // publication will never decode. Skipped
+                                            // mid-transaction so a reply can't confirm
+                                            // past an unapplied commit.
+                                            if !stream.in_transaction() {
+                                                stream.set_current_lsn(ka.wal_end);
+                                            }
+
                                             if ka.reply() {
                                                 slot.status_update(stream.status_update()).await?;
                                             }

--- a/pgdog/src/backend/replication/logical/subscriber/stream.rs
+++ b/pgdog/src/backend/replication/logical/subscriber/stream.rs
@@ -941,7 +941,6 @@ impl StreamSubscriber {
     }
 
     /// Whether we are inside a transaction.
-    #[cfg(test)]
     pub(crate) fn in_transaction(&self) -> bool {
         self.in_transaction
     }


### PR DESCRIPTION
Make sure the commited_lsn updated on keep-alive messages in order to prevent stuck replication lag value if no updates to the original publication were made, but other changes advances the global lsn on the source