### PR TITLE
Port StatementRewrite::sharding_key_update_check to the new parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3299,7 +3299,7 @@ dependencies = [
 [[package]]
 name = "pg_raw_parse"
 version = "0.1.0"
-source = "git+https://github.com/pgdogdev/pg_raw_parse.git?rev=5cc700b#5cc700b0376390763124f4acaa78a6ab8276a4f0"
+source = "git+https://github.com/pgdogdev/pg_raw_parse.git?rev=10e8b34#10e8b3476e746de225d7ce9a5924d1206af9c7b2"
 dependencies = [
  "bindgen 0.72.1",
  "cc",

--- a/pgdog/Cargo.toml
+++ b/pgdog/Cargo.toml
@@ -80,7 +80,7 @@ smallvec = "1"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-webpki-roots-no-provider", "json"] }
 hex = "0.4"
 x509-parser = "0.18"
-pg_raw_parse = { git = "https://github.com/pgdogdev/pg_raw_parse.git", rev = "5cc700b", optional = true }
+pg_raw_parse = { git = "https://github.com/pgdogdev/pg_raw_parse.git", rev = "10e8b34", optional = true }
 itertools = "0.15.0"
 
 [target.'cfg(unix)'.dependencies]

--- a/pgdog/src/frontend/router/parser/cache/ast.rs
+++ b/pgdog/src/frontend/router/parser/cache/ast.rs
@@ -100,7 +100,7 @@ impl Ast {
         let rewrite_plan = StatementRewrite::new(StatementRewriteContext {
             stmt: &mut ast.protobuf,
             #[cfg(feature = "new_parser")]
-            new_stmt: Some(&new_ast),
+            new_stmt: &new_ast,
             extended: query.original_query.extended(),
             prepared: query.original_query.prepared(),
             prepared_statements,

--- a/pgdog/src/frontend/router/parser/column.rs
+++ b/pgdog/src/frontend/router/parser/column.rs
@@ -129,10 +129,7 @@ impl<'a> TryFrom<pg_raw_parse::Node<'a>> for Column<'a> {
         use pg_raw_parse::Node;
         match value {
             Node::ColumnRef(c) => Self::try_from(c),
-            Node::ResTarget(r) => Ok(Self {
-                name: r.name().ok_or(Error::ColumnDecode)?,
-                ..Default::default()
-            }),
+            Node::ResTarget(r) => Self::try_from(r),
             Node::DefElem(d) if d.defname() == Some("owned_by") => Self::try_from(d.arg()),
             Node::NodeList(l) => Self::try_from(l),
             _ => Err(Error::ColumnDecode),
@@ -146,6 +143,18 @@ impl<'a> TryFrom<&'a nodes::ColumnRef> for Column<'a> {
 
     fn try_from(value: &'a nodes::ColumnRef) -> Result<Self, Self::Error> {
         Self::try_from(value.fields())
+    }
+}
+
+#[cfg(feature = "new_parser")]
+impl<'a> TryFrom<&'a nodes::ResTarget> for Column<'a> {
+    type Error = Error;
+
+    fn try_from(value: &'a nodes::ResTarget) -> Result<Self, Self::Error> {
+        Ok(Self {
+            name: value.name().ok_or(Error::ColumnDecode)?,
+            ..Default::default()
+        })
     }
 }
 

--- a/pgdog/src/frontend/router/parser/rewrite/statement/auto_id.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/auto_id.rs
@@ -98,11 +98,7 @@ impl StatementRewrite<'_> {
         let stmt = self.stmt.stmts.first()?;
         let node = stmt.stmt.as_ref()?;
         #[cfg(feature = "new_parser")]
-        // FIXME(sage): Propagate Nones when port is finished
-        let new_stmt = self
-            .new_stmt
-            .and_then(|r| r.stmts().next())
-            .unwrap_or(pg_raw_parse::Node::None);
+        let new_stmt = self.new_stmt.stmts().next()?;
 
         if let NodeEnum::InsertStmt(insert) = node.node.as_ref()? {
             let relation = insert.relation.as_ref()?;
@@ -368,12 +364,13 @@ mod tests {
     ) -> Result<(String, RewritePlan), Error> {
         let _guard = set_env_var("NODE_ID", "pgdog-1");
         let mut ast = pg_query::parse(sql).unwrap().protobuf;
+        let stmt = pg_raw_parse::parse(sql).unwrap();
         let mut prepared = PreparedStatements::default();
         let schema = sharding_schema_with_mode(mode);
         let mut rewriter = StatementRewrite::new(StatementRewriteContext {
             stmt: &mut ast,
             #[cfg(feature = "new_parser")]
-            new_stmt: None,
+            new_stmt: &stmt,
             extended: false,
             prepared: false,
             prepared_statements: &mut prepared,
@@ -587,7 +584,7 @@ mod tests {
         let mut rewriter = StatementRewrite::new(StatementRewriteContext {
             stmt: &mut ast,
             #[cfg(feature = "new_parser")]
-            new_stmt: Some(&new_ast),
+            new_stmt: &new_ast,
             extended: false,
             prepared: false,
             prepared_statements: &mut prepared,

--- a/pgdog/src/frontend/router/parser/rewrite/statement/auto_id.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/auto_id.rs
@@ -364,6 +364,7 @@ mod tests {
     ) -> Result<(String, RewritePlan), Error> {
         let _guard = set_env_var("NODE_ID", "pgdog-1");
         let mut ast = pg_query::parse(sql).unwrap().protobuf;
+        #[cfg(feature = "new_parser")]
         let stmt = pg_raw_parse::parse(sql).unwrap();
         let mut prepared = PreparedStatements::default();
         let schema = sharding_schema_with_mode(mode);

--- a/pgdog/src/frontend/router/parser/rewrite/statement/error.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/error.rs
@@ -8,6 +8,10 @@ pub enum Error {
     #[error("pg_query: {0}")]
     PgQuery(#[from] pg_query::Error),
 
+    #[error("parser: {0}")]
+    #[cfg(feature = "new_parser")]
+    Parser(#[from] pg_raw_parse::Error),
+
     #[error("cache: {0}")]
     Cache(String),
 

--- a/pgdog/src/frontend/router/parser/rewrite/statement/insert.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/insert.rs
@@ -334,13 +334,14 @@ mod tests {
 
     fn parse_and_split(sql: &str) -> Vec<InsertSplit> {
         let mut ast = pg_query::parse(sql).unwrap().protobuf;
+        let stmt = pg_raw_parse::parse(sql).unwrap();
         let mut prepared = PreparedStatements::default();
         let schema = default_schema();
         let db_schema = default_db_schema();
         let mut rewriter = StatementRewrite::new(StatementRewriteContext {
             stmt: &mut ast,
             #[cfg(feature = "new_parser")]
-            new_stmt: None,
+            new_stmt: &stmt,
             extended: false,
             prepared: false,
             prepared_statements: &mut prepared,

--- a/pgdog/src/frontend/router/parser/rewrite/statement/insert.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/insert.rs
@@ -334,6 +334,7 @@ mod tests {
 
     fn parse_and_split(sql: &str) -> Vec<InsertSplit> {
         let mut ast = pg_query::parse(sql).unwrap().protobuf;
+        #[cfg(feature = "new_parser")]
         let stmt = pg_raw_parse::parse(sql).unwrap();
         let mut prepared = PreparedStatements::default();
         let schema = default_schema();

--- a/pgdog/src/frontend/router/parser/rewrite/statement/mod.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/mod.rs
@@ -33,7 +33,7 @@ pub struct StatementRewriteContext<'a> {
     /// The AST of the statement we are rewriting.
     pub stmt: &'a mut ParseResult,
     #[cfg(feature = "new_parser")]
-    pub(crate) new_stmt: Option<&'a pg_raw_parse::ParseResult>,
+    pub(crate) new_stmt: &'a pg_raw_parse::ParseResult,
     /// The statement is using the extended protocol with placeholders.
     pub extended: bool,
     /// The statement is named, so we need to save any derivatives into the global
@@ -56,7 +56,7 @@ pub struct StatementRewrite<'a> {
     /// SQL statement.
     stmt: &'a mut ParseResult,
     #[cfg(feature = "new_parser")]
-    new_stmt: Option<&'a pg_raw_parse::ParseResult>,
+    new_stmt: &'a pg_raw_parse::ParseResult,
     /// The statement was rewritten.
     rewritten: bool,
     /// Statement is using the extended protocol, so

--- a/pgdog/src/frontend/router/parser/rewrite/statement/offset.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/offset.rs
@@ -281,12 +281,13 @@ mod tests {
 
     fn run_limit_offset(sql: &str, schema: &ShardingSchema) -> RewritePlan {
         let mut ast = pg_query::parse(sql).unwrap();
+        let stmt = pg_raw_parse::parse(sql).unwrap();
         let db_schema = Schema::default();
         let mut ps = PreparedStatements::default();
         let mut rewrite = StatementRewrite::new(StatementRewriteContext {
             stmt: &mut ast.protobuf,
             #[cfg(feature = "new_parser")]
-            new_stmt: None,
+            new_stmt: &stmt,
             extended: false,
             prepared: false,
             prepared_statements: &mut ps,

--- a/pgdog/src/frontend/router/parser/rewrite/statement/offset.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/offset.rs
@@ -281,6 +281,7 @@ mod tests {
 
     fn run_limit_offset(sql: &str, schema: &ShardingSchema) -> RewritePlan {
         let mut ast = pg_query::parse(sql).unwrap();
+        #[cfg(feature = "new_parser")]
         let stmt = pg_raw_parse::parse(sql).unwrap();
         let db_schema = Schema::default();
         let mut ps = PreparedStatements::default();

--- a/pgdog/src/frontend/router/parser/rewrite/statement/simple_prepared.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/simple_prepared.rs
@@ -154,10 +154,11 @@ mod tests {
 
         fn rewrite(&mut self, sql: &str) -> Result<(ParseResult, RewritePlan), Error> {
             let mut ast = parse(sql).unwrap().protobuf;
+            let stmt = pg_raw_parse::parse(sql).unwrap();
             let mut rewrite = StatementRewrite::new(StatementRewriteContext {
                 stmt: &mut ast,
                 #[cfg(feature = "new_parser")]
-                new_stmt: None,
+                new_stmt: &stmt,
                 extended: false,
                 prepared: false,
                 prepared_statements: &mut self.ps,

--- a/pgdog/src/frontend/router/parser/rewrite/statement/simple_prepared.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/simple_prepared.rs
@@ -154,6 +154,7 @@ mod tests {
 
         fn rewrite(&mut self, sql: &str) -> Result<(ParseResult, RewritePlan), Error> {
             let mut ast = parse(sql).unwrap().protobuf;
+            #[cfg(feature = "new_parser")]
             let stmt = pg_raw_parse::parse(sql).unwrap();
             let mut rewrite = StatementRewrite::new(StatementRewriteContext {
                 stmt: &mut ast,

--- a/pgdog/src/frontend/router/parser/rewrite/statement/unique_id.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/unique_id.rs
@@ -120,7 +120,9 @@ mod tests {
     use crate::backend::schema::Schema;
     use crate::frontend::PreparedStatements;
     use crate::frontend::router::parser::StatementRewriteContext;
+    use crate::frontend::router::parser::rewrite::statement::RewritePlan;
     use crate::test_utils::set_env_var;
+    use pg_query::protobuf::ParseResult;
 
     fn default_schema() -> ShardingSchema {
         ShardingSchema {
@@ -184,25 +186,7 @@ mod tests {
 
     #[test]
     fn test_rewrite_select_extended_single() {
-        let mut ast = pg_query::parse("SELECT pgdog.unique_id()")
-            .unwrap()
-            .protobuf;
-        let mut ps = PreparedStatements::default();
-        let schema = default_schema();
-        let db_schema = default_db_schema();
-        let mut rewrite = StatementRewrite::new(StatementRewriteContext {
-            stmt: &mut ast,
-            #[cfg(feature = "new_parser")]
-            new_stmt: None,
-            extended: true,
-            prepared: false,
-            prepared_statements: &mut ps,
-            schema: &schema,
-            db_schema: &db_schema,
-            user: "",
-            search_path: None,
-        });
-        let plan = rewrite.maybe_rewrite().unwrap();
+        let (ast, plan) = run_test("SELECT pgdog.unique_id()", true);
 
         let sql = ast.deparse().unwrap();
         assert_eq!(sql, "SELECT $1::bigint");
@@ -212,25 +196,7 @@ mod tests {
 
     #[test]
     fn test_rewrite_select_extended_with_existing_params() {
-        let mut ast = pg_query::parse("SELECT pgdog.unique_id(), $1, $2")
-            .unwrap()
-            .protobuf;
-        let mut ps = PreparedStatements::default();
-        let schema = default_schema();
-        let db_schema = default_db_schema();
-        let mut rewrite = StatementRewrite::new(StatementRewriteContext {
-            stmt: &mut ast,
-            #[cfg(feature = "new_parser")]
-            new_stmt: None,
-            extended: true,
-            prepared: false,
-            prepared_statements: &mut ps,
-            schema: &schema,
-            db_schema: &db_schema,
-            user: "",
-            search_path: None,
-        });
-        let plan = rewrite.maybe_rewrite().unwrap();
+        let (ast, plan) = run_test("SELECT pgdog.unique_id(), $1, $2", true);
 
         let sql = ast.deparse().unwrap();
         assert_eq!(sql, "SELECT $3::bigint, $1, $2");
@@ -240,25 +206,7 @@ mod tests {
 
     #[test]
     fn test_rewrite_select_extended_multiple_unique_ids() {
-        let mut ast = pg_query::parse("SELECT pgdog.unique_id(), pgdog.unique_id()")
-            .unwrap()
-            .protobuf;
-        let mut ps = PreparedStatements::default();
-        let schema = default_schema();
-        let db_schema = default_db_schema();
-        let mut rewrite = StatementRewrite::new(StatementRewriteContext {
-            stmt: &mut ast,
-            #[cfg(feature = "new_parser")]
-            new_stmt: None,
-            extended: true,
-            prepared: false,
-            prepared_statements: &mut ps,
-            schema: &schema,
-            db_schema: &db_schema,
-            user: "",
-            search_path: None,
-        });
-        let plan = rewrite.maybe_rewrite().unwrap();
+        let (ast, plan) = run_test("SELECT pgdog.unique_id(), pgdog.unique_id()", true);
 
         let sql = ast.deparse().unwrap();
         assert_eq!(sql, "SELECT $1::bigint, $2::bigint");
@@ -269,25 +217,7 @@ mod tests {
     #[test]
     fn test_rewrite_select_simple() {
         let _guard = set_env_var("NODE_ID", "pgdog-1");
-        let mut ast = pg_query::parse("SELECT pgdog.unique_id()")
-            .unwrap()
-            .protobuf;
-        let mut ps = PreparedStatements::default();
-        let schema = default_schema();
-        let db_schema = default_db_schema();
-        let mut rewrite = StatementRewrite::new(StatementRewriteContext {
-            stmt: &mut ast,
-            #[cfg(feature = "new_parser")]
-            new_stmt: None,
-            extended: false,
-            prepared: false,
-            prepared_statements: &mut ps,
-            schema: &schema,
-            db_schema: &db_schema,
-            user: "",
-            search_path: None,
-        });
-        let plan = rewrite.maybe_rewrite().unwrap();
+        let (ast, plan) = run_test("SELECT pgdog.unique_id()", false);
 
         let sql = ast.deparse().unwrap();
         // Value should be a bigint literal cast
@@ -306,25 +236,7 @@ mod tests {
     #[test]
     fn test_rewrite_select_simple_multiple_unique_ids() {
         let _guard = set_env_var("NODE_ID", "pgdog-1");
-        let mut ast = pg_query::parse("SELECT pgdog.unique_id(), pgdog.unique_id()")
-            .unwrap()
-            .protobuf;
-        let mut ps = PreparedStatements::default();
-        let schema = default_schema();
-        let db_schema = default_db_schema();
-        let mut rewrite = StatementRewrite::new(StatementRewriteContext {
-            stmt: &mut ast,
-            #[cfg(feature = "new_parser")]
-            new_stmt: None,
-            extended: false,
-            prepared: false,
-            prepared_statements: &mut ps,
-            schema: &schema,
-            db_schema: &db_schema,
-            user: "",
-            search_path: None,
-        });
-        let plan = rewrite.maybe_rewrite().unwrap();
+        let (ast, plan) = run_test("SELECT pgdog.unique_id(), pgdog.unique_id()", false);
 
         let sql = ast.deparse().unwrap();
         // Each unique_id call should get a different value
@@ -337,23 +249,7 @@ mod tests {
 
     #[test]
     fn test_rewrite_no_unique_id() {
-        let mut ast = pg_query::parse("SELECT 1, 2, 3").unwrap().protobuf;
-        let mut ps = PreparedStatements::default();
-        let schema = default_schema();
-        let db_schema = default_db_schema();
-        let mut rewrite = StatementRewrite::new(StatementRewriteContext {
-            stmt: &mut ast,
-            #[cfg(feature = "new_parser")]
-            new_stmt: None,
-            extended: true,
-            prepared: false,
-            prepared_statements: &mut ps,
-            schema: &schema,
-            db_schema: &db_schema,
-            user: "",
-            search_path: None,
-        });
-        let plan = rewrite.maybe_rewrite().unwrap();
+        let (ast, plan) = run_test("SELECT 1, 2, 3", true);
 
         let sql = ast.deparse().unwrap();
         assert_eq!(sql, "SELECT 1, 2, 3");
@@ -362,26 +258,10 @@ mod tests {
 
     #[test]
     fn test_rewrite_insert_values() {
-        let mut ast =
-            pg_query::parse("INSERT INTO t (id, name) VALUES (pgdog.unique_id(), 'test')")
-                .unwrap()
-                .protobuf;
-        let mut ps = PreparedStatements::default();
-        let schema = default_schema();
-        let db_schema = default_db_schema();
-        let mut rewrite = StatementRewrite::new(StatementRewriteContext {
-            stmt: &mut ast,
-            #[cfg(feature = "new_parser")]
-            new_stmt: None,
-            extended: true,
-            prepared: false,
-            prepared_statements: &mut ps,
-            schema: &schema,
-            db_schema: &db_schema,
-            user: "",
-            search_path: None,
-        });
-        let plan = rewrite.maybe_rewrite().unwrap();
+        let (ast, plan) = run_test(
+            "INSERT INTO t (id, name) VALUES (pgdog.unique_id(), 'test')",
+            true,
+        );
 
         let sql = ast.deparse().unwrap();
         assert_eq!(sql, "INSERT INTO t (id, name) VALUES ($1::bigint, 'test')");
@@ -390,26 +270,10 @@ mod tests {
 
     #[test]
     fn test_rewrite_insert_multiple_rows() {
-        let mut ast =
-            pg_query::parse("INSERT INTO t (id) VALUES (pgdog.unique_id()), (pgdog.unique_id())")
-                .unwrap()
-                .protobuf;
-        let mut ps = PreparedStatements::default();
-        let schema = default_schema();
-        let db_schema = default_db_schema();
-        let mut rewrite = StatementRewrite::new(StatementRewriteContext {
-            stmt: &mut ast,
-            #[cfg(feature = "new_parser")]
-            new_stmt: None,
-            extended: true,
-            prepared: false,
-            prepared_statements: &mut ps,
-            schema: &schema,
-            db_schema: &db_schema,
-            user: "",
-            search_path: None,
-        });
-        let plan = rewrite.maybe_rewrite().unwrap();
+        let (ast, plan) = run_test(
+            "INSERT INTO t (id) VALUES (pgdog.unique_id()), (pgdog.unique_id())",
+            true,
+        );
 
         let sql = ast.deparse().unwrap();
         assert_eq!(sql, "INSERT INTO t (id) VALUES ($1::bigint), ($2::bigint)");
@@ -418,25 +282,7 @@ mod tests {
 
     #[test]
     fn test_rewrite_insert_select() {
-        let mut ast = pg_query::parse("INSERT INTO t (id) SELECT pgdog.unique_id() FROM s")
-            .unwrap()
-            .protobuf;
-        let mut ps = PreparedStatements::default();
-        let schema = default_schema();
-        let db_schema = default_db_schema();
-        let mut rewrite = StatementRewrite::new(StatementRewriteContext {
-            stmt: &mut ast,
-            #[cfg(feature = "new_parser")]
-            new_stmt: None,
-            extended: true,
-            prepared: false,
-            prepared_statements: &mut ps,
-            schema: &schema,
-            db_schema: &db_schema,
-            user: "",
-            search_path: None,
-        });
-        let plan = rewrite.maybe_rewrite().unwrap();
+        let (ast, plan) = run_test("INSERT INTO t (id) SELECT pgdog.unique_id() FROM s", true);
 
         let sql = ast.deparse().unwrap();
         assert_eq!(sql, "INSERT INTO t (id) SELECT $1::bigint FROM s");
@@ -445,25 +291,10 @@ mod tests {
 
     #[test]
     fn test_rewrite_update_set() {
-        let mut ast = pg_query::parse("UPDATE t SET id = pgdog.unique_id() WHERE name = 'test'")
-            .unwrap()
-            .protobuf;
-        let mut ps = PreparedStatements::default();
-        let schema = default_schema();
-        let db_schema = default_db_schema();
-        let mut rewrite = StatementRewrite::new(StatementRewriteContext {
-            stmt: &mut ast,
-            #[cfg(feature = "new_parser")]
-            new_stmt: None,
-            extended: true,
-            prepared: false,
-            prepared_statements: &mut ps,
-            schema: &schema,
-            db_schema: &db_schema,
-            user: "",
-            search_path: None,
-        });
-        let plan = rewrite.maybe_rewrite().unwrap();
+        let (ast, plan) = run_test(
+            "UPDATE t SET id = pgdog.unique_id() WHERE name = 'test'",
+            true,
+        );
 
         let sql = ast.deparse().unwrap();
         assert_eq!(sql, "UPDATE t SET id = $1::bigint WHERE name = 'test'");
@@ -472,25 +303,10 @@ mod tests {
 
     #[test]
     fn test_rewrite_update_where() {
-        let mut ast = pg_query::parse("UPDATE t SET name = 'new' WHERE id = pgdog.unique_id()")
-            .unwrap()
-            .protobuf;
-        let mut ps = PreparedStatements::default();
-        let schema = default_schema();
-        let db_schema = default_db_schema();
-        let mut rewrite = StatementRewrite::new(StatementRewriteContext {
-            stmt: &mut ast,
-            #[cfg(feature = "new_parser")]
-            new_stmt: None,
-            extended: true,
-            prepared: false,
-            prepared_statements: &mut ps,
-            schema: &schema,
-            db_schema: &db_schema,
-            user: "",
-            search_path: None,
-        });
-        let plan = rewrite.maybe_rewrite().unwrap();
+        let (ast, plan) = run_test(
+            "UPDATE t SET name = 'new' WHERE id = pgdog.unique_id()",
+            true,
+        );
 
         let sql = ast.deparse().unwrap();
         assert_eq!(sql, "UPDATE t SET name = 'new' WHERE id = $1::bigint");
@@ -499,25 +315,7 @@ mod tests {
 
     #[test]
     fn test_rewrite_delete_where() {
-        let mut ast = pg_query::parse("DELETE FROM t WHERE id = pgdog.unique_id()")
-            .unwrap()
-            .protobuf;
-        let mut ps = PreparedStatements::default();
-        let schema = default_schema();
-        let db_schema = default_db_schema();
-        let mut rewrite = StatementRewrite::new(StatementRewriteContext {
-            stmt: &mut ast,
-            #[cfg(feature = "new_parser")]
-            new_stmt: None,
-            extended: true,
-            prepared: false,
-            prepared_statements: &mut ps,
-            schema: &schema,
-            db_schema: &db_schema,
-            user: "",
-            search_path: None,
-        });
-        let plan = rewrite.maybe_rewrite().unwrap();
+        let (ast, plan) = run_test("DELETE FROM t WHERE id = pgdog.unique_id()", true);
 
         let sql = ast.deparse().unwrap();
         assert_eq!(sql, "DELETE FROM t WHERE id = $1::bigint");
@@ -526,27 +324,10 @@ mod tests {
 
     #[test]
     fn test_rewrite_insert_returning() {
-        let mut ast = pg_query::parse(
+        let (ast, plan) = run_test(
             "INSERT INTO t (id) VALUES (pgdog.unique_id()) RETURNING pgdog.unique_id()",
-        )
-        .unwrap()
-        .protobuf;
-        let mut ps = PreparedStatements::default();
-        let schema = default_schema();
-        let db_schema = default_db_schema();
-        let mut rewrite = StatementRewrite::new(StatementRewriteContext {
-            stmt: &mut ast,
-            #[cfg(feature = "new_parser")]
-            new_stmt: None,
-            extended: true,
-            prepared: false,
-            prepared_statements: &mut ps,
-            schema: &schema,
-            db_schema: &db_schema,
-            user: "",
-            search_path: None,
-        });
-        let plan = rewrite.maybe_rewrite().unwrap();
+            true,
+        );
 
         let sql = ast.deparse().unwrap();
         assert_eq!(
@@ -558,25 +339,10 @@ mod tests {
 
     #[test]
     fn test_rewrite_explain_insert_select() {
-        let mut ast = pg_query::parse("EXPLAIN INSERT INTO t (id) SELECT pgdog.unique_id() FROM s")
-            .unwrap()
-            .protobuf;
-        let mut ps = PreparedStatements::default();
-        let schema = default_schema();
-        let db_schema = default_db_schema();
-        let mut rewrite = StatementRewrite::new(StatementRewriteContext {
-            stmt: &mut ast,
-            #[cfg(feature = "new_parser")]
-            new_stmt: None,
-            extended: true,
-            prepared: false,
-            prepared_statements: &mut ps,
-            schema: &schema,
-            db_schema: &db_schema,
-            user: "",
-            search_path: None,
-        });
-        let plan = rewrite.maybe_rewrite().unwrap();
+        let (ast, plan) = run_test(
+            "EXPLAIN INSERT INTO t (id) SELECT pgdog.unique_id() FROM s",
+            true,
+        );
 
         let sql = ast.deparse().unwrap();
         assert_eq!(sql, "EXPLAIN INSERT INTO t (id) SELECT $1::bigint FROM s");
@@ -585,17 +351,24 @@ mod tests {
 
     #[test]
     fn test_rewrite_explain_select() {
-        let mut ast = pg_query::parse("EXPLAIN SELECT pgdog.unique_id()")
-            .unwrap()
-            .protobuf;
+        let (ast, plan) = run_test("EXPLAIN SELECT pgdog.unique_id()", true);
+
+        let sql = ast.deparse().unwrap();
+        assert_eq!(sql, "EXPLAIN SELECT $1::bigint");
+        assert_eq!(plan.unique_ids, 1);
+    }
+
+    fn run_test(sql: &str, extended: bool) -> (ParseResult, RewritePlan) {
+        let mut ast = pg_query::parse(sql).unwrap().protobuf;
+        let stmt = pg_raw_parse::parse(sql).unwrap();
         let mut ps = PreparedStatements::default();
         let schema = default_schema();
         let db_schema = default_db_schema();
         let mut rewrite = StatementRewrite::new(StatementRewriteContext {
             stmt: &mut ast,
             #[cfg(feature = "new_parser")]
-            new_stmt: None,
-            extended: true,
+            new_stmt: &stmt,
+            extended,
             prepared: false,
             prepared_statements: &mut ps,
             schema: &schema,
@@ -604,9 +377,6 @@ mod tests {
             search_path: None,
         });
         let plan = rewrite.maybe_rewrite().unwrap();
-
-        let sql = ast.deparse().unwrap();
-        assert_eq!(sql, "EXPLAIN SELECT $1::bigint");
-        assert_eq!(plan.unique_ids, 1);
+        (ast, plan)
     }
 }

--- a/pgdog/src/frontend/router/parser/rewrite/statement/unique_id.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/unique_id.rs
@@ -360,6 +360,7 @@ mod tests {
 
     fn run_test(sql: &str, extended: bool) -> (ParseResult, RewritePlan) {
         let mut ast = pg_query::parse(sql).unwrap().protobuf;
+        #[cfg(feature = "new_parser")]
         let stmt = pg_raw_parse::parse(sql).unwrap();
         let mut ps = PreparedStatements::default();
         let schema = default_schema();

--- a/pgdog/src/frontend/router/parser/rewrite/statement/update.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/update.rs
@@ -1,13 +1,17 @@
 use std::{collections::HashMap, ops::Deref, sync::Arc};
 
 use pg_query::{
-    Node, NodeEnum,
+    Node as PgNode, NodeEnum,
     protobuf::{
         AExpr, AExprKind, AStar, ColumnRef, DeleteStmt, InsertStmt, LimitOption, List,
         OverridingKind, ParamRef, ParseResult, RangeVar, RawStmt, ResTarget, SelectStmt,
         SetOperation, String as PgString, UpdateStmt,
     },
 };
+#[cfg(feature = "new_parser")]
+use pg_raw_parse::make::owned;
+#[cfg(feature = "new_parser")]
+use pg_raw_parse::{DeparseResult, Node, deparse, nodes};
 use pgdog_config::{QueryParserEngine, RewriteMode};
 
 use crate::{
@@ -147,7 +151,7 @@ pub(crate) struct Insert {
     /// the original UPDATE statement.
     pub(super) mapping: HashMap<String, UpdateValue>,
     /// Return columns.
-    pub(super) returning_list: Vec<Node>,
+    pub(super) returning_list: Vec<PgNode>,
     /// Returning list deparsed.
     pub(super) returnin_list_deparsed: Option<String>,
 }
@@ -231,14 +235,14 @@ impl Insert {
                 values_str.push(format!("${}", bind_idx + 1));
             }
 
-            columns.push(Node {
+            columns.push(PgNode {
                 node: Some(NodeEnum::ResTarget(Box::new(ResTarget {
                     name: field.name.clone(),
                     ..Default::default()
                 }))),
             });
 
-            values.push(Node {
+            values.push(PgNode {
                 node: Some(NodeEnum::ParamRef(ParamRef {
                     number: bind_idx + 1,
                     ..Default::default()
@@ -251,14 +255,14 @@ impl Insert {
         let insert = InsertStmt {
             relation: self.table.clone(),
             cols: columns,
-            select_stmt: Some(Box::new(Node {
+            select_stmt: Some(Box::new(PgNode {
                 node: Some(NodeEnum::SelectStmt(Box::new(SelectStmt {
                     target_list: vec![],
                     from_clause: vec![],
                     limit_option: LimitOption::Default.into(),
                     where_clause: None,
                     op: SetOperation::SetopNone.into(),
-                    values_lists: vec![Node {
+                    values_lists: vec![PgNode {
                         node: Some(NodeEnum::List(List { items: values })),
                     }],
                     ..Default::default()
@@ -322,14 +326,14 @@ impl<'a> StatementRewrite<'a> {
             return Ok(());
         }
 
-        let stmt = self
+        let stmt_old = self
             .stmt
             .stmts
             .first()
             .and_then(|stmt| stmt.stmt.as_ref().map(|stmt| stmt.node.as_ref()))
             .flatten();
 
-        let stmt = if let Some(NodeEnum::UpdateStmt(stmt)) = stmt {
+        let stmt_old = if let Some(NodeEnum::UpdateStmt(stmt)) = stmt_old {
             stmt
         } else {
             // TODO: Handle EXPLAIN ANALYZE which needs to execute.
@@ -338,20 +342,95 @@ impl<'a> StatementRewrite<'a> {
             return Ok(());
         };
 
-        if let Some(value) = self.sharding_key_update_check(stmt)? {
+        #[cfg(feature = "new_parser")]
+        let Some(Node::UpdateStmt(stmt)) = self.new_stmt.stmts().next() else {
+            // TODO: Handle EXPLAIN ANALYZE which needs to execute.
+            // We could return a combined plan for all 3 queries
+            // we need to execute.
+            return Ok(());
+        };
+
+        if let Some(value) = self.sharding_key_update_check(
+            #[cfg(not(feature = "new_parser"))]
+            stmt_old,
+            #[cfg(feature = "new_parser")]
+            stmt,
+        )? {
+            #[cfg(feature = "new_parser")]
+            // Convert from pg_raw_parse::nodes::ResTarget to pg_query::protobuf::ResTarget
+            let parse_result = {
+                let sql = deparse_node(value)?;
+                pg_query::parse(sql.as_str())?.protobuf
+            };
+            #[cfg(feature = "new_parser")]
+            let value = {
+                let raw_stmt = parse_result.stmts.first().unwrap();
+                let Some(NodeEnum::SelectStmt(s)) = raw_stmt.stmt.as_ref().unwrap().node.as_ref()
+                else {
+                    unreachable!()
+                };
+                let Some(NodeEnum::ResTarget(r)) = s.target_list.first().unwrap().node.as_ref()
+                else {
+                    unreachable!()
+                };
+                r
+            };
             // Without a WHERE clause, this is a huge
             // cross-shard rewrite.
-            if stmt.where_clause.is_none() {
+            if stmt_old.where_clause.is_none() {
                 return Err(Error::WhereClauseMissing);
             }
-            plan.sharding_key_update =
-                Some(create_stmts(stmt, value, self.schema.query_parser_engine)?);
+            plan.sharding_key_update = Some(create_stmts(
+                stmt_old,
+                value,
+                self.schema.query_parser_engine,
+            )?);
         }
 
         Ok(())
     }
 
     /// Check if the sharding key could be updated.
+    #[cfg(feature = "new_parser")]
+    fn sharding_key_update_check(
+        &'a self,
+        stmt: &'a nodes::UpdateStmt,
+    ) -> Result<Option<&'a nodes::ResTarget>, Error> {
+        let table = stmt
+            .relation()
+            .map(Table::from)
+            .expect("UPDATE always has a table");
+
+        let Some(shard_key_assignment) = stmt.targetList().into_iter().find(|c| {
+            Column::try_from(*c).is_ok_and(|mut c| {
+                c.qualify(table);
+                self.schema.tables().get_table(c).is_some()
+            })
+        }) else {
+            return Ok(None);
+        };
+
+        // Check that it's a value assignment and not something like
+        // id = id + 1
+        if Value::try_from(shard_key_assignment.val()).is_ok() {
+            Ok(Some(shard_key_assignment))
+        } else {
+            let expr = shard_key_assignment.val();
+            let expr = deparse_expr(expr)?;
+            // FIXME:
+            //
+            // We can technically support this. We can inject this into
+            // the `SELECT` statement we use to pull the existing row
+            // and use the computed value for assignment.
+            Err(Error::UnsupportedShardingKeyUpdate(format!(
+                "\"{}\" = {}",
+                shard_key_assignment.name().unwrap_or_default(),
+                expr.as_str().strip_prefix("SELECT ").unwrap_or("<unknown>"),
+            )))
+        }
+    }
+
+    #[cfg(not(feature = "new_parser"))]
     fn sharding_key_update_check(
         &'a self,
         stmt: &'a UpdateStmt,
@@ -395,7 +474,7 @@ impl<'a> StatementRewrite<'a> {
                         let expr = res
                             .val
                             .as_ref()
-                            .map(|node| deparse_expr(node, self.schema.query_parser_engine))
+                            .map(|node| deparse_expr_old(node, self.schema.query_parser_engine))
                             .transpose()?
                             .unwrap_or_else(|| "<unknown>".to_string());
                         Err(Error::UnsupportedShardingKeyUpdate(format!(
@@ -418,7 +497,7 @@ impl<'a> StatementRewrite<'a> {
 fn rewrite_params(parse_result: &mut ParseResult) -> Result<Vec<u16>, Error> {
     let mut params = HashMap::new();
 
-    visit_and_mutate_nodes(parse_result, |node| -> Result<Option<Node>, Error> {
+    visit_and_mutate_nodes(parse_result, |node| -> Result<Option<PgNode>, Error> {
         if let Some(NodeEnum::ParamRef(ref mut param)) = node.node {
             if let Some(existing) = params.get(&param.number) {
                 param.number = *existing;
@@ -443,7 +522,7 @@ fn rewrite_params(parse_result: &mut ParseResult) -> Result<Vec<u16>, Error> {
 
 #[derive(Debug, Clone)]
 pub(super) enum UpdateValue {
-    Value(Box<Node>),
+    Value(Box<PgNode>),
     Expr(String), // We deparse the expression because we can't handle it yet.
 }
 
@@ -477,7 +556,7 @@ fn res_targets_to_insert_res_targets(
             let value = if valid {
                 UpdateValue::Value(target.val.clone().unwrap())
             } else {
-                UpdateValue::Expr(deparse_expr(
+                UpdateValue::Expr(deparse_expr_old(
                     target.val.as_ref().unwrap(),
                     query_parser_engine,
                 )?)
@@ -495,7 +574,7 @@ fn res_targets_to_insert_res_targets(
 /// for use in shard routing validation.
 fn res_target_to_a_expr(res_target: &ResTarget) -> AExpr {
     let column_ref = ColumnRef {
-        fields: vec![Node {
+        fields: vec![PgNode {
             node: Some(NodeEnum::String(PgString {
                 sval: res_target.name.clone(),
             })),
@@ -505,10 +584,10 @@ fn res_target_to_a_expr(res_target: &ResTarget) -> AExpr {
 
     AExpr {
         kind: AExprKind::AexprOp.into(),
-        name: vec![Node {
+        name: vec![PgNode {
             node: Some(NodeEnum::String(PgString { sval: "=".into() })),
         }],
-        lexpr: Some(Box::new(Node {
+        lexpr: Some(Box::new(PgNode {
             node: Some(NodeEnum::ColumnRef(column_ref)),
         })),
         rexpr: res_target.val.clone(),
@@ -516,13 +595,13 @@ fn res_target_to_a_expr(res_target: &ResTarget) -> AExpr {
     }
 }
 
-fn select_star() -> Vec<Node> {
-    vec![Node {
+fn select_star() -> Vec<PgNode> {
+    vec![PgNode {
         node: Some(NodeEnum::ResTarget(Box::new(ResTarget {
             name: "".into(),
-            val: Some(Box::new(Node {
+            val: Some(Box::new(PgNode {
                 node: Some(NodeEnum::ColumnRef(ColumnRef {
-                    fields: vec![Node {
+                    fields: vec![PgNode {
                         node: Some(NodeEnum::AStar(AStar {})),
                     }],
                     ..Default::default()
@@ -537,7 +616,7 @@ fn parse_result(node: NodeEnum) -> ParseResult {
     ParseResult {
         version: pg_query::PG_VERSION_NUM as i32,
         stmts: vec![RawStmt {
-            stmt: Some(Box::new(Node { node: Some(node) })),
+            stmt: Some(Box::new(PgNode { node: Some(node) })),
             stmt_location: 0,
             stmt_len: 0,
         }],
@@ -545,9 +624,36 @@ fn parse_result(node: NodeEnum) -> ParseResult {
 }
 
 /// Deparse an expression node by wrapping it in a SELECT statement.
-fn deparse_expr(node: &Node, query_parser_engine: QueryParserEngine) -> Result<String, Error> {
+#[cfg(feature = "new_parser")]
+fn deparse_expr(node: Node<'_>) -> Result<DeparseResult, Error> {
+    let res_target = owned(|mem| {
+        let mut res_target = mem.make_node::<nodes::ResTarget>();
+        res_target.as_mut().set_val(mem.make_unique(node));
+        res_target
+    });
+    deparse_node(&res_target)
+}
+
+#[cfg(feature = "new_parser")]
+fn deparse_node(node: &nodes::ResTarget) -> Result<DeparseResult, Error> {
+    let node = owned(|mem| {
+        let mut stmt = mem.make_node::<nodes::RawStmt>();
+        let mut select = mem.make_node::<nodes::SelectStmt>();
+        select
+            .as_mut()
+            .set_targetList(mem.make_List(&[mem.make_unique(node)]));
+        stmt.as_mut().set_stmt(select.as_node());
+        stmt
+    });
+    deparse(&*node).map_err(Into::into)
+}
+
+fn deparse_expr_old(
+    node: &PgNode,
+    query_parser_engine: QueryParserEngine,
+) -> Result<String, Error> {
     Ok(deparse_list(
-        &[Node {
+        &[PgNode {
             node: Some(NodeEnum::ResTarget(Box::new(ResTarget {
                 val: Some(Box::new(node.clone())),
                 ..Default::default()
@@ -560,7 +666,7 @@ fn deparse_expr(node: &Node, query_parser_engine: QueryParserEngine) -> Result<S
 
 /// Deparse a list of expressions by wrapping them into a SELECT statement.
 fn deparse_list(
-    list: &[Node],
+    list: &[PgNode],
     query_parser_engine: QueryParserEngine,
 ) -> Result<Option<String>, Error> {
     if list.is_empty() {
@@ -592,7 +698,7 @@ fn create_stmts(
 ) -> Result<ShardingKeyUpdate, Error> {
     let select = SelectStmt {
         target_list: select_star(),
-        from_clause: vec![Node {
+        from_clause: vec![PgNode {
             node: Some(NodeEnum::RangeVar(stmt.relation.clone().unwrap())), // SAFETY: we checked the UPDATE stmt has a table name.
         }],
         limit_option: LimitOption::Default.into(),
@@ -638,11 +744,11 @@ fn create_stmts(
 
     let check = SelectStmt {
         target_list: select_star(),
-        from_clause: vec![Node {
+        from_clause: vec![PgNode {
             node: Some(NodeEnum::RangeVar(stmt.relation.clone().unwrap())), // SAFETY: we checked the UPDATE stmt has a table name.
         }],
         limit_option: LimitOption::Default.into(),
-        where_clause: Some(Box::new(Node {
+        where_clause: Some(Box::new(PgNode {
             node: Some(NodeEnum::AExpr(Box::new(res_target_to_a_expr(new_value)))),
         })),
         op: SetOperation::SetopNone.into(),
@@ -718,15 +824,16 @@ mod test {
     }
 
     fn run_test(query: &str) -> Result<Option<ShardingKeyUpdate>, Error> {
-        let mut stmt = parse(query)?;
+        let mut stmt_old = parse(query)?;
+        let stmt = pg_raw_parse::parse(query)?;
         let schema = default_schema();
         let db_schema = default_db_schema();
         let mut stmts = PreparedStatements::new();
 
         let ctx = StatementRewriteContext {
-            stmt: &mut stmt.protobuf,
+            stmt: &mut stmt_old.protobuf,
             #[cfg(feature = "new_parser")]
-            new_stmt: None,
+            new_stmt: &stmt,
             schema: &schema,
             db_schema: &db_schema,
             extended: true,
@@ -1031,102 +1138,102 @@ mod test {
     #[test]
     fn test_unsupported_assignment() {
         let result = run_test("UPDATE sharded SET id = random() WHERE id = $1");
-        assert!(matches!(
+        std::assert_matches!(
             result,
             Err(Error::UnsupportedShardingKeyUpdate(msg)) if msg == "\"id\" = random()"
-        ));
+        );
     }
 
     #[test]
     fn test_unsupported_assignment_arithmetic_add() {
         let result = run_test("UPDATE sharded SET id = id + 1 WHERE id = $1");
-        assert!(matches!(
+        std::assert_matches!(
             result,
             Err(Error::UnsupportedShardingKeyUpdate(msg)) if msg == "\"id\" = id + 1"
-        ));
+        );
     }
 
     #[test]
     fn test_unsupported_assignment_arithmetic_multiply() {
         let result = run_test("UPDATE sharded SET id = id * 2 WHERE id = $1");
-        assert!(matches!(
+        std::assert_matches!(
             result,
             Err(Error::UnsupportedShardingKeyUpdate(msg)) if msg == "\"id\" = id * 2"
-        ));
+        );
     }
 
     #[test]
     fn test_unsupported_assignment_arithmetic_with_param() {
         let result = run_test("UPDATE sharded SET id = id + $2 WHERE id = $1");
-        assert!(matches!(
+        std::assert_matches!(
             result,
             Err(Error::UnsupportedShardingKeyUpdate(msg)) if msg == "\"id\" = id + $2"
-        ));
+        );
     }
 
     #[test]
     fn test_unsupported_assignment_now() {
         let result = run_test("UPDATE sharded SET id = now() WHERE id = $1");
-        assert!(matches!(
+        std::assert_matches!(
             result,
             Err(Error::UnsupportedShardingKeyUpdate(msg)) if msg == "\"id\" = now()"
-        ));
+        );
     }
 
     #[test]
     fn test_unsupported_assignment_coalesce() {
         let result = run_test("UPDATE sharded SET id = coalesce(id, 0) WHERE id = $1");
-        assert!(matches!(
+        std::assert_matches!(
             result,
             Err(Error::UnsupportedShardingKeyUpdate(msg)) if msg == "\"id\" = COALESCE(id, 0)"
-        ));
+        );
     }
 
     #[test]
     fn test_unsupported_assignment_case() {
         let result =
             run_test("UPDATE sharded SET id = CASE WHEN id > 0 THEN 1 ELSE 0 END WHERE id = $1");
-        assert!(matches!(
+        std::assert_matches!(
             result,
             Err(Error::UnsupportedShardingKeyUpdate(msg)) if msg == "\"id\" = CASE WHEN id > 0 THEN 1 ELSE 0 END"
-        ));
+        );
     }
 
     #[test]
     fn test_unsupported_assignment_subquery() {
         let result =
             run_test("UPDATE sharded SET id = (SELECT max(id) FROM sharded) WHERE id = $1");
-        assert!(matches!(
+        std::assert_matches!(
             result,
             Err(Error::UnsupportedShardingKeyUpdate(msg)) if msg == "\"id\" = (SELECT max(id) FROM sharded)"
-        ));
+        );
     }
 
     #[test]
     fn test_unsupported_assignment_column_reference() {
         let result = run_test("UPDATE sharded SET id = other_column WHERE id = $1");
-        assert!(matches!(
+        std::assert_matches!(
             result,
             Err(Error::UnsupportedShardingKeyUpdate(msg)) if msg == "\"id\" = other_column"
-        ));
+        );
     }
 
     #[test]
     fn test_unsupported_assignment_concat() {
         let result = run_test("UPDATE sharded SET id = id || '_suffix' WHERE id = $1");
-        assert!(matches!(
+        std::assert_matches!(
             result,
             Err(Error::UnsupportedShardingKeyUpdate(msg)) if msg == "\"id\" = id || '_suffix'"
-        ));
+        );
     }
 
     #[test]
     fn test_unsupported_assignment_negation() {
         let result = run_test("UPDATE sharded SET id = -id WHERE id = $1");
-        assert!(matches!(
+        std::assert_matches!(
             result,
             Err(Error::UnsupportedShardingKeyUpdate(msg)) if msg == "\"id\" = - id"
-        ));
+        );
     }
 
     #[test]
@@ -1156,7 +1263,7 @@ mod test {
 
         // The id column should be UpdateValue::Value (simple parameter)
         let id_value = result.insert.mapping.get("id").unwrap();
-        assert!(matches!(id_value, UpdateValue::Value(_)));
+        std::assert_matches!(id_value, UpdateValue::Value(_));
 
         // The email column should be UpdateValue::Expr with the deparsed expression
         let email_value = result.insert.mapping.get("email").unwrap();

--- a/pgdog/src/frontend/router/parser/rewrite/statement/update.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/update.rs
@@ -825,6 +825,7 @@ mod test {
 
     fn run_test(query: &str) -> Result<Option<ShardingKeyUpdate>, Error> {
         let mut stmt_old = parse(query)?;
+        #[cfg(feature = "new_parser")]
         let stmt = pg_raw_parse::parse(query)?;
         let schema = default_schema();
         let db_schema = default_db_schema();


### PR DESCRIPTION
There's quite a bit of churn in this one, as I needed to change StatementRewrite to always have the new AST so every test that was previously passing `None` needed to be updated. One file in particular had a *bunch* of repeated code in its test, which I extracted to a helper function.

The other bit of funkiness here is that since the return value of this function is actually passed to later functions, and I am still trying to break this port up into pieces, we deparse and reparse to convert to the equivalent node in the old parser