### PR TITLE
feat: per-database query parser setting

### DIFF
--- a/.schema/pgdog.schema.json
+++ b/.schema/pgdog.schema.json
@@ -189,6 +189,14 @@
         "$ref": "#/$defs/Plugin"
       }
     },
+    "query_parser": {
+      "description": "Query parser levels per-database.",
+      "type": "array",
+      "default": [],
+      "items": {
+        "$ref": "#/$defs/QueryParser"
+      }
+    },
     "replica_lag": {
       "description": "Replica lag configuration.",
       "anyOf": [
@@ -1601,6 +1609,30 @@
           "type": "string",
           "const": "full"
         }
+      ]
+    },
+    "QueryParser": {
+      "description": "Per-database query parser configuration.",
+      "type": "object",
+      "properties": {
+        "database": {
+          "description": "Database name.",
+          "type": "string"
+        },
+        "engine": {
+          "description": "Query parser engine used.",
+          "$ref": "#/$defs/QueryParserEngine"
+        },
+        "level": {
+          "description": "Query parser level.",
+          "$ref": "#/$defs/QueryParserLevel"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "database",
+        "level",
+        "engine"
       ]
     },
     "QueryParserEngine": {

--- a/integration/pgdog.toml
+++ b/integration/pgdog.toml
@@ -489,3 +489,8 @@ shard = 1
 
 [admin]
 password = "pgdog"
+
+[[query_parser]]
+database = "pgdog"
+level = "auto"
+engine = "pg_query_raw"

--- a/pgdog-config/src/core.rs
+++ b/pgdog-config/src/core.rs
@@ -282,6 +282,7 @@ pub struct Config {
     pub vault: Option<Vault>,
 
     /// Query parser levels per-database.
+    #[serde(default)]
     pub query_parser: Vec<QueryParser>,
 }
 
@@ -580,9 +581,13 @@ impl Config {
             self.general.query_parser = QueryParserLevel::On;
         }
 
-        if self.general.query_parser_engine == QueryParserEngine::PgQueryRaw
-            && self.memory.stack_size < 32 * 1024 * 1024
-        {
+        let raw_query_parser = self.general.query_parser_engine == QueryParserEngine::PgQueryRaw
+            || self
+                .query_parser
+                .iter()
+                .any(|query_parser| query_parser.engine == QueryParserEngine::PgQueryRaw);
+
+        if raw_query_parser && self.memory.stack_size < 32 * 1024 * 1024 {
             self.memory.stack_size = 32 * 1024 * 1024;
             warn!(
                 r#""pg_query_raw" parser engine requires a large thread stack, setting it to 32MiB for each Tokio worker"#

--- a/pgdog-config/src/core.rs
+++ b/pgdog-config/src/core.rs
@@ -9,7 +9,7 @@ use tracing::{error, info, warn};
 use crate::sharding::ShardedSchema;
 use crate::util::random_string;
 use crate::{
-    EnumeratedDatabase, Memory, OmnishardedTable, PassthroughAuth, PreparedStatements,
+    EnumeratedDatabase, Memory, OmnishardedTable, PassthroughAuth, PreparedStatements, QueryParser,
     QueryParserEngine, QueryParserLevel, ReadWriteSplit, RewriteMode, Role, ShardedMappingKey,
     ShardedTableConfig, SystemCatalogsBehavior, system_catalogs,
 };
@@ -280,6 +280,9 @@ pub struct Config {
 
     /// HashiCorp Vault settings, required for users configured with `server_auth = "vault"`.
     pub vault: Option<Vault>,
+
+    /// Query parser levels per-database.
+    pub query_parser: Vec<QueryParser>,
 }
 
 impl Config {

--- a/pgdog-config/src/sharding.rs
+++ b/pgdog-config/src/sharding.rs
@@ -380,7 +380,20 @@ impl<'a> From<&'a FlexibleType> for FlexibleTypeRef<'a> {
 /// Controls when the query parser is active.
 ///
 /// https://docs.pgdog.dev/configuration/pgdog.toml/general/#query_parser
-#[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq, Hash, Default, JsonSchema)]
+#[derive(
+    Serialize,
+    Deserialize,
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    Default,
+    JsonSchema,
+    PartialOrd,
+    Ord,
+)]
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
 pub enum QueryParserLevel {
     /// Always enable the query parser.
@@ -540,4 +553,16 @@ impl Display for UniqueIdFunction {
             Self::Standard => write!(f, "standard"),
         }
     }
+}
+
+/// Per-database query parser configuration.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash, Default, JsonSchema)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub struct QueryParser {
+    /// Database name.
+    pub database: String,
+    /// Query parser level.
+    pub level: QueryParserLevel,
+    /// Query parser engine used.
+    pub engine: QueryParserEngine,
 }

--- a/pgdog/src/backend/databases.rs
+++ b/pgdog/src/backend/databases.rs
@@ -12,8 +12,8 @@ use parking_lot::lock_api::MutexGuard;
 use parking_lot::{Mutex, RawMutex};
 use pgdog_config::users::PasswordKind;
 use pgdog_config::{
-    ShardedMappingConfig, ShardedMappingKey, ShardedMappingKeyRef, ShardedMappingKindDeprecated,
-    ShardedMappingList, ShardedMappingRange, ShardedTableConfig,
+    QueryParser, ShardedMappingConfig, ShardedMappingKey, ShardedMappingKeyRef,
+    ShardedMappingKindDeprecated, ShardedMappingList, ShardedMappingRange, ShardedTableConfig,
 };
 use tracing::{debug, error, info, warn};
 
@@ -615,6 +615,16 @@ fn new_pool(user: &crate::config::User, config: &crate::config::Config) -> Optio
         general.system_catalogs,
     );
     let sharded_schemas = ShardedSchemas::new(sharded_schemas);
+    let query_parser = config
+        .query_parser
+        .iter()
+        .find(|config| config.database == user.database)
+        .cloned()
+        .unwrap_or(QueryParser {
+            database: user.database.clone(),
+            level: config.general.query_parser,
+            engine: config.general.query_parser_engine,
+        });
 
     let cluster_config = ClusterConfig::new(
         config,
@@ -622,6 +632,7 @@ fn new_pool(user: &crate::config::User, config: &crate::config::Config) -> Optio
         &shard_configs,
         sharded_tables,
         sharded_schemas,
+        query_parser,
     );
 
     Some((

--- a/pgdog/src/backend/pool/cluster.rs
+++ b/pgdog/src/backend/pool/cluster.rs
@@ -3,8 +3,8 @@
 use futures::future::try_join_all;
 use parking_lot::Mutex;
 use pgdog_config::{
-    LoadSchema, PreparedStatements, QueryParserEngine, QueryParserLevel, Rewrite, RewriteMode,
-    users::PasswordKind,
+    LoadSchema, PreparedStatements, QueryParser, QueryParserEngine, QueryParserLevel, Rewrite,
+    RewriteMode, users::PasswordKind,
 };
 use std::{
     sync::{
@@ -184,6 +184,7 @@ impl<'a> ClusterConfig<'a> {
         shards: &'a [ClusterShardConfig],
         sharded_tables: ShardedTables,
         sharded_schemas: ShardedSchemas,
+        query_parser: QueryParser,
     ) -> Self {
         let general = &config.general;
         let multi_tenant = config.multi_tenant();
@@ -220,8 +221,8 @@ impl<'a> ClusterConfig<'a> {
             dry_run: general.dry_run,
             expanded_explain: general.expanded_explain,
             pub_sub_channel_size: general.pub_sub_channel_size,
-            query_parser: general.query_parser,
-            query_parser_engine: general.query_parser_engine,
+            query_parser: query_parser.level,
+            query_parser_engine: query_parser.engine,
             log_min_duration_parse: general.log_min_duration_parse(),
             log_query_sample_length: general.log_query_sample_length,
             connection_recovery: general.connection_recovery,


### PR DESCRIPTION
Add the ability to configure the query parser on a per-database level, e.g.:

```toml
[[query_parsers]]
database = "prod"
level = "off"
```