### PR TITLE
fix: add default to engine in [[query_parsers]]

### DIFF
--- a/.schema/pgdog.schema.json
+++ b/.schema/pgdog.schema.json
@@ -189,7 +189,7 @@
         "$ref": "#/$defs/Plugin"
       }
     },
-    "query_parser": {
+    "query_parsers": {
       "description": "Query parser levels per-database.",
       "type": "array",
       "default": [],
@@ -1621,18 +1621,18 @@
         },
         "engine": {
           "description": "Query parser engine used.",
-          "$ref": "#/$defs/QueryParserEngine"
+          "$ref": "#/$defs/QueryParserEngine",
+          "default": "pg_query_protobuf"
         },
         "level": {
           "description": "Query parser level.",
-          "$ref": "#/$defs/QueryParserLevel"
+          "$ref": "#/$defs/QueryParserLevel",
+          "default": "auto"
         }
       },
       "additionalProperties": false,
       "required": [
-        "database",
-        "level",
-        "engine"
+        "database"
       ]
     },
     "QueryParserEngine": {

--- a/pgdog-config/src/sharding.rs
+++ b/pgdog-config/src/sharding.rs
@@ -561,8 +561,37 @@ impl Display for UniqueIdFunction {
 pub struct QueryParser {
     /// Database name.
     pub database: String,
+
+    #[serde(default)]
     /// Query parser level.
     pub level: QueryParserLevel,
+
     /// Query parser engine used.
+    #[serde(default)]
     pub engine: QueryParserEngine,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Config;
+
+    use super::{QueryParserEngine, QueryParserLevel};
+
+    #[test]
+    fn query_parser_reads_default_values_from_config() {
+        let source = r#"
+[[query_parsers]]
+database = "production"
+"#;
+
+        let config: Config = toml::from_str(source).unwrap();
+
+        assert_eq!(config.query_parsers.len(), 1);
+        assert_eq!(config.query_parsers[0].database, "production");
+        assert_eq!(config.query_parsers[0].level, QueryParserLevel::Auto);
+        assert_eq!(
+            config.query_parsers[0].engine,
+            QueryParserEngine::PgQueryProtobuf
+        );
+    }
 }


### PR DESCRIPTION
Add default so people don't need to set it, or worry about it. We'll be removing this one soon anyway.