### PR TITLE
Port StatementRewrite::rewrite_aggregates to the new parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3299,7 +3299,7 @@ dependencies = [
 [[package]]
 name = "pg_raw_parse"
 version = "0.1.0"
-source = "git+https://github.com/pgdogdev/pg_raw_parse.git?rev=34e5987#34e598782a612d2dc3d894264602240232870fb5"
+source = "git+https://github.com/pgdogdev/pg_raw_parse.git?rev=d7f132e#d7f132e754b9469a866e098b2e6d2abfeeb23e61"
 dependencies = [
  "bindgen 0.72.1",
  "cc",

--- a/pgdog/Cargo.toml
+++ b/pgdog/Cargo.toml
@@ -80,7 +80,7 @@ smallvec = "1"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-webpki-roots-no-provider", "json"] }
 hex = "0.4"
 x509-parser = "0.18"
-pg_raw_parse = { git = "https://github.com/pgdogdev/pg_raw_parse.git", rev = "34e5987", optional = true }
+pg_raw_parse = { git = "https://github.com/pgdogdev/pg_raw_parse.git", rev = "d7f132e", optional = true }
 itertools = "0.15.0"
 
 [target.'cfg(unix)'.dependencies]

--- a/pgdog/src/frontend/router/parser/function.rs
+++ b/pgdog/src/frontend/router/parser/function.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "new_parser"))]
 use pg_query::{Node, NodeEnum, protobuf};
 #[cfg(feature = "new_parser")]
-use pg_raw_parse::Node;
+use pg_raw_parse::{Node, nodes};
 
 const WRITE_ONLY: &[&str] = &["nextval", "setval"];
 
@@ -38,6 +38,16 @@ impl<'a> Function<'a> {
             cross_shard: CROSS_SHARD.contains(&(self.schema, self.name)),
         }
     }
+
+    #[cfg(feature = "new_parser")]
+    pub(crate) fn extract_func_call(node: Node<'a>) -> Option<&'a nodes::FuncCall> {
+        match node {
+            Node::FuncCall(func) => Some(func),
+            Node::TypeCast(cast) => Self::extract_func_call(cast.arg()),
+            Node::NullTest(test) => Self::extract_func_call(test.arg()),
+            _ => None,
+        }
+    }
 }
 
 #[cfg(feature = "new_parser")]
@@ -45,15 +55,9 @@ impl<'a> TryFrom<Node<'a>> for Function<'a> {
     type Error = ();
 
     fn try_from(value: Node<'a>) -> Result<Self, Self::Error> {
-        match value {
-            Node::FuncCall(f) => {
-                Self::from_strings(f.funcname().iter().filter_map(Node::as_str)).ok_or(())
-            }
-
-            Node::TypeCast(n) => Self::try_from(n.arg()),
-            Node::NullTest(n) => Self::try_from(n.arg()),
-            _ => Err(()),
-        }
+        Self::extract_func_call(value)
+            .and_then(|f| Self::from_strings(f.funcname().iter().filter_map(Node::as_str)))
+            .ok_or(())
     }
 }
 

--- a/pgdog/src/frontend/router/parser/rewrite/statement/aggregate/engine.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/aggregate/engine.rs
@@ -1,11 +1,18 @@
-use crate::frontend::router::parser::{
-    aggregate::{Aggregate, AggregateFunction},
-    util::pg_string,
-};
+#[cfg(feature = "new_parser")]
+use crate::frontend::router::parser::Function;
+use crate::frontend::router::parser::aggregate::{Aggregate, AggregateFunction};
+#[cfg(not(feature = "new_parser"))]
+use crate::frontend::router::parser::util::pg_string;
+#[cfg(feature = "new_parser")]
+use itertools::*;
+#[cfg(not(feature = "new_parser"))]
 use pg_query::NodeEnum;
+#[cfg(not(feature = "new_parser"))]
 use pg_query::protobuf::{
     AConst, FuncCall, Integer, Node, ResTarget, SelectStmt, TypeCast, TypeName, a_const::Val,
 };
+#[cfg(feature = "new_parser")]
+use pg_raw_parse::{Node, make, nodes};
 
 use super::{AggregateRewritePlan, HelperKind, HelperMapping, RewriteOutput};
 
@@ -13,14 +20,76 @@ use super::{AggregateRewritePlan, HelperKind, HelperMapping, RewriteOutput};
 /// variance-related functions that require additional helper aggregates when run
 /// across shards.
 #[derive(Default)]
-pub struct AggregatesRewrite;
+pub(crate) struct AggregatesRewrite;
 
 impl AggregatesRewrite {
     /// Rewrite a SELECT query in-place, adding helper aggregates when necessary.
-    pub fn rewrite_select(&self, ast: &mut SelectStmt, aggregate: &Aggregate) -> RewriteOutput {
+    #[cfg(feature = "new_parser")]
+    pub(crate) fn rewrite_select<'a>(
+        mut select: nodes::SelectStmtMut<'a, '_>,
+        mem: make::MemoryToken<'a>,
+        aggregate: &Aggregate,
+    ) -> RewriteOutput {
+        let mut plan = AggregateRewritePlan::new();
+
+        let helper_nodes = aggregate
+            .targets()
+            .iter()
+            .flat_map(|target| {
+                let Some(node) = select.targetList().iter().nth(target.column()) else {
+                    // FIXME: We should make this impossible statically
+                    panic!("SelectStmt did not contain previously parsed column");
+                };
+
+                let Some(func_call) = Function::extract_func_call(node.val()) else {
+                    panic!("Previously parsed function was not a FuncCall");
+                };
+
+                Self::helper_specs(func_call, target.function(), mem)
+                    .into_iter()
+                    .map(move |spec| (target, spec))
+            })
+            .enumerate()
+            .map(|(idx, (target, HelperSpec { func, kind }))| {
+                let helper_alias =
+                    format!("__pgdog_{}_col{}", kind.alias_suffix(), target.column());
+                let node = mem.make_ResTarget(Some(&helper_alias), mem.empty(), func.uncast());
+
+                plan.add_helper(HelperMapping {
+                    target_column: target.column(),
+                    helper_column: select.targetList().len() + idx,
+                    distinct: target.is_distinct(),
+                    kind,
+                    alias: helper_alias,
+                });
+                node
+            })
+            .collect::<Vec<_>>();
+
+        if helper_nodes.is_empty() {
+            RewriteOutput::default()
+        } else {
+            let mut target_list = select
+                .targetList()
+                .into_iter()
+                .map(|n| mem.make_unique(n))
+                .collect::<Vec<_>>();
+            target_list.extend(helper_nodes);
+            select.set_targetList(mem.make_List(&target_list));
+            RewriteOutput::new(plan)
+        }
+    }
+
+    #[cfg(not(feature = "new_parser"))]
+    pub(crate) fn rewrite_select(
+        &self,
+        ast: &mut SelectStmt,
+        aggregate: &Aggregate,
+    ) -> RewriteOutput {
         self.rewrite_parsed(ast, aggregate)
     }
 
+    #[cfg(not(feature = "new_parser"))]
     fn rewrite_parsed(&self, select: &mut SelectStmt, aggregate: &Aggregate) -> RewriteOutput {
         let mut plan = AggregateRewritePlan::new();
         let mut helper_nodes: Vec<Node> = Vec::new();
@@ -100,6 +169,7 @@ impl AggregatesRewrite {
         RewriteOutput::new(plan)
     }
 
+    #[cfg(not(feature = "new_parser"))]
     fn extract_func_call(node: &Node) -> Option<&FuncCall> {
         match node.node.as_ref()? {
             NodeEnum::FuncCall(func) => Some(func),
@@ -123,6 +193,7 @@ impl AggregatesRewrite {
         }
     }
 
+    #[cfg(not(feature = "new_parser"))]
     fn build_count_func(original: &FuncCall, distinct: bool) -> FuncCall {
         FuncCall {
             funcname: vec![pg_string("count")],
@@ -139,6 +210,7 @@ impl AggregatesRewrite {
         }
     }
 
+    #[cfg(not(feature = "new_parser"))]
     fn build_sum_func(original: &FuncCall, distinct: bool) -> FuncCall {
         FuncCall {
             funcname: vec![pg_string("sum")],
@@ -155,6 +227,43 @@ impl AggregatesRewrite {
         }
     }
 
+    #[cfg(feature = "new_parser")]
+    fn build_sum_of_squares_func<'a>(
+        original: &nodes::FuncCall,
+        mem: make::MemoryToken<'a>,
+    ) -> make::Unique<'a, &'a nodes::FuncCall> {
+        let mut sumsq = Self::copy_and_rename_function(original, "sum", mem);
+        let arg = sumsq
+            .args()
+            .iter()
+            .exactly_one()
+            .expect("Aggregate functions should have exactly one argument");
+
+        // We need to cast to NUMERIC to avoid overflow
+        let mut numeric_type = mem.make_node::<nodes::TypeName>();
+        numeric_type.as_mut().set_names(mem.make_List(&[
+            mem.make_String(Some("pg_catalog")),
+            mem.make_String(Some("numeric")),
+        ]));
+        numeric_type.as_mut().set_typeOid(1700);
+
+        let mut cast_arg = mem.make_node::<nodes::TypeCast>();
+        cast_arg.as_mut().set_typeName(numeric_type.as_option());
+        cast_arg.as_mut().set_arg(mem.make_unique(arg));
+
+        let arg_squared = mem.make_A_Expr(
+            nodes::A_Expr_Kind::AEXPR_OP,
+            mem.make_List(&[mem.make_String(Some("*")).uncast()]),
+            mem.make_unique(Node::from(cast_arg.as_ref())),
+            cast_arg.uncast(),
+        );
+        sumsq
+            .as_mut()
+            .set_args(mem.make_List(&[arg_squared.uncast()]));
+        sumsq
+    }
+
+    #[cfg(not(feature = "new_parser"))]
     fn build_sum_of_squares_func(original: &FuncCall, distinct: bool) -> FuncCall {
         let arg = original.args.first().cloned();
         // POWER will return double even when dealing with integer inputs.
@@ -212,6 +321,61 @@ impl AggregatesRewrite {
         }
     }
 
+    #[cfg(feature = "new_parser")]
+    fn helper_specs<'a>(
+        func_call: &nodes::FuncCall,
+        function: &AggregateFunction,
+        mem: make::MemoryToken<'a>,
+    ) -> Vec<HelperSpec<'a>> {
+        match function {
+            AggregateFunction::Avg => {
+                vec![HelperSpec {
+                    func: Self::copy_and_rename_function(func_call, "count", mem),
+                    kind: HelperKind::Count,
+                }]
+            }
+            AggregateFunction::StddevSamp
+            | AggregateFunction::StddevPop
+            | AggregateFunction::VarSamp
+            | AggregateFunction::VarPop => {
+                vec![
+                    HelperSpec {
+                        func: Self::copy_and_rename_function(func_call, "count", mem),
+                        kind: HelperKind::Count,
+                    },
+                    HelperSpec {
+                        func: Self::copy_and_rename_function(func_call, "sum", mem),
+                        kind: HelperKind::Sum,
+                    },
+                    HelperSpec {
+                        func: Self::build_sum_of_squares_func(func_call, mem),
+                        kind: HelperKind::SumSquares,
+                    },
+                ]
+            }
+            // Computable from the original aggregate alone
+            AggregateFunction::Count
+            | AggregateFunction::Sum
+            | AggregateFunction::Max
+            | AggregateFunction::Min => Vec::new(),
+            // We'll error later
+            AggregateFunction::Unrecognized(_) => Vec::new(),
+        }
+    }
+
+    #[cfg(feature = "new_parser")]
+    fn copy_and_rename_function<'a>(
+        func_call: &nodes::FuncCall,
+        name: &str,
+        mem: make::MemoryToken<'a>,
+    ) -> make::Unique<'a, &'a nodes::FuncCall> {
+        let mut func = mem.make_unique(func_call);
+        func.as_mut()
+            .set_funcname(mem.make_List(&[mem.make_String(Some(name)).uncast()]));
+        func
+    }
+
+    #[cfg(not(feature = "new_parser"))]
     fn helper_specs(
         func_call: &FuncCall,
         function: &AggregateFunction,
@@ -247,31 +411,29 @@ impl AggregatesRewrite {
 }
 
 #[derive(Debug, Clone)]
+#[cfg(not(feature = "new_parser"))]
 struct HelperSpec {
     func: FuncCall,
     kind: HelperKind,
 }
 
+#[cfg(feature = "new_parser")]
+struct HelperSpec<'a> {
+    func: make::Unique<'a, &'a nodes::FuncCall>,
+    kind: HelperKind,
+}
+
 #[cfg(test)]
 mod tests {
+    #![cfg_attr(feature = "new_parser", allow(unused_mut))]
     use super::*;
     use crate::frontend::router::parser::aggregate::Aggregate;
+    #[cfg(not(feature = "new_parser"))]
     use pg_query::protobuf::ParseResult;
     #[cfg(feature = "new_parser")]
     use pg_raw_parse::{Node, Owned, make, nodes};
 
-    #[cfg(feature = "new_parser")]
-    fn select_stmt(ast: &ParseResult) -> Owned<nodes::SelectStmt> {
-        let sql = pg_query::deparse(ast).unwrap();
-        let ast = pg_raw_parse::parse(&sql).unwrap();
-        make::owned(|mem| {
-            let Node::SelectStmt(stmt) = ast.stmts().next().unwrap() else {
-                unreachable!("not a select");
-            };
-            mem.make_unique(stmt)
-        })
-    }
-
+    #[cfg(not(feature = "new_parser"))]
     fn select(ast: &mut ParseResult) -> &mut pg_query::protobuf::SelectStmt {
         match ast
             .stmts
@@ -284,17 +446,34 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "new_parser")]
+    fn rewrite(sql: &str) -> (Owned<nodes::SelectStmt>, RewriteOutput) {
+        let ast = pg_raw_parse::parse(sql).unwrap();
+
+        let mut output = None;
+        let select = make::owned(|mem| {
+            let Node::SelectStmt(stmt) = ast.stmts().next().unwrap() else {
+                unreachable!("not a select");
+            };
+            let mut stmt = mem.make_unique(stmt);
+
+            let aggregate = Aggregate::parse(&*stmt, &Default::default());
+            output = Some(AggregatesRewrite::rewrite_select(
+                stmt.as_mut(),
+                mem,
+                &aggregate,
+            ));
+            stmt
+        });
+        (select, output.unwrap())
+    }
+
+    #[cfg(not(feature = "new_parser"))]
     fn rewrite(sql: &str) -> (ParseResult, RewriteOutput) {
         let mut parsed = pg_query::parse(sql).unwrap().protobuf;
 
-        #[cfg(not(feature = "new_parser"))]
         let stmt_mut = select(&mut parsed);
-        #[cfg(feature = "new_parser")]
-        let aggregate = Aggregate::parse(&select_stmt(&parsed), &Default::default());
-        #[cfg(not(feature = "new_parser"))]
         let aggregate = Aggregate::parse(stmt_mut, &Default::default());
-        #[cfg(feature = "new_parser")]
-        let stmt_mut = select(&mut parsed);
 
         let output = AggregatesRewrite.rewrite_select(stmt_mut, &aggregate);
         (parsed, output)
@@ -304,6 +483,9 @@ mod tests {
     fn rewrite_engine_noop() {
         let (mut ast, output) = rewrite("SELECT COUNT(price) FROM menu");
         assert!(output.plan.is_noop());
+        #[cfg(feature = "new_parser")]
+        assert_eq!(ast.targetList().len(), 1);
+        #[cfg(not(feature = "new_parser"))]
         assert_eq!(select(&mut ast).target_list.len(), 1);
     }
 
@@ -320,7 +502,7 @@ mod tests {
         assert!(matches!(helper.kind, HelperKind::Count));
 
         #[cfg(feature = "new_parser")]
-        let aggregate = Aggregate::parse(&select_stmt(&mut ast), &Default::default());
+        let aggregate = Aggregate::parse(&ast, &Default::default());
         #[cfg(not(feature = "new_parser"))]
         let aggregate = Aggregate::parse(select(&mut ast), &Default::default());
         assert_eq!(aggregate.targets().len(), 2);
@@ -344,7 +526,7 @@ mod tests {
         assert!(matches!(helper.kind, HelperKind::Count));
 
         #[cfg(feature = "new_parser")]
-        let aggregate = Aggregate::parse(&select_stmt(&mut ast), &Default::default());
+        let aggregate = Aggregate::parse(&ast, &Default::default());
         #[cfg(not(feature = "new_parser"))]
         let aggregate = Aggregate::parse(select(&mut ast), &Default::default());
         assert_eq!(aggregate.targets().len(), 3);
@@ -375,7 +557,7 @@ mod tests {
         assert!(matches!(helper_discount.kind, HelperKind::Count));
 
         #[cfg(feature = "new_parser")]
-        let aggregate = Aggregate::parse(&select_stmt(&mut ast), &Default::default());
+        let aggregate = Aggregate::parse(&ast, &Default::default());
         #[cfg(not(feature = "new_parser"))]
         let aggregate = Aggregate::parse(select(&mut ast), &Default::default());
         assert_eq!(aggregate.targets().len(), 4);
@@ -411,6 +593,9 @@ mod tests {
         assert!(kinds.contains(&HelperKind::SumSquares));
 
         // Expect original STDDEV plus three helpers.
+        #[cfg(feature = "new_parser")]
+        assert_eq!(ast.targetList().len(), 4);
+        #[cfg(not(feature = "new_parser"))]
         assert_eq!(select(&mut ast).target_list.len(), 4);
     }
 }

--- a/pgdog/src/frontend/router/parser/rewrite/statement/aggregate/mod.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/aggregate/mod.rs
@@ -42,7 +42,7 @@ impl StatementRewrite<'_> {
     }
 
     #[cfg(not(feature = "new_parser"))]
-    pub(super) fn rewrite_aggregates<'a>(
+    pub(super) fn rewrite_aggregates(
         &mut self,
         plan: &mut RewritePlan,
         schema: &Schema,

--- a/pgdog/src/frontend/router/parser/rewrite/statement/aggregate/mod.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/aggregate/mod.rs
@@ -1,21 +1,49 @@
-pub mod engine;
-pub mod plan;
+mod engine;
+mod plan;
 
 use super::{Error, RewritePlan, StatementRewrite};
 use crate::backend::schema::Schema;
 use crate::frontend::router::parser::aggregate::Aggregate;
+#[cfg(not(feature = "new_parser"))]
 use pg_query::NodeEnum;
 #[cfg(feature = "new_parser")]
-use pg_raw_parse::nodes;
+use pg_raw_parse::{make::MemoryToken, nodes::SelectStmtMut};
 
-pub use engine::AggregatesRewrite;
-pub use plan::{AggregateRewritePlan, HelperKind, HelperMapping, RewriteOutput};
+pub(crate) use engine::AggregatesRewrite;
+pub(crate) use plan::{AggregateRewritePlan, HelperKind, HelperMapping, RewriteOutput};
 
 impl StatementRewrite<'_> {
     /// Add missing COUNT(*) and other helps when using aggregates.
-    pub(super) fn rewrite_aggregates(
+    #[cfg(feature = "new_parser")]
+    pub(super) fn rewrite_aggregates<'a>(
         &mut self,
-        #[cfg(feature = "new_parser")] select: &nodes::SelectStmt,
+        select: SelectStmtMut<'a, '_>,
+        mem: MemoryToken<'a>,
+        plan: &mut RewritePlan,
+        schema: &Schema,
+    ) -> Result<(), Error> {
+        if self.schema.shards == 1 {
+            return Ok(());
+        }
+
+        let aggregate = Aggregate::parse(&select, schema);
+        if aggregate.is_empty() {
+            return Ok(());
+        }
+
+        let output = AggregatesRewrite::rewrite_select(select, mem, &aggregate);
+        if output.plan.is_noop() {
+            return Ok(());
+        }
+
+        plan.aggregates = output.plan;
+        self.rewritten = true;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "new_parser"))]
+    pub(super) fn rewrite_aggregates<'a>(
+        &mut self,
         plan: &mut RewritePlan,
         schema: &Schema,
     ) -> Result<(), Error> {
@@ -31,19 +59,16 @@ impl StatementRewrite<'_> {
             return Ok(());
         };
 
-        let Some(NodeEnum::SelectStmt(select_old)) = stmt.node.as_mut() else {
+        let Some(NodeEnum::SelectStmt(select)) = stmt.node.as_mut() else {
             return Ok(());
         };
-
-        #[cfg(not(feature = "new_parser"))]
-        let select = &*select_old;
 
         let aggregate = Aggregate::parse(select, schema);
         if aggregate.is_empty() {
             return Ok(());
         }
 
-        let output = AggregatesRewrite.rewrite_select(select_old, &aggregate);
+        let output = AggregatesRewrite.rewrite_select(select, &aggregate);
         if output.plan.is_noop() {
             return Ok(());
         }

--- a/pgdog/src/frontend/router/parser/rewrite/statement/aggregate/plan.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/aggregate/plan.rs
@@ -1,6 +1,6 @@
 /// Type of aggregate function added to the result set.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum HelperKind {
+pub(crate) enum HelperKind {
     /// COUNT(*) or COUNT(name)
     Count,
     /// SUM(column)
@@ -11,7 +11,7 @@ pub enum HelperKind {
 
 impl HelperKind {
     /// Suffix for the aggregate function.
-    pub fn alias_suffix(&self) -> &'static str {
+    pub(crate) fn alias_suffix(&self) -> &'static str {
         match self {
             HelperKind::Count => "count",
             HelperKind::Sum => "sum",
@@ -22,53 +22,53 @@ impl HelperKind {
 
 /// Context on the aggregate function column added to the result set.
 #[derive(Debug, Clone, PartialEq)]
-pub struct HelperMapping {
-    pub target_column: usize,
-    pub helper_column: usize,
-    pub distinct: bool,
-    pub kind: HelperKind,
-    pub alias: String,
+pub(crate) struct HelperMapping {
+    pub(crate) target_column: usize,
+    pub(crate) helper_column: usize,
+    pub(crate) distinct: bool,
+    pub(crate) kind: HelperKind,
+    pub(crate) alias: String,
 }
 
 /// Plan describing how the proxy rewrites a query and its results.
 #[derive(Debug, Clone, Default, PartialEq)]
-pub struct AggregateRewritePlan {
+pub(crate) struct AggregateRewritePlan {
     helpers: Vec<HelperMapping>,
 }
 
 impl AggregateRewritePlan {
     /// Create new no-op aggregate rewrite plan.
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             helpers: Vec::new(),
         }
     }
 
     /// Is this plan a no-op? Doesn't do anything.
-    pub fn is_noop(&self) -> bool {
+    pub(crate) fn is_noop(&self) -> bool {
         self.helpers.is_empty()
     }
 
-    pub fn drop_columns(&self) -> impl Iterator<Item = usize> + '_ {
+    pub(crate) fn drop_columns(&self) -> impl Iterator<Item = usize> + '_ {
         self.helpers.iter().map(|h| h.helper_column)
     }
 
-    pub fn helpers(&self) -> &[HelperMapping] {
+    pub(crate) fn helpers(&self) -> &[HelperMapping] {
         &self.helpers
     }
 
-    pub fn add_helper(&mut self, mapping: HelperMapping) {
+    pub(crate) fn add_helper(&mut self, mapping: HelperMapping) {
         self.helpers.push(mapping);
     }
 }
 
 #[derive(Debug, Default, Clone)]
-pub struct RewriteOutput {
-    pub plan: AggregateRewritePlan,
+pub(crate) struct RewriteOutput {
+    pub(crate) plan: AggregateRewritePlan,
 }
 
 impl RewriteOutput {
-    pub fn new(plan: AggregateRewritePlan) -> Self {
+    pub(crate) fn new(plan: AggregateRewritePlan) -> Self {
         Self { plan }
     }
 }

--- a/pgdog/src/frontend/router/parser/rewrite/statement/mod.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/mod.rs
@@ -3,7 +3,7 @@
 use pg_query::Node as PgNode;
 use pg_query::protobuf::ParseResult;
 #[cfg(feature = "new_parser")]
-use pg_raw_parse::Node;
+use pg_raw_parse::{Node, make};
 use pgdog_config::QueryParserEngine;
 
 use crate::backend::ShardingSchema;
@@ -148,16 +148,26 @@ impl<'a> StatementRewrite<'a> {
             }
         })?;
 
+        #[cfg(not(feature = "new_parser"))]
+        self.rewrite_aggregates(&mut plan, self.db_schema)?;
+
+        #[cfg(feature = "new_parser")]
+        let reparsed = pg_raw_parse::parse(&pg_query::deparse(self.stmt)?)?;
+        #[cfg(feature = "new_parser")]
+        let node = reparsed.stmts().next().unwrap();
         #[cfg(feature = "new_parser")]
         if let Node::SelectStmt(select) = node {
-            self.rewrite_aggregates(select, &mut plan, self.db_schema)?;
-            self.limit_offset(&mut plan)?;
+            let stmt = make::try_owned(|mem| {
+                let mut select = mem.make_unique(select);
+                self.rewrite_aggregates(select.as_mut(), mem, &mut plan, self.db_schema)?;
+                Ok::<_, Error>(mem.make_RawStmt(select.uncast()))
+            })?;
+            self.stmt.stmts = pg_query::parse(pg_raw_parse::deparse(&stmt)?.as_str())?
+                .protobuf
+                .stmts;
         }
-        #[cfg(not(feature = "new_parser"))]
-        {
-            self.rewrite_aggregates(&mut plan, self.db_schema)?;
-            self.limit_offset(&mut plan)?;
-        }
+
+        self.limit_offset(&mut plan)?;
 
         if self.rewritten {
             plan.stmt = Some(match self.schema.query_parser_engine {

--- a/pgdog/src/frontend/router/parser/route.rs
+++ b/pgdog/src/frontend/router/parser/route.rs
@@ -368,11 +368,11 @@ impl Route {
         self.is_cross_shard() && self.is_write()
     }
 
-    pub fn aggregate_rewrite_plan(&self) -> &AggregateRewritePlan {
+    pub(crate) fn aggregate_rewrite_plan(&self) -> &AggregateRewritePlan {
         &self.rewrite_plan
     }
 
-    pub fn set_rewrite_plan(&mut self, plan: AggregateRewritePlan) {
+    pub(crate) fn set_rewrite_plan(&mut self, plan: AggregateRewritePlan) {
         self.rewrite_plan = plan;
     }
 }

--- a/pgdog/src/frontend/router/parser/util.rs
+++ b/pgdog/src/frontend/router/parser/util.rs
@@ -2,10 +2,12 @@ use pg_query::NodeEnum;
 use pg_query::protobuf::{Node, String as PgString};
 use std::cmp::PartialEq;
 
+#[cfg(not(feature = "new_parser"))]
 pub(crate) fn pg_string(s: impl Into<String>) -> Node {
     node(NodeEnum::String(PgString { sval: s.into() }))
 }
 
+#[cfg(not(feature = "new_parser"))]
 pub(crate) fn node(n: NodeEnum) -> Node {
     Node { node: Some(n) }
 }


### PR DESCRIPTION
This is mostly a line for line port, with some minor refactoring to make the code flow better. There is a minor behavioral change in that we generate `SUM(arg::numeric * arg::numeric)` for sum of squares instead of `SUM(POWER(arg::numeric, 2))`. This was slightly more convenient to write, and in most languages `x * x` tends to be more performant than `pow(x, 2)` since generic power functions have to handle fractional exponents