### PR TITLE
Pass the node to the statement rewriter

### DIFF
--- a/pgdog/src/frontend/router/parser/cache/ast.rs
+++ b/pgdog/src/frontend/router/parser/cache/ast.rs
@@ -120,10 +120,8 @@ impl Ast {
         // route the query to a specific shard, we need to know whether the
         // same query body (without the comment) would require a rewrite, so
         // `Cache::query` can decide whether this entry is safe to cache.
-        let rewrite_plan = StatementRewrite::new(StatementRewriteContext {
+        let mut rewriter = StatementRewrite::new(StatementRewriteContext {
             stmt: &mut ast.protobuf,
-            #[cfg(feature = "new_parser")]
-            new_stmt: &new_ast,
             extended: query.original_query.extended(),
             prepared: query.original_query.prepared(),
             prepared_statements,
@@ -131,8 +129,16 @@ impl Ast {
             db_schema,
             user,
             search_path,
-        })
-        .maybe_rewrite()?;
+        });
+        #[cfg(feature = "new_parser")]
+        let rewrite_plan = if let Some(node) = new_ast.stmts().next() {
+            rewriter.maybe_rewrite(node)?
+        } else {
+            Default::default()
+        };
+
+        #[cfg(not(feature = "new_parser"))]
+        let rewrite_plan = rewriter.maybe_rewrite()?;
 
         let elapsed = now.elapsed();
         let mut stats = Stats::new();

--- a/pgdog/src/frontend/router/parser/rewrite/statement/aggregate/mod.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/aggregate/mod.rs
@@ -6,7 +6,7 @@ use crate::backend::schema::Schema;
 use crate::frontend::router::parser::aggregate::Aggregate;
 use pg_query::NodeEnum;
 #[cfg(feature = "new_parser")]
-use pg_raw_parse::Node;
+use pg_raw_parse::nodes;
 
 pub use engine::AggregatesRewrite;
 pub use plan::{AggregateRewritePlan, HelperKind, HelperMapping, RewriteOutput};
@@ -15,6 +15,7 @@ impl StatementRewrite<'_> {
     /// Add missing COUNT(*) and other helps when using aggregates.
     pub(super) fn rewrite_aggregates(
         &mut self,
+        #[cfg(feature = "new_parser")] select: &nodes::SelectStmt,
         plan: &mut RewritePlan,
         schema: &Schema,
     ) -> Result<(), Error> {
@@ -36,11 +37,6 @@ impl StatementRewrite<'_> {
 
         #[cfg(not(feature = "new_parser"))]
         let select = &*select_old;
-
-        #[cfg(feature = "new_parser")]
-        let Some(Node::SelectStmt(select)) = self.new_stmt.stmts().next() else {
-            return Ok(());
-        };
 
         let aggregate = Aggregate::parse(select, schema);
         if aggregate.is_empty() {

--- a/pgdog/src/frontend/router/parser/rewrite/statement/auto_id.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/auto_id.rs
@@ -2,7 +2,9 @@
 
 use indexmap::IndexSet;
 use pg_query::protobuf::{FuncCall, ResTarget, String as PgString};
-use pg_query::{Node, NodeEnum};
+use pg_query::{Node as PgNode, NodeEnum};
+#[cfg(feature = "new_parser")]
+use pg_raw_parse::Node;
 use pgdog_config::RewriteMode;
 
 use super::{Error, RewritePlan, StatementRewrite};
@@ -19,14 +21,21 @@ impl StatementRewrite<'_> {
     ///
     /// This runs before unique_id replacement so injected function calls
     /// will be processed by the unique_id rewriter.
-    pub(super) fn inject_auto_id(&mut self, plan: &mut RewritePlan) -> Result<(), Error> {
+    pub(super) fn inject_auto_id(
+        &mut self,
+        #[cfg(feature = "new_parser")] node: Node<'_>,
+        plan: &mut RewritePlan,
+    ) -> Result<(), Error> {
         let mode = self.schema.rewrite.primary_key;
 
         if mode == RewriteMode::Ignore || self.schema.shards == 1 {
             return Ok(());
         }
 
-        let Some((table, is_sharded)) = self.get_insert_table() else {
+        let Some((table, is_sharded)) = self.get_insert_table(
+            #[cfg(feature = "new_parser")]
+            node,
+        ) else {
             return Ok(());
         };
 
@@ -94,19 +103,20 @@ impl StatementRewrite<'_> {
     }
 
     /// Get the table from an INSERT statement.
-    fn get_insert_table(&self) -> Option<(Table<'_>, bool)> {
+    fn get_insert_table(
+        &self,
+        #[cfg(feature = "new_parser")] node: Node<'_>,
+    ) -> Option<(Table<'_>, bool)> {
         let stmt = self.stmt.stmts.first()?;
-        let node = stmt.stmt.as_ref()?;
-        #[cfg(feature = "new_parser")]
-        let new_stmt = self.new_stmt.stmts().next()?;
+        let pg_node = stmt.stmt.as_ref()?;
 
-        if let NodeEnum::InsertStmt(insert) = node.node.as_ref()? {
+        if let NodeEnum::InsertStmt(insert) = pg_node.node.as_ref()? {
             let relation = insert.relation.as_ref()?;
             let is_sharded = StatementParser::from_insert(
                 #[cfg(not(feature = "new_parser"))]
                 insert,
                 #[cfg(feature = "new_parser")]
-                new_stmt,
+                node,
                 None,
                 self.schema,
                 None,
@@ -195,7 +205,7 @@ impl StatementRewrite<'_> {
         };
 
         // Add the column to the column list
-        let col_node = Node {
+        let col_node = PgNode {
             node: Some(NodeEnum::ResTarget(Box::new(ResTarget {
                 name: column_name.to_string(),
                 ..Default::default()
@@ -223,16 +233,16 @@ impl StatementRewrite<'_> {
     }
 
     /// Create a function call node for pgdog.unique_id().
-    fn unique_id_func_call() -> Node {
-        Node {
+    fn unique_id_func_call() -> PgNode {
+        PgNode {
             node: Some(NodeEnum::FuncCall(Box::new(FuncCall {
                 funcname: vec![
-                    Node {
+                    PgNode {
                         node: Some(NodeEnum::String(PgString {
                             sval: "pgdog".to_string(),
                         })),
                     },
-                    Node {
+                    PgNode {
                         node: Some(NodeEnum::String(PgString {
                             sval: "unique_id".to_string(),
                         })),
@@ -370,8 +380,6 @@ mod tests {
         let schema = sharding_schema_with_mode(mode);
         let mut rewriter = StatementRewrite::new(StatementRewriteContext {
             stmt: &mut ast,
-            #[cfg(feature = "new_parser")]
-            new_stmt: &stmt,
             extended: false,
             prepared: false,
             prepared_statements: &mut prepared,
@@ -380,7 +388,10 @@ mod tests {
             user: "",
             search_path: None,
         });
-        let plan = rewriter.maybe_rewrite()?;
+        let plan = rewriter.maybe_rewrite(
+            #[cfg(feature = "new_parser")]
+            stmt.stmts().next().unwrap(),
+        )?;
         let result = if plan.stmt.is_some() {
             plan.stmt.clone().unwrap()
         } else {
@@ -584,8 +595,6 @@ mod tests {
         let mut prepared = PreparedStatements::default();
         let mut rewriter = StatementRewrite::new(StatementRewriteContext {
             stmt: &mut ast,
-            #[cfg(feature = "new_parser")]
-            new_stmt: &new_ast,
             extended: false,
             prepared: false,
             prepared_statements: &mut prepared,
@@ -594,7 +603,10 @@ mod tests {
             user: "",
             search_path: None,
         });
-        let plan = rewriter.maybe_rewrite()?;
+        let plan = rewriter.maybe_rewrite(
+            #[cfg(feature = "new_parser")]
+            new_ast.stmts().next().unwrap(),
+        )?;
         let result = if plan.stmt.is_some() {
             plan.stmt.clone().unwrap()
         } else {

--- a/pgdog/src/frontend/router/parser/rewrite/statement/insert.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/insert.rs
@@ -334,15 +334,11 @@ mod tests {
 
     fn parse_and_split(sql: &str) -> Vec<InsertSplit> {
         let mut ast = pg_query::parse(sql).unwrap().protobuf;
-        #[cfg(feature = "new_parser")]
-        let stmt = pg_raw_parse::parse(sql).unwrap();
         let mut prepared = PreparedStatements::default();
         let schema = default_schema();
         let db_schema = default_db_schema();
         let mut rewriter = StatementRewrite::new(StatementRewriteContext {
             stmt: &mut ast,
-            #[cfg(feature = "new_parser")]
-            new_stmt: &stmt,
             extended: false,
             prepared: false,
             prepared_statements: &mut prepared,

--- a/pgdog/src/frontend/router/parser/rewrite/statement/mod.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/mod.rs
@@ -1,7 +1,9 @@
 //! Statement rewriter.
 
-use pg_query::Node;
+use pg_query::Node as PgNode;
 use pg_query::protobuf::ParseResult;
+#[cfg(feature = "new_parser")]
+use pg_raw_parse::Node;
 use pgdog_config::QueryParserEngine;
 
 use crate::backend::ShardingSchema;
@@ -32,8 +34,6 @@ pub(crate) use update::*;
 pub struct StatementRewriteContext<'a> {
     /// The AST of the statement we are rewriting.
     pub stmt: &'a mut ParseResult,
-    #[cfg(feature = "new_parser")]
-    pub(crate) new_stmt: &'a pg_raw_parse::ParseResult,
     /// The statement is using the extended protocol with placeholders.
     pub extended: bool,
     /// The statement is named, so we need to save any derivatives into the global
@@ -55,8 +55,6 @@ pub struct StatementRewriteContext<'a> {
 pub struct StatementRewrite<'a> {
     /// SQL statement.
     stmt: &'a mut ParseResult,
-    #[cfg(feature = "new_parser")]
-    new_stmt: &'a pg_raw_parse::ParseResult,
     /// The statement was rewritten.
     rewritten: bool,
     /// Statement is using the extended protocol, so
@@ -86,8 +84,6 @@ impl<'a> StatementRewrite<'a> {
     pub fn new(ctx: StatementRewriteContext<'a>) -> Self {
         Self {
             stmt: ctx.stmt,
-            #[cfg(feature = "new_parser")]
-            new_stmt: ctx.new_stmt,
             rewritten: false,
             extended: ctx.extended,
             prepared: ctx.prepared,
@@ -111,7 +107,10 @@ impl<'a> StatementRewrite<'a> {
 
     /// Maybe rewrite the statement and produce a rewrite plan
     /// we can apply to Bind messages.
-    pub fn maybe_rewrite(&mut self) -> Result<RewritePlan, Error> {
+    pub fn maybe_rewrite(
+        &mut self,
+        #[cfg(feature = "new_parser")] node: Node<'a>,
+    ) -> Result<RewritePlan, Error> {
         let params = visitor::count_params(self.stmt);
         let mut plan = RewritePlan {
             params,
@@ -128,14 +127,17 @@ impl<'a> StatementRewrite<'a> {
         // Inject pgdog.unique_id() for missing BIGINT primary keys.
         // This must run BEFORE the unique_id rewriter so the injected
         // function calls get processed.
-        self.inject_auto_id(&mut plan)?;
+        self.inject_auto_id(
+            #[cfg(feature = "new_parser")]
+            node,
+            &mut plan,
+        )?;
 
         // Track the next parameter number to use
         let mut next_param = plan.params as i32 + 1;
 
-        // if self.schema.rewrite.enabled {
         let extended = self.extended;
-        visitor::visit_and_mutate_nodes(self.stmt, |node| -> Result<Option<Node>, Error> {
+        visitor::visit_and_mutate_nodes(self.stmt, |node| -> Result<Option<PgNode>, Error> {
             match Self::rewrite_unique_id(node, extended, &mut next_param)? {
                 Some(replacement) => {
                     plan.unique_ids += 1;
@@ -146,8 +148,16 @@ impl<'a> StatementRewrite<'a> {
             }
         })?;
 
-        self.rewrite_aggregates(&mut plan, self.db_schema)?;
-        self.limit_offset(&mut plan)?;
+        #[cfg(feature = "new_parser")]
+        if let Node::SelectStmt(select) = node {
+            self.rewrite_aggregates(select, &mut plan, self.db_schema)?;
+            self.limit_offset(&mut plan)?;
+        }
+        #[cfg(not(feature = "new_parser"))]
+        {
+            self.rewrite_aggregates(&mut plan, self.db_schema)?;
+            self.limit_offset(&mut plan)?;
+        }
 
         if self.rewritten {
             plan.stmt = Some(match self.schema.query_parser_engine {
@@ -157,6 +167,11 @@ impl<'a> StatementRewrite<'a> {
         }
 
         self.split_insert(&mut plan)?;
+        #[cfg(feature = "new_parser")]
+        if let Node::UpdateStmt(stmt) = node {
+            self.sharding_key_update(stmt, &mut plan)?;
+        }
+        #[cfg(not(feature = "new_parser"))]
         self.sharding_key_update(&mut plan)?;
 
         Ok(plan)

--- a/pgdog/src/frontend/router/parser/rewrite/statement/offset.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/offset.rs
@@ -281,14 +281,10 @@ mod tests {
 
     fn run_limit_offset(sql: &str, schema: &ShardingSchema) -> RewritePlan {
         let mut ast = pg_query::parse(sql).unwrap();
-        #[cfg(feature = "new_parser")]
-        let stmt = pg_raw_parse::parse(sql).unwrap();
         let db_schema = Schema::default();
         let mut ps = PreparedStatements::default();
         let mut rewrite = StatementRewrite::new(StatementRewriteContext {
             stmt: &mut ast.protobuf,
-            #[cfg(feature = "new_parser")]
-            new_stmt: &stmt,
             extended: false,
             prepared: false,
             prepared_statements: &mut ps,

--- a/pgdog/src/frontend/router/parser/rewrite/statement/simple_prepared.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/simple_prepared.rs
@@ -158,8 +158,6 @@ mod tests {
             let stmt = pg_raw_parse::parse(sql).unwrap();
             let mut rewrite = StatementRewrite::new(StatementRewriteContext {
                 stmt: &mut ast,
-                #[cfg(feature = "new_parser")]
-                new_stmt: &stmt,
                 extended: false,
                 prepared: false,
                 prepared_statements: &mut self.ps,
@@ -168,7 +166,10 @@ mod tests {
                 user: "",
                 search_path: None,
             });
-            let plan = rewrite.maybe_rewrite()?;
+            let plan = rewrite.maybe_rewrite(
+                #[cfg(feature = "new_parser")]
+                stmt.stmts().next().unwrap(),
+            )?;
             Ok((ast, plan))
         }
     }

--- a/pgdog/src/frontend/router/parser/rewrite/statement/unique_id.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/unique_id.rs
@@ -367,8 +367,6 @@ mod tests {
         let db_schema = default_db_schema();
         let mut rewrite = StatementRewrite::new(StatementRewriteContext {
             stmt: &mut ast,
-            #[cfg(feature = "new_parser")]
-            new_stmt: &stmt,
             extended,
             prepared: false,
             prepared_statements: &mut ps,
@@ -377,7 +375,12 @@ mod tests {
             user: "",
             search_path: None,
         });
-        let plan = rewrite.maybe_rewrite().unwrap();
+        let plan = rewrite
+            .maybe_rewrite(
+                #[cfg(feature = "new_parser")]
+                stmt.stmts().next().unwrap(),
+            )
+            .unwrap();
         (ast, plan)
     }
 }

--- a/pgdog/src/frontend/router/parser/rewrite/statement/update.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/update.rs
@@ -469,7 +469,11 @@ impl Insert {
 impl<'a> StatementRewrite<'a> {
     /// Create a plan for shardking key updates, if we suspect there is one
     /// in the query.
-    pub(super) fn sharding_key_update(&mut self, plan: &mut RewritePlan) -> Result<(), Error> {
+    pub(super) fn sharding_key_update(
+        &mut self,
+        #[cfg(feature = "new_parser")] stmt: &nodes::UpdateStmt,
+        plan: &mut RewritePlan,
+    ) -> Result<(), Error> {
         if self.schema.shards == 1 || self.schema.rewrite.shard_key == RewriteMode::Ignore {
             return Ok(());
         }
@@ -482,14 +486,6 @@ impl<'a> StatementRewrite<'a> {
             .and_then(|stmt| stmt.stmt.as_ref().map(|stmt| stmt.node.as_ref()))
             .flatten()
         else {
-            // TODO: Handle EXPLAIN ANALYZE which needs to execute.
-            // We could return a combined plan for all 3 queries
-            // we need to execute.
-            return Ok(());
-        };
-
-        #[cfg(feature = "new_parser")]
-        let Some(Node::UpdateStmt(stmt)) = self.new_stmt.stmts().next() else {
             // TODO: Handle EXPLAIN ANALYZE which needs to execute.
             // We could return a combined plan for all 3 queries
             // we need to execute.
@@ -1076,8 +1072,6 @@ mod test {
 
         let ctx = StatementRewriteContext {
             stmt: &mut stmt_old.protobuf,
-            #[cfg(feature = "new_parser")]
-            new_stmt: &stmt,
             schema: &schema,
             db_schema: &db_schema,
             extended: true,
@@ -1087,7 +1081,14 @@ mod test {
             search_path: None,
         };
         let mut plan = RewritePlan::default();
-        StatementRewrite::new(ctx).sharding_key_update(&mut plan)?;
+        StatementRewrite::new(ctx).sharding_key_update(
+            #[cfg(feature = "new_parser")]
+            match stmt.stmts().next().unwrap() {
+                Node::UpdateStmt(stmt) => stmt,
+                _ => panic!("Not an update"),
+            },
+            &mut plan,
+        )?;
         Ok(plan.sharding_key_update)
     }
 


### PR DESCRIPTION
The API for how mutation works on the new parser is pretty fundamentally different from the old one. It doesn't make sense to have it as a field on the struct, and passing it explicitly will also make it clear when I need to deparse/reparse as I'm porting individual functions over.