### PR TITLE
Port QueryParser::ddl to the new parser

### DIFF
--- a/pgdog/src/frontend/router/parser/query/ddl.rs
+++ b/pgdog/src/frontend/router/parser/query/ddl.rs
@@ -1,14 +1,11 @@
-use pg_query::parse;
-#[cfg(feature = "new_parser")]
-use pg_query::protobuf::{ObjectType, RangeVar};
-
 use super::*;
 
 impl QueryParser {
     /// Handle DDL, e.g. CREATE, DROP, ALTER, etc.
     pub(super) fn ddl(
         &mut self,
-        node: &Option<NodeEnum>,
+        #[cfg(feature = "new_parser")] node: Node<'_>,
+        #[cfg(not(feature = "new_parser"))] node: &Option<NodeEnum>,
         context: &mut QueryParserContext<'_>,
     ) -> Result<Command, Error> {
         let command = Self::shard_ddl(
@@ -20,30 +17,32 @@ impl QueryParser {
         Ok(command)
     }
 
+    #[cfg(feature = "new_parser")]
     pub(super) fn shard_ddl(
-        node: &Option<NodeEnum>,
+        node: Node<'_>,
         schema: &ShardingSchema,
         calculator: &mut ShardsWithPriority,
     ) -> Result<Command, Error> {
+        use nodes::ObjectType;
         let mut shard = Shard::All;
         let mut schema_changed = false;
 
         match node {
-            Some(NodeEnum::CreateStmt(stmt)) => {
+            Node::CreateStmt(stmt) => {
                 schema_changed = true;
-                shard = Self::shard_ddl_table(&stmt.relation, schema)?.unwrap_or(Shard::All);
+                shard = Self::shard_ddl_table(stmt.relation(), schema)?.unwrap_or(Shard::All);
             }
 
-            Some(NodeEnum::CreateSeqStmt(stmt)) => {
-                shard = Self::shard_ddl_table(&stmt.sequence, schema)?.unwrap_or(Shard::All);
+            Node::CreateSeqStmt(stmt) => {
+                shard = Self::shard_ddl_table(stmt.sequence(), schema)?.unwrap_or(Shard::All);
             }
 
-            Some(NodeEnum::DropStmt(stmt)) => match stmt.remove_type() {
-                ObjectType::ObjectTable
-                | ObjectType::ObjectIndex
-                | ObjectType::ObjectView
-                | ObjectType::ObjectSequence => {
-                    let table = Table::try_from(&stmt.objects).ok();
+            Node::DropStmt(stmt) => match stmt.remove_type {
+                ObjectType::OBJECT_TABLE
+                | ObjectType::OBJECT_INDEX
+                | ObjectType::OBJECT_VIEW
+                | ObjectType::OBJECT_SEQUENCE => {
+                    let table = Table::try_from(stmt.objects()).ok();
                     if let Some(table) = table
                         && let Some(schema) = schema.schemas.get(table.schema())
                     {
@@ -52,11 +51,9 @@ impl QueryParser {
                     schema_changed = true;
                 }
 
-                ObjectType::ObjectSchema => {
-                    if let Some(PgNode {
-                        node: Some(NodeEnum::String(string)),
-                    }) = stmt.objects.first()
-                        && let Some(schema) = schema.schemas.get(Some(string.sval.as_str().into()))
+                ObjectType::OBJECT_SCHEMA => {
+                    if let Some(string) = stmt.objects().first().and_then(Node::as_str)
+                        && let Some(schema) = schema.schemas.get(Some(string.into()))
                     {
                         shard = schema.shard().into();
                     }
@@ -65,30 +62,30 @@ impl QueryParser {
                 _ => (),
             },
 
-            Some(NodeEnum::CreateSchemaStmt(stmt)) => {
-                if let Some(schema) = schema.schemas.get(Some(stmt.schemaname.as_str().into())) {
+            Node::CreateSchemaStmt(stmt) => {
+                if let Some(schema) = schema.schemas.get(stmt.schemaname().map(Into::into)) {
                     shard = schema.shard().into();
                 }
             }
 
-            Some(NodeEnum::IndexStmt(stmt)) => {
-                shard = Self::shard_ddl_table(&stmt.relation, schema)?.unwrap_or(Shard::All);
+            Node::IndexStmt(stmt) => {
+                shard = Self::shard_ddl_table(stmt.relation(), schema)?.unwrap_or(Shard::All);
             }
 
-            Some(NodeEnum::ViewStmt(stmt)) => {
+            Node::ViewStmt(stmt) => {
                 schema_changed = true;
-                shard = Self::shard_ddl_table(&stmt.view, schema)?.unwrap_or(Shard::All);
+                shard = Self::shard_ddl_table(stmt.view(), schema)?.unwrap_or(Shard::All);
             }
 
-            Some(NodeEnum::CreateTableAsStmt(stmt)) => {
+            Node::CreateTableAsStmt(stmt) => {
                 schema_changed = true;
-                if let Some(into) = &stmt.into {
-                    shard = Self::shard_ddl_table(&into.rel, schema)?.unwrap_or(Shard::All);
+                if let Some(into) = stmt.into() {
+                    shard = Self::shard_ddl_table(into.rel(), schema)?.unwrap_or(Shard::All);
                 }
             }
 
-            Some(NodeEnum::CreateFunctionStmt(stmt)) => {
-                let table = Table::try_from(&stmt.funcname).ok();
+            Node::CreateFunctionStmt(stmt) => {
+                let table = Table::try_from(stmt.funcname()).ok();
                 if let Some(table) = table {
                     shard = schema
                         .schemas
@@ -98,8 +95,8 @@ impl QueryParser {
                 }
             }
 
-            Some(NodeEnum::CreateEnumStmt(stmt)) => {
-                let table = Table::try_from(&stmt.type_name).ok();
+            Node::CreateEnumStmt(stmt) => {
+                let table = Table::try_from(stmt.type_name()).ok();
                 if let Some(table) = table {
                     shard = schema
                         .schemas
@@ -109,26 +106,26 @@ impl QueryParser {
                 }
             }
 
-            Some(NodeEnum::AlterOwnerStmt(stmt)) => {
-                shard = Self::shard_ddl_table(&stmt.relation, schema)?.unwrap_or(Shard::All);
+            Node::AlterOwnerStmt(stmt) => {
+                shard = Self::shard_ddl_table(stmt.relation(), schema)?.unwrap_or(Shard::All);
             }
 
-            Some(NodeEnum::RenameStmt(stmt)) => {
-                shard = Self::shard_ddl_table(&stmt.relation, schema)?.unwrap_or(Shard::All);
+            Node::RenameStmt(stmt) => {
+                shard = Self::shard_ddl_table(stmt.relation(), schema)?.unwrap_or(Shard::All);
             }
 
-            Some(NodeEnum::AlterTableStmt(stmt)) => {
+            Node::AlterTableStmt(stmt) => {
                 schema_changed = true;
-                shard = Self::shard_ddl_table(&stmt.relation, schema)?.unwrap_or(Shard::All);
+                shard = Self::shard_ddl_table(stmt.relation(), schema)?.unwrap_or(Shard::All);
             }
 
-            Some(NodeEnum::AlterSeqStmt(stmt)) => {
-                shard = Self::shard_ddl_table(&stmt.sequence, schema)?.unwrap_or(Shard::All);
+            Node::AlterSeqStmt(stmt) => {
+                shard = Self::shard_ddl_table(stmt.sequence(), schema)?.unwrap_or(Shard::All);
             }
 
-            Some(NodeEnum::LockStmt(stmt)) => {
-                if let Some(node) = stmt.relations.first()
-                    && let Some(NodeEnum::RangeVar(ref table)) = node.node
+            Node::LockStmt(stmt) => {
+                if let Some(node) = stmt.relations().first()
+                    && let Node::RangeVar(table) = node
                 {
                     let table = Table::from(table);
                     shard = schema
@@ -139,46 +136,37 @@ impl QueryParser {
                 }
             }
 
-            Some(NodeEnum::VacuumStmt(stmt)) => {
-                for rel in &stmt.rels {
-                    if let Some(NodeEnum::VacuumRelation(ref stmt)) = rel.node {
-                        shard =
-                            Self::shard_ddl_table(&stmt.relation, schema)?.unwrap_or(Shard::All);
-                    }
+            Node::VacuumStmt(stmt) => {
+                for rel in stmt.rels() {
+                    // FIXME: This almost certainly needs to be combining
+                    // shards, not setting it to the target of the last
+                    // relation mentioned
+                    shard = Self::shard_ddl_table(rel.relation(), schema)?.unwrap_or(Shard::All);
                 }
             }
 
-            Some(NodeEnum::VacuumRelation(stmt)) => {
-                shard = Self::shard_ddl_table(&stmt.relation, schema)?.unwrap_or(Shard::All);
+            Node::VacuumRelation(stmt) => {
+                shard = Self::shard_ddl_table(stmt.relation(), schema)?.unwrap_or(Shard::All);
             }
 
             // DO $$ BEGIN ... END
-            Some(NodeEnum::DoStmt(stmt)) => {
-                if let Some(inner) = stmt.args.first()
-                    && let Some(NodeEnum::DefElem(ref elem)) = inner.node
-                    && let Some(ref arg) = elem.arg
-                    && let Some(NodeEnum::String(ref string)) = arg.node
+            Node::DoStmt(stmt) => {
+                if let Some(elem) = stmt.args().iter().find(|elem| elem.defname() == Some("as"))
+                    && let Some(string) = elem.arg().as_str()
                 {
                     // Parse each statement individually.
                     // The first DDL statement to return a direct shard will be used.
                     // TODO: handle non-DDL statements in here as well,
                     // need a full recursive call back to QueryParser::query basically, but that requires a refactor.
-                    for stmt in string.sval.lines() {
-                        if let Ok(stmt) = parse(stmt)
-                            && let Some(node) = stmt
-                                .protobuf
-                                .stmts
-                                .first()
-                                .map(|stmt| &stmt.stmt)
-                                .cloned()
-                                .flatten()
+                    for line in string.lines() {
+                        if let Ok(ast) = pg_raw_parse::parse(line)
+                            && let Some(node) = ast.stmts().next()
                         {
                             // Use a fresh calculator for each inner statement
                             // to avoid pollution from statements that don't match
                             // any DDL pattern (like BEGIN, END, etc.)
                             let mut inner_calculator = ShardsWithPriority::default();
-                            let command =
-                                Self::shard_ddl(&node.node, schema, &mut inner_calculator)?;
+                            let command = Self::shard_ddl(node, schema, &mut inner_calculator)?;
                             if let Command::Query(query) = command
                                 && !query.is_cross_shard()
                             {
@@ -190,13 +178,12 @@ impl QueryParser {
                 }
             }
 
-            Some(NodeEnum::TruncateStmt(stmt)) => {
+            Node::TruncateStmt(stmt) => {
                 let mut shards = HashSet::new();
-                for relation in &stmt.relations {
-                    if let Some(NodeEnum::RangeVar(ref relation)) = relation.node {
+                for relation in stmt.relations() {
+                    if let Node::RangeVar(relation) = relation {
                         shards.insert(
-                            Self::shard_ddl_table(&Some(relation.clone()), schema)?
-                                .unwrap_or(Shard::All),
+                            Self::shard_ddl_table(Some(relation), schema)?.unwrap_or(Shard::All),
                         );
                     }
                 }
@@ -222,11 +209,219 @@ impl QueryParser {
         ))
     }
 
+    cfg_select! {
+        not(feature = "new_parser") => {
+            pub(super) fn shard_ddl(
+                node: &Option<NodeEnum>,
+                schema: &ShardingSchema,
+                calculator: &mut ShardsWithPriority,
+            ) -> Result<Command, Error> {
+                let mut shard = Shard::All;
+                let mut schema_changed = false;
+
+                match node {
+                    Some(NodeEnum::CreateStmt(stmt)) => {
+                        schema_changed = true;
+                        shard = Self::shard_ddl_table(&stmt.relation, schema)?.unwrap_or(Shard::All);
+                    }
+
+                    Some(NodeEnum::CreateSeqStmt(stmt)) => {
+                        shard = Self::shard_ddl_table(&stmt.sequence, schema)?.unwrap_or(Shard::All);
+                    }
+
+                    Some(NodeEnum::DropStmt(stmt)) => match stmt.remove_type() {
+                        ObjectType::ObjectTable
+                        | ObjectType::ObjectIndex
+                        | ObjectType::ObjectView
+                        | ObjectType::ObjectSequence => {
+                            let table = Table::try_from(&stmt.objects).ok();
+                            if let Some(table) = table
+                                && let Some(schema) = schema.schemas.get(table.schema())
+                            {
+                                shard = schema.shard().into();
+                            }
+                            schema_changed = true;
+                        }
+
+                        ObjectType::ObjectSchema => {
+                            if let Some(PgNode {
+                                node: Some(NodeEnum::String(string)),
+                            }) = stmt.objects.first()
+                                && let Some(schema) = schema.schemas.get(Some(string.sval.as_str().into()))
+                            {
+                                shard = schema.shard().into();
+                            }
+                        }
+
+                        _ => (),
+                    },
+
+                    Some(NodeEnum::CreateSchemaStmt(stmt)) => {
+                        if let Some(schema) = schema.schemas.get(Some(stmt.schemaname.as_str().into())) {
+                            shard = schema.shard().into();
+                        }
+                    }
+
+                    Some(NodeEnum::IndexStmt(stmt)) => {
+                        shard = Self::shard_ddl_table(&stmt.relation, schema)?.unwrap_or(Shard::All);
+                    }
+
+                    Some(NodeEnum::ViewStmt(stmt)) => {
+                        schema_changed = true;
+                        shard = Self::shard_ddl_table(&stmt.view, schema)?.unwrap_or(Shard::All);
+                    }
+
+                    Some(NodeEnum::CreateTableAsStmt(stmt)) => {
+                        schema_changed = true;
+                        if let Some(into) = &stmt.into {
+                            shard = Self::shard_ddl_table(&into.rel, schema)?.unwrap_or(Shard::All);
+                        }
+                    }
+
+                    Some(NodeEnum::CreateFunctionStmt(stmt)) => {
+                        let table = Table::try_from(&stmt.funcname).ok();
+                        if let Some(table) = table {
+                            shard = schema
+                                .schemas
+                                .get(table.schema())
+                                .map(|schema| schema.shard().into())
+                                .unwrap_or(Shard::All);
+                        }
+                    }
+
+                    Some(NodeEnum::CreateEnumStmt(stmt)) => {
+                        let table = Table::try_from(&stmt.type_name).ok();
+                        if let Some(table) = table {
+                            shard = schema
+                                .schemas
+                                .get(table.schema())
+                                .map(|schema| schema.shard().into())
+                                .unwrap_or(Shard::All);
+                        }
+                    }
+
+                    Some(NodeEnum::AlterOwnerStmt(stmt)) => {
+                        shard = Self::shard_ddl_table(&stmt.relation, schema)?.unwrap_or(Shard::All);
+                    }
+
+                    Some(NodeEnum::RenameStmt(stmt)) => {
+                        shard = Self::shard_ddl_table(&stmt.relation, schema)?.unwrap_or(Shard::All);
+                    }
+
+                    Some(NodeEnum::AlterTableStmt(stmt)) => {
+                        schema_changed = true;
+                        shard = Self::shard_ddl_table(&stmt.relation, schema)?.unwrap_or(Shard::All);
+                    }
+
+                    Some(NodeEnum::AlterSeqStmt(stmt)) => {
+                        shard = Self::shard_ddl_table(&stmt.sequence, schema)?.unwrap_or(Shard::All);
+                    }
+
+                    Some(NodeEnum::LockStmt(stmt)) => {
+                        if let Some(node) = stmt.relations.first()
+                            && let Some(NodeEnum::RangeVar(ref table)) = node.node
+                        {
+                            let table = Table::from(table);
+                            shard = schema
+                                .schemas
+                                .get(table.schema())
+                                .map(|schema| schema.shard().into())
+                                .unwrap_or(Shard::All);
+                        }
+                    }
+
+                    Some(NodeEnum::VacuumStmt(stmt)) => {
+                        for rel in &stmt.rels {
+                            if let Some(NodeEnum::VacuumRelation(ref stmt)) = rel.node {
+                                shard =
+                                    Self::shard_ddl_table(&stmt.relation, schema)?.unwrap_or(Shard::All);
+                            }
+                        }
+                    }
+
+                    Some(NodeEnum::VacuumRelation(stmt)) => {
+                        shard = Self::shard_ddl_table(&stmt.relation, schema)?.unwrap_or(Shard::All);
+                    }
+
+                    // DO $$ BEGIN ... END
+                    Some(NodeEnum::DoStmt(stmt)) => {
+                        if let Some(inner) = stmt.args.first()
+                            && let Some(NodeEnum::DefElem(ref elem)) = inner.node
+                            && let Some(ref arg) = elem.arg
+                            && let Some(NodeEnum::String(ref string)) = arg.node
+                        {
+                            // Parse each statement individually.
+                            // The first DDL statement to return a direct shard will be used.
+                            // TODO: handle non-DDL statements in here as well,
+                            // need a full recursive call back to QueryParser::query basically, but that requires a refactor.
+                            for stmt in string.sval.lines() {
+                                if let Ok(stmt) = pg_query::parse(stmt)
+                                    && let Some(node) = stmt
+                                        .protobuf
+                                        .stmts
+                                        .first()
+                                        .map(|stmt| &stmt.stmt)
+                                        .cloned()
+                                        .flatten()
+                                {
+                                    // Use a fresh calculator for each inner statement
+                                    // to avoid pollution from statements that don't match
+                                    // any DDL pattern (like BEGIN, END, etc.)
+                                    let mut inner_calculator = ShardsWithPriority::default();
+                                    let command =
+                                        Self::shard_ddl(&node.node, schema, &mut inner_calculator)?;
+                                    if let Command::Query(query) = command
+                                        && !query.is_cross_shard()
+                                    {
+                                        shard = query.shard().clone();
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    Some(NodeEnum::TruncateStmt(stmt)) => {
+                        let mut shards = HashSet::new();
+                        for relation in &stmt.relations {
+                            if let Some(NodeEnum::RangeVar(ref relation)) = relation.node {
+                                shards.insert(
+                                    Self::shard_ddl_table(&Some(relation.clone()), schema)?
+                                        .unwrap_or(Shard::All),
+                                );
+                            }
+                        }
+
+                        match shards.len() {
+                            0 => (),
+                            1 => {
+                                shard = shards.iter().next().unwrap().clone();
+                            }
+                            _ => return Err(Error::CrossShardTruncateSchemaSharding),
+                        }
+                    }
+
+                    // All others are not handled.
+                    // They are sent to all shards concurrently.
+                    _ => (),
+                };
+
+                calculator.push(ShardWithPriority::new_table(shard));
+
+                Ok(Command::Query(
+                    Route::write(calculator.shard()).with_schema_changed(schema_changed),
+                ))
+            }
+        }
+        _ => {}
+    }
+
+    #[cfg(feature = "new_parser")]
     pub(super) fn shard_ddl_table(
-        range_var: &Option<RangeVar>,
+        range_var: Option<&nodes::RangeVar>,
         schema: &ShardingSchema,
     ) -> Result<Option<Shard>, Error> {
-        let table = range_var.as_ref().map(Table::from);
+        let table = range_var.map(Table::from);
         if let Some(table) = table
             && let Some(sharded_schema) = schema.schemas.get(table.schema())
         {
@@ -235,20 +430,32 @@ impl QueryParser {
 
         Ok(None)
     }
+
+    cfg_select! {
+        not(feature = "new_parser") => {
+            pub(super) fn shard_ddl_table(
+                range_var: &Option<RangeVar>,
+                schema: &ShardingSchema,
+            ) -> Result<Option<Shard>, Error> {
+                let table = range_var.as_ref().map(Table::from);
+                if let Some(table) = table
+                    && let Some(sharded_schema) = schema.schemas.get(table.schema())
+                {
+                    return Ok(Some(sharded_schema.shard().into()));
+                }
+
+                Ok(None)
+            }
+        }
+        _ => {}
+    }
 }
 
 #[cfg(test)]
 mod test {
-    use pg_query::{NodeEnum, parse};
+    use super::*;
+    use crate::backend::replication::ShardedSchemas;
     use pgdog_config::ShardedSchema;
-
-    use crate::{
-        backend::{ShardingSchema, replication::ShardedSchemas},
-        frontend::router::{
-            QueryParser,
-            parser::{Shard, ShardsWithPriority},
-        },
-    };
 
     fn test_schema() -> ShardingSchema {
         ShardingSchema {
@@ -269,265 +476,226 @@ mod test {
         }
     }
 
-    fn parse_stmt(query: &str) -> Option<NodeEnum> {
-        parse(query)
-            .unwrap()
-            .protobuf
-            .stmts
-            .first()
-            .unwrap()
-            .clone()
-            .stmt
-            .unwrap()
-            .node
+    #[cfg(feature = "new_parser")]
+    fn parse_stmt(query: &str) -> Command {
+        let ast = pg_raw_parse::parse(query).unwrap();
+        let root = ast.stmts().next().unwrap();
+        let mut calculator = ShardsWithPriority::default();
+        QueryParser::shard_ddl(root, &test_schema(), &mut calculator).unwrap()
+    }
+
+    cfg_select! {
+        not(feature = "new_parser") => {
+            fn parse_stmt(query: &str) -> Command {
+                let root = pg_query::parse(query)
+                    .unwrap()
+                    .protobuf
+                    .stmts
+                    .first()
+                    .unwrap()
+                    .clone()
+                    .stmt
+                    .unwrap()
+                    .node;
+                let mut calculator = ShardsWithPriority::default();
+                QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap()
+            }
+        }
+        _ => {}
     }
 
     #[test]
     fn test_create_table_sharded_schema() {
-        let root = parse_stmt("CREATE TABLE shard_0.test (id BIGINT)");
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
+        let command = parse_stmt("CREATE TABLE shard_0.test (id BIGINT)");
         assert_eq!(command.route().shard(), &Shard::Direct(0));
         assert!(command.route().is_schema_changed());
     }
 
     #[test]
     fn test_create_table_unsharded_schema() {
-        let root = parse_stmt("CREATE TABLE unsharded.test (id BIGINT)");
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
+        let command = parse_stmt("CREATE TABLE unsharded.test (id BIGINT)");
         assert_eq!(command.route().shard(), &Shard::All);
         assert!(command.route().is_schema_changed());
     }
 
     #[test]
     fn test_create_table_no_schema() {
-        let root = parse_stmt("CREATE TABLE test (id BIGINT)");
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
+        let command = parse_stmt("CREATE TABLE test (id BIGINT)");
         assert_eq!(command.route().shard(), &Shard::All);
         assert!(command.route().is_schema_changed());
     }
 
     #[test]
     fn test_create_sequence_sharded() {
-        let root = parse_stmt("CREATE SEQUENCE shard_1.test_seq");
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
+        let command = parse_stmt("CREATE SEQUENCE shard_1.test_seq");
         assert_eq!(command.route().shard(), &Shard::Direct(1));
         assert!(!command.route().is_schema_changed());
     }
 
     #[test]
     fn test_create_sequence_unsharded() {
-        let root = parse_stmt("CREATE SEQUENCE public.test_seq");
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
+        let command = parse_stmt("CREATE SEQUENCE public.test_seq");
         assert_eq!(command.route().shard(), &Shard::All);
         assert!(!command.route().is_schema_changed());
     }
 
     #[test]
     fn test_drop_table_sharded() {
-        let root = parse_stmt("DROP TABLE shard_0.test");
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
+        let command = parse_stmt("DROP TABLE shard_0.test");
         assert_eq!(command.route().shard(), &Shard::Direct(0));
         assert!(command.route().is_schema_changed());
     }
 
     #[test]
     fn test_drop_table_unsharded() {
-        let root = parse_stmt("DROP TABLE public.test");
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
+        let command = parse_stmt("DROP TABLE public.test");
         assert_eq!(command.route().shard(), &Shard::All);
         assert!(command.route().is_schema_changed());
     }
 
     #[test]
     fn test_drop_index_sharded() {
-        let root = parse_stmt("DROP INDEX shard_1.test_idx");
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
+        let command = parse_stmt("DROP INDEX shard_1.test_idx");
         assert_eq!(command.route().shard(), &Shard::Direct(1));
         assert!(command.route().is_schema_changed());
     }
 
     #[test]
     fn test_drop_view_sharded() {
-        let root = parse_stmt("DROP VIEW shard_0.test_view");
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
+        let command = parse_stmt("DROP VIEW shard_0.test_view");
         assert_eq!(command.route().shard(), &Shard::Direct(0));
         assert!(command.route().is_schema_changed());
     }
 
     #[test]
     fn test_drop_sequence_sharded() {
-        let root = parse_stmt("DROP SEQUENCE shard_1.test_seq");
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
+        let command = parse_stmt("DROP SEQUENCE shard_1.test_seq");
         assert_eq!(command.route().shard(), &Shard::Direct(1));
         assert!(command.route().is_schema_changed());
     }
 
     #[test]
     fn test_drop_schema_sharded() {
-        let root = parse_stmt("DROP SCHEMA shard_0");
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
+        let command = parse_stmt("DROP SCHEMA shard_0");
         assert_eq!(command.route().shard(), &Shard::Direct(0));
         assert!(!command.route().is_schema_changed());
     }
 
     #[test]
     fn test_drop_schema_unsharded() {
-        let root = parse_stmt("DROP SCHEMA public");
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
+        let command = parse_stmt("DROP SCHEMA public");
         assert_eq!(command.route().shard(), &Shard::All);
         assert!(!command.route().is_schema_changed());
     }
 
     #[test]
     fn test_create_schema_sharded() {
-        let root = parse_stmt("CREATE SCHEMA shard_0");
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
+        let command = parse_stmt("CREATE SCHEMA shard_0");
         assert_eq!(command.route().shard(), &Shard::Direct(0));
         assert!(!command.route().is_schema_changed());
     }
 
     #[test]
     fn test_create_schema_unsharded() {
-        let root = parse_stmt("CREATE SCHEMA new_schema");
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
+        let command = parse_stmt("CREATE SCHEMA new_schema");
         assert_eq!(command.route().shard(), &Shard::All);
         assert!(!command.route().is_schema_changed());
     }
 
     #[test]
     fn test_create_index_sharded() {
-        let root = parse_stmt("CREATE INDEX test_idx ON shard_1.test (id)");
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
+        let command = parse_stmt("CREATE INDEX test_idx ON shard_1.test (id)");
         assert_eq!(command.route().shard(), &Shard::Direct(1));
         assert!(!command.route().is_schema_changed());
 
-        let root = parse_stmt("CREATE UNIQUE INDEX test_idx ON shard_1.test (id)");
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
+        let command = parse_stmt("CREATE UNIQUE INDEX test_idx ON shard_1.test (id)");
         assert_eq!(command.route().shard(), &Shard::Direct(1));
         assert!(!command.route().is_schema_changed());
     }
 
     #[test]
     fn test_do_begin() {
-        let root = parse_stmt(
+        let command = parse_stmt(
             r#"DO $$ BEGIN
          ALTER TABLE "shard_1"."foo" ADD CONSTRAINT "foo_id_foo2_id_fk" FOREIGN KEY ("id") REFERENCES "shard_1"."foo2"("id") ON DELETE cascade ON UPDATE cascade;
         EXCEPTION
          WHEN duplicate_object THEN null;
         END $$;"#,
         );
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
         assert_eq!(command.route().shard(), &Shard::Direct(1));
         assert!(!command.route().is_schema_changed());
     }
 
     #[test]
     fn test_create_index_unsharded() {
-        let root = parse_stmt("CREATE INDEX test_idx ON public.test (id)");
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
+        let command = parse_stmt("CREATE INDEX test_idx ON public.test (id)");
         assert_eq!(command.route().shard(), &Shard::All);
         assert!(!command.route().is_schema_changed());
     }
 
     #[test]
     fn test_create_view_sharded() {
-        let root = parse_stmt("CREATE VIEW shard_0.test_view AS SELECT 1");
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
+        let command = parse_stmt("CREATE VIEW shard_0.test_view AS SELECT 1");
         assert_eq!(command.route().shard(), &Shard::Direct(0));
         assert!(command.route().is_schema_changed());
     }
 
     #[test]
     fn test_create_view_unsharded() {
-        let root = parse_stmt("CREATE VIEW public.test_view AS SELECT 1");
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
+        let command = parse_stmt("CREATE VIEW public.test_view AS SELECT 1");
         assert_eq!(command.route().shard(), &Shard::All);
         assert!(command.route().is_schema_changed());
     }
 
     #[test]
     fn test_create_table_as_sharded() {
-        let root = parse_stmt("CREATE TABLE shard_1.new_table AS SELECT * FROM other");
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
+        let command = parse_stmt("CREATE TABLE shard_1.new_table AS SELECT * FROM other");
         assert_eq!(command.route().shard(), &Shard::Direct(1));
         assert!(command.route().is_schema_changed());
     }
 
     #[test]
     fn test_create_table_as_unsharded() {
-        let root = parse_stmt("CREATE TABLE public.new_table AS SELECT * FROM other");
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
+        let command = parse_stmt("CREATE TABLE public.new_table AS SELECT * FROM other");
         assert_eq!(command.route().shard(), &Shard::All);
         assert!(command.route().is_schema_changed());
     }
 
     #[test]
     fn test_lock_table() {
-        let root = parse_stmt(r#"LOCK TABLE "shard_1"."__migrations_table""#);
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
+        let command = parse_stmt(r#"LOCK TABLE "shard_1"."__migrations_table""#);
         assert_eq!(command.route().shard(), &Shard::Direct(1));
         assert!(!command.route().is_schema_changed());
     }
 
     #[test]
     fn test_create_function_sharded() {
-        let root = parse_stmt(
+        let command = parse_stmt(
             "CREATE FUNCTION shard_0.test_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql",
         );
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
         assert_eq!(command.route().shard(), &Shard::Direct(0));
         assert!(!command.route().is_schema_changed());
     }
 
     #[test]
     fn test_create_function_unsharded() {
-        let root = parse_stmt(
+        let command = parse_stmt(
             "CREATE FUNCTION public.test_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql",
         );
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
         assert_eq!(command.route().shard(), &Shard::All);
         assert!(!command.route().is_schema_changed());
     }
 
     #[test]
     fn test_create_enum_sharded() {
-        let root = parse_stmt("CREATE TYPE shard_1.mood AS ENUM ('sad', 'ok', 'happy')");
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
+        let command = parse_stmt("CREATE TYPE shard_1.mood AS ENUM ('sad', 'ok', 'happy')");
         assert_eq!(command.route().shard(), &Shard::Direct(1));
         assert!(!command.route().is_schema_changed());
     }
 
     #[test]
     fn test_create_enum_unsharded() {
-        let root = parse_stmt("CREATE TYPE public.mood AS ENUM ('sad', 'ok', 'happy')");
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
+        let command = parse_stmt("CREATE TYPE public.mood AS ENUM ('sad', 'ok', 'happy')");
         assert_eq!(command.route().shard(), &Shard::All);
         assert!(!command.route().is_schema_changed());
     }
@@ -535,9 +703,7 @@ mod test {
     #[test]
     fn test_alter_owner_sharded() {
         // Note: ALTER TABLE ... OWNER TO is parsed as AlterTableStmt, not AlterOwnerStmt
-        let root = parse_stmt("ALTER TABLE shard_0.test OWNER TO new_owner");
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
+        let command = parse_stmt("ALTER TABLE shard_0.test OWNER TO new_owner");
         assert_eq!(command.route().shard(), &Shard::Direct(0));
         assert!(command.route().is_schema_changed());
     }
@@ -545,134 +711,104 @@ mod test {
     #[test]
     fn test_alter_owner_unsharded() {
         // Note: ALTER TABLE ... OWNER TO is parsed as AlterTableStmt, not AlterOwnerStmt
-        let root = parse_stmt("ALTER TABLE public.test OWNER TO new_owner");
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
+        let command = parse_stmt("ALTER TABLE public.test OWNER TO new_owner");
         assert_eq!(command.route().shard(), &Shard::All);
         assert!(command.route().is_schema_changed());
     }
 
     #[test]
     fn test_rename_table_sharded() {
-        let root = parse_stmt("ALTER TABLE shard_1.test RENAME TO new_test");
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
+        let command = parse_stmt("ALTER TABLE shard_1.test RENAME TO new_test");
         assert_eq!(command.route().shard(), &Shard::Direct(1));
         assert!(!command.route().is_schema_changed());
     }
 
     #[test]
     fn test_rename_table_unsharded() {
-        let root = parse_stmt("ALTER TABLE public.test RENAME TO new_test");
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
+        let command = parse_stmt("ALTER TABLE public.test RENAME TO new_test");
         assert_eq!(command.route().shard(), &Shard::All);
         assert!(!command.route().is_schema_changed());
     }
 
     #[test]
     fn test_alter_table_sharded() {
-        let root = parse_stmt("ALTER TABLE shard_0.test ADD COLUMN new_col INT");
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
+        let command = parse_stmt("ALTER TABLE shard_0.test ADD COLUMN new_col INT");
         assert_eq!(command.route().shard(), &Shard::Direct(0));
         assert!(command.route().is_schema_changed());
     }
 
     #[test]
     fn test_alter_table_unsharded() {
-        let root = parse_stmt("ALTER TABLE public.test ADD COLUMN new_col INT");
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
+        let command = parse_stmt("ALTER TABLE public.test ADD COLUMN new_col INT");
         assert_eq!(command.route().shard(), &Shard::All);
         assert!(command.route().is_schema_changed());
     }
 
     #[test]
     fn test_alter_sequence_sharded() {
-        let root = parse_stmt("ALTER SEQUENCE shard_1.test_seq RESTART WITH 100");
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
+        let command = parse_stmt("ALTER SEQUENCE shard_1.test_seq RESTART WITH 100");
         assert_eq!(command.route().shard(), &Shard::Direct(1));
         assert!(!command.route().is_schema_changed());
     }
 
     #[test]
     fn test_alter_sequence_unsharded() {
-        let root = parse_stmt("ALTER SEQUENCE public.test_seq RESTART WITH 100");
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
+        let command = parse_stmt("ALTER SEQUENCE public.test_seq RESTART WITH 100");
         assert_eq!(command.route().shard(), &Shard::All);
         assert!(!command.route().is_schema_changed());
     }
 
     #[test]
     fn test_vacuum_sharded() {
-        let root = parse_stmt("VACUUM shard_0.test");
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
+        let command = parse_stmt("VACUUM shard_0.test");
         assert_eq!(command.route().shard(), &Shard::Direct(0));
         assert!(!command.route().is_schema_changed());
     }
 
     #[test]
     fn test_vacuum_unsharded() {
-        let root = parse_stmt("VACUUM public.test");
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
+        let command = parse_stmt("VACUUM public.test");
         assert_eq!(command.route().shard(), &Shard::All);
         assert!(!command.route().is_schema_changed());
     }
 
     #[test]
     fn test_vacuum_no_table() {
-        let root = parse_stmt("VACUUM");
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
+        let command = parse_stmt("VACUUM");
         assert_eq!(command.route().shard(), &Shard::All);
         assert!(!command.route().is_schema_changed());
     }
 
     #[test]
     fn test_truncate_single_table_sharded() {
-        let root = parse_stmt("TRUNCATE shard_0.test");
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
+        let command = parse_stmt("TRUNCATE shard_0.test");
         assert_eq!(command.route().shard(), &Shard::Direct(0));
         assert!(!command.route().is_schema_changed());
     }
 
     #[test]
     fn test_truncate_single_table_unsharded() {
-        let root = parse_stmt("TRUNCATE public.test");
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
+        let command = parse_stmt("TRUNCATE public.test");
         assert_eq!(command.route().shard(), &Shard::All);
         assert!(!command.route().is_schema_changed());
     }
 
     #[test]
     fn test_truncate_multiple_tables_same_shard() {
-        let root = parse_stmt("TRUNCATE shard_0.test1, shard_0.test2");
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
+        let command = parse_stmt("TRUNCATE shard_0.test1, shard_0.test2");
         assert_eq!(command.route().shard(), &Shard::Direct(0));
         assert!(!command.route().is_schema_changed());
     }
 
     #[test]
+    #[should_panic]
     fn test_truncate_cross_shard_error() {
-        let root = parse_stmt("TRUNCATE shard_0.test1, shard_1.test2");
-        let mut calculator = ShardsWithPriority::default();
-        let result = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator);
-        assert!(result.is_err());
+        parse_stmt("TRUNCATE shard_0.test1, shard_1.test2");
     }
 
     #[test]
     fn test_unhandled_ddl_defaults_to_all() {
-        let root = parse_stmt("COMMENT ON TABLE public.test IS 'test comment'");
-        let mut calculator = ShardsWithPriority::default();
-        let command = QueryParser::shard_ddl(&root, &test_schema(), &mut calculator).unwrap();
+        let command = parse_stmt("COMMENT ON TABLE public.test IS 'test comment'");
         assert_eq!(command.route().shard(), &Shard::All);
         assert!(!command.route().is_schema_changed());
     }

--- a/pgdog/src/frontend/router/parser/query/mod.rs
+++ b/pgdog/src/frontend/router/parser/query/mod.rs
@@ -38,12 +38,13 @@ mod update;
 #[cfg(feature = "new_parser")]
 use itertools::*;
 use multi_tenant::MultiTenantCheck;
-use pg_query::NodeEnum;
-use pg_query::protobuf::Node as PgNode;
 #[cfg(feature = "new_parser")]
 use pg_raw_parse::{Node, nodes};
 #[cfg(not(feature = "new_parser"))]
-use pgdog_plugin::pg_query::protobuf::{a_const::Val, *};
+use pgdog_plugin::pg_query::{
+    Node as PgNode, NodeEnum,
+    protobuf::{a_const::Val, *},
+};
 use plugins::PluginOutput;
 
 use tracing::{debug, trace};
@@ -314,16 +315,6 @@ impl QueryParser {
             )));
         };
 
-        let old_root = &statement
-            .parse_result()
-            .protobuf
-            .stmts
-            .first()
-            .unwrap()
-            .stmt
-            .as_ref()
-            .unwrap()
-            .node;
         let mut command = match root.stmt() {
             Node::VariableSetStmt(stmt) => return self.set(stmt, context),
 
@@ -397,7 +388,7 @@ impl QueryParser {
                 });
             }
 
-            _ => self.ddl(old_root, context),
+            node => self.ddl(node, context),
         }?;
 
         // e.g. Parse, Describe, Flush-style flow.

--- a/pgdog/src/frontend/router/parser/query/update.rs
+++ b/pgdog/src/frontend/router/parser/query/update.rs
@@ -59,6 +59,8 @@ impl QueryParser {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "new_parser")]
+    use pg_query::NodeEnum;
 
     #[test]
     fn update_preserves_decimal_values() {

--- a/pgdog/src/frontend/router/parser/table.rs
+++ b/pgdog/src/frontend/router/parser/table.rs
@@ -164,7 +164,7 @@ impl<'a> TryFrom<&'a CastNodeList<nodes::String>> for Table<'a> {
     type Error = Error;
 
     fn try_from(value: &'a CastNodeList<nodes::String>) -> Result<Self, Self::Error> {
-        let mut list = value.into_iter();
+        let mut list = value.into_iter().rev();
         let name = list
             .next()
             .and_then(nodes::String::sval)
@@ -190,7 +190,7 @@ impl<'a> TryFrom<&'a NodeList> for Table<'a> {
     type Error = Error;
 
     fn try_from(value: &'a NodeList) -> Result<Self, Self::Error> {
-        let mut list = value.into_iter();
+        let mut list = value.into_iter().rev();
         let name = list
             .next()
             .and_then(Node::as_str)

--- a/pgdog/src/frontend/router/parser/table.rs
+++ b/pgdog/src/frontend/router/parser/table.rs
@@ -1,9 +1,14 @@
 use std::fmt::Display;
 
+use pg_query::Node as PgNode;
 use pg_query::{
-    Node, NodeEnum,
+    NodeEnum,
     protobuf::{List, RangeVar},
 };
+#[cfg(feature = "new_parser")]
+use pg_raw_parse::list::{CastNodeList, NodeList};
+#[cfg(feature = "new_parser")]
+use pg_raw_parse::{Node, nodes};
 
 use super::{Error, Schema};
 use crate::util::escape_identifier;
@@ -56,10 +61,10 @@ impl<'a> TryFrom<pg_raw_parse::Node<'a>> for Table<'a> {
     }
 }
 
-impl<'a> TryFrom<&'a Node> for Table<'a> {
+impl<'a> TryFrom<&'a PgNode> for Table<'a> {
     type Error = ();
 
-    fn try_from(value: &'a Node) -> Result<Self, Self::Error> {
+    fn try_from(value: &'a PgNode) -> Result<Self, Self::Error> {
         if let Some(NodeEnum::RangeVar(range_var)) = &value.node {
             return Ok(range_var.into());
         }
@@ -68,10 +73,10 @@ impl<'a> TryFrom<&'a Node> for Table<'a> {
     }
 }
 
-impl<'a> TryFrom<&'a Vec<Node>> for Table<'a> {
+impl<'a> TryFrom<&'a Vec<PgNode>> for Table<'a> {
     type Error = Error;
 
-    fn try_from(value: &'a Vec<Node>) -> Result<Self, Self::Error> {
+    fn try_from(value: &'a Vec<PgNode>) -> Result<Self, Self::Error> {
         match value.len() {
             1 => {
                 let table = value
@@ -151,6 +156,57 @@ impl<'a> From<&'a RangeVar> for Table<'a> {
                 None
             },
             alias,
+        }
+    }
+}
+#[cfg(feature = "new_parser")]
+impl<'a> TryFrom<&'a CastNodeList<nodes::String>> for Table<'a> {
+    type Error = Error;
+
+    fn try_from(value: &'a CastNodeList<nodes::String>) -> Result<Self, Self::Error> {
+        let mut list = value.into_iter();
+        let name = list
+            .next()
+            .and_then(nodes::String::sval)
+            .ok_or(Error::TableDecode)?;
+        match (list.next(), list.next()) {
+            (schema, None) => {
+                let schema = schema
+                    .map(|s| s.sval().ok_or(Error::TableDecode))
+                    .transpose()?;
+                Ok(Self {
+                    schema,
+                    name,
+                    alias: None,
+                })
+            }
+            (_, Some(_)) => Err(Error::TableDecode),
+        }
+    }
+}
+
+#[cfg(feature = "new_parser")]
+impl<'a> TryFrom<&'a NodeList> for Table<'a> {
+    type Error = Error;
+
+    fn try_from(value: &'a NodeList) -> Result<Self, Self::Error> {
+        let mut list = value.into_iter();
+        let name = list
+            .next()
+            .and_then(Node::as_str)
+            .ok_or(Error::TableDecode)?;
+        match (list.next(), list.next()) {
+            (schema, None) => {
+                let schema = schema
+                    .map(|s| s.as_str().ok_or(Error::TableDecode))
+                    .transpose()?;
+                Ok(Self {
+                    schema,
+                    name,
+                    alias: None,
+                })
+            }
+            (_, Some(_)) => Err(Error::TableDecode),
         }
     }
 }

--- a/pgdog/src/frontend/router/parser/table.rs
+++ b/pgdog/src/frontend/router/parser/table.rs
@@ -191,10 +191,13 @@ impl<'a> TryFrom<&'a NodeList> for Table<'a> {
 
     fn try_from(value: &'a NodeList) -> Result<Self, Self::Error> {
         let mut list = value.into_iter().rev();
-        let name = list
-            .next()
-            .and_then(Node::as_str)
-            .ok_or(Error::TableDecode)?;
+        let name = match list.next() {
+            Some(Node::String(s)) => s.sval(),
+            Some(Node::NodeList(l)) if value.len() == 1 => return Self::try_from(l),
+            _ => None,
+        }
+        .ok_or(Error::TableDecode)?;
+
         match (list.next(), list.next()) {
             (schema, None) => {
                 let schema = schema


### PR DESCRIPTION
This contains a minor behavioral change for `DO` statements, ensuring we operate on the actual code block and not the language declaration. The behavior for this type of node is somewhat nonsensical though, as we're parsing individual lines which may not be a complete statement, and the body is always going to be a language we can't actually parse. Even if the language is plpgsql, correctly finding a line that is a valid DDL statement is unlikely to succeed

Other than that, the only other change is some refactoring of tests.