### PR TITLE
Revert "test: disable copy_data retry_tests temporarily"

### DIFF
--- a/integration/copy_data/run.sh
+++ b/integration/copy_data/run.sh
@@ -15,11 +15,10 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 echo "=== [copy_data] data_sync ==="
 bash "${SCRIPT_DIR}/data_sync/run.sh"
 
-# TODO: reenable test, after fixing the flakiness https://github.com/pgdogdev/pgdog/issues/1185
-# echo "=== [copy_data] retry_test ==="
-# bash "${SCRIPT_DIR}/retry_test/run.sh"
+echo "=== [copy_data] retry_test ==="
+bash "${SCRIPT_DIR}/retry_test/run.sh"
 
-# echo "=== [copy_data] commit_sync ==="
-# bash "${SCRIPT_DIR}/commit_sync/run.sh"
+echo "=== [copy_data] commit_sync ==="
+bash "${SCRIPT_DIR}/commit_sync/run.sh"
 
 echo "=== [copy_data] all tests passed ==="


### PR DESCRIPTION
Reverts pgdogdev/pgdog#1192

This test has been working fine. See #1185 