### PR TITLE
Port QueryParser::set to the new parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3313,7 +3313,7 @@ dependencies = [
 [[package]]
 name = "pg_raw_parse"
 version = "0.1.0"
-source = "git+https://github.com/pgdogdev/pg_raw_parse.git?rev=6b424c4#6b424c4510ef4e9c482ef8a7fd7246b66f15de0a"
+source = "git+https://github.com/pgdogdev/pg_raw_parse.git?rev=576226d#576226dd9d9e86539bc0b9d9baeb16c3601b346d"
 dependencies = [
  "bindgen 0.72.1",
  "cc",

--- a/pgdog/Cargo.toml
+++ b/pgdog/Cargo.toml
@@ -80,7 +80,7 @@ smallvec = "1"
 reqwest.workspace = true
 hex = "0.4"
 x509-parser = "0.18"
-pg_raw_parse = { git = "https://github.com/pgdogdev/pg_raw_parse.git", rev = "6b424c4", optional = true }
+pg_raw_parse = { git = "https://github.com/pgdogdev/pg_raw_parse.git", rev = "576226d", optional = true }
 itertools = "0.15.0"
 
 [target.'cfg(unix)'.dependencies]

--- a/pgdog/src/frontend/router/parser/query/mod.rs
+++ b/pgdog/src/frontend/router/parser/query/mod.rs
@@ -277,11 +277,15 @@ impl QueryParser {
             .run()?;
         }
 
+        #[cfg(feature = "new_parser")]
+        let stmts = &statement.new_ast;
+        #[cfg(not(feature = "new_parser"))]
         let stmts = &statement.parse_result().protobuf.stmts;
 
         // Handle multi-statement SET commands (e.g. "SET x TO 1; SET y TO 2").
+        #[cfg_attr(not(feature = "new_parser"), allow(clippy::explicit_auto_deref))]
         if stmts.len() > 1
-            && let Some(command) = self.try_multi_set(stmts, context)?
+            && let Some(command) = self.try_multi_set(&**stmts, context)?
         {
             return Ok(command);
         }
@@ -292,6 +296,9 @@ impl QueryParser {
         // We don't expect clients to send multiple queries. If they do
         // only the first one is used for routing.
         //
+        #[cfg(feature = "new_parser")]
+        let root = statement.parse_result().protobuf.stmts.first();
+        #[cfg(not(feature = "new_parser"))]
         let root = stmts.first();
 
         let root = if let Some(root) = root {
@@ -312,7 +319,19 @@ impl QueryParser {
 
         let mut command = match root.node {
             // SET statements -> return immediately.
-            Some(NodeEnum::VariableSetStmt(ref stmt)) => return self.set(stmt, context),
+            #[cfg_attr(feature = "new_parser", allow(unused))]
+            Some(NodeEnum::VariableSetStmt(ref stmt)) => {
+                return self.set(
+                    #[cfg(feature = "new_parser")]
+                    match new_root {
+                        Node::VariableSetStmt(stmt) => stmt,
+                        _ => unreachable!(),
+                    },
+                    #[cfg(not(feature = "new_parser"))]
+                    stmt,
+                    context,
+                );
+            }
 
             // SELECT set_config(...) -> treat as SET and return
             Some(NodeEnum::SelectStmt(ref stmt))

--- a/pgdog/src/frontend/router/parser/query/set.rs
+++ b/pgdog/src/frontend/router/parser/query/set.rs
@@ -89,6 +89,11 @@ impl QueryParser {
     cfg_select! {
         not(feature = "new_parser") => {
             fn parse_set_param(stmt: &VariableSetStmt) -> Result<Option<SetParam>, Error> {
+                let transaction_state = stmt.name.starts_with("TRANSACTION");
+                if transaction_state {
+                    return Ok(None);
+                }
+
                 let is_reset = stmt.kind() == VariableSetKind::VarReset;
                 let value = Self::parse_set_value(stmt)?;
 

--- a/pgdog/src/frontend/router/parser/query/set.rs
+++ b/pgdog/src/frontend/router/parser/query/set.rs
@@ -1,4 +1,6 @@
 use super::*;
+#[cfg(feature = "new_parser")]
+use pg_raw_parse::{Node, nodes, nodes::VariableSetKind::*};
 
 impl QueryParser {
     /// Handle the SET command.
@@ -8,51 +10,104 @@ impl QueryParser {
     ///
     /// All other SETs change the params on the client and are eventually sent to the server
     /// when the client is connected to the server.
+    #[cfg(feature = "new_parser")]
     pub(super) fn set(
         &mut self,
-        stmt: &VariableSetStmt,
+        stmt: &nodes::VariableSetStmt,
         context: &QueryParserContext,
     ) -> Result<Command, Error> {
-        if stmt.kind() == VariableSetKind::VarResetAll {
-            return Ok(Command::ResetAll);
-        }
-
-        if let Some(param) = Self::parse_set_param(stmt)? {
-            return Ok(Command::Set {
+        if stmt.kind == VAR_RESET_ALL {
+            Ok(Command::ResetAll)
+        } else if stmt.kind == VAR_SET_MULTI {
+            // SET TRANSACTION
+            Ok(Command::Query(
+                Route::write(context.shards_calculator.shard().clone())
+                    .with_read(context.read_only),
+            ))
+        } else {
+            let param = Self::parse_set_param(stmt)?;
+            Ok(Command::Set {
                 params: vec![param],
                 route: Route::write(context.shards_calculator.shard()),
                 behave_like_select: false,
-            });
+            })
         }
-
-        Ok(Command::Query(
-            Route::write(context.shards_calculator.shard().clone()).with_read(context.read_only),
-        ))
     }
 
-    /// Parse a single SET statement into a SetParam, if it's not a transaction-level SET.
-    pub fn parse_set_param(stmt: &VariableSetStmt) -> Result<Option<SetParam>, Error> {
-        let transaction_state = stmt.name.starts_with("TRANSACTION");
-        if transaction_state {
-            return Ok(None);
-        }
+    cfg_select! {
+        not(feature = "new_parser") => {
+            pub(super) fn set(
+                &mut self,
+                stmt: &VariableSetStmt,
+                context: &QueryParserContext,
+            ) -> Result<Command, Error> {
+                if stmt.kind() == VariableSetKind::VarResetAll {
+                    return Ok(Command::ResetAll);
+                }
 
-        let is_reset = stmt.kind() == VariableSetKind::VarReset;
-        let value = Self::parse_set_value(stmt)?;
+                if let Some(param) = Self::parse_set_param(stmt)? {
+                    return Ok(Command::Set {
+                        params: vec![param],
+                        route: Route::write(context.shards_calculator.shard()),
+                        behave_like_select: false,
+                    });
+                }
+
+                Ok(Command::Query(
+                    Route::write(context.shards_calculator.shard().clone()).with_read(context.read_only),
+                ))
+            }
+        }
+        _ => {}
+    }
+
+    /// Parse a single SET statement into a SetParam
+    #[cfg(feature = "new_parser")]
+    fn parse_set_param(stmt: &nodes::VariableSetStmt) -> Result<SetParam, Error> {
+        let value = if stmt.kind == VAR_SET_VALUE {
+            Some(Self::parse_set_values(stmt)?)
+        } else if stmt.kind == VAR_RESET || stmt.kind == VAR_SET_DEFAULT {
+            None
+        } else {
+            panic!("parse_set_param called on invalid kind {}", stmt.kind);
+        };
 
         match value {
-            value @ Some(_) => Ok(Some(SetParam {
-                name: stmt.name.to_string(),
+            value @ Some(_) => Ok(SetParam {
+                name: stmt.name().expect("SET always has name").to_string(),
                 value,
                 local: stmt.is_local,
-            })),
-            None if is_reset => Ok(Some(SetParam {
-                name: stmt.name.to_string(),
+            }),
+            None => Ok(SetParam {
+                name: stmt.name().expect("SET always has name").to_string(),
                 value: None,
                 local: false,
-            })),
-            None => Ok(None),
+            }),
         }
+    }
+
+    cfg_select! {
+        not(feature = "new_parser") => {
+            fn parse_set_param(stmt: &VariableSetStmt) -> Result<Option<SetParam>, Error> {
+                let is_reset = stmt.kind() == VariableSetKind::VarReset;
+                let value = Self::parse_set_value(stmt)?;
+
+                match value {
+                    value @ Some(_) => Ok(Some(SetParam {
+                        name: stmt.name.to_string(),
+                        value,
+                        local: stmt.is_local,
+                    })),
+                    None if is_reset => Ok(Some(SetParam {
+                        name: stmt.name.to_string(),
+                        value: None,
+                        local: false,
+                    })),
+                    None => Ok(None),
+                }
+            }
+        }
+        _ => {}
     }
 
     /// Try to handle multi-statement queries containing SET commands.
@@ -63,9 +118,10 @@ impl QueryParser {
     ///
     /// In session mode, returns `Ok(Some(Command::Query(..)))` immediately so that
     /// all multi-statement queries are forwarded to the server verbatim.
-    pub(super) fn try_multi_set(
+    #[cfg(feature = "new_parser")]
+    pub(super) fn try_multi_set<'a>(
         &mut self,
-        stmts: &[RawStmt],
+        stmts: impl IntoIterator<Item = &'a nodes::RawStmt>,
         context: &QueryParserContext,
     ) -> Result<Option<Command>, Error> {
         // In session mode, pass through without validation — the server
@@ -75,80 +131,158 @@ impl QueryParser {
                 context.shards_calculator.shard(),
             ))));
         }
-        let mut params = Vec::with_capacity(stmts.len());
-        let mut has_set = false;
         let mut has_other = false;
 
-        for raw_stmt in stmts {
-            let node = raw_stmt
-                .stmt
-                .as_ref()
-                .and_then(|s| s.node.as_ref())
-                .ok_or(Error::EmptyQuery)?;
-
-            match node {
-                NodeEnum::VariableSetStmt(stmt) => {
-                    if stmt.name.starts_with("TRANSACTION") {
-                        has_other = true;
-                    } else {
-                        has_set = true;
-                        if let Some(param) = Self::parse_set_param(stmt)? {
-                            params.push(param);
-                        }
-                    }
+        let params = stmts
+            .into_iter()
+            .filter_map(|stmt| match stmt.stmt() {
+                Node::VariableSetStmt(stmt) if stmt.kind != VAR_SET_MULTI => {
+                    Some(Self::parse_set_param(stmt))
                 }
-                _ => has_other = true,
-            }
-
-            if has_set && has_other {
-                return Err(Error::MultiStatementMixedSet);
-            }
-        }
+                _ => {
+                    has_other = true;
+                    None
+                }
+            })
+            .collect::<Result<Vec<_>, _>>()?;
 
         if params.is_empty() {
-            return Ok(None);
+            Ok(None)
+        } else if has_other {
+            Err(Error::MultiStatementMixedSet)
+        } else {
+            Ok(Some(Command::Set {
+                params,
+                route: Route::write(context.shards_calculator.shard()),
+                behave_like_select: false,
+            }))
         }
-
-        Ok(Some(Command::Set {
-            params,
-            route: Route::write(context.shards_calculator.shard()),
-            behave_like_select: false,
-        }))
     }
 
-    pub fn parse_set_value(stmt: &VariableSetStmt) -> Result<Option<ParameterValue>, Error> {
-        let mut value = vec![];
+    cfg_select! {
+        not(feature = "new_parser") => {
+            pub(super) fn try_multi_set(
+                &mut self,
+                stmts: &[RawStmt],
+                context: &QueryParserContext,
+            ) -> Result<Option<Command>, Error> {
+                // In session mode, pass through without validation — the server
+                // owns the session and can handle mixed SET + other statements.
+                if context.is_session_mode() {
+                    return Ok(Some(Command::Query(Route::write(
+                        context.shards_calculator.shard(),
+                    ))));
+                }
+                let mut params = Vec::with_capacity(stmts.len());
+                let mut has_set = false;
+                let mut has_other = false;
 
-        for node in &stmt.args {
-            match &node.node {
-                Some(NodeEnum::AConst(AConst { val: Some(val), .. })) => match val {
-                    Val::Sval(String { sval }) => value.push(sval.to_string()),
-                    Val::Ival(Integer { ival }) => value.push(ival.to_string()),
-                    Val::Fval(Float { fval }) => value.push(fval.to_string()),
-                    Val::Boolval(Boolean { boolval }) => value.push(boolval.to_string()),
-                    _ => (),
-                },
-                // e.g. SET TIME ZONE INTERVAL '+00:00' HOUR TO MINUTE
-                Some(NodeEnum::TypeCast(tc)) => {
-                    if let Some(ref arg) = tc.arg
-                        && let Some(NodeEnum::AConst(AConst {
-                            val: Some(Val::Sval(String { ref sval })),
-                            ..
-                        })) = arg.node
-                    {
-                        value.push(sval.to_string());
+                for raw_stmt in stmts {
+                    let node = raw_stmt
+                        .stmt
+                        .as_ref()
+                        .and_then(|s| s.node.as_ref())
+                        .ok_or(Error::EmptyQuery)?;
+
+                    match node {
+                        NodeEnum::VariableSetStmt(stmt) => {
+                            if stmt.name.starts_with("TRANSACTION") {
+                                has_other = true;
+                            } else {
+                                has_set = true;
+                                if let Some(param) = Self::parse_set_param(stmt)? {
+                                    params.push(param);
+                                }
+                            }
+                        }
+                        _ => has_other = true,
+                    }
+
+                    if has_set && has_other {
+                        return Err(Error::MultiStatementMixedSet);
                     }
                 }
-                _ => (),
+
+                if params.is_empty() {
+                    return Ok(None);
+                }
+
+                Ok(Some(Command::Set {
+                    params,
+                    route: Route::write(context.shards_calculator.shard()),
+                    behave_like_select: false,
+                }))
             }
         }
+        _ => {}
+    }
+
+    #[cfg(feature = "new_parser")]
+    fn parse_set_values(stmt: &nodes::VariableSetStmt) -> Result<ParameterValue, Error> {
+        let mut value = stmt
+            .args()
+            .iter()
+            .map(|node| match node {
+                Node::A_Const(a) => Ok(a
+                    .val()
+                    .expect("SET value TO NULL is a parse error")
+                    .to_string()),
+                // e.g. SET TIME ZONE INTERVAL '+00:00' HOUR TO MINUTE
+                Node::TypeCast(tc) if let Node::A_Const(a) = tc.arg() => Ok(a
+                    .val()
+                    .expect("SET value TO NULL is a parse error")
+                    .to_string()),
+                _ => Err(Error::ColumnDecode),
+            })
+            .collect::<Result<Vec<_>, _>>()?;
 
         let value = match value.len() {
-            0 => None,
-            1 => Some(ParameterValue::String(value.pop().unwrap())),
-            _ => Some(ParameterValue::Tuple(value)),
+            0 => panic!("parse_set_values called on RESET or SET TRANSACTION"),
+            1 => ParameterValue::String(value.pop().unwrap()),
+            _ => ParameterValue::Tuple(value),
         };
 
         Ok(value)
+    }
+
+    cfg_select! {
+        not(feature = "new_parser") => {
+            fn parse_set_value(stmt: &VariableSetStmt) -> Result<Option<ParameterValue>, Error> {
+                let mut value = vec![];
+
+                for node in &stmt.args {
+                    match &node.node {
+                        Some(NodeEnum::AConst(AConst { val: Some(val), .. })) => match val {
+                            Val::Sval(String { sval }) => value.push(sval.to_string()),
+                            Val::Ival(Integer { ival }) => value.push(ival.to_string()),
+                            Val::Fval(Float { fval }) => value.push(fval.to_string()),
+                            Val::Boolval(Boolean { boolval }) => value.push(boolval.to_string()),
+                            _ => (),
+                        },
+                        // e.g. SET TIME ZONE INTERVAL '+00:00' HOUR TO MINUTE
+                        Some(NodeEnum::TypeCast(tc)) => {
+                            if let Some(ref arg) = tc.arg
+                                && let Some(NodeEnum::AConst(AConst {
+                                    val: Some(Val::Sval(String { ref sval })),
+                                    ..
+                                })) = arg.node
+                            {
+                                value.push(sval.to_string());
+                            }
+                        }
+                        _ => (),
+                    }
+                }
+
+                let value = match value.len() {
+                    0 => None,
+                    1 => Some(ParameterValue::String(value.pop().unwrap())),
+                    _ => Some(ParameterValue::Tuple(value)),
+                };
+
+                Ok(value)
+            }
+        }
+        _ => {}
     }
 }

--- a/pgdog/src/frontend/router/parser/rewrite/statement/update.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/update.rs
@@ -1018,6 +1018,7 @@ mod test {
     use crate::frontend::router::sharding::ShardedTable;
     #[cfg(feature = "new_parser")]
     use indexmap::indexset;
+    #[cfg(not(feature = "new_parser"))]
     use pg_query::parse;
     use pgdog_config::Rewrite;
 


### PR DESCRIPTION
There's a few significant changes here. First, we're more explicitly checking for `SET TRANSACTION` by looking at the `kind` flag, rather than the name that happens to be set as an implementation detail. Second, we're much more intentional about where we expect the parsing functions to be called. We only expect to parse values for `VAR_SET_VALUE`. We explicitly look at the kind before calling that now, so that an unexpected condition is properly elevated as the error that it is, and not just silently passed through to the shard to leave things in a bad state.

For posterity, here is the expected (and implemented in the ported code) behavior for each type of set statement:

- `VAR_RESET | VAR_SET_DEFAULT`: These are different spellings of the same thing, which we treat as a `Set` command
- `VAR_SET_VALUE`: We expect either a constant or a type cast constant expression. We treat this as a `Set` command.
- `VAR_SET_MULTI`: This is `SET TRANSACTION`, and is passed through as `Query`
- `VAR_RESET_ALL`: `Command::ResetAll`
- `VAR_SET_CURRENT`: Unreachable, this is part of `ALTER DATABASE` DDL statements