### PR TITLE
fix(replication): fix wait_for_replication logic for unrelated changes

### DIFF
--- a/pgdog/src/backend/replication/logical/orchestrator.rs
+++ b/pgdog/src/backend/replication/logical/orchestrator.rs
@@ -910,7 +910,7 @@ mod tests {
 
         // 30s margin: keepalive cadence (wal_sender_timeout) is not bounded by
         // the 1s sleep, so give confirmed_flush_lsn room to advance.
-        let result = timeout(Duration::from_secs(30), waiter.wait_for_replication()).await;
+        let result = timeout(Duration::from_secs(20), waiter.wait_for_replication()).await;
         let maintenance_on = maintenance_mode::is_on("");
 
         // Clean up before asserting so a failure can't leak slots or maintenance mode.

--- a/pgdog/src/backend/replication/logical/publisher/publisher_impl.rs
+++ b/pgdog/src/backend/replication/logical/publisher/publisher_impl.rs
@@ -271,18 +271,20 @@ impl Publisher {
                                         if let Some(ReplicationMeta::KeepAlive(ka)) =
                                             data.replication_meta()
                                         {
-                                            // Between transactions, advance the
-                                            // confirmed position to the keepalive's
-                                            // wal_end: the slot has drained and the
-                                            // gap to wal_end is unrelated WAL the
-                                            // publication will never decode. Skipped
-                                            // mid-transaction so a reply can't confirm
-                                            // past an unapplied commit.
-                                            if !stream.in_transaction() {
-                                                stream.set_current_lsn(ka.wal_end);
-                                            }
+                                            // Advance the lsn if we are not in the transaction currently
+                                            // (we don't use transactions actually without streaming on protocol version 4,
+                                            // but let it be as a safeguard).
+                                            // If we got the keep-alive message and not the update message
+                                            // then it's for the unrelated changes that advanced WAL.
+                                            // Since it's unrelated we can advance our progress and
+                                            // consider that lag replication
+                                            let advanced = !stream.in_transaction()
+                                                && stream.set_current_lsn(ka.wal_end);
 
-                                            if ka.reply() {
+                                            // Reply to walsender if it asked for reply or
+                                            // if we advanced due to the WAL progress but
+                                            // the update was not related
+                                            if advanced || ka.reply() {
                                                 slot.status_update(stream.status_update()).await?;
                                             }
                                             debug!(

--- a/pgdog/src/backend/replication/logical/publisher/slot.rs
+++ b/pgdog/src/backend/replication/logical/publisher/slot.rs
@@ -49,6 +49,9 @@ pub struct ReplicationSlot {
     snapshot: Snapshot,
     lsn: Lsn,
     dropped: bool,
+    /// CopyDone sent — our copy-in half is closed, so no further CopyData
+    /// (status updates included) may be written until the stream restarts.
+    stopped: bool,
     server: Option<Server>,
     kind: SlotKind,
     server_meta: Option<Server>,
@@ -73,6 +76,7 @@ impl ReplicationSlot {
             lsn: Lsn::default(),
             publication: publication.to_string(),
             dropped: false,
+            stopped: false,
             server: None,
             kind: SlotKind::Replication,
             server_meta: None,
@@ -91,6 +95,7 @@ impl ReplicationSlot {
             lsn: Lsn::default(),
             publication: publication.to_string(),
             dropped: true, // Temporary.
+            stopped: false,
             server: None,
             kind: SlotKind::DataSync,
             server_meta: None,
@@ -296,6 +301,8 @@ impl ReplicationSlot {
 
     /// Start replication.
     pub async fn start_replication(&mut self) -> Result<(), Error> {
+        // Fresh copy stream (including after a reconnect): re-enable status updates.
+        self.stopped = false;
         let is_binary = config().config.general.resharding_copy_format == CopyFormat::Binary;
         // TODO: This is definitely Postgres version-specific.
         let query = Query::new(format!(
@@ -359,6 +366,14 @@ impl ReplicationSlot {
 
     /// Update origin on last flushed LSN.
     pub async fn status_update(&mut self, status_update: StatusUpdate) -> Result<(), Error> {
+        // Once CopyDone is sent, our copy-in half is closed and any further
+        // CopyData would violate the copy protocol. The origin resends
+        // unconfirmed WAL on reconnect and our applies are idempotent, so
+        // dropping the confirm during teardown is safe.
+        if self.stopped {
+            return Ok(());
+        }
+
         debug!(
             "confirmed {} flushed [{}]",
             status_update.last_flushed,
@@ -391,6 +406,7 @@ impl ReplicationSlot {
     pub async fn stop_replication(&mut self) -> Result<(), Error> {
         self.server()?.send_one(&CopyDone.into()).await?;
         self.server()?.flush().await?;
+        self.stopped = true;
 
         Ok(())
     }


### PR DESCRIPTION
Send the updates to the walsender also when we advance the LSN track. 

That updates the walsender pointer more often and that makes our check for replication lag more relevant. The issue with the test was that it were sent only when walsender was asking for the reply, but with default settings it happens like around once in 30sec, just like the test initial waiting time - so it passed sometimes. Too bad on my local machine I had the timeout like 1sec (thanks clunker I guess) and I haven't caught the issue earlier.