### PR TITLE
fix: skip multi-statement SET validation in session mode

### DIFF
--- a/pgdog/src/backend/pool/cluster.rs
+++ b/pgdog/src/backend/pool/cluster.rs
@@ -737,7 +737,9 @@ impl Cluster {
 mod test {
     use std::{sync::Arc, time::Duration};
 
-    use pgdog_config::{ConfigAndUsers, OmnishardedTable, QueryParserLevel, ShardedSchema};
+    use pgdog_config::{
+        ConfigAndUsers, OmnishardedTable, PoolerMode, QueryParserLevel, ShardedSchema,
+    };
 
     use crate::frontend::router::sharding::ShardedTable;
     use crate::{
@@ -876,6 +878,12 @@ mod test {
             let mut cluster = Self::new_test(config);
             cluster.shards.pop();
 
+            cluster
+        }
+
+        pub fn new_test_session_mode(config: &ConfigAndUsers) -> Cluster {
+            let mut cluster = Self::new_test(config);
+            cluster.pooler_mode = PoolerMode::Session;
             cluster
         }
 

--- a/pgdog/src/frontend/router/parser/context.rs
+++ b/pgdog/src/frontend/router/parser/context.rs
@@ -149,4 +149,12 @@ impl<'a> QueryParserContext<'a> {
     pub(super) fn expanded_explain(&self) -> bool {
         self.expanded_explain
     }
+
+    /// Are we running in session mode?
+    ///
+    /// In session mode, queries are forwarded to the server without
+    /// parsing or validation beyond what's required for routing.
+    pub(super) fn is_session_mode(&self) -> bool {
+        self.router_context.cluster.pooler_mode() == crate::config::PoolerMode::Session
+    }
 }

--- a/pgdog/src/frontend/router/parser/query/set.rs
+++ b/pgdog/src/frontend/router/parser/query/set.rs
@@ -60,11 +60,21 @@ impl QueryParser {
     /// - All SETs → returns `Ok(Some(Command::Set { .. }))`
     /// - No SETs → returns `Ok(None)`, caller falls through to default parsing
     /// - Mix of SET + non-SET → returns `Err(MultiStatementMixedSet)`
+    ///
+    /// In session mode, returns `Ok(Some(Command::Query(..)))` immediately so that
+    /// all multi-statement queries are forwarded to the server verbatim.
     pub(super) fn try_multi_set(
         &mut self,
         stmts: &[RawStmt],
         context: &QueryParserContext,
     ) -> Result<Option<Command>, Error> {
+        // In session mode, pass through without validation — the server
+        // owns the session and can handle mixed SET + other statements.
+        if context.is_session_mode() {
+            return Ok(Some(Command::Query(Route::write(
+                context.shards_calculator.shard(),
+            ))));
+        }
         let mut params = Vec::with_capacity(stmts.len());
         let mut has_set = false;
         let mut has_other = false;

--- a/pgdog/src/frontend/router/parser/query/test/setup.rs
+++ b/pgdog/src/frontend/router/parser/query/test/setup.rs
@@ -72,6 +72,13 @@ impl QueryParserTest {
         me
     }
 
+    pub(crate) fn new_session_mode(config: &ConfigAndUsers) -> Self {
+        let mut me = Self::new_with_config(config);
+        me.cluster = Cluster::new_test_session_mode(config);
+
+        me
+    }
+
     /// Set whether we're in a transaction.
     pub(crate) fn in_transaction(mut self, in_tx: bool) -> Self {
         self.transaction = if in_tx {

--- a/pgdog/src/frontend/router/parser/query/test/test_set.rs
+++ b/pgdog/src/frontend/router/parser/query/test/test_set.rs
@@ -13,6 +13,35 @@ use crate::{
 use super::setup::*;
 
 #[test]
+fn test_mixed_set_passthrough_in_session_mode() {
+    let mut test = QueryParserTest::new_session_mode(&config());
+
+    // In session mode, mixed SET + non-SET multi-statement queries must not be rejected.
+    // This is the exact batch psqlODBC sends during connection startup (issue #1087).
+    let command = test.execute(vec![
+        Query::new("SET DateStyle='ISO';SET extra_float_digits = 2;show transaction_isolation")
+            .into(),
+    ]);
+    assert!(
+        matches!(command, Command::Query(_)),
+        "expected Command::Query passthrough in session mode, got {command:#?}",
+    );
+}
+
+#[test]
+fn test_mixed_set_rejected_in_transaction_mode() {
+    let mut test = QueryParserTest::new();
+
+    let result = test.try_execute(vec![
+        Query::new("SET DateStyle='ISO'; show transaction_isolation").into(),
+    ]);
+    assert!(
+        result.is_err(),
+        "expected error for mixed SET in transaction mode, got {result:#?}",
+    );
+}
+
+#[test]
 fn test_set_comment() {
     let mut test = QueryParserTest::new();
 


### PR DESCRIPTION
## Summary

In session mode, PgDog should forward multi-statement queries to the server verbatim without validating whether they mix SET with other commands. The server owns the session and can handle these naturally.

Previously, `try_multi_set` unconditionally rejected any multi-statement batch mixing SET with non-SET statements (e.g. SHOW), returning `Error::MultiStatementMixedSet`. This broke psqlODBC connections, which send exactly such a batch during connection startup:

```sql
SET DateStyle='ISO';SET extra_float_digits = 2;show transaction_isolation
```

## Changes

- `QueryParserContext::is_session_mode()` — checks the cluster's pooler mode
- `try_multi_set` returns `Ok(None)` early in session mode, letting the query fall through to the server unchanged
- `cargo fmt` fix in `context.rs` (method-chain line break)
- Unit tests: `test_mixed_set_passthrough_in_session_mode` and `test_mixed_set_rejected_in_transaction_mode`
- `Cluster::new_test_session_mode` / `QueryParserTest::new_session_mode` added as test helpers

## Test plan

- [ ] `cargo nextest run` — new unit tests cover both session-mode passthrough and transaction-mode rejection
- [ ] Manual: connect via psqlODBC with `pooler_mode = session` and verify the connection startup batch succeeds

Closes #1087