### PR TITLE
Port `Aggregate::parse` to the new parser

### DIFF
--- a/pgdog/src/backend/pool/connection/aggregate.rs
+++ b/pgdog/src/backend/pool/connection/aggregate.rs
@@ -402,7 +402,7 @@ mod test {
     };
     use bytes::Bytes;
     #[cfg(not(feature = "new_parser"))]
-    use pg_query::{NodeEnum, protobuf::SelectStmt};
+    use pg_query::NodeEnum;
     #[cfg(feature = "new_parser")]
     use pg_raw_parse::Node;
     use pgdog_postgres_types::Double;
@@ -463,10 +463,10 @@ mod test {
             .remove(0)
             .stmt
             .unwrap();
-        match stmt.node.unwrap() {
+        let stmt = match stmt.node.unwrap() {
             NodeEnum::SelectStmt(stmt) => *stmt,
             _ => panic!("not a select"),
-        }
+        };
         Aggregate::parse(&stmt, &Default::default())
     }
 

--- a/pgdog/src/backend/pool/connection/aggregate.rs
+++ b/pgdog/src/backend/pool/connection/aggregate.rs
@@ -401,7 +401,10 @@ mod test {
         messages::{Field, Format, RowDescription},
     };
     use bytes::Bytes;
+    #[cfg(not(feature = "new_parser"))]
     use pg_query::{NodeEnum, protobuf::SelectStmt};
+    #[cfg(feature = "new_parser")]
+    use pg_raw_parse::Node;
     use pgdog_postgres_types::Double;
     use std::assert_matches;
     use std::collections::VecDeque;
@@ -442,7 +445,17 @@ mod test {
         }
     }
 
-    fn select(stmt: &str) -> SelectStmt {
+    #[cfg(feature = "new_parser")]
+    fn parse(stmt: &str) -> Aggregate {
+        let ast = pg_raw_parse::parse(stmt).unwrap();
+        let Node::SelectStmt(stmt) = ast.stmts().next().unwrap() else {
+            panic!("not a select")
+        };
+        Aggregate::parse(&stmt, &Default::default())
+    }
+
+    #[cfg(not(feature = "new_parser"))]
+    fn parse(stmt: &str) -> Aggregate {
         let stmt = pg_query::parse(stmt)
             .unwrap()
             .protobuf
@@ -454,10 +467,7 @@ mod test {
             NodeEnum::SelectStmt(stmt) => *stmt,
             _ => panic!("not a select"),
         }
-    }
-
-    fn parse(stmt: &str) -> Aggregate {
-        Aggregate::parse(&select(stmt), &Default::default())
+        Aggregate::parse(&stmt, &Default::default())
     }
 
     #[test]

--- a/pgdog/src/frontend/router/parser/aggregate.rs
+++ b/pgdog/src/frontend/router/parser/aggregate.rs
@@ -1,6 +1,10 @@
-use pg_query::NodeEnum;
-use pg_query::protobuf::Integer;
-use pg_query::protobuf::{Node, SelectStmt, String as PgQueryString, a_const::Val};
+#[cfg(not(feature = "new_parser"))]
+use pg_query::{
+    NodeEnum,
+    protobuf::{Integer, Node, SelectStmt, String as PgQueryString, a_const::Val},
+};
+#[cfg(feature = "new_parser")]
+use pg_raw_parse::{Node, nodes};
 use std::fmt;
 
 use super::Function;
@@ -64,14 +68,30 @@ pub struct Aggregate {
     group_by: Vec<usize>,
 }
 
-fn target_list_to_index(stmt: &SelectStmt, column_names: Vec<&String>) -> Option<usize> {
+#[cfg(feature = "new_parser")]
+fn index_of_column(stmt: &nodes::SelectStmt, qualified_column_name: &[&str]) -> Option<usize> {
+    stmt.targetList().iter().position(|node| {
+        let Node::ColumnRef(c) = node.val() else {
+            return false;
+        };
+        let selected_column = c
+            .fields()
+            .iter()
+            .filter_map(Node::as_str)
+            .collect::<Vec<_>>();
+        columns_match(&selected_column, qualified_column_name)
+    })
+}
+
+#[cfg(not(feature = "new_parser"))]
+fn target_list_to_index(stmt: &SelectStmt, column_names: &[&str]) -> Option<usize> {
     for (idx, node) in stmt.target_list.iter().enumerate() {
         if let Some(NodeEnum::ResTarget(res_target_box)) = node.node.as_ref() {
             let res_target = res_target_box.as_ref();
             if let Some(node_box) = res_target.val.as_ref()
                 && let Some(NodeEnum::ColumnRef(column_ref)) = node_box.node.as_ref()
             {
-                let select_names: Vec<&String> = column_ref
+                let select_names: Vec<_> = column_ref
                     .fields
                     .iter()
                     .filter_map(|field_node| {
@@ -80,7 +100,7 @@ fn target_list_to_index(stmt: &SelectStmt, column_names: Vec<&String>) -> Option
                                 NodeEnum::String(PgQueryString {
                                     sval: found_column_name,
                                     ..
-                                }) => Some(found_column_name),
+                                }) => Some(found_column_name.as_str()),
                                 _ => None,
                             }
                         } else {
@@ -93,7 +113,7 @@ fn target_list_to_index(stmt: &SelectStmt, column_names: Vec<&String>) -> Option
                     continue;
                 }
 
-                if columns_match(&column_names, &select_names) {
+                if columns_match(column_names, &select_names) {
                     return Some(idx);
                 }
             }
@@ -102,7 +122,7 @@ fn target_list_to_index(stmt: &SelectStmt, column_names: Vec<&String>) -> Option
     None
 }
 
-fn columns_match(group_by_names: &[&String], select_names: &[&String]) -> bool {
+fn columns_match(group_by_names: &[&str], select_names: &[&str]) -> bool {
     if group_by_names == select_names {
         return true;
     }
@@ -120,6 +140,71 @@ fn columns_match(group_by_names: &[&String], select_names: &[&String]) -> bool {
 
 impl Aggregate {
     /// Figure out what aggregates are present and which ones PgDog supports.
+    #[cfg(feature = "new_parser")]
+    pub(crate) fn parse(stmt: &nodes::SelectStmt, schema: &Schema) -> Self {
+        let group_by = stmt
+            .groupClause()
+            .iter()
+            .filter_map(|node| match node {
+                // We use 0-indexed arrays, Postgres uses 1-indexed.
+                Node::A_Const(c) => c
+                    .val()
+                    .and_then(|v| v.numeric_value::<i32>().map(|x| x as usize - 1)),
+                Node::ColumnRef(c) => index_of_column(
+                    stmt,
+                    &c.fields()
+                        .iter()
+                        .filter_map(Node::as_str)
+                        .collect::<Vec<_>>(),
+                ),
+                _ => None, // FIXME: We should error instead of silently skipping
+            })
+            .collect();
+
+        let targets = stmt
+            .targetList()
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, node)| {
+                let func = Function::try_from(node.val()).ok()?;
+                let function = match func.name {
+                    "count" => AggregateFunction::Count,
+                    "max" => AggregateFunction::Max,
+                    "min" => AggregateFunction::Min,
+                    "sum" => AggregateFunction::Sum,
+                    "avg" => AggregateFunction::Avg,
+                    "stddev" | "stddev_samp" => AggregateFunction::StddevSamp,
+                    "stddev_pop" => AggregateFunction::StddevPop,
+                    "variance" | "var_samp" => AggregateFunction::VarSamp,
+                    "var_pop" => AggregateFunction::VarPop,
+                    fname => {
+                        if schema.aggregate_functions.contains(fname) {
+                            AggregateFunction::Unrecognized(fname.to_owned())
+                        } else {
+                            return None;
+                        }
+                    }
+                };
+
+                // FIXME: This doesn't correctly handle distinct behind type
+                // casts any other nodes that Function::try_from handles
+                let distinct = if let Node::FuncCall(func) = node.val() {
+                    func.agg_distinct
+                } else {
+                    false
+                };
+
+                Some(AggregateTarget {
+                    column: idx,
+                    function,
+                    distinct,
+                })
+            })
+            .collect();
+        Self { group_by, targets }
+    }
+
+    #[cfg(not(feature = "new_parser"))]
     pub fn parse(stmt: &SelectStmt, schema: &Schema) -> Self {
         let mut targets = vec![];
         let group_by = stmt
@@ -132,18 +217,18 @@ impl Aggregate {
                         _ => None,
                     }),
                     NodeEnum::ColumnRef(column_ref) => {
-                        let column_names: Vec<&String> = column_ref
+                        let column_names: Vec<_> = column_ref
                             .fields
                             .iter()
                             .filter_map(|node| match node {
                                 Node {
                                     node:
                                         Some(NodeEnum::String(PgQueryString { sval: column_name })),
-                                } => Some(column_name),
+                                } => Some(column_name.as_str()),
                                 _ => None,
                             })
                             .collect();
-                        Some(target_list_to_index(stmt, column_names))
+                        Some(target_list_to_index(stmt, &column_names))
                     }
                     _ => None,
                 })
@@ -236,7 +321,18 @@ impl Aggregate {
 #[cfg(test)]
 mod test {
     use super::*;
+    #[cfg(feature = "new_parser")]
+    use pg_raw_parse::{Owned, make};
 
+    #[cfg(feature = "new_parser")]
+    fn select(stmt: &str) -> Owned<nodes::SelectStmt> {
+        match pg_raw_parse::parse(stmt).unwrap().stmts().next().unwrap() {
+            Node::SelectStmt(stmt) => make::owned(|mem| mem.make_unique(stmt)),
+            _ => panic!("not a select"),
+        }
+    }
+
+    #[cfg(not(feature = "new_parser"))]
     fn select(stmt: &str) -> SelectStmt {
         let stmt = pg_query::parse(stmt)
             .unwrap()

--- a/pgdog/src/frontend/router/parser/function.rs
+++ b/pgdog/src/frontend/router/parser/function.rs
@@ -115,7 +115,7 @@ mod test {
         let root = ast.protobuf.stmts.first().unwrap().stmt.as_ref().unwrap();
 
         match root.node.as_ref() {
-            Some(Node::SelectStmt(stmt)) => {
+            Some(NodeEnum::SelectStmt(stmt)) => {
                 for node in &stmt.target_list {
                     let func = Function::try_from(node).unwrap();
                     assert!(func.name.contains("advisory_lock"));

--- a/pgdog/src/frontend/router/parser/function.rs
+++ b/pgdog/src/frontend/router/parser/function.rs
@@ -1,4 +1,7 @@
+#[cfg(not(feature = "new_parser"))]
 use pg_query::{Node, NodeEnum, protobuf};
+#[cfg(feature = "new_parser")]
+use pg_raw_parse::Node;
 
 const WRITE_ONLY: &[&str] = &["nextval", "setval"];
 
@@ -37,6 +40,24 @@ impl<'a> Function<'a> {
     }
 }
 
+#[cfg(feature = "new_parser")]
+impl<'a> TryFrom<Node<'a>> for Function<'a> {
+    type Error = ();
+
+    fn try_from(value: Node<'a>) -> Result<Self, Self::Error> {
+        match value {
+            Node::FuncCall(f) => {
+                Self::from_strings(f.funcname().iter().filter_map(Node::as_str)).ok_or(())
+            }
+
+            Node::TypeCast(n) => Self::try_from(n.arg()),
+            Node::NullTest(n) => Self::try_from(n.arg()),
+            _ => Err(()),
+        }
+    }
+}
+
+#[cfg(not(feature = "new_parser"))]
 impl<'a> TryFrom<&'a Node> for Function<'a> {
     type Error = ();
     fn try_from(value: &'a Node) -> Result<Self, Self::Error> {
@@ -68,18 +89,33 @@ impl<'a> TryFrom<&'a Node> for Function<'a> {
 
 #[cfg(test)]
 mod test {
+    #[cfg(not(feature = "new_parser"))]
     use pg_query::parse;
+    #[cfg(feature = "new_parser")]
+    use pg_raw_parse::parse;
 
     use super::*;
 
     #[test]
+    #[cfg(feature = "new_parser")]
+    fn test_function() {
+        let query = "SELECT pg_advisory_lock(234234), pg_try_advisory_lock(23234)::bool";
+        funcs(query, |func| {
+            assert!(func.name.contains("advisory_lock"));
+            assert!(func.schema.is_none());
+            assert!(!func.behavior().cross_shard);
+        });
+    }
+
+    #[test]
+    #[cfg(not(feature = "new_parser"))]
     fn test_function() {
         let ast =
             parse("SELECT pg_advisory_lock(234234), pg_try_advisory_lock(23234)::bool").unwrap();
         let root = ast.protobuf.stmts.first().unwrap().stmt.as_ref().unwrap();
 
         match root.node.as_ref() {
-            Some(NodeEnum::SelectStmt(stmt)) => {
+            Some(Node::SelectStmt(stmt)) => {
                 for node in &stmt.target_list {
                     let func = Function::try_from(node).unwrap();
                     assert!(func.name.contains("advisory_lock"));
@@ -92,6 +128,28 @@ mod test {
         }
     }
 
+    #[cfg(feature = "new_parser")]
+    fn funcs(query: &str, mut check: impl FnMut(Function<'_>)) {
+        let ast = parse(query).unwrap();
+        let Node::SelectStmt(stmt) = ast.stmts().next().unwrap() else {
+            unreachable!();
+        };
+
+        for node in stmt.targetList() {
+            let func = Function::try_from(node.val()).unwrap();
+            check(func);
+        }
+    }
+
+    #[cfg(feature = "new_parser")]
+    fn first_func(query: &str, check: impl FnOnce(Function<'_>)) {
+        let mut check = Some(check);
+        funcs(query, |func| {
+            check.take().map(|c| c(func));
+        });
+    }
+
+    #[cfg(not(feature = "new_parser"))]
     fn first_func<R>(query: &str, check: impl FnOnce(Function<'_>) -> R) -> R {
         let ast = parse(query).unwrap();
         let root = ast.protobuf.stmts.first().unwrap().stmt.as_ref().unwrap();

--- a/pgdog/src/frontend/router/parser/query/select.rs
+++ b/pgdog/src/frontend/router/parser/query/select.rs
@@ -179,8 +179,10 @@ impl QueryParser {
             }
         }
 
+        #[cfg(not(feature = "new_parser"))]
+        let stmt = stmt_old;
         let shard = Self::converge(&shards, ConvergeAlgorithm::default());
-        let aggregates = Aggregate::parse(stmt_old, &context.router_context.schema);
+        let aggregates = Aggregate::parse(stmt, &context.router_context.schema);
         let limit = LimitClause::new(stmt_old, context.router_context.bind).limit_offset()?;
         let distinct = Distinct::new(stmt_old).distinct()?;
 

--- a/pgdog/src/frontend/router/parser/rewrite/statement/aggregate/engine.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/aggregate/engine.rs
@@ -257,6 +257,20 @@ mod tests {
     use super::*;
     use crate::frontend::router::parser::aggregate::Aggregate;
     use pg_query::protobuf::ParseResult;
+    #[cfg(feature = "new_parser")]
+    use pg_raw_parse::{Node, Owned, make, nodes};
+
+    #[cfg(feature = "new_parser")]
+    fn select_stmt(ast: &ParseResult) -> Owned<nodes::SelectStmt> {
+        let sql = pg_query::deparse(ast).unwrap();
+        let ast = pg_raw_parse::parse(&sql).unwrap();
+        make::owned(|mem| {
+            let Node::SelectStmt(stmt) = ast.stmts().next().unwrap() else {
+                unreachable!("not a select");
+            };
+            mem.make_unique(stmt)
+        })
+    }
 
     fn select(ast: &mut ParseResult) -> &mut pg_query::protobuf::SelectStmt {
         match ast
@@ -272,9 +286,17 @@ mod tests {
 
     fn rewrite(sql: &str) -> (ParseResult, RewriteOutput) {
         let mut parsed = pg_query::parse(sql).unwrap().protobuf;
-        let stmt = select(&mut parsed);
-        let aggregate = Aggregate::parse(stmt, &Default::default());
-        let output = AggregatesRewrite.rewrite_select(stmt, &aggregate);
+
+        #[cfg(not(feature = "new_parser"))]
+        let stmt_mut = select(&mut parsed);
+        #[cfg(feature = "new_parser")]
+        let aggregate = Aggregate::parse(&select_stmt(&parsed), &Default::default());
+        #[cfg(not(feature = "new_parser"))]
+        let aggregate = Aggregate::parse(stmt_mut, &Default::default());
+        #[cfg(feature = "new_parser")]
+        let stmt_mut = select(&mut parsed);
+
+        let output = AggregatesRewrite.rewrite_select(stmt_mut, &aggregate);
         (parsed, output)
     }
 
@@ -297,6 +319,9 @@ mod tests {
         assert!(!helper.distinct);
         assert!(matches!(helper.kind, HelperKind::Count));
 
+        #[cfg(feature = "new_parser")]
+        let aggregate = Aggregate::parse(&select_stmt(&mut ast), &Default::default());
+        #[cfg(not(feature = "new_parser"))]
         let aggregate = Aggregate::parse(select(&mut ast), &Default::default());
         assert_eq!(aggregate.targets().len(), 2);
         assert!(
@@ -318,6 +343,9 @@ mod tests {
         assert!(!helper.distinct);
         assert!(matches!(helper.kind, HelperKind::Count));
 
+        #[cfg(feature = "new_parser")]
+        let aggregate = Aggregate::parse(&select_stmt(&mut ast), &Default::default());
+        #[cfg(not(feature = "new_parser"))]
         let aggregate = Aggregate::parse(select(&mut ast), &Default::default());
         assert_eq!(aggregate.targets().len(), 3);
         assert!(
@@ -346,6 +374,9 @@ mod tests {
         assert_eq!(helper_discount.helper_column, 3);
         assert!(matches!(helper_discount.kind, HelperKind::Count));
 
+        #[cfg(feature = "new_parser")]
+        let aggregate = Aggregate::parse(&select_stmt(&mut ast), &Default::default());
+        #[cfg(not(feature = "new_parser"))]
         let aggregate = Aggregate::parse(select(&mut ast), &Default::default());
         assert_eq!(aggregate.targets().len(), 4);
         assert_eq!(

--- a/pgdog/src/frontend/router/parser/rewrite/statement/aggregate/mod.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/aggregate/mod.rs
@@ -35,7 +35,7 @@ impl StatementRewrite<'_> {
         };
 
         #[cfg(not(feature = "new_parser"))]
-        let select = select_old;
+        let select = &*select_old;
 
         #[cfg(feature = "new_parser")]
         let Some(Node::SelectStmt(select)) = self.new_stmt.stmts().next() else {

--- a/pgdog/src/frontend/router/parser/rewrite/statement/aggregate/mod.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/aggregate/mod.rs
@@ -5,6 +5,8 @@ use super::{Error, RewritePlan, StatementRewrite};
 use crate::backend::schema::Schema;
 use crate::frontend::router::parser::aggregate::Aggregate;
 use pg_query::NodeEnum;
+#[cfg(feature = "new_parser")]
+use pg_raw_parse::Node;
 
 pub use engine::AggregatesRewrite;
 pub use plan::{AggregateRewritePlan, HelperKind, HelperMapping, RewriteOutput};
@@ -28,7 +30,15 @@ impl StatementRewrite<'_> {
             return Ok(());
         };
 
-        let Some(NodeEnum::SelectStmt(select)) = stmt.node.as_mut() else {
+        let Some(NodeEnum::SelectStmt(select_old)) = stmt.node.as_mut() else {
+            return Ok(());
+        };
+
+        #[cfg(not(feature = "new_parser"))]
+        let select = select_old;
+
+        #[cfg(feature = "new_parser")]
+        let Some(Node::SelectStmt(select)) = self.new_stmt.stmts().next() else {
             return Ok(());
         };
 
@@ -37,7 +47,7 @@ impl StatementRewrite<'_> {
             return Ok(());
         }
 
-        let output = AggregatesRewrite.rewrite_select(select, &aggregate);
+        let output = AggregatesRewrite.rewrite_select(select_old, &aggregate);
         if output.plan.is_noop() {
             return Ok(());
         }


### PR DESCRIPTION
This is more or less a line for line rewrite, though with some minor refactoring to make the code flow a bit more clearly. A few tests got a bit funky because they're assuming the AST passed to `Aggregate::parse` is the same AST that gets rewritten later, which is not currently the case. That funkiness should go away as soon as I port the aggregate rewrite code to the new parser