### PR TITLE
Port `StatementRewrite::rewrite_simple_prepared` to the new parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3299,7 +3299,7 @@ dependencies = [
 [[package]]
 name = "pg_raw_parse"
 version = "0.1.0"
-source = "git+https://github.com/pgdogdev/pg_raw_parse.git?rev=6b13f77#6b13f7747f638c354ca2f1bb35e38158051fcec4"
+source = "git+https://github.com/pgdogdev/pg_raw_parse.git?rev=92a3be8#92a3be878b98f46f968717a6ba0c0e37c3dc118e"
 dependencies = [
  "bindgen 0.72.1",
  "cc",

--- a/pgdog/Cargo.toml
+++ b/pgdog/Cargo.toml
@@ -80,7 +80,7 @@ smallvec = "1"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-webpki-roots-no-provider", "json"] }
 hex = "0.4"
 x509-parser = "0.18"
-pg_raw_parse = { git = "https://github.com/pgdogdev/pg_raw_parse.git", rev = "6b13f77", optional = true }
+pg_raw_parse = { git = "https://github.com/pgdogdev/pg_raw_parse.git", rev = "92a3be8", optional = true }
 itertools = "0.15.0"
 
 [target.'cfg(unix)'.dependencies]

--- a/pgdog/src/frontend/router/parser/rewrite/statement/error.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/error.rs
@@ -41,4 +41,7 @@ pub enum Error {
 
     #[error("missing AST on request")]
     MissingAst,
+
+    #[error("prepared statement '{0}' does not exist")]
+    ExecuteMissingPrepare(String),
 }

--- a/pgdog/src/frontend/router/parser/rewrite/statement/mod.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/mod.rs
@@ -124,17 +124,22 @@ impl<'a> StatementRewrite<'a> {
                 _ => (),
             }
 
+            let mut node = mem.make_unique(node);
+
             // Handle top-level PREPARE/EXECUTE statements.
-            let prepared_result = self.rewrite_simple_prepared()?;
+            let prepared_result = self.rewrite_simple_prepared(node.as_mut(), mem)?;
             if prepared_result.rewritten {
                 self.rewritten = true;
                 plan.prepares = prepared_result.prepares;
+                self.stmt.stmts = pg_query::parse(pg_raw_parse::deparse(node.as_ref())?.as_str())?
+                    .protobuf
+                    .stmts;
             }
 
             // Inject pgdog.unique_id() for missing BIGINT primary keys.
             // This must run BEFORE the unique_id rewriter so the injected
             // function calls get processed.
-            self.inject_auto_id(node, &mut plan)?;
+            self.inject_auto_id(node.as_ref(), &mut plan)?;
 
             // Track the next parameter number to use
             let mut next_param = plan.params as i32 + 1;

--- a/pgdog/src/frontend/router/parser/rewrite/statement/simple_prepared.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/simple_prepared.rs
@@ -1,4 +1,8 @@
+#[cfg(not(feature = "new_parser"))]
 use pg_query::{Error as PgQueryError, NodeEnum};
+#[cfg(feature = "new_parser")]
+use pg_raw_parse::{NodeMut, make::MemoryToken};
+#[cfg(not(feature = "new_parser"))]
 use pgdog_config::QueryParserEngine;
 
 use crate::net::Parse;
@@ -39,82 +43,159 @@ impl StatementRewrite<'_> {
     /// should prepend `ProtocolMessage::Prepare` to the client request using the returned
     /// name and statement.
     ///
-    pub(super) fn rewrite_simple_prepared(&mut self) -> Result<SimplePreparedResult, Error> {
+    #[cfg(feature = "new_parser")]
+    pub(super) fn rewrite_simple_prepared<'a>(
+        &mut self,
+        node: NodeMut<'a, '_>,
+        mem: MemoryToken<'a>,
+    ) -> Result<SimplePreparedResult, Error> {
         let mut result = SimplePreparedResult::default();
 
         if !self.prepared_statements.level.full() {
             return Ok(result);
         }
 
-        for stmt in &mut self.stmt.stmts {
-            if let Some(ref mut node) = stmt.stmt
-                && let Some(ref mut inner) = node.node
-            {
-                match rewrite_single_prepared(inner, self.prepared_statements, self.schema)? {
-                    SimplePreparedRewrite::Prepared => {
-                        result.rewritten = true;
-                    }
-                    SimplePreparedRewrite::Executed { name, statement } => {
-                        result.prepares.push((name, statement));
-                        result.rewritten = true;
-                    }
-                    SimplePreparedRewrite::None => {}
-                }
+        match rewrite_single_prepared(node, mem, self.prepared_statements, self.schema)? {
+            SimplePreparedRewrite::Prepared => {
+                result.rewritten = true;
             }
+            SimplePreparedRewrite::Executed { name, statement } => {
+                result.prepares.push((name, statement));
+                result.rewritten = true;
+            }
+            SimplePreparedRewrite::None => {}
         }
 
         Ok(result)
     }
+
+    cfg_select! {
+        not(feature = "new_parser") => {
+            pub(super) fn rewrite_simple_prepared(&mut self) -> Result<SimplePreparedResult, Error> {
+                let mut result = SimplePreparedResult::default();
+
+                if !self.prepared_statements.level.full() {
+                    return Ok(result);
+                }
+
+                for stmt in &mut self.stmt.stmts {
+                    if let Some(ref mut node) = stmt.stmt
+                        && let Some(ref mut inner) = node.node
+                    {
+                        match rewrite_single_prepared(inner, self.prepared_statements, self.schema)? {
+                            SimplePreparedRewrite::Prepared => {
+                                result.rewritten = true;
+                            }
+                            SimplePreparedRewrite::Executed { name, statement } => {
+                                result.prepares.push((name, statement));
+                                result.rewritten = true;
+                            }
+                            SimplePreparedRewrite::None => {}
+                        }
+                    }
+                }
+
+                Ok(result)
+            }
+        }
+        _ => {}
+    }
 }
 
 /// Rewrites a single `PREPARE` or `EXECUTE` node.
-fn rewrite_single_prepared(
-    node: &mut NodeEnum,
+#[cfg(feature = "new_parser")]
+fn rewrite_single_prepared<'a>(
+    node: NodeMut<'a, '_>,
+    mem: MemoryToken<'a>,
     prepared_statements: &mut PreparedStatements,
-    schema: &ShardingSchema,
 ) -> Result<SimplePreparedRewrite, Error> {
     match node {
-        NodeEnum::PrepareStmt(stmt) => {
-            let query = stmt
-                .query
-                .as_ref()
-                .ok_or(Error::PgQuery(PgQueryError::Parse(
-                    "missing query in PREPARE".into(),
-                )))?;
-            let query = match schema.query_parser_engine {
-                QueryParserEngine::PgQueryProtobuf => query.deparse(),
-                QueryParserEngine::PgQueryRaw => query.deparse_raw(),
-            }
-            .map_err(Error::PgQuery)?;
+        NodeMut::PrepareStmt(mut stmt) => {
+            let query = pg_raw_parse::deparse(stmt.query())?;
 
-            let mut parse = Parse::named(&stmt.name, &query);
+            let mut parse = Parse::named(
+                &stmt.name().expect("PREPARE always has a name"),
+                query.as_str(),
+            );
             prepared_statements.insert_anyway(&mut parse);
-            stmt.name = parse.name().to_string();
+            stmt.set_name(Some(mem.copy_string(parse.name())));
 
             Ok(SimplePreparedRewrite::Prepared)
         }
 
-        NodeEnum::ExecuteStmt(stmt) => {
-            let parse = prepared_statements.parse(&stmt.name);
+        NodeMut::ExecuteStmt(mut stmt) => {
+            let stmt_name = stmt.name().expect("EXECUTE always has name");
+            let parse = prepared_statements.parse(stmt_name);
             if let Some(parse) = parse {
                 let global_name = parse.name().to_string();
                 let statement = parse.query().to_string();
-                stmt.name = global_name.clone();
+                stmt.set_name(Some(mem.copy_string(&global_name)));
 
                 Ok(SimplePreparedRewrite::Executed {
                     name: global_name,
                     statement,
                 })
             } else {
-                Err(Error::PgQuery(PgQueryError::Parse(format!(
-                    "prepared statement '{}' does not exist",
-                    stmt.name
-                ))))
+                Err(Error::ExecuteMissingPrepare(stmt_name.to_owned()))
             }
         }
 
         _ => Ok(SimplePreparedRewrite::None),
     }
+}
+
+cfg_select! {
+    not(feature = "new_parser") => {
+        fn rewrite_single_prepared(
+            node: &mut NodeEnum,
+            prepared_statements: &mut PreparedStatements,
+            schema: &ShardingSchema,
+        ) -> Result<SimplePreparedRewrite, Error> {
+            match node {
+                NodeEnum::PrepareStmt(stmt) => {
+                    let query = stmt
+                        .query
+                        .as_ref()
+                        .ok_or(Error::PgQuery(PgQueryError::Parse(
+                            "missing query in PREPARE".into(),
+                        )))?;
+                    let query = match schema.query_parser_engine {
+                        QueryParserEngine::PgQueryProtobuf => query.deparse(),
+                        QueryParserEngine::PgQueryRaw => query.deparse_raw(),
+                    }
+                    .map_err(Error::PgQuery)?;
+
+                    let mut parse = Parse::named(&stmt.name, &query);
+                    prepared_statements.insert_anyway(&mut parse);
+                    stmt.name = parse.name().to_string();
+
+                    Ok(SimplePreparedRewrite::Prepared)
+                }
+
+                NodeEnum::ExecuteStmt(stmt) => {
+                    let parse = prepared_statements.parse(&stmt.name);
+                    if let Some(parse) = parse {
+                        let global_name = parse.name().to_string();
+                        let statement = parse.query().to_string();
+                        stmt.name = global_name.clone();
+
+                        Ok(SimplePreparedRewrite::Executed {
+                            name: global_name,
+                            statement,
+                        })
+                    } else {
+                        Err(Error::PgQuery(PgQueryError::Parse(format!(
+                            "prepared statement '{}' does not exist",
+                            stmt.name
+                        ))))
+                    }
+                }
+
+                _ => Ok(SimplePreparedRewrite::None),
+            }
+        }
+    }
+    _ => {}
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I'm trying something new with this function, I'm intentionally using a silly form of cfg'ing the old code out to force those lines to have an indentation change, as this causes the diff to interpret the new code as changed lines and the old code as an addition. This will result in less churn in the long run (since the old code is getting deleted), and gives way nicer diffs for review