### PR TITLE
authentication plugins as a generic client-auth hook

### DIFF
--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -1,22 +1,21 @@
 name: plugin-ci
+
 on:
   push:
-    branches:
-      - main
   pull_request:
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   plugin-unit-tests:
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    continue-on-error: true
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Install CI deps
         run: bash integration/ci/install-deps.sh
-      - uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: "plugin-unit-v1"
       - name: Run plugin unit tests
-        run: cargo nextest run -E 'package(pgdog-example-plugin)' --no-fail-fast
+        run: cargo nextest run -E 'package(pgdog-example-plugin) | package(pgdog-google-auth)' --no-fail-fast

--- a/.schema/pgdog.schema.json
+++ b/.schema/pgdog.schema.json
@@ -26,6 +26,7 @@
       "$ref": "#/$defs/General",
       "default": {
         "auth_type": "scram",
+        "background_workers": 4,
         "ban_replica_lag": 9223372036854775807,
         "ban_replica_lag_bytes": 9223372036854775807,
         "ban_timeout": 300000,
@@ -312,6 +313,11 @@
           "description": "Plaintext password.",
           "type": "string",
           "const": "plain"
+        },
+        {
+          "description": "Delegate client authentication to a loaded plugin exposing the `pgdog_authenticate` hook.",
+          "type": "string",
+          "const": "plugin"
         }
       ]
     },
@@ -594,6 +600,13 @@
           "description": "What kind of authentication mechanism to use for client connections.\n\n_Default:_ `scram`\n\nhttps://docs.pgdog.dev/configuration/pgdog.toml/general/#auth_type",
           "$ref": "#/$defs/AuthType",
           "default": "scram"
+        },
+        "background_workers": {
+          "description": "Maximum number of authentication-plugin calls allowed to run concurrently.\nAuthentication plugins run on a blocking thread pool (auth happens once per\nconnection and may block on I/O); this bounds how many run at the same time.\n\n**Note:** Only relevant when `auth_type = \"plugin\"`.\n\n_Default:_ `4`\n\nhttps://docs.pgdog.dev/configuration/pgdog.toml/general/#background_workers",
+          "type": "integer",
+          "format": "uint",
+          "default": 4,
+          "minimum": 0
         },
         "ban_replica_lag": {
           "description": "Ban a replica from serving read queries if its replication lag (in milliseconds) exceeds this threshold.\n\nhttps://docs.pgdog.dev/configuration/pgdog.toml/general/#ban_replica_lag",

--- a/.schema/pgdog.schema.json
+++ b/.schema/pgdog.schema.json
@@ -26,6 +26,7 @@
       "$ref": "#/$defs/General",
       "default": {
         "auth_type": "scram",
+        "background_workers": 4,
         "ban_replica_lag": 9223372036854775807,
         "ban_replica_lag_bytes": 9223372036854775807,
         "ban_timeout": 300000,
@@ -321,6 +322,11 @@
           "description": "Plaintext password.",
           "type": "string",
           "const": "plain"
+        },
+        {
+          "description": "Delegate client authentication to a loaded plugin exposing the `pgdog_authenticate` hook.",
+          "type": "string",
+          "const": "plugin"
         }
       ]
     },
@@ -657,6 +663,13 @@
           "description": "What kind of authentication mechanism to use for client connections.\n\n_Default:_ `scram`\n\n<https://docs.pgdog.dev/configuration/pgdog.toml/general/#auth_type>",
           "$ref": "#/$defs/AuthType",
           "default": "scram"
+        },
+        "background_workers": {
+          "description": "Maximum number of authentication-plugin calls allowed to run concurrently.\nAuthentication plugins run on a blocking thread pool (auth happens once per\nconnection and may block on I/O); this bounds how many run at the same time.\n\n**Note:** Only relevant when `auth_type = \"plugin\"`.\n\n_Default:_ `4`\n\nhttps://docs.pgdog.dev/configuration/pgdog.toml/general/#background_workers",
+          "type": "integer",
+          "format": "uint",
+          "default": 4,
+          "minimum": 0
         },
         "ban_replica_lag": {
           "description": "Ban a replica from serving read queries if its replication lag (in milliseconds) exceeds this threshold.\n\n<https://docs.pgdog.dev/configuration/pgdog.toml/general/#ban_replica_lag>",

--- a/.schema/users.schema.json
+++ b/.schema/users.schema.json
@@ -268,6 +268,13 @@
             "null"
           ]
         },
+        "server_role": {
+          "description": "PostgreSQL role this user's backend connections assume via the `role` startup\nparameter, used for impersonation with `auth_type = \"plugin\"`.\n\n**Note:** The user config no longer supplies the Postgres password when a plugin\nderives the login, so a working backend credential must be provided via\n`server_password` or a non-default `server_auth`. `SET ROLE`, `RESET ROLE`, and\n`SET SESSION AUTHORIZATION` are rejected on pools that set this.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "server_user": {
           "description": "Which user to connect with when creating backend connections from PgDog to PostgreSQL. By default, the user configured in `name` is used. This setting allows you to override this configuration and use a different user.\n\n**Note:** Values specified in `pgdog.toml` take priority over this configuration.\n\nhttps://docs.pgdog.dev/configuration/users.toml/users/#server_user",
           "type": [

--- a/.schema/users.schema.json
+++ b/.schema/users.schema.json
@@ -322,6 +322,13 @@
             "null"
           ]
         },
+        "server_role": {
+          "description": "PostgreSQL role this user's backend connections assume via the `role` startup\nparameter, used for impersonation with `auth_type = \"plugin\"`.\n\n**Note:** The user config no longer supplies the Postgres password when a plugin\nderives the login, so a working backend credential must be provided via\n`server_password` or a non-default `server_auth`. `SET ROLE`, `RESET ROLE`, and\n`SET SESSION AUTHORIZATION` are rejected on pools that set this.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "server_user": {
           "description": "Which user to connect with when creating backend connections from PgDog to PostgreSQL. By default, the user configured in `name` is used. This setting allows you to override this configuration and use a different user.\n\n**Note:** Values specified in `pgdog.toml` take priority over this configuration.\n\n<https://docs.pgdog.dev/configuration/users.toml/users/#server_user>",
           "type": [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3463,7 +3463,7 @@ dependencies = [
 
 [[package]]
 name = "pgdog-plugin"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bindgen 0.71.1",
  "libloading",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3122,7 +3122,7 @@ dependencies = [
 
 [[package]]
 name = "pgdog-plugin"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bindgen 0.71.1",
  "libloading",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3099,6 +3099,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "pgdog-google-auth"
+version = "0.1.0"
+dependencies = [
+ "once_cell",
+ "parking_lot",
+ "pgdog-plugin",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+ "toml",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "pgdog-jsonschema"
 version = "0.1.0"
 dependencies = [
@@ -3625,6 +3642,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -3645,6 +3663,7 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 edition = "2024"
 
 [workspace.dependencies]
-pgdog-plugin = { path = "./pgdog-plugin", version = "0.4.0", default-features = false }
+pgdog-plugin = { path = "./pgdog-plugin", version = "0.5.0", default-features = false }
 pgdog-config = { path = "./pgdog-config", version = "0.1.0" }
 pgdog-postgres-types = { path = "./pgdog-postgres-types"}
 pg_raw_parse = { git = "https://github.com/pgdogdev/pg_raw_parse.git", rev = "457b7c9" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,9 @@ members = [
   "pgdog-postgres-types",
   "pgdog-stats",
   "pgdog-vector",
-  "plugins/pgdog-example-plugin", "plugins/pgdog-primary-only-tables",
+  "plugins/pgdog-example-plugin",
+  "plugins/pgdog-google-auth",
+  "plugins/pgdog-primary-only-tables",
   "scripts/*",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 edition = "2024"
 
 [workspace.dependencies]
-pgdog-plugin = { path = "./pgdog-plugin", version = "0.4.0", default-features = false }
+pgdog-plugin = { path = "./pgdog-plugin", version = "0.5.0", default-features = false }
 pgdog-config = { path = "./pgdog-config", version = "0.1.0" }
 pgdog-postgres-types = { path = "./pgdog-postgres-types"}
 pg_raw_parse = { git = "https://github.com/pgdogdev/pg_raw_parse.git", rev = "6870860" }

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,13 +17,15 @@ RUN source ~/.cargo/env && \
     cd pgdog && \
     cargo build --release "${cargo_features[@]}" && \
     cd .. && \
-    cargo build --release -p pgdog-primary-only-tables "${cargo_features[@]}"
+    cargo build --release -p pgdog-primary-only-tables && \
+    cargo build --release -p pgdog-google-auth
 
 FROM ${RUNTIME_BASE}
 ENV RUST_LOG=info
 
 COPY --from=builder /build/target/release/pgdog /usr/local/bin/pgdog
 COPY --from=builder /build/target/release/libpgdog_primary_only_tables.so /usr/lib/libpgdog_primary_only_tables.so
+COPY --from=builder /build/target/release/libpgdog_google_auth.so /usr/lib/libpgdog_google_auth.so
 
 WORKDIR /pgdog
 STOPSIGNAL SIGINT

--- a/example.pgdog.toml
+++ b/example.pgdog.toml
@@ -26,6 +26,12 @@ port = 6432
 # Default: 2
 # Recommended: 2 per CPU
 workers = 2
+# Maximum number of authentication-plugin calls allowed to run concurrently.
+# Auth plugins run on a blocking thread pool; this caps how many run at once.
+# Only relevant when auth_type = "plugin".
+#
+# Default: 4
+background_workers = 4
 # Maximum number of Postgres connections per user/database connection pool.
 #
 # Default: 10
@@ -265,6 +271,13 @@ mirror_queue = 128
 # - scram
 # - md5
 # - trust
+# - plain
+# - plugin: delegate client authentication to a loaded plugin exposing the
+#   `pgdog_authenticate` hook (see the [[plugins]] section). When set, every
+#   plugin returning Skip results in a denied login (there is no password
+#   fallback), so a capable plugin must be loaded. Use `background_workers`
+#   to cap concurrent plugin calls.
+# auth_type = "plugin"
 auth_type = "scram"
 # Disable cross-shard queries.
 #

--- a/example.pgdog.toml
+++ b/example.pgdog.toml
@@ -26,6 +26,12 @@ port = 6432
 # Default: 2
 # Recommended: 2 per CPU
 workers = 2
+# Maximum number of authentication-plugin calls allowed to run concurrently.
+# Auth plugins run on a blocking thread pool; this caps how many run at once.
+# Only relevant when auth_type = "plugin".
+#
+# Default: 4
+background_workers = 4
 # Maximum number of Postgres connections per user/database connection pool.
 #
 # Default: 10
@@ -291,6 +297,13 @@ mirror_queue = 128
 # - scram
 # - md5
 # - trust
+# - plain
+# - plugin: delegate client authentication to a loaded plugin exposing the
+#   `pgdog_authenticate` hook (see the [[plugins]] section). When set, every
+#   plugin returning Skip results in a denied login (there is no password
+#   fallback), so a capable plugin must be loaded. Use `background_workers`
+#   to cap concurrent plugin calls.
+# auth_type = "plugin"
 auth_type = "scram"
 # Disable cross-shard queries.
 #

--- a/example.pgdog.toml
+++ b/example.pgdog.toml
@@ -299,10 +299,11 @@ mirror_queue = 128
 # - trust
 # - plain
 # - plugin: delegate client authentication to a loaded plugin exposing the
-#   `pgdog_authenticate` hook (see the [[plugins]] section). When set, every
-#   plugin returning Skip results in a denied login (there is no password
-#   fallback), so a capable plugin must be loaded. Use `background_workers`
-#   to cap concurrent plugin calls.
+#   `pgdog_authenticate` hook (see the [[plugins]] section). When every plugin
+#   returns Skip, PgDog falls back to the configured user password or
+#   passthrough authentication for users not already configured as plugin-only.
+#   An explicit Deny remains terminal. Use `background_workers` to cap
+#   concurrent plugin calls.
 # auth_type = "plugin"
 auth_type = "scram"
 # Disable cross-shard queries.

--- a/example.users.toml
+++ b/example.users.toml
@@ -43,3 +43,19 @@ password = "pgdog"
 # server_user = "pgdog_service"
 # server_auth = "vault_static"
 # server_vault_path = "database/static-creds/pgdog-service"
+
+# Example: role impersonation with plugin authentication (`auth_type = "plugin"`
+# in pgdog.toml). Backend connections for this user assume `server_role` via the
+# `role` startup parameter, and `SET ROLE` / `RESET ROLE` / `SET SESSION
+# AUTHORIZATION` are rejected on the resulting pools.
+#
+# NOTE: the client no longer supplies the Postgres password (the plugin derives
+# the login), so a working backend credential MUST be provided here via
+# `server_password` (or a non-default `server_auth`). Without one, PgDog cannot
+# open server connections and warns at config load time.
+# [[users]]
+# name = "analytics"
+# database = "pgdog"
+# server_role = "analytics_ro"
+# server_user = "pgdog"
+# server_password = "pgdog"

--- a/example.users.toml
+++ b/example.users.toml
@@ -48,3 +48,19 @@ password = "pgdog"
 # a client certificate, while mTLS users share the same listener. Defaults to true.
 # Only applies when `tls_client_ca_certificate` is set in pgdog.toml.
 # tls_client_certificate_required = false
+
+# Example: role impersonation with plugin authentication (`auth_type = "plugin"`
+# in pgdog.toml). Backend connections for this user assume `server_role` via the
+# `role` startup parameter, and `SET ROLE` / `RESET ROLE` / `SET SESSION
+# AUTHORIZATION` are rejected on the resulting pools.
+#
+# NOTE: the client no longer supplies the Postgres password (the plugin derives
+# the login), so a working backend credential MUST be provided here via
+# `server_password` (or a non-default `server_auth`). Without one, PgDog cannot
+# open server connections and warns at config load time.
+# [[users]]
+# name = "analytics"
+# database = "pgdog"
+# server_role = "analytics_ro"
+# server_user = "pgdog"
+# server_password = "pgdog"

--- a/integration/common.sh
+++ b/integration/common.sh
@@ -63,10 +63,12 @@ function run_pgdog() {
                 --users ${config_path}/users.toml \
             > ${COMMON_DIR}/log.txt 2>&1 &
     else
+        # Capture stdout AND stderr: PgDog's tracing logs go to stderr, and the
+        # plugins auth suite asserts on log lines via integration/log.txt.
         "${binary}" \
             --config ${config_path}/pgdog.toml \
             --users ${config_path}/users.toml \
-            > ${COMMON_DIR}/log.txt &
+            > ${COMMON_DIR}/log.txt 2>&1 &
     fi
     echo $! > "${pid_file}"
     printf '%s\n' "${config_path}" > "${config_file}"

--- a/integration/plugins/auth/auth_spec.rb
+++ b/integration/plugins/auth/auth_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require 'pg'
+require 'rspec'
+
+# PgDog's stdout/stderr is redirected here by integration/common.sh's run_pgdog.
+# The authentication driver warn!-logs deny reasons, so the suite can assert
+# they land in the log but never reach the client.
+LOG_FILE = File.expand_path('../../../log.txt', __FILE__)
+
+GENERIC_AUTH_ERROR = /is wrong, or the database does not exist/
+
+def connect(user, password, dbname: 'pgdog')
+  # Hash form avoids URL-encoding the ':' in credentials like
+  # "impersonate:reporting".
+  PG.connect(host: '127.0.0.1', port: 6432, user: user, password: password, dbname: dbname)
+end
+
+def current_user(conn)
+  conn.exec('SELECT current_user AS u')[0]['u']
+end
+
+# Poll the PgDog log for a line matching `pattern`. Rust's stdout is
+# line-buffered even when redirected, so a short poll is enough.
+def wait_for_log(pattern, timeout: 5.0)
+  deadline = Time.now + timeout
+  loop do
+    return true if File.exist?(LOG_FILE) && File.read(LOG_FILE).match?(pattern)
+    return false if Time.now > deadline
+
+    sleep 0.1
+  end
+end
+
+describe 'authentication plugin' do
+  it 'allows a client whose credential matches secret-<user> and can query' do
+    conn = connect('alice', 'secret-alice')
+    expect(conn.exec('SELECT 1 AS n')[0]['n'].to_i).to eq(1)
+    conn.close
+  end
+
+  it 'rejects a wrong credential with a generic auth error' do
+    expect { connect('alice', 'secret-bob') }
+      .to raise_error(PG::ConnectionBad, GENERIC_AUTH_ERROR)
+  end
+
+  it 'denies "deny" generically, logging the reason only in PgDog' do
+    error = nil
+    begin
+      connect('alice', 'deny')
+      raise 'expected the connection to be denied'
+    rescue PG::ConnectionBad => e
+      error = e
+    end
+
+    # Client sees the generic error, never the plugin's reason.
+    expect(error.message).to match(GENERIC_AUTH_ERROR)
+    expect(error.message).not_to include('test deny')
+
+    # PgDog logs the actual reason for the operator.
+    expect(wait_for_log(/denied by plugin .*test deny/)).to be(true)
+  end
+
+  it 'survives a panicking plugin and keeps serving' do
+    expect { connect('alice', 'panic') }
+      .to raise_error(PG::ConnectionBad, GENERIC_AUTH_ERROR)
+
+    # PgDog is still alive: a subsequent good login works.
+    conn = connect('alice', 'secret-alice')
+    expect(conn.exec('SELECT 1 AS n')[0]['n'].to_i).to eq(1)
+    conn.close
+  end
+
+  it 'denies an unknown credential when every plugin skips' do
+    expect { connect('alice', 'no-such-credential') }
+      .to raise_error(PG::ConnectionBad, GENERIC_AUTH_ERROR)
+  end
+
+  it 'provisions a pool and impersonates the derived role' do
+    conn = connect('reporting', 'impersonate:reporting')
+    expect(current_user(conn)).to eq('reporting')
+    conn.close
+  end
+
+  it 'keeps the impersonated role across connection reuse and cleanup' do
+    conn = connect('reporting', 'impersonate:reporting')
+
+    # Several transactions force the backend connection through the pool's
+    # cleanup path (RESET ALL / DISCARD ALL) between checkouts. Dirtying the
+    # session with a SET must not clear the role, which is a startup-parameter
+    # session default rather than a runtime SET.
+    10.times do
+      conn.exec('BEGIN')
+      conn.exec("SET work_mem = '8MB'")
+      expect(current_user(conn)).to eq('reporting')
+      conn.exec('COMMIT')
+    end
+
+    expect(current_user(conn)).to eq('reporting')
+    conn.close
+  end
+
+  it 'rejects role escapes on the impersonation pool but keeps the session usable' do
+    conn = connect('reporting', 'impersonate:reporting')
+
+    escapes = [
+      'SET ROLE someone_else',
+      'RESET ROLE',
+      'SET SESSION AUTHORIZATION someone_else',
+      # Multi-statement batch: the role change must be rejected even when it
+      # rides along with an innocuous statement.
+      'SELECT 1; SET ROLE someone_else',
+      # set_config with a non-constant value would otherwise pass through
+      # verbatim, escaping the guard.
+      "SELECT set_config('role', 'some' || 'one_else', false)"
+    ]
+    escapes.each do |stmt|
+      expect { conn.exec(stmt) }.to raise_error(PG::Error, /impersonates a fixed role/)
+      # Session survives the rejection and the role is unchanged.
+      expect(current_user(conn)).to eq('reporting')
+    end
+
+    # A multi-statement batch with no role change is still accepted.
+    conn.exec('SELECT 1; SELECT 2')
+    expect(current_user(conn)).to eq('reporting')
+
+    conn.close
+  end
+
+  it 'rejects INSERT on a read-only pool' do
+    conn = connect('readonly', 'secret-readonly')
+    expect { conn.exec('INSERT INTO auth_test (id) VALUES (1)') }
+      .to raise_error(PG::Error, /read-only transaction/)
+    conn.close
+  end
+end

--- a/integration/plugins/auth/auth_spec.rb
+++ b/integration/plugins/auth/auth_spec.rb
@@ -88,6 +88,14 @@ describe 'authentication plugin' do
     conn.close
   end
 
+  it 'impersonates the derived role on a pre-configured pool' do
+    # `auditor` is configured in users.toml without `server_role`; the grant
+    # must fill it in so queries do not run as the `pgdog` service account.
+    conn = connect('auditor', 'impersonate:auditor')
+    expect(current_user(conn)).to eq('auditor')
+    conn.close
+  end
+
   it 'keeps the impersonated role across connection reuse and cleanup' do
     conn = connect('reporting', 'impersonate:reporting')
 

--- a/integration/plugins/auth/auth_spec.rb
+++ b/integration/plugins/auth/auth_spec.rb
@@ -39,6 +39,12 @@ describe 'authentication plugin' do
     conn.close
   end
 
+  it 'falls back to the configured password when every plugin skips' do
+    conn = connect('alice', 'postgres-alice')
+    expect(conn.exec('SELECT 1 AS n')[0]['n'].to_i).to eq(1)
+    conn.close
+  end
+
   it 'rejects a wrong credential with a generic auth error' do
     expect { connect('alice', 'secret-bob') }
       .to raise_error(PG::ConnectionBad, GENERIC_AUTH_ERROR)
@@ -71,7 +77,7 @@ describe 'authentication plugin' do
     conn.close
   end
 
-  it 'denies an unknown credential when every plugin skips' do
+  it 'rejects an unknown credential when plugin and password authentication fail' do
     expect { connect('alice', 'no-such-credential') }
       .to raise_error(PG::ConnectionBad, GENERIC_AUTH_ERROR)
   end

--- a/integration/plugins/auth/pgdog.toml
+++ b/integration/plugins/auth/pgdog.toml
@@ -1,0 +1,19 @@
+#
+# Authentication-plugin integration suite.
+#
+# `auth_type = "plugin"` routes every non-admin login through the loaded
+# authentication plugins. `test_plugin_auth` (see
+# test-plugins/test-plugin-auth) makes the decisions the specs assert on.
+#
+[general]
+auth_type = "plugin"
+# Deny reasons are warn!-logged regardless, but log every connection attempt so
+# the spec can also observe the auth-error line.
+log_connections = true
+
+[[plugins]]
+name = "test_plugin_auth"
+
+[[databases]]
+name = "pgdog"
+host = "127.0.0.1"

--- a/integration/plugins/auth/pgdog.toml
+++ b/integration/plugins/auth/pgdog.toml
@@ -1,8 +1,8 @@
 #
 # Authentication-plugin integration suite.
 #
-# `auth_type = "plugin"` routes every non-admin login through the loaded
-# authentication plugins. `test_plugin_auth` (see
+# `auth_type = "plugin"` tries the loaded authentication plugins before
+# configured password authentication. `test_plugin_auth` (see
 # test-plugins/test-plugin-auth) makes the decisions the specs assert on.
 #
 [general]

--- a/integration/plugins/auth/setup.sql
+++ b/integration/plugins/auth/setup.sql
@@ -1,0 +1,15 @@
+-- Postgres-side prerequisites for the authentication-plugin suite.
+--
+-- Run directly against PostgreSQL (not through PgDog) as the `pgdog` service
+-- account. `run.sh` applies this before starting PgDog.
+
+-- Role impersonated via `impersonate:reporting`. It needs no LOGIN: PgDog
+-- connects as the `pgdog` service account and assumes the role through the
+-- `role` startup parameter. Grant it to the service account so a non-superuser
+-- deployment could assume it too.
+DROP ROLE IF EXISTS reporting;
+CREATE ROLE reporting NOLOGIN;
+GRANT reporting TO pgdog;
+
+-- Target table for the read-only pool INSERT rejection test.
+CREATE TABLE IF NOT EXISTS auth_test (id BIGINT);

--- a/integration/plugins/auth/setup.sql
+++ b/integration/plugins/auth/setup.sql
@@ -11,5 +11,12 @@ DROP ROLE IF EXISTS reporting;
 CREATE ROLE reporting NOLOGIN;
 GRANT reporting TO pgdog;
 
+-- Role impersonated via `impersonate:auditor`. Unlike `reporting`, its pool is
+-- pre-configured in users.toml (without `server_role`), so the plugin's grant
+-- has to fill the gap rather than provision the pool.
+DROP ROLE IF EXISTS auditor;
+CREATE ROLE auditor NOLOGIN;
+GRANT auditor TO pgdog;
+
 -- Target table for the read-only pool INSERT rejection test.
 CREATE TABLE IF NOT EXISTS auth_test (id BIGINT);

--- a/integration/plugins/auth/users.toml
+++ b/integration/plugins/auth/users.toml
@@ -1,0 +1,25 @@
+#
+# Users for the authentication-plugin suite.
+#
+# With `auth_type = "plugin"` the client no longer supplies the Postgres
+# password (the plugin authenticates the login), so these entries only define
+# the backend pool: `server_user`/`server_password` are the credentials PgDog
+# uses to connect to PostgreSQL.
+#
+# Impersonation users (e.g. `impersonate:reporting`) are not listed here: the
+# plugin derives them and PgDog auto-provisions their pools.
+
+# Plain allow via `secret-alice`, no derivation, read-write.
+[[users]]
+name = "alice"
+database = "pgdog"
+server_user = "pgdog"
+server_password = "pgdog"
+
+# Read-only pool: `INSERT` must fail with a read-only error.
+[[users]]
+name = "readonly"
+database = "pgdog"
+server_user = "pgdog"
+server_password = "pgdog"
+read_only = true

--- a/integration/plugins/auth/users.toml
+++ b/integration/plugins/auth/users.toml
@@ -23,3 +23,12 @@ database = "pgdog"
 server_user = "pgdog"
 server_password = "pgdog"
 read_only = true
+
+# Pre-configured pool with no `server_role`: the plugin's grant must fill the
+# gap so `impersonate:auditor` still runs queries as `auditor`, not as the
+# `pgdog` service account.
+[[users]]
+name = "auditor"
+database = "pgdog"
+server_user = "pgdog"
+server_password = "pgdog"

--- a/integration/plugins/auth/users.toml
+++ b/integration/plugins/auth/users.toml
@@ -1,10 +1,9 @@
 #
 # Users for the authentication-plugin suite.
 #
-# With `auth_type = "plugin"` the client no longer supplies the Postgres
-# password (the plugin authenticates the login), so these entries only define
-# the backend pool: `server_user`/`server_password` are the credentials PgDog
-# uses to connect to PostgreSQL.
+# Plugin-authenticated clients use `server_user`/`server_password` for the
+# backend pool. The `alice` entry also has a client password to exercise the
+# fallback used when every plugin skips.
 #
 # Impersonation users (e.g. `impersonate:reporting`) are not listed here: the
 # plugin derives them and PgDog auto-provisions their pools.
@@ -13,6 +12,7 @@
 [[users]]
 name = "alice"
 database = "pgdog"
+password = "postgres-alice"
 server_user = "pgdog"
 server_password = "pgdog"
 

--- a/integration/plugins/google/google-auth.toml
+++ b/integration/plugins/google/google-auth.toml
@@ -1,6 +1,6 @@
 tokeninfo_url = "http://127.0.0.1:18080/tokeninfo"
 require_tls = false
 require_user_match = true
-allowed_emails = ["alice@example.com"]
+allowed_emails = ["alice@example.com", "dave@example.com", "carol@example.com"]
 allowed_audiences = ["gcloud-client"]
 required_scopes = ["https://www.googleapis.com/auth/cloud-platform"]

--- a/integration/plugins/google/google-auth.toml
+++ b/integration/plugins/google/google-auth.toml
@@ -1,0 +1,6 @@
+tokeninfo_url = "http://127.0.0.1:18080/tokeninfo"
+require_tls = false
+require_user_match = true
+allowed_emails = ["alice@example.com"]
+allowed_audiences = ["gcloud-client"]
+required_scopes = ["https://www.googleapis.com/auth/cloud-platform"]

--- a/integration/plugins/google/google_auth_spec.rb
+++ b/integration/plugins/google/google_auth_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require 'pg'
+require 'rspec'
+require 'json'
+require 'socket'
+require 'uri'
+
+GENERIC_AUTH_ERROR = /is wrong, or the database does not exist/
+
+TOKEN_RESPONSES = {
+  'valid-google-token' => {
+    audience: 'gcloud-client',
+    user_id: '1234567890',
+    scope: 'openid email https://www.googleapis.com/auth/cloud-platform',
+    expires_in: 3600,
+    email: 'alice@example.com',
+    verified_email: true
+  },
+  'expired-google-token' => {
+    audience: 'gcloud-client',
+    user_id: '1234567890',
+    scope: 'https://www.googleapis.com/auth/cloud-platform',
+    expires_in: 0,
+    email: 'alice@example.com',
+    verified_email: true
+  },
+  'wrong-email-token' => {
+    audience: 'gcloud-client',
+    user_id: '9876543210',
+    scope: 'https://www.googleapis.com/auth/cloud-platform',
+    expires_in: 3600,
+    email: 'bob@example.com',
+    verified_email: true
+  },
+  'missing-scope-token' => {
+    audience: 'gcloud-client',
+    user_id: '1234567890',
+    scope: 'openid email',
+    expires_in: 3600,
+    email: 'alice@example.com',
+    verified_email: true
+  }
+}.freeze
+
+class TokenInfoServer
+  def initialize
+    @server = TCPServer.new('127.0.0.1', 18_080)
+    @thread = Thread.new { serve }
+  end
+
+  def stop
+    @server.close
+    @thread.join
+  end
+
+  private
+
+  def serve
+    loop do
+      socket = @server.accept
+      request_line = socket.gets
+      while (line = socket.gets)
+        break if line == "\r\n"
+      end
+
+      token = request_line && access_token(request_line)
+      body = TOKEN_RESPONSES[token]
+      if body
+        respond(socket, '200 OK', JSON.generate(body))
+      else
+        respond(socket, '400 Bad Request', JSON.generate(error: 'invalid_token'))
+      end
+    rescue IOError, Errno::EBADF
+      break
+    ensure
+      socket&.close
+    end
+  end
+
+  def access_token(request_line)
+    target = request_line.split[1]
+    URI.decode_www_form(URI(target).query.to_s).to_h['access_token']
+  end
+
+  def respond(socket, status, body)
+    socket.write(
+      "HTTP/1.1 #{status}\r\n" \
+      "Content-Type: application/json\r\n" \
+      "Content-Length: #{body.bytesize}\r\n" \
+      "Connection: close\r\n\r\n" \
+      "#{body}"
+    )
+  end
+end
+
+def connect(user, token)
+  PG.connect(
+    host: '127.0.0.1',
+    port: 6432,
+    user: user,
+    password: token,
+    dbname: 'pgdog'
+  )
+end
+
+describe 'Google access-token authentication plugin' do
+  before(:all) do
+    @token_info = TokenInfoServer.new
+  end
+
+  after(:all) do
+    @token_info.stop
+  end
+
+  it 'accepts a valid Google access token and runs a query' do
+    conn = connect('alice@example.com', 'valid-google-token')
+    expect(conn.exec('SELECT 1 AS n')[0]['n'].to_i).to eq(1)
+    conn.close
+  end
+
+  it 'rejects a token Google does not recognize with a generic error' do
+    expect { connect('alice@example.com', 'invalid-google-token') }
+      .to raise_error(PG::ConnectionBad, GENERIC_AUTH_ERROR)
+  end
+
+  it 'rejects an expired token' do
+    expect { connect('alice@example.com', 'expired-google-token') }
+      .to raise_error(PG::ConnectionBad, GENERIC_AUTH_ERROR)
+  end
+
+  it 'rejects a token for a different Google identity' do
+    expect { connect('alice@example.com', 'wrong-email-token') }
+      .to raise_error(PG::ConnectionBad, GENERIC_AUTH_ERROR)
+  end
+
+  it 'rejects a token missing a required scope' do
+    expect { connect('alice@example.com', 'missing-scope-token') }
+      .to raise_error(PG::ConnectionBad, GENERIC_AUTH_ERROR)
+  end
+end

--- a/integration/plugins/google/google_auth_spec.rb
+++ b/integration/plugins/google/google_auth_spec.rb
@@ -15,7 +15,7 @@ TOKEN_RESPONSES = {
     scope: 'openid email https://www.googleapis.com/auth/cloud-platform',
     expires_in: '3600',
     email: 'alice@example.com',
-    verified_email: true
+    verified_email: 'true'
   },
   'expired-google-token' => {
     audience: 'gcloud-client',
@@ -23,7 +23,7 @@ TOKEN_RESPONSES = {
     scope: 'https://www.googleapis.com/auth/cloud-platform',
     expires_in: '0',
     email: 'alice@example.com',
-    verified_email: true
+    verified_email: 'true'
   },
   'wrong-email-token' => {
     audience: 'gcloud-client',
@@ -31,7 +31,7 @@ TOKEN_RESPONSES = {
     scope: 'https://www.googleapis.com/auth/cloud-platform',
     expires_in: '3600',
     email: 'bob@example.com',
-    verified_email: true
+    verified_email: 'true'
   },
   'missing-scope-token' => {
     audience: 'gcloud-client',
@@ -39,7 +39,23 @@ TOKEN_RESPONSES = {
     scope: 'openid email',
     expires_in: '3600',
     email: 'alice@example.com',
-    verified_email: true
+    verified_email: 'true'
+  },
+  'dave-google-token' => {
+    audience: 'gcloud-client',
+    user_id: '2222222222',
+    scope: 'https://www.googleapis.com/auth/cloud-platform',
+    expires_in: '3600',
+    email: 'dave@example.com',
+    verified_email: 'true'
+  },
+  'carol-google-token' => {
+    audience: 'gcloud-client',
+    user_id: '3333333333',
+    scope: 'https://www.googleapis.com/auth/cloud-platform',
+    expires_in: '3600',
+    email: 'carol@example.com',
+    verified_email: 'true'
   }
 }.freeze
 
@@ -119,6 +135,14 @@ describe 'Google access-token authentication plugin' do
     conn.close
   end
 
+  it 'impersonates the Google identity on a pre-configured pool' do
+    # alice's users.toml entry has no `server_role`; the plugin's grant fills
+    # it, so queries run as the authenticated identity, not the service account.
+    conn = connect('alice@example.com', 'valid-google-token')
+    expect(conn.exec('SELECT current_user AS u')[0]['u']).to eq('alice@example.com')
+    conn.close
+  end
+
   it 'skips excluded users so PostgreSQL passthrough can authenticate them' do
     conn = connect('pgdog', 'pgdog')
     expect(conn.exec('SELECT 1 AS n')[0]['n'].to_i).to eq(1)
@@ -143,5 +167,26 @@ describe 'Google access-token authentication plugin' do
   it 'rejects a token missing a required scope' do
     expect { connect('alice@example.com', 'missing-scope-token') }
       .to raise_error(PG::ConnectionBad, GENERIC_AUTH_ERROR)
+  end
+
+  it 'rejects a valid login for an identity with no pool when provisioning is off' do
+    expect { connect('carol@example.com', 'carol-google-token') }
+      .to raise_error(PG::ConnectionBad, GENERIC_AUTH_ERROR)
+  end
+
+  # Keep this last: it leaves dave's pool unable to connect to Postgres.
+  it 'fails the connection when the impersonated role does not exist in Postgres' do
+    # dave authenticates and has a configured pool, but setup.sql never created
+    # his Postgres role: the backend refuses the `role` startup parameter, so
+    # the login (or, with cached server parameters, the first query) fails
+    # rather than falling back to the service account.
+    expect do
+      conn = connect('dave@example.com', 'dave-google-token')
+      begin
+        conn.exec('SELECT current_user')
+      ensure
+        conn.close
+      end
+    end.to raise_error(PG::Error)
   end
 end

--- a/integration/plugins/google/google_auth_spec.rb
+++ b/integration/plugins/google/google_auth_spec.rb
@@ -119,6 +119,12 @@ describe 'Google access-token authentication plugin' do
     conn.close
   end
 
+  it 'skips excluded users so PostgreSQL passthrough can authenticate them' do
+    conn = connect('pgdog', 'pgdog')
+    expect(conn.exec('SELECT 1 AS n')[0]['n'].to_i).to eq(1)
+    conn.close
+  end
+
   it 'rejects a token Google does not recognize with a generic error' do
     expect { connect('alice@example.com', 'invalid-google-token') }
       .to raise_error(PG::ConnectionBad, GENERIC_AUTH_ERROR)

--- a/integration/plugins/google/google_auth_spec.rb
+++ b/integration/plugins/google/google_auth_spec.rb
@@ -13,7 +13,7 @@ TOKEN_RESPONSES = {
     audience: 'gcloud-client',
     user_id: '1234567890',
     scope: 'openid email https://www.googleapis.com/auth/cloud-platform',
-    expires_in: 3600,
+    expires_in: '3600',
     email: 'alice@example.com',
     verified_email: true
   },
@@ -21,7 +21,7 @@ TOKEN_RESPONSES = {
     audience: 'gcloud-client',
     user_id: '1234567890',
     scope: 'https://www.googleapis.com/auth/cloud-platform',
-    expires_in: 0,
+    expires_in: '0',
     email: 'alice@example.com',
     verified_email: true
   },
@@ -29,7 +29,7 @@ TOKEN_RESPONSES = {
     audience: 'gcloud-client',
     user_id: '9876543210',
     scope: 'https://www.googleapis.com/auth/cloud-platform',
-    expires_in: 3600,
+    expires_in: '3600',
     email: 'bob@example.com',
     verified_email: true
   },
@@ -37,7 +37,7 @@ TOKEN_RESPONSES = {
     audience: 'gcloud-client',
     user_id: '1234567890',
     scope: 'openid email',
-    expires_in: 3600,
+    expires_in: '3600',
     email: 'alice@example.com',
     verified_email: true
   }

--- a/integration/plugins/google/pgdog.toml
+++ b/integration/plugins/google/pgdog.toml
@@ -1,5 +1,6 @@
 [general]
 auth_type = "plugin"
+passthrough_auth = "enabled_plain"
 log_connections = true
 
 [[plugins]]

--- a/integration/plugins/google/pgdog.toml
+++ b/integration/plugins/google/pgdog.toml
@@ -1,0 +1,11 @@
+[general]
+auth_type = "plugin"
+log_connections = true
+
+[[plugins]]
+name = "pgdog_google_auth"
+config = "integration/plugins/google/google-auth.toml"
+
+[[databases]]
+name = "pgdog"
+host = "127.0.0.1"

--- a/integration/plugins/google/users.toml
+++ b/integration/plugins/google/users.toml
@@ -1,0 +1,5 @@
+[[users]]
+name = "alice@example.com"
+database = "pgdog"
+server_user = "pgdog"
+server_password = "pgdog"

--- a/integration/plugins/google/users.toml
+++ b/integration/plugins/google/users.toml
@@ -1,5 +1,19 @@
+# Pre-configured pool without `server_role`: the plugin's grant fills it in on
+# login, so queries run as "alice@example.com", not as the service account.
+# `setup.sql` creates the role and grants it to `pgdog`.
 [[users]]
 name = "alice@example.com"
 database = "pgdog"
 server_user = "pgdog"
 server_password = "pgdog"
+
+# Same shape, but `setup.sql` deliberately does NOT create the Postgres role,
+# so the backend connection (and therefore the login) must fail.
+[[users]]
+name = "dave@example.com"
+database = "pgdog"
+server_user = "pgdog"
+server_password = "pgdog"
+
+# carol@example.com has no [[users]] entry and provisioning is off: her valid
+# Google login must fail because there is no pool for her identity.

--- a/integration/plugins/run.sh
+++ b/integration/plugins/run.sh
@@ -21,6 +21,10 @@ pushd ${SCRIPT_DIR}/test-plugins/test-plugin-compatible
 build_plugin
 popd
 
+pushd ${SCRIPT_DIR}/test-plugins/test-plugin-auth
+build_plugin
+popd
+
 pushd ${SCRIPT_DIR}/test-plugins/test-plugin-outdated
 cargo build --release
 popd
@@ -39,4 +43,17 @@ wait_for_pgdog
 
 bash ${SCRIPT_DIR}/dev.sh
 
+stop_pgdog
+
+# Phase 2: authentication plugin (auth_type = "plugin").
+# Postgres-side prerequisites (impersonated role, target table) go in first,
+# applied directly against PostgreSQL rather than through PgDog.
+PGPASSWORD=pgdog psql -h 127.0.0.1 -p 5432 -U pgdog -d pgdog -v ON_ERROR_STOP=1 \
+    -f ${SCRIPT_DIR}/auth/setup.sql
+
+run_pgdog ${SCRIPT_DIR}/auth
+wait_for_pgdog
+pushd ${SCRIPT_DIR}
+bundle exec rspec auth/auth_spec.rb
+popd
 stop_pgdog

--- a/integration/plugins/run.sh
+++ b/integration/plugins/run.sh
@@ -1,59 +1,72 @@
-#!/bin/bash
-set -e
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-source ${SCRIPT_DIR}/../common.sh
+#!/usr/bin/env bash
+set -euo pipefail
 
-# dev.sh runs rspec via bundler; native gem extensions need yaml + libpq headers.
-bash ${SCRIPT_DIR}/../ci/apt.sh ruby-dev libyaml-dev libpq-dev build-essential
-command -v bundle >/dev/null || sudo gem install bundler --no-document
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+source "${SCRIPT_DIR}/../common.sh"
 
-export CARGO_TARGET_DIR=${SCRIPT_DIR}/target
-
-function build_plugin() {
-    if [ -n "${PGDOG_PLUGIN_FEATURES:-}" ]; then
-        cargo build --release --no-default-features --features "${PGDOG_PLUGIN_FEATURES}"
-    else
-        cargo build --release
-    fi
+build_plugin() {
+  if [[ -n "${PGDOG_PLUGIN_FEATURES:-}" ]]; then
+    cargo build --release --no-default-features --features "${PGDOG_PLUGIN_FEATURES}"
+  else
+    cargo build --release
+  fi
 }
 
-pushd ${SCRIPT_DIR}/test-plugins/test-plugin-compatible
-build_plugin
-popd
+main() {
+  # dev.sh runs rspec via bundler; native gem extensions need yaml + libpq headers.
+  bash "${SCRIPT_DIR}/../ci/apt.sh" ruby-dev libyaml-dev libpq-dev build-essential
+  command -v bundle >/dev/null || sudo gem install bundler --no-document
 
-pushd ${SCRIPT_DIR}/test-plugins/test-plugin-auth
-build_plugin
-popd
+  export CARGO_TARGET_DIR="${SCRIPT_DIR}/target"
 
-pushd ${SCRIPT_DIR}/test-plugins/test-plugin-outdated
-cargo build --release
-popd
+  pushd "${SCRIPT_DIR}/test-plugins/test-plugin-compatible" >/dev/null
+  build_plugin
+  popd >/dev/null
 
-unset CARGO_TARGET_DIR
+  pushd "${SCRIPT_DIR}/test-plugins/test-plugin-auth" >/dev/null
+  build_plugin
+  popd >/dev/null
 
-pushd ${SCRIPT_DIR}/../../plugins/pgdog-example-plugin
-build_plugin
-popd
+  pushd "${SCRIPT_DIR}/test-plugins/test-plugin-outdated" >/dev/null
+  cargo build --release
+  popd >/dev/null
 
-export LD_LIBRARY_PATH=${SCRIPT_DIR}/target/release:${SCRIPT_DIR}/../../target/release
-export DYLD_LIBRARY_PATH=${LD_LIBRARY_PATH}
+  unset CARGO_TARGET_DIR
 
-run_pgdog $SCRIPT_DIR
-wait_for_pgdog
+  pushd "${SCRIPT_DIR}/../../plugins/pgdog-example-plugin" >/dev/null
+  build_plugin
+  popd >/dev/null
 
-bash ${SCRIPT_DIR}/dev.sh
+  pushd "${SCRIPT_DIR}/../../plugins/pgdog-google-auth" >/dev/null
+  cargo build --release
+  popd >/dev/null
 
-stop_pgdog
+  export LD_LIBRARY_PATH="${SCRIPT_DIR}/target/release:${SCRIPT_DIR}/../../target/release"
+  export DYLD_LIBRARY_PATH="${LD_LIBRARY_PATH}"
 
-# Phase 2: authentication plugin (auth_type = "plugin").
-# Postgres-side prerequisites (impersonated role, target table) go in first,
-# applied directly against PostgreSQL rather than through PgDog.
-PGPASSWORD=pgdog psql -h 127.0.0.1 -p 5432 -U pgdog -d pgdog -v ON_ERROR_STOP=1 \
-    -f ${SCRIPT_DIR}/auth/setup.sql
+  run_pgdog "${SCRIPT_DIR}"
+  wait_for_pgdog
+  bash "${SCRIPT_DIR}/dev.sh"
+  stop_pgdog
 
-run_pgdog ${SCRIPT_DIR}/auth
-wait_for_pgdog
-pushd ${SCRIPT_DIR}
-bundle exec rspec auth/auth_spec.rb
-popd
-stop_pgdog
+  # Phase 2: generic authentication plugin.
+  PGPASSWORD=pgdog psql -h 127.0.0.1 -p 5432 -U pgdog -d pgdog -v ON_ERROR_STOP=1 \
+    -f "${SCRIPT_DIR}/auth/setup.sql"
+
+  run_pgdog "${SCRIPT_DIR}/auth"
+  wait_for_pgdog
+  pushd "${SCRIPT_DIR}" >/dev/null
+  bundle exec rspec auth/auth_spec.rb
+  popd >/dev/null
+  stop_pgdog
+
+  # Phase 3: Google access-token plugin with a local tokeninfo mock.
+  run_pgdog "${SCRIPT_DIR}/google"
+  wait_for_pgdog
+  pushd "${SCRIPT_DIR}" >/dev/null
+  bundle exec rspec google/google_auth_spec.rb
+  popd >/dev/null
+  stop_pgdog
+}
+
+main "$@"

--- a/integration/plugins/run.sh
+++ b/integration/plugins/run.sh
@@ -61,6 +61,9 @@ main() {
   stop_pgdog
 
   # Phase 3: Google access-token plugin with a local tokeninfo mock.
+  PGPASSWORD=pgdog psql -h 127.0.0.1 -p 5432 -U pgdog -d pgdog -v ON_ERROR_STOP=1 \
+    -f "${SCRIPT_DIR}/google/setup.sql"
+
   run_pgdog "${SCRIPT_DIR}/google"
   wait_for_pgdog
   pushd "${SCRIPT_DIR}" >/dev/null

--- a/integration/plugins/test-plugins/test-plugin-auth/Cargo.toml
+++ b/integration/plugins/test-plugins/test-plugin-auth/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "test-plugin-auth"
+version = "0.1.0"
+edition = "2024"
+
+[workspace]
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+pgdog-plugin = { path = "../../../../pgdog-plugin", default-features = false }
+
+[features]
+default = ["pgdog-plugin/pg_query"]
+new_parser = ["pgdog-plugin/new_parser"]

--- a/integration/plugins/test-plugins/test-plugin-auth/Cargo.toml
+++ b/integration/plugins/test-plugins/test-plugin-auth/Cargo.toml
@@ -9,8 +9,4 @@ edition = "2024"
 crate-type = ["cdylib"]
 
 [dependencies]
-pgdog-plugin = { path = "../../../../pgdog-plugin", default-features = false }
-
-[features]
-default = ["pgdog-plugin/pg_query"]
-new_parser = ["pgdog-plugin/new_parser"]
+pgdog-plugin = { path = "../../../../pgdog-plugin" }

--- a/integration/plugins/test-plugins/test-plugin-auth/src/lib.rs
+++ b/integration/plugins/test-plugins/test-plugin-auth/src/lib.rs
@@ -1,0 +1,63 @@
+//! Authentication plugin used by the integration suite.
+//!
+//! It exercises the `authenticate` extension point added in this PR. The
+//! credential the client sends (as a cleartext password) drives the decision:
+//!
+//! - `"deny"`               => [`AuthDecision::Deny`] with a reason PgDog logs
+//!   but never sends to the client.
+//! - `"panic"`              => `panic!()`. The plugin runs on PgDog's blocking
+//!   pool, which catches the unwind, so PgDog denies the client and stays up.
+//! - `"secret-<user>"`      => [`AuthDecision::Allow`] with no derivation; the
+//!   client connects to its pre-configured pool.
+//! - `"impersonate:<role>"` => [`AuthDecision::Allow`] deriving `<role>`,
+//!   impersonating it via `server_role`, and asking PgDog to provision a pool.
+//! - anything else          => [`AuthDecision::Skip`] (all-skip => PgDog denies).
+
+use pgdog_plugin::{AuthContext, AuthDecision, AuthGrant, PdStr, Plugin, plugin};
+
+plugin!(TestAuthPlugin);
+
+struct TestAuthPlugin;
+
+/// Backend credentials PgDog uses when a grant provisions a pool. The
+/// integration `setup.sh` creates the `pgdog` superuser with this password, and
+/// the suite's `setup.sql` grants the impersonated roles to it. A real plugin
+/// would read these from its own config; hardcoding keeps the test hermetic.
+const SERVER_USER: &str = "pgdog";
+const SERVER_PASSWORD: &str = "pgdog";
+
+impl Plugin for TestAuthPlugin {
+    extern "C-unwind" fn version() -> PdStr<'static> {
+        env!("CARGO_PKG_VERSION").into()
+    }
+
+    fn authenticate(context: AuthContext<'_>) -> AuthDecision {
+        let credential = &*context.credential;
+
+        if credential == "deny" {
+            return AuthDecision::Deny("test deny".into());
+        }
+
+        if credential == "panic" {
+            panic!("test plugin panic");
+        }
+
+        if let Some(role) = credential.strip_prefix("impersonate:") {
+            return AuthDecision::Allow(AuthGrant {
+                derived_user: Some(role.to_string()),
+                server_role: Some(role.to_string()),
+                server_user: Some(SERVER_USER.to_string()),
+                server_password: Some(SERVER_PASSWORD.to_string()),
+                read_only: None,
+                provision: true,
+            });
+        }
+
+        // `secret-<user>` allows the matching client through to its configured pool.
+        if credential == format!("secret-{}", &*context.user) {
+            return AuthDecision::Allow(AuthGrant::default());
+        }
+
+        AuthDecision::Skip
+    }
+}

--- a/integration/plugins/test-plugins/test-plugin-auth/src/lib.rs
+++ b/integration/plugins/test-plugins/test-plugin-auth/src/lib.rs
@@ -11,7 +11,8 @@
 //!   client connects to its pre-configured pool.
 //! - `"impersonate:<role>"` => [`AuthDecision::Allow`] deriving `<role>`,
 //!   impersonating it via `server_role`, and asking PgDog to provision a pool.
-//! - anything else          => [`AuthDecision::Skip`] (all-skip => PgDog denies).
+//! - anything else          => [`AuthDecision::Skip`] so PgDog tries its
+//!   configured password or passthrough authentication.
 
 use pgdog_plugin::{AuthContext, AuthDecision, AuthGrant, PdStr, Plugin, plugin};
 

--- a/pgdog-config/src/auth.rs
+++ b/pgdog-config/src/auth.rs
@@ -49,6 +49,8 @@ pub enum AuthType {
     Trust,
     /// Plaintext password.
     Plain,
+    /// Delegate client authentication to a loaded plugin exposing the `pgdog_authenticate` hook.
+    Plugin,
 }
 
 impl Display for AuthType {
@@ -58,6 +60,7 @@ impl Display for AuthType {
             Self::Scram => write!(f, "scram"),
             Self::Trust => write!(f, "trust"),
             Self::Plain => write!(f, "plain"),
+            Self::Plugin => write!(f, "plugin"),
         }
     }
 }
@@ -74,6 +77,10 @@ impl AuthType {
     pub fn trust(&self) -> bool {
         matches!(self, Self::Trust)
     }
+
+    pub fn plugin(&self) -> bool {
+        matches!(self, Self::Plugin)
+    }
 }
 
 impl FromStr for AuthType {
@@ -85,7 +92,67 @@ impl FromStr for AuthType {
             "scram" => Ok(Self::Scram),
             "trust" => Ok(Self::Trust),
             "plain" => Ok(Self::Plain),
+            "plugin" => Ok(Self::Plugin),
             _ => Err(format!("Invalid auth type: {}", s)),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_auth_type_default_is_scram() {
+        assert_eq!(AuthType::default(), AuthType::Scram);
+    }
+
+    #[test]
+    fn test_auth_type_display() {
+        assert_eq!(AuthType::Md5.to_string(), "md5");
+        assert_eq!(AuthType::Scram.to_string(), "scram");
+        assert_eq!(AuthType::Trust.to_string(), "trust");
+        assert_eq!(AuthType::Plain.to_string(), "plain");
+        assert_eq!(AuthType::Plugin.to_string(), "plugin");
+    }
+
+    #[test]
+    fn test_auth_type_from_str() {
+        assert_eq!("md5".parse::<AuthType>().unwrap(), AuthType::Md5);
+        assert_eq!("scram".parse::<AuthType>().unwrap(), AuthType::Scram);
+        assert_eq!("trust".parse::<AuthType>().unwrap(), AuthType::Trust);
+        assert_eq!("plain".parse::<AuthType>().unwrap(), AuthType::Plain);
+        assert_eq!("plugin".parse::<AuthType>().unwrap(), AuthType::Plugin);
+        // Case-insensitive.
+        assert_eq!("PLUGIN".parse::<AuthType>().unwrap(), AuthType::Plugin);
+        assert!("nonsense".parse::<AuthType>().is_err());
+    }
+
+    #[test]
+    fn test_auth_type_predicates() {
+        assert!(AuthType::Plugin.plugin());
+        assert!(!AuthType::Scram.plugin());
+        assert!(!AuthType::Plugin.scram());
+        assert!(!AuthType::Plugin.md5());
+        assert!(!AuthType::Plugin.trust());
+    }
+
+    #[test]
+    fn test_auth_type_serde_round_trip() {
+        // serde uses snake_case renaming; "plugin" is a single lowercase word.
+        #[derive(Serialize, Deserialize, PartialEq, Debug)]
+        struct Wrapper {
+            auth_type: AuthType,
+        }
+
+        let source = r#"auth_type = "plugin""#;
+        let parsed: Wrapper = toml::from_str(source).unwrap();
+        assert_eq!(parsed.auth_type, AuthType::Plugin);
+
+        let serialized = toml::to_string(&parsed).unwrap();
+        assert!(serialized.contains(r#"auth_type = "plugin""#));
+
+        let round_tripped: Wrapper = toml::from_str(&serialized).unwrap();
+        assert_eq!(round_tripped, parsed);
     }
 }

--- a/pgdog-config/src/auth.rs
+++ b/pgdog-config/src/auth.rs
@@ -49,7 +49,8 @@ pub enum AuthType {
     Trust,
     /// Plaintext password.
     Plain,
-    /// Delegate client authentication to a loaded plugin exposing the `pgdog_authenticate` hook.
+    /// Delegate client authentication to loaded plugins, falling back to the
+    /// configured password or passthrough authentication when every plugin skips.
     Plugin,
 }
 

--- a/pgdog-config/src/general.rs
+++ b/pgdog-config/src/general.rs
@@ -105,6 +105,18 @@ pub struct General {
     #[serde(default = "General::workers")]
     pub workers: usize,
 
+    /// Maximum number of authentication-plugin calls allowed to run concurrently.
+    /// Authentication plugins run on a blocking thread pool (auth happens once per
+    /// connection and may block on I/O); this bounds how many run at the same time.
+    ///
+    /// **Note:** Only relevant when `auth_type = "plugin"`.
+    ///
+    /// _Default:_ `4`
+    ///
+    /// https://docs.pgdog.dev/configuration/pgdog.toml/general/#background_workers
+    #[serde(default = "General::background_workers")]
+    pub background_workers: usize,
+
     /// Default maximum number of server connections per database pool.
     ///
     /// **Note:** We strongly recommend keeping this value well below the supported connections of the backend database(s) to allow connections for maintenance in high load scenarios.
@@ -814,6 +826,7 @@ impl Default for General {
             host: Self::host(),
             port: Self::port(),
             workers: Self::workers(),
+            background_workers: Self::background_workers(),
             default_pool_size: Self::default_pool_size(),
             min_pool_size: Self::min_pool_size(),
             pooler_mode: Self::pooler_mode(),
@@ -964,6 +977,10 @@ impl General {
 
     fn workers() -> usize {
         Self::env_or_default("PGDOG_WORKERS", 2)
+    }
+
+    fn background_workers() -> usize {
+        Self::env_or_default("PGDOG_BACKGROUND_WORKERS", 4)
     }
 
     fn default_pool_size() -> usize {
@@ -1499,6 +1516,35 @@ mod tests {
         assert_eq!(General::workers(), 8);
         let _guard = remove_env_var("PGDOG_WORKERS");
         assert_eq!(General::workers(), 2);
+    }
+
+    #[test]
+    fn test_env_background_workers() {
+        let _guard = set_env_var("PGDOG_BACKGROUND_WORKERS", "16");
+        assert_eq!(General::background_workers(), 16);
+        let _guard = remove_env_var("PGDOG_BACKGROUND_WORKERS");
+        assert_eq!(General::background_workers(), 4);
+    }
+
+    #[test]
+    fn test_background_workers_default() {
+        let _guard = remove_env_var("PGDOG_BACKGROUND_WORKERS");
+        assert_eq!(General::default().background_workers, 4);
+    }
+
+    #[test]
+    fn test_background_workers_serde_round_trip() {
+        let _guard = remove_env_var("PGDOG_BACKGROUND_WORKERS");
+
+        // Omitted: falls back to the default.
+        let general: General = toml::from_str("").unwrap();
+        assert_eq!(general.background_workers, 4);
+
+        // Explicit value is parsed and re-serialized.
+        let general: General = toml::from_str("background_workers = 8").unwrap();
+        assert_eq!(general.background_workers, 8);
+        let serialized = toml::to_string(&general).unwrap();
+        assert!(serialized.contains("background_workers = 8"));
     }
 
     #[test]

--- a/pgdog-config/src/general.rs
+++ b/pgdog-config/src/general.rs
@@ -105,6 +105,18 @@ pub struct General {
     #[serde(default = "General::workers")]
     pub workers: usize,
 
+    /// Maximum number of authentication-plugin calls allowed to run concurrently.
+    /// Authentication plugins run on a blocking thread pool (auth happens once per
+    /// connection and may block on I/O); this bounds how many run at the same time.
+    ///
+    /// **Note:** Only relevant when `auth_type = "plugin"`.
+    ///
+    /// _Default:_ `4`
+    ///
+    /// https://docs.pgdog.dev/configuration/pgdog.toml/general/#background_workers
+    #[serde(default = "General::background_workers")]
+    pub background_workers: usize,
+
     /// Default maximum number of server connections per database pool.
     ///
     /// **Note:** We strongly recommend keeping this value well below the supported connections of the backend database(s) to allow connections for maintenance in high load scenarios.
@@ -888,6 +900,7 @@ impl Default for General {
             host: Self::host(),
             port: Self::port(),
             workers: Self::workers(),
+            background_workers: Self::background_workers(),
             default_pool_size: Self::default_pool_size(),
             min_pool_size: Self::min_pool_size(),
             pooler_mode: Self::pooler_mode(),
@@ -1047,6 +1060,10 @@ impl General {
 
     fn workers() -> usize {
         Self::env_or_default("PGDOG_WORKERS", 2)
+    }
+
+    fn background_workers() -> usize {
+        Self::env_or_default("PGDOG_BACKGROUND_WORKERS", 4)
     }
 
     fn default_pool_size() -> usize {
@@ -1740,6 +1757,35 @@ mod tests {
         assert_eq!(General::workers(), 8);
         let _guard = remove_env_var("PGDOG_WORKERS");
         assert_eq!(General::workers(), 2);
+    }
+
+    #[test]
+    fn test_env_background_workers() {
+        let _guard = set_env_var("PGDOG_BACKGROUND_WORKERS", "16");
+        assert_eq!(General::background_workers(), 16);
+        let _guard = remove_env_var("PGDOG_BACKGROUND_WORKERS");
+        assert_eq!(General::background_workers(), 4);
+    }
+
+    #[test]
+    fn test_background_workers_default() {
+        let _guard = remove_env_var("PGDOG_BACKGROUND_WORKERS");
+        assert_eq!(General::default().background_workers, 4);
+    }
+
+    #[test]
+    fn test_background_workers_serde_round_trip() {
+        let _guard = remove_env_var("PGDOG_BACKGROUND_WORKERS");
+
+        // Omitted: falls back to the default.
+        let general: General = toml::from_str("").unwrap();
+        assert_eq!(general.background_workers, 4);
+
+        // Explicit value is parsed and re-serialized.
+        let general: General = toml::from_str("background_workers = 8").unwrap();
+        assert_eq!(general.background_workers, 8);
+        let serialized = toml::to_string(&general).unwrap();
+        assert!(serialized.contains("background_workers = 8"));
     }
 
     #[test]

--- a/pgdog-config/src/users.rs
+++ b/pgdog-config/src/users.rs
@@ -312,6 +312,14 @@ pub struct User {
     ///
     /// https://docs.pgdog.dev/configuration/users.toml/users/#server_password
     pub server_password: Option<String>,
+    /// PostgreSQL role this user's backend connections assume via the `role` startup
+    /// parameter, used for impersonation with `auth_type = "plugin"`.
+    ///
+    /// **Note:** The user config no longer supplies the Postgres password when a plugin
+    /// derives the login, so a working backend credential must be provided via
+    /// `server_password` or a non-default `server_auth`. `SET ROLE`, `RESET ROLE`, and
+    /// `SET SESSION AUTHORIZATION` are rejected on pools that set this.
+    pub server_role: Option<String>,
     /// Backend auth mode for server connections.
     #[serde(default)]
     pub server_auth: ServerAuth,
@@ -790,6 +798,40 @@ vault_refresh_percent = 60
                 .any(|p| matches!(p, PasswordKind::Plain(s) if s == "fallback"))
         );
         assert!(passwords.iter().any(|p| matches!(p, PasswordKind::VaultStaticRole(s) if s == "database/static-creds/alice-role")));
+    }
+
+    #[test]
+    fn test_user_server_role_defaults_to_none() {
+        let source = r#"
+[[users]]
+name = "alice"
+database = "db"
+password = "secret"
+"#;
+
+        let users: Users = toml::from_str(source).unwrap();
+        let user = users.users.first().unwrap();
+        assert!(user.server_role.is_none());
+    }
+
+    #[test]
+    fn test_user_server_role_round_trip() {
+        let source = r#"
+[[users]]
+name = "alice"
+database = "db"
+server_role = "analytics"
+server_user = "svc"
+server_password = "svc_secret"
+"#;
+
+        let users: Users = toml::from_str(source).unwrap();
+        let user = users.users.first().unwrap();
+        assert_eq!(user.server_role.as_deref(), Some("analytics"));
+
+        let serialized = toml::to_string(users.users.first().unwrap()).unwrap();
+        let reparsed: User = toml::from_str(&serialized).unwrap();
+        assert_eq!(reparsed.server_role.as_deref(), Some("analytics"));
     }
 
     #[test]

--- a/pgdog-config/src/users.rs
+++ b/pgdog-config/src/users.rs
@@ -289,6 +289,19 @@ pub struct User {
     ///
     /// <https://docs.pgdog.dev/configuration/users.toml/users/#password>
     pub password: Option<String>,
+    /// Runtime marker: `password` was learned from a client through passthrough
+    /// authentication instead of being read from `users.toml`. Lets PgDog evict
+    /// the credential if the server rejects it. Internal field, never serialized.
+    #[serde(skip)]
+    #[schemars(skip)]
+    pub password_from_passthrough: bool,
+    /// Runtime marker: this whole entry was discovered through passthrough
+    /// authentication (the user is not present in `users.toml`). Lets PgDog
+    /// remove the entry if the server rejects its credential. Internal field,
+    /// never serialized.
+    #[serde(skip)]
+    #[schemars(skip)]
+    pub created_by_passthrough: bool,
     /// Multiple passwords for this user, all of which will be attempted during auth to server and client.
     #[serde(default)]
     pub passwords: Vec<String>,

--- a/pgdog-config/src/users.rs
+++ b/pgdog-config/src/users.rs
@@ -319,6 +319,14 @@ pub struct User {
     ///
     /// <https://docs.pgdog.dev/configuration/users.toml/users/#server_password>
     pub server_password: Option<String>,
+    /// PostgreSQL role this user's backend connections assume via the `role` startup
+    /// parameter, used for impersonation with `auth_type = "plugin"`.
+    ///
+    /// **Note:** The user config no longer supplies the Postgres password when a plugin
+    /// derives the login, so a working backend credential must be provided via
+    /// `server_password` or a non-default `server_auth`. `SET ROLE`, `RESET ROLE`, and
+    /// `SET SESSION AUTHORIZATION` are rejected on pools that set this.
+    pub server_role: Option<String>,
     /// Backend auth mode for server connections.
     #[serde(default)]
     pub server_auth: ServerAuth,
@@ -846,6 +854,40 @@ vault_refresh_percent = 60
                 .any(|p| matches!(p, PasswordKind::Plain(s) if s == "fallback"))
         );
         assert!(passwords.iter().any(|p| matches!(p, PasswordKind::VaultStaticRole(s) if s == "database/static-creds/alice-role")));
+    }
+
+    #[test]
+    fn test_user_server_role_defaults_to_none() {
+        let source = r#"
+[[users]]
+name = "alice"
+database = "db"
+password = "secret"
+"#;
+
+        let users: Users = toml::from_str(source).unwrap();
+        let user = users.users.first().unwrap();
+        assert!(user.server_role.is_none());
+    }
+
+    #[test]
+    fn test_user_server_role_round_trip() {
+        let source = r#"
+[[users]]
+name = "alice"
+database = "db"
+server_role = "analytics"
+server_user = "svc"
+server_password = "svc_secret"
+"#;
+
+        let users: Users = toml::from_str(source).unwrap();
+        let user = users.users.first().unwrap();
+        assert_eq!(user.server_role.as_deref(), Some("analytics"));
+
+        let serialized = toml::to_string(users.users.first().unwrap()).unwrap();
+        let reparsed: User = toml::from_str(&serialized).unwrap();
+        assert_eq!(reparsed.server_role.as_deref(), Some("analytics"));
     }
 
     #[test]

--- a/pgdog-plugin/Cargo.toml
+++ b/pgdog-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgdog-plugin"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 license = "MIT"
 authors = ["Lev Kokotov <lev.kokotov@gmail.com>"]

--- a/pgdog-plugin/src/auth.rs
+++ b/pgdog-plugin/src/auth.rs
@@ -1,0 +1,140 @@
+//! Client authentication hook.
+//!
+//! Plugins can validate the credential a client presents at login (a password,
+//! a JWT, an API key, ...) and, on success, derive the Postgres role the
+//! session should run as and how its pool should connect to the backend.
+//!
+//! # No ownership crosses the FFI boundary
+//!
+//! [`AuthDecision`] and [`AuthGrant`] are ordinary owned Rust values used by
+//! plugin authors. They never cross FFI. The generated bridge keeps the owned
+//! decision alive on the plugin's stack and streams each string field to the
+//! host as a borrowed [`PdStr`] through the [`AuthSink`] callback, returning
+//! only the POD [`AuthOutcome`] by value. This mirrors how [`crate::Config`]
+//! hands borrowed strings the other way.
+
+use crate::PdStr;
+use std::ffi::c_void;
+
+/// Context for a single client authentication attempt.
+///
+/// All strings are borrowed and only valid for the duration of the
+/// [`Plugin::authenticate`](crate::Plugin::authenticate) call.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct AuthContext<'a> {
+    /// User from the startup packet.
+    pub user: PdStr<'a>,
+    /// Database from the startup packet.
+    pub database: PdStr<'a>,
+    /// Credential the client presented (password, JWT, token, ...).
+    pub credential: PdStr<'a>,
+    /// Client socket address, e.g. `"10.0.0.1:54321"`.
+    pub client_addr: PdStr<'a>,
+    /// TLS certificate identity; empty when the connection has none.
+    pub tls_identity: PdStr<'a>,
+    /// Whether the connection uses TLS.
+    pub tls: bool,
+}
+
+/// Backend and pool details returned when a plugin authenticates a client.
+///
+/// A plain owned Rust value; it never crosses the FFI boundary.
+#[derive(Debug, Default, Clone)]
+pub struct AuthGrant {
+    /// Postgres role the pool runs as; `None` keeps the startup-packet user.
+    pub derived_user: Option<String>,
+    /// Role assumed on the backend via the `role` startup parameter.
+    pub server_role: Option<String>,
+    /// Backend user for an auto-provisioned pool.
+    pub server_user: Option<String>,
+    /// Backend password for an auto-provisioned pool.
+    pub server_password: Option<String>,
+    /// Whether the provisioned pool is read-only. `None` leaves it unset.
+    pub read_only: Option<bool>,
+    /// Auto-provision a pool for `derived_user` when one does not exist.
+    pub provision: bool,
+}
+
+/// A plugin's verdict on a client authentication attempt.
+#[derive(Debug, Clone)]
+pub enum AuthDecision {
+    /// Not this plugin's credential; consult the next plugin.
+    Skip,
+    /// Authenticated; optionally derive a role and provision a pool.
+    Allow(AuthGrant),
+    /// Rejected. The reason is logged by PgDog, never sent to the client.
+    Deny(String),
+}
+
+/// FFI tag for an [`AuthDecision`], returned by value across the boundary.
+#[repr(u8)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum AuthDecisionTag {
+    /// Defer to the next plugin.
+    Skip = 0,
+    /// Client authenticated.
+    Allow = 1,
+    /// Client rejected.
+    Deny = 2,
+}
+
+/// Which [`AuthGrant`] field (or deny reason) a plugin is reporting through the
+/// [`AuthSink`] callback.
+#[repr(u8)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum AuthField {
+    /// [`AuthGrant::derived_user`].
+    DerivedUser = 0,
+    /// [`AuthGrant::server_role`].
+    ServerRole = 1,
+    /// [`AuthGrant::server_user`].
+    ServerUser = 2,
+    /// [`AuthGrant::server_password`].
+    ServerPassword = 3,
+    /// [`AuthDecision::Deny`] reason.
+    Error = 4,
+}
+
+/// POD result of an FFI authenticate call.
+///
+/// String fields are not carried here; they are streamed to the host through
+/// the [`AuthSink`] while the plugin-owned [`AuthDecision`] is still alive, so
+/// no ownership crosses FFI.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct AuthOutcome {
+    /// The decision kind.
+    pub tag: AuthDecisionTag,
+    /// `0` = read-write, `1` = read-only, `2` = unset.
+    pub read_only: u8,
+    /// Auto-provision the derived user's pool.
+    pub provision: bool,
+}
+
+impl AuthOutcome {
+    /// The neutral "defer to the next plugin" outcome.
+    pub(crate) const fn skip() -> Self {
+        Self {
+            tag: AuthDecisionTag::Skip,
+            read_only: 2,
+            provision: false,
+        }
+    }
+}
+
+/// Encode an `Option<bool>` read-only flag as its [`AuthOutcome::read_only`] code.
+pub(crate) fn read_only_code(value: Option<bool>) -> u8 {
+    match value {
+        None => 2,
+        Some(false) => 0,
+        Some(true) => 1,
+    }
+}
+
+/// Callback the plugin invokes to hand a borrowed field value to the host.
+///
+/// The first argument is an opaque host pointer passed straight back; the host
+/// side reconstructs its closure from it. Only ever called synchronously from
+/// within the authenticate call, on the same thread.
+pub type AuthSink = extern "C-unwind" fn(*mut c_void, AuthField, PdStr<'_>);

--- a/pgdog-plugin/src/lib.rs
+++ b/pgdog-plugin/src/lib.rs
@@ -195,6 +195,7 @@ compile_error!(
     r#"pg-plugin must be built with either default features, or features = "new_parser""#
 );
 
+pub mod auth;
 mod config;
 pub mod context;
 pub mod logging;
@@ -204,6 +205,7 @@ pub mod plugin;
 pub mod prelude;
 pub mod string;
 
+pub use auth::*;
 pub use config::Config;
 pub use context::*;
 pub use parameters::*;

--- a/pgdog-plugin/src/lib.rs
+++ b/pgdog-plugin/src/lib.rs
@@ -175,6 +175,7 @@
 //! ```
 //!
 
+pub mod auth;
 mod config;
 pub mod context;
 pub mod logging;
@@ -184,6 +185,7 @@ pub mod plugin;
 pub mod prelude;
 pub mod string;
 
+pub use auth::*;
 pub use config::Config;
 pub use context::*;
 pub use parameters::*;

--- a/pgdog-plugin/src/plugin.rs
+++ b/pgdog-plugin/src/plugin.rs
@@ -4,10 +4,12 @@
 //! a safe interface to the plugin's methods.
 //!
 
+use std::ffi::c_void;
 use std::path::Path;
 
 use crate::{
     Config, Context, PdStr, Route,
+    auth::{AuthContext, AuthDecision, AuthField, AuthOutcome, AuthSink, read_only_code},
     parameters::{Parameters, RawParameters},
 };
 use libloading::{Library, Symbol, library_filename};
@@ -59,6 +61,9 @@ pub struct PluginVtable {
     ) -> Route,
     /// Logging initialization.
     logging_init: extern "C-unwind" fn(Config<'_>),
+    /// Authenticate a client connection. Streams grant/deny strings to the
+    /// sink callback and returns the decision as POD.
+    authenticate: extern "C-unwind" fn(AuthContext<'_>, *mut c_void, AuthSink) -> AuthOutcome,
 }
 
 pub trait Plugin {
@@ -127,6 +132,67 @@ pub trait Plugin {
     extern "C-unwind" fn logging_init(config: Config<'_>) {
         crate::logging::init(config)
     }
+
+    /// Authenticate a client connection.
+    ///
+    /// Return [`AuthDecision::Skip`] (the default) to defer to the next plugin
+    /// or to PgDog's configured authentication. [`AuthDecision::Allow`] accepts
+    /// the client and may derive a role and provision a pool;
+    /// [`AuthDecision::Deny`] rejects it (the reason is logged, never sent to
+    /// the client).
+    fn authenticate(_context: AuthContext<'_>) -> AuthDecision {
+        AuthDecision::Skip
+    }
+
+    #[doc(hidden)]
+    extern "C-unwind" fn authenticate_raw(
+        context: AuthContext<'_>,
+        sink_ctx: *mut c_void,
+        sink: AuthSink,
+    ) -> AuthOutcome {
+        // Catch a panic here, inside the plugin, before it can unwind across
+        // the FFI boundary. A panic that crosses `extern "C-unwind"` becomes a
+        // "foreign exception" the host cannot catch, which aborts the whole
+        // process; catching it here turns a buggy auth plugin into a denial
+        // instead. `AuthContext` is Copy, so the closure captures it by value.
+        let decision =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| Self::authenticate(context)))
+                .unwrap_or_else(|_| AuthDecision::Deny("authentication plugin panicked".into()));
+
+        // The owned decision lives here, on the plugin's stack, for the whole
+        // call. We stream each field to the host as a borrowed PdStr; nothing
+        // owned crosses the FFI boundary.
+        match decision {
+            AuthDecision::Skip => AuthOutcome::skip(),
+            AuthDecision::Deny(reason) => {
+                sink(sink_ctx, AuthField::Error, PdStr::from(reason.as_str()));
+                AuthOutcome {
+                    tag: crate::auth::AuthDecisionTag::Deny,
+                    read_only: 2,
+                    provision: false,
+                }
+            }
+            AuthDecision::Allow(grant) => {
+                if let Some(value) = grant.derived_user.as_deref() {
+                    sink(sink_ctx, AuthField::DerivedUser, PdStr::from(value));
+                }
+                if let Some(value) = grant.server_role.as_deref() {
+                    sink(sink_ctx, AuthField::ServerRole, PdStr::from(value));
+                }
+                if let Some(value) = grant.server_user.as_deref() {
+                    sink(sink_ctx, AuthField::ServerUser, PdStr::from(value));
+                }
+                if let Some(value) = grant.server_password.as_deref() {
+                    sink(sink_ctx, AuthField::ServerPassword, PdStr::from(value));
+                }
+                AuthOutcome {
+                    tag: crate::auth::AuthDecisionTag::Allow,
+                    read_only: read_only_code(grant.read_only),
+                    provision: grant.provision,
+                }
+            }
+        }
+    }
 }
 
 impl PluginVtable {
@@ -141,6 +207,7 @@ impl PluginVtable {
             plugin_version: T::version,
             pgdog_plugin_api_version: T::plugin_api_version,
             logging_init: T::logging_init,
+            authenticate: T::authenticate_raw,
         }
     }
 
@@ -219,5 +286,32 @@ impl PluginVtable {
 
     pub fn logging_init(&self, config: Config<'_>) {
         (self.logging_init)(config)
+    }
+
+    /// Authenticate a client. `on_field` is invoked with each grant/deny string
+    /// the plugin reports (borrowed for the duration of the call); the caller
+    /// copies what it needs into owned storage.
+    pub fn authenticate<F: FnMut(AuthField, &str)>(
+        &self,
+        context: AuthContext<'_>,
+        mut on_field: F,
+    ) -> AuthOutcome {
+        extern "C-unwind" fn trampoline<F: FnMut(AuthField, &str)>(
+            ctx: *mut c_void,
+            field: AuthField,
+            value: PdStr<'_>,
+        ) {
+            // SAFETY: `ctx` is the `&mut F` passed below. The plugin only calls
+            // this synchronously, on this thread, before `authenticate`
+            // returns, so the borrow is live and unaliased.
+            let on_field = unsafe { &mut *(ctx as *mut F) };
+            on_field(field, &value);
+        }
+
+        (self.authenticate)(
+            context,
+            &mut on_field as *mut F as *mut c_void,
+            trampoline::<F>,
+        )
     }
 }

--- a/pgdog-plugin/src/plugin.rs
+++ b/pgdog-plugin/src/plugin.rs
@@ -4,10 +4,12 @@
 //! a safe interface to the plugin's methods.
 //!
 
+use std::ffi::c_void;
 use std::path::Path;
 
 use crate::{
     Config, Context, PdStr, Route,
+    auth::{AuthContext, AuthDecision, AuthField, AuthOutcome, AuthSink, read_only_code},
     parameters::{Parameters, RawParameters},
 };
 use libloading::{Library, Symbol, library_filename};
@@ -48,6 +50,9 @@ pub struct PluginVtable {
     ) -> Route,
     /// Logging initialization.
     logging_init: extern "C-unwind" fn(Config<'_>),
+    /// Authenticate a client connection. Streams grant/deny strings to the
+    /// sink callback and returns the decision as POD.
+    authenticate: extern "C-unwind" fn(AuthContext<'_>, *mut c_void, AuthSink) -> AuthOutcome,
 }
 
 pub trait Plugin {
@@ -115,6 +120,67 @@ pub trait Plugin {
     extern "C-unwind" fn logging_init(config: Config<'_>) {
         crate::logging::init(config)
     }
+
+    /// Authenticate a client connection.
+    ///
+    /// Return [`AuthDecision::Skip`] (the default) to defer to the next plugin
+    /// or to PgDog's configured authentication. [`AuthDecision::Allow`] accepts
+    /// the client and may derive a role and provision a pool;
+    /// [`AuthDecision::Deny`] rejects it (the reason is logged, never sent to
+    /// the client).
+    fn authenticate(_context: AuthContext<'_>) -> AuthDecision {
+        AuthDecision::Skip
+    }
+
+    #[doc(hidden)]
+    extern "C-unwind" fn authenticate_raw(
+        context: AuthContext<'_>,
+        sink_ctx: *mut c_void,
+        sink: AuthSink,
+    ) -> AuthOutcome {
+        // Catch a panic here, inside the plugin, before it can unwind across
+        // the FFI boundary. A panic that crosses `extern "C-unwind"` becomes a
+        // "foreign exception" the host cannot catch, which aborts the whole
+        // process; catching it here turns a buggy auth plugin into a denial
+        // instead. `AuthContext` is Copy, so the closure captures it by value.
+        let decision =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| Self::authenticate(context)))
+                .unwrap_or_else(|_| AuthDecision::Deny("authentication plugin panicked".into()));
+
+        // The owned decision lives here, on the plugin's stack, for the whole
+        // call. We stream each field to the host as a borrowed PdStr; nothing
+        // owned crosses the FFI boundary.
+        match decision {
+            AuthDecision::Skip => AuthOutcome::skip(),
+            AuthDecision::Deny(reason) => {
+                sink(sink_ctx, AuthField::Error, PdStr::from(reason.as_str()));
+                AuthOutcome {
+                    tag: crate::auth::AuthDecisionTag::Deny,
+                    read_only: 2,
+                    provision: false,
+                }
+            }
+            AuthDecision::Allow(grant) => {
+                if let Some(value) = grant.derived_user.as_deref() {
+                    sink(sink_ctx, AuthField::DerivedUser, PdStr::from(value));
+                }
+                if let Some(value) = grant.server_role.as_deref() {
+                    sink(sink_ctx, AuthField::ServerRole, PdStr::from(value));
+                }
+                if let Some(value) = grant.server_user.as_deref() {
+                    sink(sink_ctx, AuthField::ServerUser, PdStr::from(value));
+                }
+                if let Some(value) = grant.server_password.as_deref() {
+                    sink(sink_ctx, AuthField::ServerPassword, PdStr::from(value));
+                }
+                AuthOutcome {
+                    tag: crate::auth::AuthDecisionTag::Allow,
+                    read_only: read_only_code(grant.read_only),
+                    provision: grant.provision,
+                }
+            }
+        }
+    }
 }
 
 impl PluginVtable {
@@ -129,6 +195,7 @@ impl PluginVtable {
             plugin_version: T::version,
             pgdog_plugin_api_version: T::plugin_api_version,
             logging_init: T::logging_init,
+            authenticate: T::authenticate_raw,
         }
     }
 
@@ -207,5 +274,32 @@ impl PluginVtable {
 
     pub fn logging_init(&self, config: Config<'_>) {
         (self.logging_init)(config)
+    }
+
+    /// Authenticate a client. `on_field` is invoked with each grant/deny string
+    /// the plugin reports (borrowed for the duration of the call); the caller
+    /// copies what it needs into owned storage.
+    pub fn authenticate<F: FnMut(AuthField, &str)>(
+        &self,
+        context: AuthContext<'_>,
+        mut on_field: F,
+    ) -> AuthOutcome {
+        extern "C-unwind" fn trampoline<F: FnMut(AuthField, &str)>(
+            ctx: *mut c_void,
+            field: AuthField,
+            value: PdStr<'_>,
+        ) {
+            // SAFETY: `ctx` is the `&mut F` passed below. The plugin only calls
+            // this synchronously, on this thread, before `authenticate`
+            // returns, so the borrow is live and unaliased.
+            let on_field = unsafe { &mut *(ctx as *mut F) };
+            on_field(field, &value);
+        }
+
+        (self.authenticate)(
+            context,
+            &mut on_field as *mut F as *mut c_void,
+            trampoline::<F>,
+        )
     }
 }

--- a/pgdog-plugin/src/prelude.rs
+++ b/pgdog-plugin/src/prelude.rs
@@ -4,5 +4,6 @@
 pub use crate::pg_query;
 pub use crate::{
     Context, ParameterFormat, PdStr, Plugin, ReadWrite, Route, Shard,
+    auth::{AuthContext, AuthDecision, AuthGrant},
     parameters::{Parameter, ParameterValue, Parameters},
 };

--- a/pgdog-plugin/src/prelude.rs
+++ b/pgdog-plugin/src/prelude.rs
@@ -2,5 +2,6 @@
 
 pub use crate::{
     Context, ParameterFormat, PdStr, Plugin, ReadWrite, Route, Shard,
+    auth::{AuthContext, AuthDecision, AuthGrant},
     parameters::{Parameter, ParameterValue, Parameters},
 };

--- a/pgdog/src/auth/auth_result.rs
+++ b/pgdog/src/auth/auth_result.rs
@@ -19,6 +19,11 @@ pub enum AuthResult {
     NoUserOrDatabase,
     /// Client didn't provide password message.
     NoPasswordMessage,
+    /// An authentication plugin explicitly denied the client.
+    PluginDenied,
+    /// No authentication plugin made a decision (all skipped). Treated as a
+    /// denial: `auth_type = "plugin"` is explicit, there is no password fallback.
+    PluginNoDecision,
 }
 
 impl AuthResult {
@@ -46,6 +51,8 @@ impl Display for AuthResult {
             }
             Self::NoUserOrDatabase => write!(f, "no user or database in config"),
             Self::NoPasswordMessage => write!(f, "client did not send password message"),
+            Self::PluginDenied => write!(f, "authentication plugin denied the client"),
+            Self::PluginNoDecision => write!(f, "no authentication plugin accepted the client"),
         }
     }
 }

--- a/pgdog/src/auth/auth_result.rs
+++ b/pgdog/src/auth/auth_result.rs
@@ -23,8 +23,8 @@ pub enum AuthResult {
     NoPasswordMessage,
     /// An authentication plugin explicitly denied the client.
     PluginDenied,
-    /// No authentication plugin made a decision (all skipped). Treated as a
-    /// denial: `auth_type = "plugin"` is explicit, there is no password fallback.
+    /// No authentication plugin made a decision (all skipped). The frontend
+    /// uses this result to fall back to password or passthrough authentication.
     PluginNoDecision,
 }
 

--- a/pgdog/src/auth/auth_result.rs
+++ b/pgdog/src/auth/auth_result.rs
@@ -17,6 +17,9 @@ pub enum AuthResult {
     NoPassthroughNoUser,
     /// Passthrough auth doesn't allow password changes.
     NoPassthroughPasswordChange,
+    /// Passthrough auth could not verify the credential against the server
+    /// (the server was unreachable or returned a non-auth error).
+    PassthroughVerificationFailed,
     /// No user or database in config.
     NoUserOrDatabase,
     /// Client didn't provide password message.
@@ -56,6 +59,12 @@ impl Display for AuthResult {
             Self::NoPassthroughNoUser => write!(f, "no user in config (passthrough auth)"),
             Self::NoPassthroughPasswordChange => {
                 write!(f, "passthrough auth does not allow password change")
+            }
+            Self::PassthroughVerificationFailed => {
+                write!(
+                    f,
+                    "could not verify password against the server (passthrough auth)"
+                )
             }
             Self::NoUserOrDatabase => write!(f, "no user or database in config"),
             Self::NoPasswordMessage => write!(f, "client did not send password message"),

--- a/pgdog/src/auth/auth_result.rs
+++ b/pgdog/src/auth/auth_result.rs
@@ -21,6 +21,11 @@ pub enum AuthResult {
     NoUserOrDatabase,
     /// Client didn't provide password message.
     NoPasswordMessage,
+    /// An authentication plugin explicitly denied the client.
+    PluginDenied,
+    /// No authentication plugin made a decision (all skipped). Treated as a
+    /// denial: `auth_type = "plugin"` is explicit, there is no password fallback.
+    PluginNoDecision,
 }
 
 impl AuthResult {
@@ -54,6 +59,8 @@ impl Display for AuthResult {
             }
             Self::NoUserOrDatabase => write!(f, "no user or database in config"),
             Self::NoPasswordMessage => write!(f, "client did not send password message"),
+            Self::PluginDenied => write!(f, "authentication plugin denied the client"),
+            Self::PluginNoDecision => write!(f, "no authentication plugin accepted the client"),
         }
     }
 }

--- a/pgdog/src/auth/mod.rs
+++ b/pgdog/src/auth/mod.rs
@@ -3,6 +3,7 @@
 pub mod auth_result;
 pub mod error;
 pub mod md5;
+pub mod plugin;
 pub mod scram;
 pub mod vault;
 

--- a/pgdog/src/auth/plugin.rs
+++ b/pgdog/src/auth/plugin.rs
@@ -1,0 +1,269 @@
+//! Authentication plugin driver.
+//!
+//! When `auth_type = "plugin"`, PgDog drives the client wire exchange (asking
+//! for a cleartext password) and hands the credential to the loaded plugins.
+//! Each plugin answers with an [`AuthDecision`]; the first plugin that does not
+//! [`Skip`](pgdog_plugin::AuthDecision::Skip) wins. If every plugin skips, PgDog
+//! denies the client: `auth_type = "plugin"` is explicit and there is no
+//! fallback to password verification (maintainer decision).
+//!
+//! Plugins run inside a single [`tokio::task::spawn_blocking`] call (they may
+//! block on I/O), and the number of concurrent authentication calls is capped by
+//! a [`Semaphore`] sized from the `background_workers` setting.
+
+use std::sync::OnceLock;
+
+use pgdog_plugin::{AuthContext, AuthDecisionTag, AuthField, AuthGrant, PdStr};
+use tokio::sync::Semaphore;
+use tracing::{debug, warn};
+
+use crate::auth::AuthResult;
+use crate::config::config;
+use crate::plugin::plugins;
+
+/// Outcome of running the authentication plugins for a single client.
+#[derive(Debug)]
+pub struct PluginAuthOutcome {
+    /// Overall result: [`AuthResult::Ok`] on Allow, otherwise a plugin denial.
+    pub result: AuthResult,
+    /// Username the plugin derived for the client, if any.
+    pub derived_user: Option<String>,
+    /// Grant returned by the accepting plugin (only set on Allow).
+    pub grant: Option<AuthGrant>,
+    /// Name of the plugin that made the decision, for logging.
+    pub plugin_name: Option<String>,
+}
+
+impl PluginAuthOutcome {
+    fn allow(grant: AuthGrant, plugin_name: String) -> Self {
+        Self {
+            result: AuthResult::Ok,
+            derived_user: grant.derived_user.clone(),
+            grant: Some(grant),
+            plugin_name: Some(plugin_name),
+        }
+    }
+
+    fn denied(plugin_name: String) -> Self {
+        Self {
+            result: AuthResult::PluginDenied,
+            derived_user: None,
+            grant: None,
+            plugin_name: Some(plugin_name),
+        }
+    }
+
+    fn no_decision() -> Self {
+        Self {
+            result: AuthResult::PluginNoDecision,
+            derived_user: None,
+            grant: None,
+            plugin_name: None,
+        }
+    }
+}
+
+/// Cap on concurrent authentication-plugin calls. Sized once from
+/// `background_workers`; plugins run on the blocking pool so this keeps a burst
+/// of logins from exhausting it.
+static SEMAPHORE: OnceLock<Semaphore> = OnceLock::new();
+
+fn semaphore() -> &'static Semaphore {
+    SEMAPHORE.get_or_init(|| {
+        let permits = config().config.general.background_workers.max(1);
+        Semaphore::new(permits)
+    })
+}
+
+/// Authenticate a client through the loaded authentication plugins.
+///
+/// The owned strings are moved into a single `spawn_blocking` call that builds
+/// the [`AuthContext`] (whose [`PdStr`] fields borrow them) and consults the
+/// plugins. A task join failure is treated as a denial.
+pub async fn authenticate(
+    user: String,
+    database: String,
+    credential: String,
+    client_addr: String,
+    tls_identity: Option<String>,
+    tls: bool,
+) -> PluginAuthOutcome {
+    let permit = match semaphore().acquire().await {
+        Ok(permit) => permit,
+        Err(_) => {
+            // The semaphore is never closed; this only happens on shutdown.
+            warn!("authentication plugin semaphore closed, denying client");
+            return PluginAuthOutcome::no_decision();
+        }
+    };
+
+    let join = tokio::task::spawn_blocking(move || {
+        // Hold the permit until the blocking work is done.
+        let _permit = permit;
+        run(
+            &user,
+            &database,
+            &credential,
+            &client_addr,
+            tls_identity,
+            tls,
+        )
+    })
+    .await;
+
+    match join {
+        Ok(outcome) => outcome,
+        Err(err) => {
+            warn!("authentication plugin task failed: {}", err);
+            PluginAuthOutcome::no_decision()
+        }
+    }
+}
+
+/// Fields a plugin streamed back through the authenticate callback.
+#[derive(Default)]
+struct Collected {
+    derived_user: Option<String>,
+    server_role: Option<String>,
+    server_user: Option<String>,
+    server_password: Option<String>,
+    error: Option<String>,
+}
+
+/// Consult the plugins. First non-Skip decision wins.
+///
+/// Plugins that do not implement `authenticate` return Skip via the trait
+/// default, so no capability check is needed. Iteration order follows the
+/// plugin registry (a map), matching how routing consults plugins.
+fn run(
+    user: &str,
+    database: &str,
+    credential: &str,
+    client_addr: &str,
+    tls_identity: Option<String>,
+    tls: bool,
+) -> PluginAuthOutcome {
+    let Some(plugins) = plugins() else {
+        return PluginAuthOutcome::no_decision();
+    };
+
+    // Empty identity == absent, matching the PdStr borrow convention.
+    let tls_identity = tls_identity.unwrap_or_default();
+
+    // AuthContext is Copy and only borrows these strings, which outlive the loop.
+    let context = AuthContext {
+        user: PdStr::from(user),
+        database: PdStr::from(database),
+        credential: PdStr::from(credential),
+        client_addr: PdStr::from(client_addr),
+        tls_identity: PdStr::from(tls_identity.as_str()),
+        tls,
+    };
+
+    for (name, plugin) in plugins {
+        let mut collected = Collected::default();
+        let outcome = plugin.authenticate(context, |field, value| {
+            let slot = match field {
+                AuthField::DerivedUser => &mut collected.derived_user,
+                AuthField::ServerRole => &mut collected.server_role,
+                AuthField::ServerUser => &mut collected.server_user,
+                AuthField::ServerPassword => &mut collected.server_password,
+                AuthField::Error => &mut collected.error,
+            };
+            *slot = Some(value.to_owned());
+        });
+
+        match outcome.tag {
+            AuthDecisionTag::Skip => continue,
+            AuthDecisionTag::Allow => {
+                let grant = AuthGrant {
+                    derived_user: collected.derived_user,
+                    server_role: collected.server_role,
+                    server_user: collected.server_user,
+                    server_password: collected.server_password,
+                    read_only: match outcome.read_only {
+                        0 => Some(false),
+                        1 => Some(true),
+                        _ => None,
+                    },
+                    provision: outcome.provision,
+                };
+                debug!(r#"client "{}" authenticated by plugin "{}""#, user, name);
+                return PluginAuthOutcome::allow(grant, name.clone());
+            }
+            AuthDecisionTag::Deny => {
+                // The reason is logged but never sent to the client.
+                warn!(
+                    r#"client "{}" denied by plugin "{}": {}"#,
+                    user,
+                    name,
+                    collected.error.as_deref().unwrap_or("no reason given"),
+                );
+                return PluginAuthOutcome::denied(name.clone());
+            }
+        }
+    }
+
+    // Every plugin skipped (or there were none). Deny: no password fallback.
+    PluginAuthOutcome::no_decision()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_all_skip_is_no_decision() {
+        // With no plugins loaded, the driver denies via PluginNoDecision.
+        let outcome = authenticate(
+            "alice".into(),
+            "pgdog".into(),
+            "secret".into(),
+            "127.0.0.1:5432".into(),
+            None,
+            false,
+        )
+        .await;
+
+        assert_eq!(outcome.result, AuthResult::PluginNoDecision);
+        assert!(outcome.grant.is_none());
+        assert!(outcome.derived_user.is_none());
+        assert!(outcome.plugin_name.is_none());
+        assert!(!outcome.result.is_ok());
+    }
+
+    #[test]
+    fn test_run_no_plugins_denies() {
+        let outcome = run("bob", "pgdog", "secret", "127.0.0.1:5432", None, false);
+        assert_eq!(outcome.result, AuthResult::PluginNoDecision);
+    }
+
+    #[tokio::test]
+    async fn test_semaphore_sized_from_config() {
+        // The semaphore is created lazily and bounded (>= 1 permit). Acquiring
+        // and releasing a permit must succeed.
+        let permit = semaphore().acquire().await;
+        assert!(permit.is_ok());
+        assert!(semaphore().available_permits() >= 1);
+    }
+
+    #[test]
+    fn test_outcome_constructors() {
+        let grant = AuthGrant {
+            derived_user: Some("reporting".into()),
+            provision: true,
+            ..Default::default()
+        };
+        let allow = PluginAuthOutcome::allow(grant, "jwt".into());
+        assert!(allow.result.is_ok());
+        assert_eq!(allow.derived_user.as_deref(), Some("reporting"));
+        assert_eq!(allow.plugin_name.as_deref(), Some("jwt"));
+
+        let denied = PluginAuthOutcome::denied("jwt".into());
+        assert_eq!(denied.result, AuthResult::PluginDenied);
+        assert!(!denied.result.is_ok());
+
+        let none = PluginAuthOutcome::no_decision();
+        assert_eq!(none.result, AuthResult::PluginNoDecision);
+    }
+}

--- a/pgdog/src/auth/plugin.rs
+++ b/pgdog/src/auth/plugin.rs
@@ -3,9 +3,8 @@
 //! When `auth_type = "plugin"`, PgDog drives the client wire exchange (asking
 //! for a cleartext password) and hands the credential to the loaded plugins.
 //! Each plugin answers with an [`AuthDecision`]; the first plugin that does not
-//! [`Skip`](pgdog_plugin::AuthDecision::Skip) wins. If every plugin skips, PgDog
-//! denies the client: `auth_type = "plugin"` is explicit and there is no
-//! fallback to password verification (maintainer decision).
+//! [`Skip`](pgdog_plugin::AuthDecision::Skip) wins. If every plugin skips, the
+//! frontend falls back to configured password or passthrough authentication.
 //!
 //! Plugins run inside a single [`tokio::task::spawn_blocking`] call (they may
 //! block on I/O), and the number of concurrent authentication calls is capped by
@@ -83,7 +82,7 @@ pub async fn authenticate(
         Err(_) => {
             // The semaphore is never closed; this only happens on shutdown.
             warn!("authentication plugin semaphore closed, denying client");
-            return PluginAuthOutcome::no_decision();
+            return PluginAuthOutcome::denied();
         }
     };
 
@@ -105,7 +104,7 @@ pub async fn authenticate(
         Ok(outcome) => outcome,
         Err(err) => {
             warn!("authentication plugin task failed: {}", err);
-            PluginAuthOutcome::no_decision()
+            PluginAuthOutcome::denied()
         }
     }
 }
@@ -194,7 +193,7 @@ fn run(
         }
     }
 
-    // Every plugin skipped (or there were none). Deny: no password fallback.
+    // Let the frontend apply its configured authentication fallback.
     PluginAuthOutcome::no_decision()
 }
 
@@ -204,7 +203,8 @@ mod test {
 
     #[tokio::test]
     async fn test_all_skip_is_no_decision() {
-        // With no plugins loaded, the driver denies via PluginNoDecision.
+        // With no plugins loaded, the frontend receives PluginNoDecision and
+        // applies its configured authentication fallback.
         let outcome = authenticate(
             "alice".into(),
             "pgdog".into(),
@@ -221,7 +221,7 @@ mod test {
     }
 
     #[test]
-    fn test_run_no_plugins_denies() {
+    fn test_run_no_plugins_returns_no_decision() {
         let outcome = run("bob", "pgdog", "secret", "127.0.0.1:5432", None, false);
         assert_eq!(outcome.result, AuthResult::PluginNoDecision);
     }

--- a/pgdog/src/auth/plugin.rs
+++ b/pgdog/src/auth/plugin.rs
@@ -1,0 +1,259 @@
+//! Authentication plugin driver.
+//!
+//! When `auth_type = "plugin"`, PgDog drives the client wire exchange (asking
+//! for a cleartext password) and hands the credential to the loaded plugins.
+//! Each plugin answers with an [`AuthDecision`]; the first plugin that does not
+//! [`Skip`](pgdog_plugin::AuthDecision::Skip) wins. If every plugin skips, PgDog
+//! denies the client: `auth_type = "plugin"` is explicit and there is no
+//! fallback to password verification (maintainer decision).
+//!
+//! Plugins run inside a single [`tokio::task::spawn_blocking`] call (they may
+//! block on I/O), and the number of concurrent authentication calls is capped by
+//! a [`Semaphore`] sized from the `background_workers` setting.
+
+use std::sync::OnceLock;
+
+use pgdog_plugin::{AuthContext, AuthDecisionTag, AuthField, AuthGrant, PdStr};
+use tokio::sync::Semaphore;
+use tracing::{debug, warn};
+
+use crate::auth::AuthResult;
+use crate::config::config;
+use crate::plugin::plugins;
+
+/// Outcome of running the authentication plugins for a single client.
+#[derive(Debug)]
+pub struct PluginAuthOutcome {
+    /// Overall result: [`AuthResult::Ok`] on Allow, otherwise a plugin denial.
+    pub result: AuthResult,
+    /// Grant returned by the accepting plugin (only set on Allow).
+    pub grant: Option<AuthGrant>,
+}
+
+impl PluginAuthOutcome {
+    fn allow(grant: AuthGrant) -> Self {
+        Self {
+            result: AuthResult::Ok,
+            grant: Some(grant),
+        }
+    }
+
+    fn denied() -> Self {
+        Self {
+            result: AuthResult::PluginDenied,
+            grant: None,
+        }
+    }
+
+    fn no_decision() -> Self {
+        Self {
+            result: AuthResult::PluginNoDecision,
+            grant: None,
+        }
+    }
+}
+
+/// Cap on concurrent authentication-plugin calls. Sized once from
+/// `background_workers`; plugins run on the blocking pool so this keeps a burst
+/// of logins from exhausting it.
+static SEMAPHORE: OnceLock<Semaphore> = OnceLock::new();
+
+fn semaphore() -> &'static Semaphore {
+    SEMAPHORE.get_or_init(|| {
+        let permits = config().config.general.background_workers.max(1);
+        Semaphore::new(permits)
+    })
+}
+
+/// Authenticate a client through the loaded authentication plugins.
+///
+/// The owned strings are moved into a single `spawn_blocking` call that builds
+/// the [`AuthContext`] (whose [`PdStr`] fields borrow them) and consults the
+/// plugins. A task join failure is treated as a denial.
+pub async fn authenticate(
+    user: String,
+    database: String,
+    credential: String,
+    client_addr: String,
+    tls_identity: Option<String>,
+    tls: bool,
+) -> PluginAuthOutcome {
+    let permit = match semaphore().acquire().await {
+        Ok(permit) => permit,
+        Err(_) => {
+            // The semaphore is never closed; this only happens on shutdown.
+            warn!("authentication plugin semaphore closed, denying client");
+            return PluginAuthOutcome::no_decision();
+        }
+    };
+
+    let join = tokio::task::spawn_blocking(move || {
+        // Hold the permit until the blocking work is done.
+        let _permit = permit;
+        run(
+            &user,
+            &database,
+            &credential,
+            &client_addr,
+            tls_identity,
+            tls,
+        )
+    })
+    .await;
+
+    match join {
+        Ok(outcome) => outcome,
+        Err(err) => {
+            warn!("authentication plugin task failed: {}", err);
+            PluginAuthOutcome::no_decision()
+        }
+    }
+}
+
+/// Fields a plugin streamed back through the authenticate callback.
+#[derive(Default)]
+struct Collected {
+    derived_user: Option<String>,
+    server_role: Option<String>,
+    server_user: Option<String>,
+    server_password: Option<String>,
+    error: Option<String>,
+}
+
+/// Consult the plugins. First non-Skip decision wins.
+///
+/// Plugins that do not implement `authenticate` return Skip via the trait
+/// default, so no capability check is needed. Iteration order follows the
+/// plugin registry (a map), matching how routing consults plugins.
+fn run(
+    user: &str,
+    database: &str,
+    credential: &str,
+    client_addr: &str,
+    tls_identity: Option<String>,
+    tls: bool,
+) -> PluginAuthOutcome {
+    let Some(plugins) = plugins() else {
+        return PluginAuthOutcome::no_decision();
+    };
+
+    // Empty identity == absent, matching the PdStr borrow convention.
+    let tls_identity = tls_identity.unwrap_or_default();
+
+    // AuthContext is Copy and only borrows these strings, which outlive the loop.
+    let context = AuthContext {
+        user: PdStr::from(user),
+        database: PdStr::from(database),
+        credential: PdStr::from(credential),
+        client_addr: PdStr::from(client_addr),
+        tls_identity: PdStr::from(tls_identity.as_str()),
+        tls,
+    };
+
+    for (name, plugin) in plugins {
+        let mut collected = Collected::default();
+        let outcome = plugin.authenticate(context, |field, value| {
+            let slot = match field {
+                AuthField::DerivedUser => &mut collected.derived_user,
+                AuthField::ServerRole => &mut collected.server_role,
+                AuthField::ServerUser => &mut collected.server_user,
+                AuthField::ServerPassword => &mut collected.server_password,
+                AuthField::Error => &mut collected.error,
+            };
+            *slot = Some(value.to_owned());
+        });
+
+        match outcome.tag {
+            AuthDecisionTag::Skip => continue,
+            AuthDecisionTag::Allow => {
+                let grant = AuthGrant {
+                    derived_user: collected.derived_user,
+                    server_role: collected.server_role,
+                    server_user: collected.server_user,
+                    server_password: collected.server_password,
+                    read_only: match outcome.read_only {
+                        0 => Some(false),
+                        1 => Some(true),
+                        _ => None,
+                    },
+                    provision: outcome.provision,
+                };
+                debug!(r#"client "{}" authenticated by plugin "{}""#, user, name);
+                return PluginAuthOutcome::allow(grant);
+            }
+            AuthDecisionTag::Deny => {
+                // The reason is logged but never sent to the client.
+                warn!(
+                    r#"client "{}" denied by plugin "{}": {}"#,
+                    user,
+                    name,
+                    collected.error.as_deref().unwrap_or("no reason given"),
+                );
+                return PluginAuthOutcome::denied();
+            }
+        }
+    }
+
+    // Every plugin skipped (or there were none). Deny: no password fallback.
+    PluginAuthOutcome::no_decision()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_all_skip_is_no_decision() {
+        // With no plugins loaded, the driver denies via PluginNoDecision.
+        let outcome = authenticate(
+            "alice".into(),
+            "pgdog".into(),
+            "secret".into(),
+            "127.0.0.1:5432".into(),
+            None,
+            false,
+        )
+        .await;
+
+        assert_eq!(outcome.result, AuthResult::PluginNoDecision);
+        assert!(outcome.grant.is_none());
+        assert!(!outcome.result.is_ok());
+    }
+
+    #[test]
+    fn test_run_no_plugins_denies() {
+        let outcome = run("bob", "pgdog", "secret", "127.0.0.1:5432", None, false);
+        assert_eq!(outcome.result, AuthResult::PluginNoDecision);
+    }
+
+    #[tokio::test]
+    async fn test_semaphore_sized_from_config() {
+        // The semaphore is created lazily and bounded (>= 1 permit). Acquiring
+        // and releasing a permit must succeed.
+        let permit = semaphore().acquire().await;
+        assert!(permit.is_ok());
+        assert!(semaphore().available_permits() >= 1);
+    }
+
+    #[test]
+    fn test_outcome_constructors() {
+        let grant = AuthGrant {
+            derived_user: Some("reporting".into()),
+            provision: true,
+            ..Default::default()
+        };
+        let allow = PluginAuthOutcome::allow(grant);
+        assert!(allow.result.is_ok());
+        assert_eq!(
+            allow.grant.and_then(|grant| grant.derived_user).as_deref(),
+            Some("reporting")
+        );
+
+        let denied = PluginAuthOutcome::denied();
+        assert_eq!(denied.result, AuthResult::PluginDenied);
+        assert!(!denied.result.is_ok());
+
+        let none = PluginAuthOutcome::no_decision();
+        assert_eq!(none.result, AuthResult::PluginNoDecision);
+    }
+}

--- a/pgdog/src/auth/plugin.rs
+++ b/pgdog/src/auth/plugin.rs
@@ -123,8 +123,8 @@ struct Collected {
 /// Consult the plugins. First non-Skip decision wins.
 ///
 /// Plugins that do not implement `authenticate` return Skip via the trait
-/// default, so no capability check is needed. Iteration order follows the
-/// plugin registry (a map), matching how routing consults plugins.
+/// default, so no capability check is needed. Iteration order follows
+/// `[[plugins]]` configuration order, matching how routing consults plugins.
 fn run(
     user: &str,
     database: &str,

--- a/pgdog/src/auth/scram/mod.rs
+++ b/pgdog/src/auth/scram/mod.rs
@@ -29,3 +29,60 @@ pub fn generate_hash(password: &str, iterations: std::num::NonZeroU32, salt: &[u
         BASE64_STANDARD.encode(server_key.as_ref()),
     )
 }
+
+/// Verify a plaintext password against a PostgreSQL SCRAM-SHA-256 verifier.
+pub fn verify_password(password: &str, verifier: &str) -> bool {
+    use std::num::NonZeroU32;
+
+    use base64::prelude::*;
+
+    let Some(rest) = verifier.strip_prefix("SCRAM-SHA-256$") else {
+        return false;
+    };
+    let Some((iterations_and_salt, _keys)) = rest.split_once('$') else {
+        return false;
+    };
+    let Some((iterations, salt)) = iterations_and_salt.split_once(':') else {
+        return false;
+    };
+    let Ok(iterations) = iterations.parse::<u32>() else {
+        return false;
+    };
+    let Some(iterations) = NonZeroU32::new(iterations) else {
+        return false;
+    };
+    let Ok(salt) = BASE64_STANDARD.decode(salt) else {
+        return false;
+    };
+
+    let candidate = generate_hash(password, iterations, &salt);
+    crate::util::constant_time_eq(candidate.as_bytes(), verifier.as_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU32;
+
+    use super::{generate_hash, verify_password};
+
+    #[test]
+    fn verifies_plaintext_against_scram_verifier() {
+        let verifier = generate_hash(
+            "correct-password",
+            NonZeroU32::new(4096).expect("iterations are non-zero"),
+            b"pgdog_test_salt!",
+        );
+
+        assert!(verify_password("correct-password", &verifier));
+        assert!(!verify_password("wrong-password", &verifier));
+    }
+
+    #[test]
+    fn rejects_invalid_scram_verifier() {
+        assert!(!verify_password("password", "not-a-scram-verifier"));
+        assert!(!verify_password(
+            "password",
+            "SCRAM-SHA-256$0:c2FsdA==$stored:server"
+        ));
+    }
+}

--- a/pgdog/src/backend/auth/azure_workload_identity.rs
+++ b/pgdog/src/backend/auth/azure_workload_identity.rs
@@ -59,6 +59,7 @@ mod tests {
             passwords: vec![],
             database_number: 0,
             server_auth: ServerAuth::AzureWorkloadIdentity,
+            server_role: None,
             server_iam_region: None,
             vault_path: Default::default(),
             vault_refresh_percent: None,

--- a/pgdog/src/backend/auth/rds_iam.rs
+++ b/pgdog/src/backend/auth/rds_iam.rs
@@ -100,6 +100,7 @@ mod tests {
             passwords: vec![],
             database_number: 0,
             server_auth: ServerAuth::RdsIam,
+            server_role: None,
             server_iam_region: Some("us-east-1".into()),
             vault_path: Default::default(),
             vault_refresh_percent: None,

--- a/pgdog/src/backend/auth/vault.rs
+++ b/pgdog/src/backend/auth/vault.rs
@@ -185,6 +185,7 @@ mod tests {
             user: "testuser".into(),
             passwords: vec![],
             server_auth: Default::default(),
+            server_role: None,
             server_iam_region: None,
             vault_path: vault_path.map(Into::into),
             vault_refresh_percent: None,

--- a/pgdog/src/backend/connect_reason.rs
+++ b/pgdog/src/backend/connect_reason.rs
@@ -9,6 +9,7 @@ pub enum ConnectReason {
     PubSub,
     Probe,
     Healthcheck,
+    PassthroughVerify,
     #[default]
     Other,
 }
@@ -23,6 +24,7 @@ impl Display for ConnectReason {
             Self::PubSub => "pub/sub",
             Self::Probe => "probe",
             Self::Healthcheck => "healthcheck",
+            Self::PassthroughVerify => "passthrough verify",
             Self::Other => "other",
         };
 

--- a/pgdog/src/backend/databases.rs
+++ b/pgdog/src/backend/databases.rs
@@ -213,6 +213,66 @@ pub(crate) fn add(user: ConfigUser) -> Result<AuthResult, Error> {
     }
 }
 
+/// Provision or complete a user during plugin authentication.
+///
+/// Unlike [`add`], this does not compare a client password: the plugin has
+/// already authenticated the client, and the credential (e.g. a JWT) differs
+/// on every login. A configured `users.toml` entry is never overwritten —
+/// only missing backend credentials are filled in.
+pub fn add_authenticated(user: ConfigUser) -> Result<AuthResult, Error> {
+    fn store(user: ConfigUser) -> Result<(), Error> {
+        let _lock = lock();
+        let mut config = (*config()).clone();
+        config.users.add_or_replace(user);
+        set(config)?;
+        Ok(())
+    }
+
+    let config = config();
+    let existing = config.users.find(&user);
+
+    if let Some(mut existing) = existing {
+        // Never overwrite a configured entry; only fill gaps so a partially
+        // configured user still gets usable backend credentials.
+        let mut changed = false;
+        if existing.server_user.is_none() && user.server_user.is_some() {
+            existing.server_user = user.server_user.clone();
+            changed = true;
+        }
+        if existing.server_password.is_none() && user.server_password.is_some() {
+            existing.server_password = user.server_password.clone();
+            changed = true;
+        }
+        if existing.server_role.is_none() && user.server_role.is_some() {
+            existing.server_role = user.server_role.clone();
+            changed = true;
+        }
+        if existing.read_only.is_none() && user.read_only.is_some() {
+            existing.read_only = user.read_only;
+            changed = true;
+        }
+
+        if changed {
+            debug!(
+                r#"filling backend-credential gaps for user "{}" on database "{}""#,
+                existing.name, existing.database
+            );
+            store(existing)?;
+            reload_from_existing()?;
+        }
+
+        Ok(AuthResult::Ok)
+    } else {
+        debug!(
+            r#"provisioning user "{}" on database "{}" via plugin authentication"#,
+            user.name, user.database
+        );
+        store(user)?;
+        reload_from_existing()?;
+        Ok(AuthResult::Ok)
+    }
+}
+
 /// Swap database configs between source and destination.
 /// Both databases keep their names, but their configs (host, port, etc.) are exchanged.
 /// User database references are also swapped.
@@ -461,7 +521,17 @@ impl Databases {
 
         // Launch all clusters
         for cluster in self.all().values() {
-            if cluster.passwords().is_empty() && cluster.identity().is_none() {
+            // A cluster is only useful if a client can authenticate to it and it
+            // can authenticate to Postgres. The empty client-password case is
+            // still allowed when the cluster carries its own backend credentials
+            // (server password, external identity, or an impersonation
+            // `server_role`): that is how plugin auth and auto-provisioned
+            // impersonation pools work — they authenticate each login via a
+            // plugin rather than a stored client password.
+            if cluster.passwords().is_empty()
+                && cluster.identity().is_none()
+                && !cluster.has_backend_credentials()
+            {
                 warn!(
                     r#"disabling pool for user "{}" and database "{}", password not set"#,
                     cluster.user(),

--- a/pgdog/src/backend/databases.rs
+++ b/pgdog/src/backend/databases.rs
@@ -417,6 +417,16 @@ pub fn add_authenticated(user: ConfigUser) -> Result<AuthResult, Error> {
         if existing.server_role.is_none() && user.server_role.is_some() {
             existing.server_role = user.server_role.clone();
             changed = true;
+        } else if let (Some(configured), Some(granted)) = (&existing.server_role, &user.server_role)
+            && configured != granted
+        {
+            // The plugin asked to impersonate a different role than the one
+            // configured; the configured value wins, so queries will not run
+            // as the authenticated identity.
+            warn!(
+                r#"user "{}" on database "{}": configured server_role "{}" overrides plugin-granted server_role "{}""#,
+                existing.name, existing.database, configured, granted
+            );
         }
         if existing.read_only.is_none() && user.read_only.is_some() {
             existing.read_only = user.read_only;
@@ -1137,6 +1147,80 @@ mod tests {
         let config = crate::config::config();
         let found = config.users.find(&make_user("dave", None));
         assert_eq!(found.unwrap().password, Some("new_pass".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_add_authenticated_fills_server_role_gap() {
+        setup_config(
+            crate::config::PassthroughAuth::Disabled,
+            vec![ConfigUser {
+                name: "alice@example.com".to_string(),
+                database: "db1".to_string(),
+                server_user: Some("service".to_string()),
+                server_password: Some("secret".to_string()),
+                ..Default::default()
+            }],
+        );
+
+        let granted = ConfigUser {
+            name: "alice@example.com".to_string(),
+            database: "db1".to_string(),
+            server_role: Some("alice@example.com".to_string()),
+            ..Default::default()
+        };
+        assert!(
+            add_authenticated(granted)
+                .expect("add_authenticated")
+                .is_ok()
+        );
+
+        let config = crate::config::config();
+        let found = config
+            .users
+            .find(&make_user("alice@example.com", None))
+            .expect("user exists");
+        // The grant filled the missing role; configured credentials stayed.
+        assert_eq!(found.server_role.as_deref(), Some("alice@example.com"));
+        assert_eq!(found.server_user.as_deref(), Some("service"));
+        assert_eq!(found.server_password.as_deref(), Some("secret"));
+
+        // The rebuilt pool impersonates the role via the startup packet.
+        let cluster = databases()
+            .cluster(("alice@example.com", "db1"))
+            .expect("cluster exists");
+        assert_eq!(cluster.server_role(), Some("alice@example.com"));
+    }
+
+    #[tokio::test]
+    async fn test_add_authenticated_keeps_configured_server_role() {
+        setup_config(
+            crate::config::PassthroughAuth::Disabled,
+            vec![ConfigUser {
+                name: "bob".to_string(),
+                database: "db1".to_string(),
+                server_role: Some("analytics".to_string()),
+                ..Default::default()
+            }],
+        );
+
+        let granted = ConfigUser {
+            name: "bob".to_string(),
+            database: "db1".to_string(),
+            server_role: Some("bob".to_string()),
+            ..Default::default()
+        };
+        assert!(
+            add_authenticated(granted)
+                .expect("add_authenticated")
+                .is_ok()
+        );
+
+        let config = crate::config::config();
+        let found = config
+            .users
+            .find(&make_user("bob", None))
+            .expect("user exists");
+        assert_eq!(found.server_role.as_deref(), Some("analytics"));
     }
 
     #[tokio::test]

--- a/pgdog/src/backend/databases.rs
+++ b/pgdog/src/backend/databases.rs
@@ -214,6 +214,66 @@ pub(crate) fn add(user: ConfigUser) -> Result<AuthResult, Error> {
     }
 }
 
+/// Provision or complete a user during plugin authentication.
+///
+/// Unlike [`add`], this does not compare a client password: the plugin has
+/// already authenticated the client, and the credential (e.g. a JWT) differs
+/// on every login. A configured `users.toml` entry is never overwritten —
+/// only missing backend credentials are filled in.
+pub fn add_authenticated(user: ConfigUser) -> Result<AuthResult, Error> {
+    fn store(user: ConfigUser) -> Result<(), Error> {
+        let _lock = lock();
+        let mut config = (*config()).clone();
+        config.users.add_or_replace(user);
+        set(config)?;
+        Ok(())
+    }
+
+    let config = config();
+    let existing = config.users.find(&user);
+
+    if let Some(mut existing) = existing {
+        // Never overwrite a configured entry; only fill gaps so a partially
+        // configured user still gets usable backend credentials.
+        let mut changed = false;
+        if existing.server_user.is_none() && user.server_user.is_some() {
+            existing.server_user = user.server_user.clone();
+            changed = true;
+        }
+        if existing.server_password.is_none() && user.server_password.is_some() {
+            existing.server_password = user.server_password.clone();
+            changed = true;
+        }
+        if existing.server_role.is_none() && user.server_role.is_some() {
+            existing.server_role = user.server_role.clone();
+            changed = true;
+        }
+        if existing.read_only.is_none() && user.read_only.is_some() {
+            existing.read_only = user.read_only;
+            changed = true;
+        }
+
+        if changed {
+            debug!(
+                r#"filling backend-credential gaps for user "{}" on database "{}""#,
+                existing.name, existing.database
+            );
+            store(existing)?;
+            reload_from_existing()?;
+        }
+
+        Ok(AuthResult::Ok)
+    } else {
+        debug!(
+            r#"provisioning user "{}" on database "{}" via plugin authentication"#,
+            user.name, user.database
+        );
+        store(user)?;
+        reload_from_existing()?;
+        Ok(AuthResult::Ok)
+    }
+}
+
 /// Swap database configs between source and destination.
 /// Both databases keep their names, but their configs (host, port, etc.) are exchanged.
 /// User database references are also swapped.
@@ -441,7 +501,17 @@ impl Databases {
 
         // Launch all clusters
         for cluster in self.all().values() {
-            if cluster.passwords().is_empty() && cluster.identity().is_none() {
+            // A cluster is only useful if a client can authenticate to it and it
+            // can authenticate to Postgres. The empty client-password case is
+            // still allowed when the cluster carries its own backend credentials
+            // (server password, external identity, or an impersonation
+            // `server_role`): that is how plugin auth and auto-provisioned
+            // impersonation pools work — they authenticate each login via a
+            // plugin rather than a stored client password.
+            if cluster.passwords().is_empty()
+                && cluster.identity().is_none()
+                && !cluster.has_backend_credentials()
+            {
                 warn!(
                     r#"disabling pool for user "{}" and database "{}", password not set"#,
                     cluster.user(),

--- a/pgdog/src/backend/databases.rs
+++ b/pgdog/src/backend/databases.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 use std::ops::Deref;
 use std::sync::Arc;
+use std::time::Duration;
 
 use arc_swap::ArcSwap;
 use futures::future::try_join_all;
@@ -32,10 +33,11 @@ use crate::{
         ConfigAndUsers, Role, ShardedMappingDeprecated, User as ConfigUser, config, load, set,
     },
     net::{messages::FrontendPid, tls},
+    util::safe_timeout,
 };
 
 use super::{
-    Cluster, ClusterShardConfig, Error, ShardedTables,
+    Cluster, ClusterShardConfig, ConnectReason, Error, Server, ServerOptions, ShardedTables,
     pool::{Address, ClusterConfig, Config},
     reload_notify,
 };
@@ -158,6 +160,122 @@ pub fn reload() -> Result<(), Error> {
     Ok(())
 }
 
+/// What passthrough authentication should do with a client-supplied credential.
+#[derive(Debug, PartialEq)]
+enum PassthroughAction {
+    /// Credential matches the stored password; the client is authenticated.
+    Match,
+    /// Credential must be stored: the user is new, has no password yet, or a
+    /// password change is permitted by the configuration.
+    Store,
+    /// Credential is rejected.
+    Deny(AuthResult),
+}
+
+fn passthrough_action(user: &ConfigUser, config: &ConfigAndUsers) -> PassthroughAction {
+    let Some(existing) = config.users.find(user) else {
+        return PassthroughAction::Store;
+    };
+
+    if existing.password.is_none() {
+        PassthroughAction::Store
+    } else if existing
+        .password
+        .as_deref()
+        .zip(user.password.as_deref())
+        .is_some_and(|(stored, provided)| {
+            crate::util::constant_time_eq(stored.as_bytes(), provided.as_bytes())
+        })
+    {
+        PassthroughAction::Match
+    } else if config.config.general.passthrough_auth.allows_change() {
+        PassthroughAction::Store
+    } else {
+        PassthroughAction::Deny(AuthResult::NoPassthroughPasswordChange)
+    }
+}
+
+/// Result of verifying a passthrough credential against the server.
+enum Verification {
+    Ok,
+    BadPassword,
+    NoDatabase,
+    Failed,
+}
+
+/// Verify a client-supplied passthrough credential against the actual
+/// PostgreSQL server before it is stored.
+///
+/// Verifies against the primary of the user's database (the first entry when
+/// no primary is configured); multi-shard deployments assume the credential
+/// is valid on every shard. When the pool would not use the client password
+/// as a server credential (a `server_password` or database-level password is
+/// configured, or an external identity provider is used), there is nothing
+/// to verify and the credential is accepted as before.
+async fn verify_passthrough_credential(user: &ConfigUser, config: &ConfigAndUsers) -> Verification {
+    let Some(password) = user.password.as_deref() else {
+        return Verification::Failed;
+    };
+
+    let candidates: Vec<_> = config
+        .config
+        .databases
+        .iter()
+        .enumerate()
+        .filter(|(_, database)| database.name == user.database)
+        .collect();
+    let Some((number, database)) = candidates
+        .iter()
+        .find(|(_, database)| database.role == Role::Primary)
+        .or_else(|| candidates.first())
+        .copied()
+    else {
+        return Verification::NoDatabase;
+    };
+
+    let address = Address::new(database, user, number);
+    if !address.passwords.iter().any(|p| p.as_str() == password) {
+        return Verification::Ok;
+    }
+
+    let connect_timeout = Duration::from_millis(config.config.general.connect_timeout);
+    match safe_timeout(
+        connect_timeout,
+        Box::pin(Server::connect(
+            &address,
+            ServerOptions::default(),
+            ConnectReason::PassthroughVerify,
+            Default::default(),
+        )),
+    )
+    .await
+    {
+        Ok(Ok(_)) => Verification::Ok,
+        Ok(Err(err)) if err.is_auth() => Verification::BadPassword,
+        Ok(Err(_)) | Err(_) => Verification::Failed,
+    }
+}
+
+/// Authenticate a client through passthrough authentication.
+///
+/// Unlike [`add`], the credential is verified against the server before it is
+/// stored: a mistyped client password gets a clean authentication error
+/// instead of becoming the pool's server credential and poisoning every
+/// connection attempt until it is replaced.
+pub(crate) async fn add_passthrough(user: ConfigUser) -> Result<AuthResult, Error> {
+    let config = config();
+    match passthrough_action(&user, &config) {
+        PassthroughAction::Match => Ok(AuthResult::Ok),
+        PassthroughAction::Deny(result) => Ok(result),
+        PassthroughAction::Store => match verify_passthrough_credential(&user, &config).await {
+            Verification::Ok => add(user),
+            Verification::BadPassword => Ok(AuthResult::NoPasswordMatch),
+            Verification::NoDatabase => Ok(AuthResult::NoUserOrDatabase),
+            Verification::Failed => Ok(AuthResult::PassthroughVerificationFailed),
+        },
+    }
+}
+
 /// Add new user to pool via passthrough authentication.
 ///
 /// Return true if user can login, false otherwise.
@@ -178,39 +296,91 @@ pub(crate) fn add(user: ConfigUser) -> Result<AuthResult, Error> {
     }
 
     let config = config();
-    let existing = config.users.find(&user);
-
-    // User already exists in users.toml.
-    if let Some(mut existing) = existing {
-        // Password hasn't been set yet.
-        if existing.password.is_none() {
-            existing.password = user.password.clone();
-            add_user(existing)?;
+    match passthrough_action(&user, &config) {
+        PassthroughAction::Match => Ok(AuthResult::Ok),
+        PassthroughAction::Deny(result) => Ok(result),
+        PassthroughAction::Store => {
+            // Keep configured settings when only the password changes; mark
+            // the credential so it can be evicted if the server rejects it.
+            let stored = match config.users.find(&user) {
+                Some(mut existing) => {
+                    existing.password = user.password.clone();
+                    existing.password_from_passthrough = true;
+                    existing
+                }
+                None => ConfigUser {
+                    password_from_passthrough: true,
+                    created_by_passthrough: true,
+                    ..user
+                },
+            };
+            add_user(stored)?;
             reload_from_existing()?;
             Ok(AuthResult::Ok)
-        } else if existing
-            .password
-            .as_deref()
-            .zip(user.password.as_deref())
-            .is_some_and(|(stored, provided)| {
-                crate::util::constant_time_eq(stored.as_bytes(), provided.as_bytes())
-            })
-        {
-            // Passwords match.
-            Ok(AuthResult::Ok)
-        } else if config.config.general.passthrough_auth.allows_change() {
-            // Passwords don't match but we can change it.
-            existing.password = user.password.clone();
-            add_user(user)?;
-            reload_from_existing()?;
-            Ok(AuthResult::Ok)
-        } else {
-            Ok(AuthResult::NoPassthroughPasswordChange)
         }
-    } else {
-        add_user(user)?;
-        reload_from_existing()?;
-        Ok(AuthResult::Ok)
+    }
+}
+
+/// Evict a passthrough-learned password the server has rejected.
+///
+/// Called when a server connection fails authentication with a credential
+/// learned through passthrough authentication (e.g. the server-side password
+/// rotated after the credential was stored). Eviction stops the pool from
+/// retrying a password that can never work and lets the next client login
+/// store the current one. Passwords configured in `users.toml` are never
+/// touched.
+pub(crate) fn passthrough_password_rejected(user_name: &str, database: &str, rejected: &str) {
+    let evicted = {
+        let _lock = lock();
+        let config_now = config();
+        let Some(user) = config_now
+            .users
+            .users
+            .iter()
+            .find(|user| user.name == user_name && user.database == database)
+        else {
+            return;
+        };
+
+        if !user.password_from_passthrough || user.password.as_deref() != Some(rejected) {
+            return;
+        }
+
+        let mut config = (*config_now).clone();
+        if user.created_by_passthrough {
+            // The whole entry was discovered through passthrough
+            // authentication: remove it, restoring the pre-discovery state.
+            config
+                .users
+                .users
+                .retain(|user| !(user.name == user_name && user.database == database));
+        } else {
+            let mut updated = user.clone();
+            updated.password = None;
+            updated.password_from_passthrough = false;
+            config.users.add_or_replace(updated);
+        }
+
+        match set(config) {
+            Ok(_) => true,
+            Err(err) => {
+                error!("error evicting rejected passthrough password: {}", err);
+                false
+            }
+        }
+    };
+
+    if evicted {
+        warn!(
+            r#"evicted passthrough password for user "{}" on database "{}": the server rejected it"#,
+            user_name, database
+        );
+        if let Err(err) = reload_from_existing() {
+            error!(
+                "error reloading after passthrough password eviction: {}",
+                err
+            );
+        }
     }
 }
 
@@ -967,6 +1137,208 @@ mod tests {
         let config = crate::config::config();
         let found = config.users.find(&make_user("dave", None));
         assert_eq!(found.unwrap().password, Some("new_pass".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_add_marks_passthrough_credentials() {
+        setup_config(
+            crate::config::PassthroughAuth::EnabledPlain,
+            vec![make_user("bob", None)],
+        );
+
+        // Discovered user: whole entry is removable on rejection.
+        add(make_user("new_user", Some("secret"))).expect("add");
+        let found = crate::config::config()
+            .users
+            .find(&make_user("new_user", None))
+            .expect("user added");
+        assert!(found.password_from_passthrough);
+        assert!(found.created_by_passthrough);
+
+        // Configured user with no password: only the password is learned.
+        add(make_user("bob", Some("secret"))).expect("add");
+        let found = crate::config::config()
+            .users
+            .find(&make_user("bob", None))
+            .expect("user exists");
+        assert!(found.password_from_passthrough);
+        assert!(!found.created_by_passthrough);
+    }
+
+    #[tokio::test]
+    async fn test_passthrough_rejected_removes_discovered_user() {
+        setup_config(crate::config::PassthroughAuth::EnabledPlain, vec![]);
+
+        add(make_user("eve", Some("stale"))).expect("add");
+        passthrough_password_rejected("eve", "db1", "stale");
+
+        let config = crate::config::config();
+        assert!(config.users.find(&make_user("eve", None)).is_none());
+    }
+
+    #[tokio::test]
+    async fn test_passthrough_rejected_clears_learned_password() {
+        setup_config(
+            crate::config::PassthroughAuth::EnabledPlain,
+            vec![make_user("bob", None)],
+        );
+
+        add(make_user("bob", Some("stale"))).expect("add");
+        passthrough_password_rejected("bob", "db1", "stale");
+
+        let found = crate::config::config()
+            .users
+            .find(&make_user("bob", None))
+            .expect("configured entry kept");
+        assert_eq!(found.password, None);
+        assert!(!found.password_from_passthrough);
+    }
+
+    #[tokio::test]
+    async fn test_passthrough_rejected_ignores_configured_password() {
+        setup_config(
+            crate::config::PassthroughAuth::EnabledPlain,
+            vec![make_user("alice", Some("configured"))],
+        );
+
+        passthrough_password_rejected("alice", "db1", "configured");
+
+        let found = crate::config::config()
+            .users
+            .find(&make_user("alice", None))
+            .expect("user exists");
+        assert_eq!(found.password, Some("configured".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_passthrough_rejected_ignores_stale_password() {
+        setup_config(crate::config::PassthroughAuth::EnabledPlain, vec![]);
+
+        add(make_user("eve", Some("current"))).expect("add");
+        passthrough_password_rejected("eve", "db1", "previous");
+
+        let found = crate::config::config()
+            .users
+            .find(&make_user("eve", None))
+            .expect("user kept");
+        assert_eq!(found.password, Some("current".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_add_passthrough_unreachable_server_stores_nothing() {
+        // Port 1 is closed: verification can't run, so the credential must
+        // not be stored and the client gets a verification error.
+        let _lock = lock();
+        let config = Config {
+            databases: vec![Database {
+                name: "db1".to_string(),
+                host: "127.0.0.1".to_string(),
+                port: 1,
+                role: Role::Primary,
+                ..Default::default()
+            }],
+            general: General {
+                passthrough_auth: crate::config::PassthroughAuth::EnabledPlain,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let cu = ConfigAndUsers {
+            config,
+            ..Default::default()
+        };
+        crate::config::set(cu).expect("set config");
+        replace_databases(from_config(&crate::config::config()), false).expect("replace");
+        drop(_lock);
+
+        let result = add_passthrough(make_user("new_user", Some("secret")))
+            .await
+            .expect("add_passthrough");
+        assert_eq!(result, AuthResult::PassthroughVerificationFailed);
+        assert!(
+            crate::config::config()
+                .users
+                .find(&make_user("new_user", None))
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_add_passthrough_no_database_stores_nothing() {
+        setup_config(crate::config::PassthroughAuth::EnabledPlain, vec![]);
+
+        let mut user = make_user("new_user", Some("secret"));
+        user.database = "does_not_exist".to_string();
+        let result = add_passthrough(user).await.expect("add_passthrough");
+        assert_eq!(result, AuthResult::NoUserOrDatabase);
+    }
+
+    #[tokio::test]
+    async fn test_add_passthrough_denies_password_change() {
+        setup_config(
+            crate::config::PassthroughAuth::EnabledPlain,
+            vec![make_user("alice", Some("configured"))],
+        );
+
+        // No server connection needed: rejected before verification.
+        let result = add_passthrough(make_user("alice", Some("other")))
+            .await
+            .expect("add_passthrough");
+        assert_eq!(result, AuthResult::NoPassthroughPasswordChange);
+    }
+
+    fn setup_live_config(users: Vec<ConfigUser>) {
+        let _lock = lock();
+        let config = Config {
+            databases: vec![Database {
+                name: "pgdog".to_string(),
+                host: "127.0.0.1".to_string(),
+                port: 5432,
+                role: Role::Primary,
+                ..Default::default()
+            }],
+            general: General {
+                passthrough_auth: crate::config::PassthroughAuth::EnabledPlain,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let cu = ConfigAndUsers {
+            config,
+            users: crate::config::Users {
+                users,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        crate::config::set(cu).expect("set config");
+        replace_databases(from_config(&crate::config::config()), false).expect("replace");
+    }
+
+    #[tokio::test]
+    async fn test_add_passthrough_verifies_against_server() {
+        setup_live_config(vec![]);
+
+        // Wrong password: rejected by the server, nothing stored.
+        let mut user = make_user("pgdog", Some("wrong_password"));
+        user.database = "pgdog".to_string();
+        let result = add_passthrough(user).await.expect("add_passthrough");
+        assert_eq!(result, AuthResult::NoPasswordMatch);
+        let mut lookup = make_user("pgdog", None);
+        lookup.database = "pgdog".to_string();
+        assert!(crate::config::config().users.find(&lookup).is_none());
+
+        // Correct password: verified and stored.
+        let mut user = make_user("pgdog", Some("pgdog"));
+        user.database = "pgdog".to_string();
+        let result = add_passthrough(user).await.expect("add_passthrough");
+        assert_eq!(result, AuthResult::Ok);
+        let found = crate::config::config()
+            .users
+            .find(&lookup)
+            .expect("user stored");
+        assert!(found.password_from_passthrough);
+        assert_eq!(found.password, Some("pgdog".to_string()));
     }
 
     #[test]

--- a/pgdog/src/backend/pool/address.rs
+++ b/pgdog/src/backend/pool/address.rs
@@ -30,6 +30,10 @@ pub struct Address {
     /// Server auth mode for backend connections.
     #[serde(default)]
     pub server_auth: ServerAuth,
+    /// PostgreSQL role backend connections assume via the `role` startup
+    /// parameter, from `User.server_role` (plugin-auth impersonation).
+    #[serde(default)]
+    pub server_role: Option<String>,
     /// Optional IAM region override.
     pub server_iam_region: Option<String>,
     /// Vault path to fetch dynamic credentials from.
@@ -94,6 +98,7 @@ impl Address {
                     .collect()
             },
             server_auth,
+            server_role: user.server_role.clone(),
             server_iam_region: user.server_iam_region.clone(),
             vault_path: user.server_vault_path.clone(),
             vault_refresh_percent: user.vault_refresh_percent,
@@ -208,6 +213,7 @@ impl Address {
             passwords: vec!["pgdog".into()],
             database_name: "pgdog".into(),
             server_auth: ServerAuth::Password,
+            server_role: None,
             server_iam_region: None,
             vault_path: None,
             vault_refresh_percent: None,

--- a/pgdog/src/backend/pool/address.rs
+++ b/pgdog/src/backend/pool/address.rs
@@ -94,7 +94,25 @@ impl Address {
                 user.passwords()
                     .into_iter()
                     .filter(|p| matches!(p, PasswordKind::Plain(_)))
-                    .map(|p| p.to_string().into())
+                    .map(|p| {
+                        let password = p.to_string();
+                        // Tag passthrough-learned credentials with the config
+                        // identity storing them, so the connection code can
+                        // evict them when the server rejects them.
+                        if user.password_from_passthrough
+                            && user.password.as_deref() == Some(password.as_str())
+                        {
+                            Password::new(
+                                &password,
+                                PasswordSource::Passthrough {
+                                    user: user.name.clone(),
+                                    database: user.database.clone(),
+                                },
+                            )
+                        } else {
+                            password.into()
+                        }
+                    })
                     .collect()
             },
             server_auth,

--- a/pgdog/src/backend/pool/cluster.rs
+++ b/pgdog/src/backend/pool/cluster.rs
@@ -88,6 +88,7 @@ pub struct Cluster {
     resharding_replication_retry_min_delay: Duration,
     regex_parser: RegexParser,
     identity: Option<String>,
+    server_role: Option<String>,
 }
 
 /// Sharding configuration from the cluster.
@@ -175,6 +176,7 @@ pub struct ClusterConfig<'a> {
     pub regex_parser_limit: usize,
     pub pub_sub_enabled: bool,
     pub identity: &'a Option<String>,
+    pub server_role: Option<String>,
 }
 
 impl<'a> ClusterConfig<'a> {
@@ -239,6 +241,7 @@ impl<'a> ClusterConfig<'a> {
             regex_parser_limit: general.regex_parser_limit,
             pub_sub_enabled: general.pub_sub_enabled(),
             identity: &user.identity,
+            server_role: user.server_role.clone(),
         }
     }
 }
@@ -285,6 +288,7 @@ impl Cluster {
             regex_parser_limit,
             pub_sub_enabled,
             identity,
+            server_role,
         } = config;
 
         let identifier = Arc::new(DatabaseUser {
@@ -346,6 +350,7 @@ impl Cluster {
             ),
             regex_parser: RegexParser::new(regex_parser_limit, query_parser),
             identity: identity.clone(),
+            server_role,
         }
     }
 
@@ -412,6 +417,33 @@ impl Cluster {
     /// when connecting.
     pub fn identity(&self) -> Option<&str> {
         self.identity.as_deref()
+    }
+
+    /// PostgreSQL role backend connections impersonate via the `role` startup
+    /// parameter. When set, client-issued `SET ROLE` / `RESET ROLE` /
+    /// `SET SESSION AUTHORIZATION` are rejected to prevent role escape.
+    pub fn server_role(&self) -> Option<&str> {
+        self.server_role.as_deref()
+    }
+
+    /// Whether this cluster carries backend credentials to authenticate to
+    /// Postgres on its own, independent of any stored client password: an
+    /// impersonation `server_role`, a server password, or an external-identity
+    /// mechanism (RDS IAM, Azure, Vault). Pools like these must launch even
+    /// when no client password is configured, e.g. under `auth_type = "plugin"`
+    /// where plugins authenticate each login.
+    pub fn has_backend_credentials(&self) -> bool {
+        if self.server_role.is_some() {
+            return true;
+        }
+
+        self.shards
+            .iter()
+            .flat_map(|shard| shard.pools())
+            .any(|pool| {
+                let addr = pool.addr();
+                !addr.passwords.is_empty() || addr.server_auth.is_external_identity()
+            })
     }
 
     /// User name.
@@ -516,6 +548,15 @@ impl Cluster {
 
     /// Use the query parser.
     pub(crate) fn use_query_parser(&self, request: &ClientRequest) -> bool {
+        // Impersonation pools must parse every statement so the role-escape
+        // guard can inspect it. Otherwise the regex fast-path would forward
+        // e.g. `SELECT 1; SET ROLE ...` or `SELECT set_config('role', ...)`
+        // verbatim, escaping the fixed `server_role`. Normal pools are
+        // unaffected — this is a single `Option` check.
+        if self.server_role.is_some() {
+            return true;
+        }
+
         match self.query_parser() {
             QueryParserLevel::Off => false,
             QueryParserLevel::On => true,
@@ -988,6 +1029,10 @@ mod test {
 
         pub(crate) fn set_rw_split(&mut self, rw_split: ReadWriteSplit) {
             self.rw_split = rw_split;
+        }
+
+        pub fn set_server_role(&mut self, server_role: Option<String>) {
+            self.server_role = server_role;
         }
     }
 

--- a/pgdog/src/backend/pool/cluster.rs
+++ b/pgdog/src/backend/pool/cluster.rs
@@ -1036,10 +1036,6 @@ mod test {
         pub(crate) fn set_rw_split(&mut self, rw_split: ReadWriteSplit) {
             self.rw_split = rw_split;
         }
-
-        pub fn set_server_role(&mut self, server_role: Option<String>) {
-            self.server_role = server_role;
-        }
     }
 
     #[test]

--- a/pgdog/src/backend/pool/cluster.rs
+++ b/pgdog/src/backend/pool/cluster.rs
@@ -81,6 +81,7 @@ pub struct Cluster {
     sharding_lookup_timeout: Duration,
     regex_parser: RegexParser,
     identity: Option<String>,
+    server_role: Option<String>,
     tls_client_certificate_required: bool,
     #[debug(skip)]
     schema_loader: Box<dyn SchemaLoader>,
@@ -131,6 +132,7 @@ impl Default for Cluster {
             sharding_lookup_timeout: Duration::from_millis(General::sharding_lookup_timeout()),
             regex_parser: Default::default(),
             identity: Default::default(),
+            server_role: Default::default(),
             tls_client_certificate_required: Default::default(),
             schema_loader: Default::default(),
             canonical_oids: Default::default(),
@@ -222,6 +224,7 @@ pub struct ClusterConfig<'a> {
     regex_parser_limit: usize,
     pub_sub_enabled: bool,
     identity: &'a Option<String>,
+    server_role: Option<String>,
     tls_client_certificate_required: bool,
     schema_cache: SchemaCache,
     canonicalize_oids: bool,
@@ -293,6 +296,7 @@ impl<'a> ClusterConfig<'a> {
             regex_parser_limit: general.regex_parser_limit,
             pub_sub_enabled: general.pub_sub_enabled(),
             identity: &user.identity,
+            server_role: user.server_role.clone(),
             tls_client_certificate_required: user.tls_client_certificate_required.unwrap_or(true),
             schema_cache,
             canonicalize_oids: general.canonicalize_type_information,
@@ -341,6 +345,7 @@ impl Cluster {
             regex_parser_limit,
             pub_sub_enabled,
             identity,
+            server_role,
             tls_client_certificate_required,
             schema_cache,
             canonicalize_oids,
@@ -411,6 +416,7 @@ impl Cluster {
             sharding_lookup_timeout: Duration::from_millis(sharding_lookup_timeout),
             regex_parser: RegexParser::new(regex_parser_limit, query_parser),
             identity: identity.clone(),
+            server_role,
             tls_client_certificate_required,
             schema_loader: Box::new(schema_loader::FromServer),
             canonical_oids,
@@ -481,6 +487,25 @@ impl Cluster {
     /// when connecting.
     pub fn identity(&self) -> Option<&str> {
         self.identity.as_deref()
+    }
+
+    /// PostgreSQL role backend connections impersonate through the `role`
+    /// startup parameter.
+    pub fn server_role(&self) -> Option<&str> {
+        self.server_role.as_deref()
+    }
+
+    /// Whether this cluster can authenticate to PostgreSQL without a stored
+    /// client password.
+    pub fn has_backend_credentials(&self) -> bool {
+        if self.server_role.is_some() {
+            return true;
+        }
+
+        self.shards.iter().flat_map(Shard::pools).any(|pool| {
+            let addr = pool.addr();
+            !addr.passwords.is_empty() || addr.server_auth.is_external_identity()
+        })
     }
 
     /// This user must present a client TLS certificate when connecting over TLS.
@@ -587,6 +612,10 @@ impl Cluster {
 
     /// Use the query parser.
     pub(crate) fn use_query_parser(&self, request: &ClientRequest) -> bool {
+        if self.server_role.is_some() {
+            return true;
+        }
+
         match self.query_parser() {
             QueryParserLevel::Off => false,
             QueryParserLevel::On => true,
@@ -1006,6 +1035,10 @@ mod test {
 
         pub(crate) fn set_rw_split(&mut self, rw_split: ReadWriteSplit) {
             self.rw_split = rw_split;
+        }
+
+        pub fn set_server_role(&mut self, server_role: Option<String>) {
+            self.server_role = server_role;
         }
     }
 

--- a/pgdog/src/backend/pool/connection/mod.rs
+++ b/pgdog/src/backend/pool/connection/mod.rs
@@ -385,6 +385,8 @@ impl Connection {
                 }
             }
 
+            // Unverified `add` is fine here: these credentials were already
+            // in use by this authenticated session before the reload.
             databases::add(user)?;
         }
 

--- a/pgdog/src/backend/pool/inner.rs
+++ b/pgdog/src/backend/pool/inner.rs
@@ -15,6 +15,13 @@ use tokio::time::Instant;
 
 use super::{Config, Error, Pool, Request, Stats, Taken, Waiter, lsn_monitor::ReplicaLag};
 
+/// How long the pool refrains from replenishing `min_pool_size` connections
+/// after the server rejected its credentials. An auth failure is
+/// deterministic, so retrying every maintenance tick only storms the server.
+/// Client-driven requests and healthchecks still attempt connections and
+/// clear the backoff on success.
+const AUTH_FAILURE_BACKOFF: Duration = Duration::from_secs(30);
+
 /// Pool internals protected by a mutex.
 #[derive(Default)]
 pub(super) struct Inner {
@@ -54,6 +61,9 @@ pub(super) struct Inner {
     pub(super) credentials_generation: u64,
     /// Pool role.
     pub(super) role: Role,
+    /// Set when the server rejected our credentials. While recent, the pool
+    /// does not replenish `min_pool_size` connections.
+    pub(super) auth_failed_at: Option<Instant>,
 }
 
 impl std::fmt::Debug for Inner {
@@ -88,6 +98,7 @@ impl Inner {
             replica_lag: ReplicaLag::default(),
             credentials_generation: 0,
             role: Role::Auto,
+            auth_failed_at: None,
         }
     }
     /// Total number of connections managed by the pool.
@@ -187,12 +198,36 @@ impl Inner {
         .value(self.role)
     }
 
+    /// Server rejected our credentials; pause `min_pool_size` replenishment.
+    #[inline]
+    pub(super) fn server_auth_failed(&mut self) {
+        self.auth_failed_at = Some(Instant::now());
+    }
+
+    /// Server accepted our credentials; resume normal replenishment.
+    #[inline]
+    pub(super) fn server_auth_ok(&mut self) {
+        self.auth_failed_at = None;
+    }
+
+    /// The server recently rejected our credentials.
+    #[inline]
+    fn auth_backoff(&self) -> bool {
+        self.auth_failed_at
+            .map(|at| at.elapsed() < AUTH_FAILURE_BACKOFF)
+            .unwrap_or(false)
+    }
+
     /// The pool should create more connections now.
     #[inline]
     pub(super) fn should_create(&self) -> ShouldCreate {
         let below_min = self.total() < self.min();
         let below_max = self.total() < self.max();
-        let maintain_min = below_min && below_max;
+        // Don't replenish min connections while the server rejects our
+        // credentials: retrying the same password every maintenance tick
+        // can't succeed and storms the server. Waiting clients still get
+        // connection attempts, which clear the backoff on success.
+        let maintain_min = below_min && below_max && !self.auth_backoff();
         let client_needs =
             below_max && !self.waiting.is_empty() && self.idle_connections.is_empty();
         let maintenance_on = self.online && !self.paused;
@@ -694,6 +729,53 @@ mod test {
                 idle: 0,
                 taken: 0,
                 waiting: 0,
+            }
+        ));
+    }
+
+    #[test]
+    fn test_should_create_auth_backoff() {
+        let mut inner = Inner {
+            online: true,
+            ..Default::default()
+        };
+        inner.config.min = 2;
+        inner.config.max = 5;
+
+        // Below min: replenishment wanted.
+        assert!(matches!(
+            inner.should_create(),
+            ShouldCreate::Yes {
+                reason: ConnectReason::BelowMin,
+                ..
+            }
+        ));
+
+        // Server rejected our credentials: pause min replenishment.
+        inner.server_auth_failed();
+        assert_eq!(inner.should_create(), ShouldCreate::No);
+
+        // A waiting client still triggers a connection attempt.
+        inner.waiting.push_back(Waiter {
+            request: Request::default(),
+            tx: channel().0,
+        });
+        assert!(matches!(
+            inner.should_create(),
+            ShouldCreate::Yes {
+                reason: ConnectReason::ClientWaiting,
+                ..
+            }
+        ));
+        inner.waiting.clear();
+
+        // A successful connection clears the backoff.
+        inner.server_auth_ok();
+        assert!(matches!(
+            inner.should_create(),
+            ShouldCreate::Yes {
+                reason: ConnectReason::BelowMin,
+                ..
             }
         ));
     }

--- a/pgdog/src/backend/pool/lsn_monitor.rs
+++ b/pgdog/src/backend/pool/lsn_monitor.rs
@@ -424,13 +424,13 @@ mod test {
     async fn test_get_connection_falls_back_to_standalone_when_saturated() {
         crate::logger();
 
-        // Single connection, short checkout timeout so the saturated checkout
-        // fails fast and the fallback path runs quickly.
+        // Keep the timeout bounded while allowing the initial connection to be
+        // established on slower test hosts.
         let config = Config {
             inner: pgdog_stats::Config {
                 max: 1,
                 min: 1,
-                checkout_timeout: Duration::from_millis(100),
+                checkout_timeout: Duration::from_secs(1),
                 ..Config::default().inner
             },
         };

--- a/pgdog/src/backend/pool/monitor.rs
+++ b/pgdog/src/backend/pool/monitor.rs
@@ -461,6 +461,7 @@ impl Monitor {
                         guard.stats.counts.connect_count += 1;
                         guard.stats.counts.connect_time += elapsed;
                         guard.stats.counts.auth_attempts += conn.password_attempts();
+                        guard.server_auth_ok();
                         conn.set_credentials_generation(guard.credentials_generation());
                     }
                     conn.apply_lifetime_jitter(max_age, max_age_jitter);
@@ -470,7 +471,9 @@ impl Monitor {
                 Ok(Err(err)) => {
                     // We tried all passwords and they were all wrong.
                     if err.is_auth() {
-                        pool.lock().stats.counts.auth_attempts += pool.addr().passwords.len();
+                        let mut guard = pool.lock();
+                        guard.stats.counts.auth_attempts += pool.addr().passwords.len();
+                        guard.server_auth_failed();
                     }
                     error!(
                         "{}error connecting to server: {} [{}]",

--- a/pgdog/src/backend/pool/password.rs
+++ b/pgdog/src/backend/pool/password.rs
@@ -16,6 +16,13 @@ pub enum PasswordSource {
     RdsIam,
     AzureIdentity,
     Vault,
+    /// Learned from a client through passthrough authentication. Carries the
+    /// config identity of the user entry storing the credential, so it can be
+    /// evicted when the server rejects it.
+    Passthrough {
+        user: String,
+        database: String,
+    },
 }
 
 impl Display for PasswordSource {
@@ -25,6 +32,7 @@ impl Display for PasswordSource {
             Self::RdsIam => write!(f, "rds iam"),
             Self::AzureIdentity => write!(f, "azure workload identity"),
             Self::Vault => write!(f, "vault"),
+            Self::Passthrough { .. } => write!(f, "passthrough"),
         }
     }
 }

--- a/pgdog/src/backend/pool/pool_impl.rs
+++ b/pgdog/src/backend/pool/pool_impl.rs
@@ -455,6 +455,16 @@ impl Pool {
             });
         }
 
+        // Impersonation role from `User.server_role`. Sent as a startup
+        // parameter so it's a session default: `RESET ALL` / `DISCARD ALL`
+        // cleanup restores rather than clears it between checkouts.
+        if let Some(role) = &self.inner.addr.server_role {
+            params.push(Parameter {
+                name: "role".into(),
+                value: role.as_str().into(),
+            });
+        }
+
         ServerOptions {
             params,
             pool_id: self.id(),

--- a/pgdog/src/backend/pool/pool_impl.rs
+++ b/pgdog/src/backend/pool/pool_impl.rs
@@ -473,6 +473,16 @@ impl Pool {
             });
         }
 
+        // Impersonation role from `User.server_role`. Sent as a startup
+        // parameter so it's a session default: `RESET ALL` / `DISCARD ALL`
+        // cleanup restores rather than clears it between checkouts.
+        if let Some(role) = &self.inner.addr.server_role {
+            params.push(Parameter {
+                name: "role".into(),
+                value: role.as_str().into(),
+            });
+        }
+
         ServerOptions {
             params,
             pool_id: self.id(),

--- a/pgdog/src/backend/pool/test/mod.rs
+++ b/pgdog/src/backend/pool/test/mod.rs
@@ -621,7 +621,7 @@ async fn test_checkout_timeout() {
         inner: pgdog_stats::Config {
             max: 1,
             min: 1,
-            checkout_timeout: Duration::from_millis(100),
+            checkout_timeout: Duration::from_secs(1),
             ..Config::default().inner
         },
     };

--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -213,6 +213,21 @@ impl Server {
                             addr
                         );
                         auth_secret.valid(false);
+                        // A passthrough-learned credential the server rejects
+                        // can never work again (e.g. the server-side password
+                        // rotated): evict it so the pool stops retrying it and
+                        // the next client login can store the current one.
+                        if let super::pool::password::PasswordSource::Passthrough {
+                            user,
+                            database,
+                        } = &auth_secret.source
+                        {
+                            super::databases::passthrough_password_rejected(
+                                user,
+                                database,
+                                &auth_secret.password,
+                            );
+                        }
                         continue;
                     } else {
                         return Err(Error::ConnectionError(error));

--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -1327,7 +1327,7 @@ impl Drop for Server {
 // Used for testing.
 #[cfg(test)]
 pub mod test {
-    use std::time::SystemTime;
+    use std::time::{Duration, SystemTime};
 
     use bytes::{BufMut, Bytes, BytesMut};
     use pgdog_stats::PreparedStatementsConfig;
@@ -1459,6 +1459,16 @@ pub mod test {
         (server, peer.await.unwrap())
     }
 
+    async fn wait_for_liveness(server: &mut Server, expected: Liveness) {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while server.liveness() != expected {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("server socket did not reach expected liveness state");
+    }
+
     #[test]
     fn test_liveness_without_stream_is_closed() {
         let mut server = Server::default();
@@ -1473,9 +1483,8 @@ pub mod test {
         assert_eq!(server.liveness(), Liveness::Clean);
 
         drop(peer);
-        tokio::task::yield_now().await;
 
-        assert_eq!(server.liveness(), Liveness::Closed);
+        wait_for_liveness(&mut server, Liveness::Closed).await;
     }
 
     #[tokio::test]
@@ -1484,9 +1493,8 @@ pub mod test {
 
         peer.write_all(b"E").await.unwrap();
         peer.flush().await.unwrap();
-        tokio::task::yield_now().await;
 
-        assert_eq!(server.liveness(), Liveness::DataPending);
+        wait_for_liveness(&mut server, Liveness::DataPending).await;
     }
 
     #[tokio::test]

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -191,7 +191,10 @@ impl Client {
                 }
             }
 
-            AuthType::Plain => {
+            // `Plugin` only reaches here on the admin path (plugin auth is
+            // driven separately in `login`), where it behaves like `Plain`:
+            // compare against the configured admin password.
+            AuthType::Plain | AuthType::Plugin => {
                 stream
                     .send_flush(&Authentication::ClearTextPassword)
                     .await?;
@@ -240,6 +243,10 @@ impl Client {
         let comms = ClientComms::new(id);
         let log_connections = config.config.general.log_connections;
 
+        // Username a plugin derived for the client (e.g. impersonation). When
+        // set, it replaces `user` for all backend operations.
+        let mut derived_user: Option<String> = None;
+
         // Check if we need to ask the client for its password in plaintext
         // because we don't actually have it configured.
         //
@@ -250,6 +257,59 @@ impl Client {
             // map, so authenticate directly against the configured admin password.
             let passwords = [PasswordKind::Plain(admin_password.clone())];
             Self::check_password(&mut stream, user, auth_type, &passwords).await?
+        } else if auth_type.plugin() {
+            // Plugin authentication: request a cleartext credential from the
+            // client (same wire flow as passthrough), then hand it to the
+            // authentication plugins. Allow can derive a user and provision a
+            // pool; Deny/all-Skip reject the client without a password fallback.
+            stream
+                .send_flush(&Authentication::ClearTextPassword)
+                .await?;
+            let password = stream.read().await?;
+            let password = Password::from_bytes(password.to_bytes())?;
+            if let Some(credential) = password.password() {
+                let tls_identity = stream.tls_identity().map(|id| id.to_string());
+                let outcome = crate::auth::plugin::authenticate(
+                    user.to_string(),
+                    database.to_string(),
+                    credential.to_string(),
+                    addr.to_string(),
+                    tls_identity,
+                    stream.is_tls(),
+                )
+                .await;
+
+                if outcome.result.is_ok() {
+                    if let Some(grant) = outcome.grant {
+                        derived_user = grant.derived_user.clone();
+                        let effective = derived_user.as_deref().unwrap_or(user);
+
+                        // Auto-provision a pool for the derived user when the
+                        // plugin asked for it and no cluster exists yet.
+                        if grant.provision
+                            && databases::databases()
+                                .cluster((effective, database))
+                                .is_err()
+                        {
+                            let provisioned = config::User {
+                                name: effective.to_string(),
+                                database: database.to_string(),
+                                server_user: grant.server_user.clone(),
+                                server_password: grant.server_password.clone(),
+                                server_role: grant.server_role.clone(),
+                                read_only: grant.read_only,
+                                ..Default::default()
+                            };
+                            databases::add_authenticated(provisioned)?;
+                        }
+                    }
+                    AuthResult::Ok
+                } else {
+                    outcome.result
+                }
+            } else {
+                AuthResult::NoPasswordMessage
+            }
         } else if passthrough {
             // Get the password. We always need it because we need to check if
             // it's current and hasn't been changed.
@@ -292,14 +352,22 @@ impl Client {
             }
         };
 
+        // When a plugin derived a user, use that name for `Connection::new`,
+        // error responses, and log lines; otherwise use the startup username.
+        // Note that comms and stats keep using the startup-packet parameters
+        // (and thus the original startup user), matching PR #1084.
+        let effective_user = derived_user.as_deref().unwrap_or(user);
+
         if !auth_result.is_ok() {
             if log_connections {
                 warn!(
                     r#"user "{}" and database "{}" auth error: {}"#,
-                    user, database, auth_result
+                    effective_user, database, auth_result
                 );
             }
-            stream.fatal(ErrorResponse::auth(user, database)).await?;
+            stream
+                .fatal(ErrorResponse::auth(effective_user, database))
+                .await?;
             return Ok(None);
         } else {
             stream.send(&Authentication::Ok).await?;
@@ -316,11 +384,13 @@ impl Client {
             return Ok(None);
         }
 
-        let mut conn = match Connection::new(user, database, admin) {
+        let mut conn = match Connection::new(effective_user, database, admin) {
             Ok(conn) => conn,
             Err(err) => {
                 debug!("connection error: {}", err);
-                stream.fatal(ErrorResponse::auth(user, database)).await?;
+                stream
+                    .fatal(ErrorResponse::auth(effective_user, database))
+                    .await?;
                 return Ok(None);
             }
         };
@@ -336,7 +406,7 @@ impl Client {
                         addr
                     );
                     stream
-                        .fatal(ErrorResponse::connection(user, database))
+                        .fatal(ErrorResponse::connection(effective_user, database))
                         .await?;
                     return Ok(None);
                 } else {

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -316,7 +316,7 @@ impl Client {
             password: Some(credential.to_string()),
             ..Default::default()
         };
-        Ok(databases::add(user)?)
+        Ok(databases::add_passthrough(user).await?)
     }
 
     /// Create new frontend client from the given TCP stream.
@@ -434,13 +434,12 @@ impl Client {
                 .await?;
             let password = stream.read().await?;
             let password = Password::from_bytes(password.to_bytes())?;
-            // Passthrough authentication assumes the client password is good
-            // and lets Postgres perform the authentication instead. If Postgres
-            // returns an error, the connection pool will be banned and the client
-            // won't be able to run queries.
+            // Passthrough authentication verifies new credentials against
+            // Postgres before storing them: a wrong password is rejected here
+            // and never becomes the pool's server credential.
             let user = user_from_params(&params, &password).ok();
             if let Some(user) = user {
-                databases::add(user)?
+                databases::add_passthrough(user).await?
             } else {
                 AuthResult::NoPassthroughNoUser
             }

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -389,14 +389,17 @@ impl Client {
                             derived_user = grant.derived_user.clone();
                             let effective = derived_user.as_deref().unwrap_or(user);
 
-                            // Auto-provision a pool for the derived user when the
-                            // plugin asked for it and no cluster exists yet.
-                            if grant.provision
-                                && databases::databases()
-                                    .cluster((effective, database))
-                                    .is_err()
-                            {
-                                let provisioned = config::User {
+                            // Reconcile the grant with the derived user's pool:
+                            // fill backend-credential gaps (e.g. `server_role`
+                            // for impersonation) on an existing entry, or
+                            // provision a new pool when the plugin asked for
+                            // it. Without a pool and without `provision`,
+                            // `Connection::new` below fails the login.
+                            let exists = databases::databases()
+                                .cluster((effective, database))
+                                .is_ok();
+                            if exists || grant.provision {
+                                let granted = config::User {
                                     name: effective.to_string(),
                                     database: database.to_string(),
                                     server_user: grant.server_user.clone(),
@@ -405,7 +408,7 @@ impl Client {
                                     read_only: grant.read_only,
                                     ..Default::default()
                                 };
-                                databases::add_authenticated(provisioned)?;
+                                databases::add_authenticated(granted)?;
                             }
                         }
                         AuthResult::Ok

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -214,7 +214,10 @@ impl Client {
                 }
             }
 
-            AuthType::Plain => {
+            // `Plugin` only reaches here on the admin path (plugin auth is
+            // driven separately in `login`), where it behaves like `Plain`:
+            // compare against the configured admin password.
+            AuthType::Plain | AuthType::Plugin => {
                 stream
                     .send_flush(&Authentication::ClearTextPassword)
                     .await?;
@@ -266,6 +269,10 @@ impl Client {
         // could never be satisfied.
         let client_ca_configured = config.config.general.tls_client_ca_certificate.is_some();
 
+        // Username a plugin derived for the client (e.g. impersonation). When
+        // set, it replaces `user` for all backend operations.
+        let mut derived_user: Option<String> = None;
+
         // Check if we need to ask the client for its password in plaintext
         // because we don't actually have it configured.
         //
@@ -276,6 +283,59 @@ impl Client {
             // map, so authenticate directly against the configured admin password.
             let passwords = [PasswordKind::Plain(admin_password.clone())];
             Self::check_password(&mut stream, user, auth_type, &passwords).await?
+        } else if auth_type.plugin() {
+            // Plugin authentication: request a cleartext credential from the
+            // client (same wire flow as passthrough), then hand it to the
+            // authentication plugins. Allow can derive a user and provision a
+            // pool; Deny/all-Skip reject the client without a password fallback.
+            stream
+                .send_flush(&Authentication::ClearTextPassword)
+                .await?;
+            let password = stream.read().await?;
+            let password = Password::from_bytes(password.to_bytes())?;
+            if let Some(credential) = password.password() {
+                let tls_identity = stream.tls_identity().map(|id| id.to_string());
+                let outcome = crate::auth::plugin::authenticate(
+                    user.to_string(),
+                    database.to_string(),
+                    credential.to_string(),
+                    addr.to_string(),
+                    tls_identity,
+                    stream.is_tls(),
+                )
+                .await;
+
+                if outcome.result.is_ok() {
+                    if let Some(grant) = outcome.grant {
+                        derived_user = grant.derived_user.clone();
+                        let effective = derived_user.as_deref().unwrap_or(user);
+
+                        // Auto-provision a pool for the derived user when the
+                        // plugin asked for it and no cluster exists yet.
+                        if grant.provision
+                            && databases::databases()
+                                .cluster((effective, database))
+                                .is_err()
+                        {
+                            let provisioned = config::User {
+                                name: effective.to_string(),
+                                database: database.to_string(),
+                                server_user: grant.server_user.clone(),
+                                server_password: grant.server_password.clone(),
+                                server_role: grant.server_role.clone(),
+                                read_only: grant.read_only,
+                                ..Default::default()
+                            };
+                            databases::add_authenticated(provisioned)?;
+                        }
+                    }
+                    AuthResult::Ok
+                } else {
+                    outcome.result
+                }
+            } else {
+                AuthResult::NoPasswordMessage
+            }
         } else if passthrough {
             // Get the password. We always need it because we need to check if
             // it's current and hasn't been changed.
@@ -329,14 +389,22 @@ impl Client {
             }
         };
 
+        // When a plugin derived a user, use that name for `Connection::new`,
+        // error responses, and log lines; otherwise use the startup username.
+        // Note that comms and stats keep using the startup-packet parameters
+        // (and thus the original startup user), matching PR #1084.
+        let effective_user = derived_user.as_deref().unwrap_or(user);
+
         if !auth_result.is_ok() {
             if log_connections {
                 warn!(
                     r#"user "{}" and database "{}" auth error: {}"#,
-                    user, database, auth_result
+                    effective_user, database, auth_result
                 );
             }
-            stream.fatal(ErrorResponse::auth(user, database)).await?;
+            stream
+                .fatal(ErrorResponse::auth(effective_user, database))
+                .await?;
             return Ok(None);
         } else {
             stream.send(&Authentication::Ok).await?;
@@ -353,11 +421,13 @@ impl Client {
             return Ok(None);
         }
 
-        let mut conn = match Connection::new(user, database, admin) {
+        let mut conn = match Connection::new(effective_user, database, admin) {
             Ok(conn) => conn,
             Err(err) => {
                 debug!("connection error: {}", err);
-                stream.fatal(ErrorResponse::auth(user, database)).await?;
+                stream
+                    .fatal(ErrorResponse::auth(effective_user, database))
+                    .await?;
                 return Ok(None);
             }
         };
@@ -373,7 +443,7 @@ impl Client {
                         addr
                     );
                     stream
-                        .fatal(ErrorResponse::connection(user, database))
+                        .fatal(ErrorResponse::connection(effective_user, database))
                         .await?;
                     return Ok(None);
                 } else {

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -223,23 +223,100 @@ impl Client {
                     .await?;
                 let response = stream.read().await?;
                 let response = Password::from_bytes(response.to_bytes())?;
-                let is_match = response.password().is_some_and(|provided| {
-                    passwords.iter().any(|p| {
-                        crate::util::constant_time_eq(p.as_str().as_bytes(), provided.as_bytes())
+                response
+                    .password()
+                    .map_or(AuthResult::NoPasswordMatch, |provided| {
+                        Self::check_cleartext_password(passwords, provided)
                     })
-                });
-
-                if is_match {
-                    AuthResult::Ok
-                } else {
-                    AuthResult::NoPasswordMatch
-                }
             }
 
             AuthType::Trust => AuthResult::Ok,
         };
 
         Ok(result)
+    }
+
+    /// Verify a credential already received through a cleartext password
+    /// exchange. This is used when all authentication plugins skip, because a
+    /// second MD5 or SCRAM exchange cannot be started on the same connection.
+    fn check_cleartext_password(passwords: &[PasswordKind], provided: &str) -> AuthResult {
+        if passwords.is_empty() {
+            return AuthResult::NoPasswordConfig;
+        }
+
+        let is_match = passwords.iter().any(|password| match password {
+            PasswordKind::Plain(password) => {
+                crate::util::constant_time_eq(password.as_bytes(), provided.as_bytes())
+            }
+            PasswordKind::Hashed(verifier) => {
+                crate::auth::scram::verify_password(provided, verifier)
+            }
+            PasswordKind::VaultStaticRole(_) => false,
+        });
+
+        if is_match {
+            AuthResult::Ok
+        } else {
+            AuthResult::NoPasswordMatch
+        }
+    }
+
+    /// Fall back after every authentication plugin returned `Skip`.
+    ///
+    /// Passthrough authentication keeps its existing precedence. Otherwise the
+    /// credential is checked against the configured user without initiating a
+    /// second wire-protocol authentication exchange.
+    async fn plugin_fallback(
+        stream: &Stream,
+        user: &str,
+        database: &str,
+        credential: &str,
+        passthrough: bool,
+        client_ca_configured: bool,
+    ) -> Result<AuthResult, Error> {
+        if let Ok(cluster) = databases::databases().cluster((user, database)) {
+            if let Some(identity) = cluster.identity() {
+                return Ok(if stream.tls_identity() == Some(identity) {
+                    AuthResult::Ok
+                } else {
+                    AuthResult::NoIdentity
+                });
+            }
+
+            if (ClientCertificateCheck {
+                client_ca_configured,
+                is_tls: stream.is_tls(),
+                required: cluster.tls_client_certificate_required(),
+                presented: stream.tls_client_certificate(),
+            })
+            .rejected()
+            {
+                return Ok(AuthResult::NoClientCertificate);
+            }
+
+            // Do not let passthrough turn a plugin-only user backed by service
+            // credentials into an account that accepts its first arbitrary
+            // password. Passthrough users are either discovered dynamically or
+            // have a configured client password.
+            if cluster.passwords().is_empty() {
+                return Ok(AuthResult::NoPasswordConfig);
+            }
+
+            if !passthrough {
+                let passwords = crate::auth::vault::resolve_passwords(cluster.passwords()).await;
+                return Ok(Self::check_cleartext_password(&passwords, credential));
+            }
+        } else if !passthrough {
+            return Ok(AuthResult::NoUserOrDatabase);
+        }
+
+        let user = config::User {
+            name: user.to_string(),
+            database: database.to_string(),
+            password: Some(credential.to_string()),
+            ..Default::default()
+        };
+        Ok(databases::add(user)?)
     }
 
     /// Create new frontend client from the given TCP stream.
@@ -287,7 +364,8 @@ impl Client {
             // Plugin authentication: request a cleartext credential from the
             // client (same wire flow as passthrough), then hand it to the
             // authentication plugins. Allow can derive a user and provision a
-            // pool; Deny/all-Skip reject the client without a password fallback.
+            // pool; Deny rejects the client; all-Skip falls back to configured
+            // password or passthrough authentication.
             stream
                 .send_flush(&Authentication::ClearTextPassword)
                 .await?;
@@ -305,33 +383,45 @@ impl Client {
                 )
                 .await;
 
-                if outcome.result.is_ok() {
-                    if let Some(grant) = outcome.grant {
-                        derived_user = grant.derived_user.clone();
-                        let effective = derived_user.as_deref().unwrap_or(user);
+                match outcome.result {
+                    AuthResult::Ok => {
+                        if let Some(grant) = outcome.grant {
+                            derived_user = grant.derived_user.clone();
+                            let effective = derived_user.as_deref().unwrap_or(user);
 
-                        // Auto-provision a pool for the derived user when the
-                        // plugin asked for it and no cluster exists yet.
-                        if grant.provision
-                            && databases::databases()
-                                .cluster((effective, database))
-                                .is_err()
-                        {
-                            let provisioned = config::User {
-                                name: effective.to_string(),
-                                database: database.to_string(),
-                                server_user: grant.server_user.clone(),
-                                server_password: grant.server_password.clone(),
-                                server_role: grant.server_role.clone(),
-                                read_only: grant.read_only,
-                                ..Default::default()
-                            };
-                            databases::add_authenticated(provisioned)?;
+                            // Auto-provision a pool for the derived user when the
+                            // plugin asked for it and no cluster exists yet.
+                            if grant.provision
+                                && databases::databases()
+                                    .cluster((effective, database))
+                                    .is_err()
+                            {
+                                let provisioned = config::User {
+                                    name: effective.to_string(),
+                                    database: database.to_string(),
+                                    server_user: grant.server_user.clone(),
+                                    server_password: grant.server_password.clone(),
+                                    server_role: grant.server_role.clone(),
+                                    read_only: grant.read_only,
+                                    ..Default::default()
+                                };
+                                databases::add_authenticated(provisioned)?;
+                            }
                         }
+                        AuthResult::Ok
                     }
-                    AuthResult::Ok
-                } else {
-                    outcome.result
+                    AuthResult::PluginNoDecision => {
+                        Self::plugin_fallback(
+                            &stream,
+                            user,
+                            database,
+                            credential,
+                            passthrough,
+                            client_ca_configured,
+                        )
+                        .await?
+                    }
+                    result => result,
                 }
             } else {
                 AuthResult::NoPasswordMessage

--- a/pgdog/src/frontend/client/query_engine/mod.rs
+++ b/pgdog/src/frontend/client/query_engine/mod.rs
@@ -249,6 +249,12 @@ impl QueryEngine {
             Command::Copy(_) => self.execute(context).await?,
             Command::Deallocate => self.deallocate(context).await?,
             Command::Discard { extended } => self.discard(context, *extended).await?,
+            Command::RoleLocked { name } => {
+                // Client tried to escape a `server_role` impersonation. Reject
+                // the statement but keep the session alive.
+                self.error_response(context, ErrorResponse::role_locked(name))
+                    .await?;
+            }
             command => self.unknown_command(context, command.clone()).await?,
         }
 

--- a/pgdog/src/frontend/client/query_engine/mod.rs
+++ b/pgdog/src/frontend/client/query_engine/mod.rs
@@ -254,6 +254,10 @@ impl QueryEngine {
             Command::Copy(_) => self.execute(context).await?,
             Command::Deallocate => self.deallocate(context).await?,
             Command::Discard { extended } => self.discard(context, *extended).await?,
+            Command::RoleLocked { name } => {
+                self.error_response(context, ErrorResponse::role_locked(name))
+                    .await?;
+            }
         }
 
         self.hooks.after_execution(context)?;

--- a/pgdog/src/frontend/client/test/auth.rs
+++ b/pgdog/src/frontend/client/test/auth.rs
@@ -1,12 +1,15 @@
 //! Client authentication tests.
 
-use pgdog_config::{AuthType, PassthroughAuth};
+use std::num::NonZeroU32;
 
 use crate::{
+    auth::scram,
     config::{config, set},
     expect_message,
+    frontend::Client,
     net::{Authentication, ErrorResponse, Parameters, Password},
 };
+use pgdog_config::{AuthType, PassthroughAuth, users::PasswordKind};
 
 use super::SpawnedClient;
 
@@ -25,6 +28,20 @@ async fn login_admin(password: &str) -> SpawnedClient {
     let request = expect_message!(client.read().await, Authentication);
     assert!(matches!(request, Authentication::ClearTextPassword));
 
+    client.send(Password::new_password(password)).await;
+    client
+}
+
+/// Connect to a regular database user and answer the cleartext credential
+/// request used by plugin authentication.
+async fn login_user(user: &str, password: &str) -> SpawnedClient {
+    let mut params = Parameters::default();
+    params.insert("user", user);
+    params.insert("database", "pgdog");
+
+    let mut client = SpawnedClient::new_with_login(params).await;
+    let request = expect_message!(client.read().await, Authentication);
+    assert!(matches!(request, Authentication::ClearTextPassword));
     client.send(Password::new_password(password)).await;
     client
 }
@@ -54,5 +71,100 @@ async fn test_admin_password_checked_with_passthrough_auth() {
     let response = expect_message!(client.read().await, Authentication);
     assert!(matches!(response, Authentication::Ok));
     client.read_until('Z').await;
+    client.join().await;
+}
+
+#[test]
+fn test_cleartext_password_supports_plain_and_scram_verifiers() {
+    let verifier = scram::generate_hash(
+        "hashed-password",
+        NonZeroU32::new(4096).expect("iterations are non-zero"),
+        b"pgdog_test_salt!",
+    );
+    let passwords = [
+        PasswordKind::Plain("plain-password".into()),
+        PasswordKind::Hashed(verifier),
+    ];
+
+    assert_eq!(
+        Client::check_cleartext_password(&passwords, "plain-password"),
+        crate::auth::AuthResult::Ok
+    );
+    assert_eq!(
+        Client::check_cleartext_password(&passwords, "hashed-password"),
+        crate::auth::AuthResult::Ok
+    );
+    assert_eq!(
+        Client::check_cleartext_password(&passwords, "wrong-password"),
+        crate::auth::AuthResult::NoPasswordMatch
+    );
+    assert_eq!(
+        Client::check_cleartext_password(&[], "anything"),
+        crate::auth::AuthResult::NoPasswordConfig
+    );
+}
+
+#[tokio::test]
+async fn test_plugin_skip_falls_back_to_configured_password() {
+    crate::logger();
+    crate::config::load_test();
+
+    let mut cfg = (*config()).clone();
+    cfg.config.general.auth_type = AuthType::Plugin;
+    set(cfg).unwrap();
+
+    let mut client = login_user("pgdog", "pgdog").await;
+    let response = expect_message!(client.read().await, Authentication);
+    assert!(matches!(response, Authentication::Ok));
+    client.read_until('Z').await;
+}
+
+#[tokio::test]
+async fn test_plugin_skip_rejects_wrong_configured_password() {
+    crate::logger();
+    crate::config::load_test();
+
+    let mut cfg = (*config()).clone();
+    cfg.config.general.auth_type = AuthType::Plugin;
+    set(cfg).unwrap();
+
+    let mut client = login_user("pgdog", "wrong-password").await;
+    let error = ErrorResponse::try_from(client.read().await).unwrap();
+    assert_eq!(error.code, "28000");
+    client.join().await;
+}
+
+#[tokio::test]
+async fn test_plugin_skip_falls_back_to_passthrough() {
+    crate::logger();
+    crate::config::load_test();
+
+    let mut cfg = (*config()).clone();
+    cfg.config.general.auth_type = AuthType::Plugin;
+    cfg.config.general.passthrough_auth = PassthroughAuth::EnabledPlain;
+    set(cfg).unwrap();
+
+    let mut client = login_user("pgdog", "pgdog").await;
+    let response = expect_message!(client.read().await, Authentication);
+    assert!(matches!(response, Authentication::Ok));
+    client.read_until('Z').await;
+}
+
+#[tokio::test]
+async fn test_plugin_skip_does_not_bootstrap_password_for_plugin_only_user() {
+    crate::logger();
+    crate::config::load_test();
+
+    let mut cfg = (*config()).clone();
+    cfg.config.general.auth_type = AuthType::Plugin;
+    cfg.config.general.passthrough_auth = PassthroughAuth::EnabledPlain;
+    cfg.users.users[0].password = None;
+    cfg.users.users[0].server_password = Some("pgdog".into());
+    set(cfg).unwrap();
+    crate::backend::databases::reload_from_existing().unwrap();
+
+    let mut client = login_user("pgdog", "arbitrary-password").await;
+    let error = ErrorResponse::try_from(client.read().await).unwrap();
+    assert_eq!(error.code, "28000");
     client.join().await;
 }

--- a/pgdog/src/frontend/router/parser/command.rs
+++ b/pgdog/src/frontend/router/parser/command.rs
@@ -54,6 +54,13 @@ pub enum Command {
     },
     Unlisten(String),
     UniqueId,
+    /// A client tried to change the backend role (`SET ROLE`, `RESET ROLE`,
+    /// `SET SESSION AUTHORIZATION`, `set_config('role', ...)`, ...) on a pool
+    /// that impersonates a fixed `server_role`. Rejected with a 42501 error;
+    /// the session stays alive. `name` is the offending variable.
+    RoleLocked {
+        name: String,
+    },
 }
 
 impl Command {

--- a/pgdog/src/frontend/router/parser/command.rs
+++ b/pgdog/src/frontend/router/parser/command.rs
@@ -53,6 +53,13 @@ pub enum Command {
     },
     Unlisten(String),
     UniqueId,
+    /// A client tried to change the backend role (`SET ROLE`, `RESET ROLE`,
+    /// `SET SESSION AUTHORIZATION`, `set_config('role', ...)`, ...) on a pool
+    /// that impersonates a fixed `server_role`. Rejected with a 42501 error;
+    /// the session stays alive. `name` is the offending variable.
+    RoleLocked {
+        name: String,
+    },
 }
 
 impl Command {

--- a/pgdog/src/frontend/router/parser/query/mod.rs
+++ b/pgdog/src/frontend/router/parser/query/mod.rs
@@ -290,6 +290,18 @@ impl QueryParser {
             .run()?;
         }
 
+        // Reject any client attempt to escape a `server_role` impersonation
+        // before routing. Single chokepoint over every statement form we
+        // forward (single SET, multi-statement batches, set_config with a
+        // non-constant value). Normal pools have no `server_role`, so this
+        // short-circuits. The engine turns `RoleLocked` into a 42501 error and
+        // keeps the session alive.
+        if context.router_context.cluster.server_role().is_some()
+            && let Some(name) = set_config::role_escape_target(stmts)
+        {
+            return Ok(Command::RoleLocked { name });
+        }
+
         // Handle multi-statement SET commands (e.g. "SET x TO 1; SET y TO 2").
         if stmts.len() > 1
             && let Some(command) = self.try_multi_set(&**stmts, context)?
@@ -554,6 +566,14 @@ impl QueryParser {
                 }
 
                 let stmts = &statement.parse_result().protobuf.stmts;
+
+                // Reject any client attempt to escape a `server_role`
+                // impersonation before routing (see the new_parser variant).
+                if context.router_context.cluster.server_role().is_some()
+                    && let Some(name) = set_config::role_escape_target(stmts)
+                {
+                    return Ok(Command::RoleLocked { name });
+                }
 
                 // Handle multi-statement SET commands (e.g. "SET x TO 1; SET y TO 2").
                 if stmts.len() > 1

--- a/pgdog/src/frontend/router/parser/query/mod.rs
+++ b/pgdog/src/frontend/router/parser/query/mod.rs
@@ -339,6 +339,12 @@ impl QueryParser {
             .run()?;
         }
 
+        if context.router_context.cluster.server_role().is_some()
+            && let Some(name) = set_config::role_escape_target(&**stmts)
+        {
+            return Ok(Command::RoleLocked { name });
+        }
+
         // Handle multi-statement SET commands (e.g. "SET x TO 1; SET y TO 2").
         if stmts.len() > 1
             && let Some(command) = self.try_multi_set(&**stmts, context)?

--- a/pgdog/src/frontend/router/parser/query/mod.rs
+++ b/pgdog/src/frontend/router/parser/query/mod.rs
@@ -340,7 +340,7 @@ impl QueryParser {
         }
 
         if context.router_context.cluster.server_role().is_some()
-            && let Some(name) = set_config::role_escape_target(&**stmts)
+            && let Some(name) = set_config::role_escape_target(stmts)
         {
             return Ok(Command::RoleLocked { name });
         }

--- a/pgdog/src/frontend/router/parser/query/set_config.rs
+++ b/pgdog/src/frontend/router/parser/query/set_config.rs
@@ -1,6 +1,8 @@
 #[cfg(not(feature = "new_parser"))]
 use super::String as PgString;
 use super::*;
+#[cfg(feature = "new_parser")]
+use pg_raw_parse::{Owned, StmtList};
 #[cfg(not(feature = "new_parser"))]
 use std::string::String;
 
@@ -46,6 +48,79 @@ impl QueryParser {
         }
         _ => {}
     }
+}
+
+/// Session variables whose modification lets a client escape a `server_role`
+/// impersonation.
+const ROLE_ESCAPE_PARAMS: [&str; 2] = ["role", "session_authorization"];
+
+fn is_role_escape(name: &str) -> bool {
+    ROLE_ESCAPE_PARAMS
+        .iter()
+        .any(|param| name.eq_ignore_ascii_case(param))
+}
+
+/// Find a client-issued attempt to change the backend role in any of the
+/// parsed statements, so impersonation pools can reject every form uniformly:
+/// `SET ROLE`, `SET SESSION ROLE`, `SET LOCAL ROLE`, `RESET ROLE`,
+/// `SET SESSION AUTHORIZATION`, `RESET SESSION AUTHORIZATION`, and
+/// `set_config('role'|'session_authorization', ...)` (including non-constant
+/// values). Returns the offending variable name, matched case-insensitively.
+///
+/// `RESET ALL` / `DISCARD ALL` are intentionally not matched: they restore
+/// session defaults (the startup-parameter role) rather than clearing it.
+#[cfg(feature = "new_parser")]
+pub(super) fn role_escape_target(stmts: &Owned<StmtList>) -> Option<String> {
+    for node in stmts.stmts() {
+        match node {
+            // SET ROLE / RESET ROLE / SET SESSION AUTHORIZATION, and their
+            // SESSION/LOCAL spellings, all land here with the same `name`.
+            Node::VariableSetStmt(stmt) => {
+                if let Some(name) = stmt.name()
+                    && is_role_escape(name)
+                {
+                    return Some(name.to_string());
+                }
+            }
+            // SELECT set_config('role', <anything>, ...) — including a
+            // non-constant value that would otherwise pass through verbatim.
+            Node::SelectStmt(stmt) => {
+                if let Some(fcall) = extract_set_config(stmt)
+                    && let Some(name) = fcall.args().first().and_then(Node::as_str)
+                    && is_role_escape(name)
+                {
+                    return Some(name.to_string());
+                }
+            }
+            _ => (),
+        }
+    }
+
+    None
+}
+
+/// See the `new_parser` variant above for what this matches and why.
+#[cfg(not(feature = "new_parser"))]
+pub(super) fn role_escape_target(stmts: &[RawStmt]) -> Option<String> {
+    for raw in stmts {
+        match raw.stmt.as_ref().and_then(|stmt| stmt.node.as_ref()) {
+            Some(NodeEnum::VariableSetStmt(stmt)) if is_role_escape(&stmt.name) => {
+                return Some(stmt.name.clone());
+            }
+            Some(NodeEnum::SelectStmt(stmt)) => {
+                if let Some(fcall) = extract_set_config(stmt)
+                    && let Some(name_arg) = fcall.args.first()
+                    && let Some(name) = parse_config_name(name_arg)
+                    && is_role_escape(&name)
+                {
+                    return Some(name);
+                }
+            }
+            _ => (),
+        }
+    }
+
+    None
 }
 
 /// Returns None if the arguments could not be parsed

--- a/pgdog/src/frontend/router/parser/query/set_config.rs
+++ b/pgdog/src/frontend/router/parser/query/set_config.rs
@@ -44,10 +44,10 @@ pub(super) fn role_escape_target(stmts: &pg_raw_parse::StmtList) -> Option<Strin
             }
             Node::SelectStmt(stmt) => {
                 if let Some(fcall) = extract_set_config(stmt)
-                    && let Some(name) = fcall.args().first().and_then(Node::as_str)
-                    && is_role_escape(name)
+                    && let Some(name) = fcall.args().first().and_then(parse_config_name)
+                    && is_role_escape(&name)
                 {
-                    return Some(name.to_string());
+                    return Some(name);
                 }
             }
             _ => {}
@@ -93,5 +93,48 @@ fn parse_is_local(arg: Node<'_>) -> Option<bool> {
     match arg {
         Node::A_Const(c) => c.val()?.bool_value(),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn role_escape(query: &str) -> Option<String> {
+        let statements = pg_raw_parse::parse(query).expect("parse query");
+        role_escape_target(&statements)
+    }
+
+    #[test]
+    fn detects_role_escape_statements() {
+        for (query, expected) in [
+            ("SET ROLE reporting", "role"),
+            ("RESET ROLE", "role"),
+            (
+                "SET SESSION AUTHORIZATION reporting",
+                "session_authorization",
+            ),
+            ("SELECT 1; SET ROLE reporting", "role"),
+            (
+                "SELECT set_config('role', 'report' || 'ing', false)",
+                "role",
+            ),
+            (
+                "SELECT set_config('session_authorization', current_user, false)",
+                "session_authorization",
+            ),
+        ] {
+            assert_eq!(role_escape(query).as_deref(), Some(expected), "{query}");
+        }
+    }
+
+    #[test]
+    fn allows_session_reset_to_startup_defaults() {
+        assert_eq!(role_escape("RESET ALL"), None);
+        assert_eq!(role_escape("DISCARD ALL"), None);
+        assert_eq!(
+            role_escape("SELECT set_config('work_mem', '8MB', false)"),
+            None
+        );
     }
 }

--- a/pgdog/src/frontend/router/parser/query/set_config.rs
+++ b/pgdog/src/frontend/router/parser/query/set_config.rs
@@ -24,6 +24,39 @@ impl QueryParser {
     }
 }
 
+const ROLE_ESCAPE_PARAMS: [&str; 2] = ["role", "session_authorization"];
+
+fn is_role_escape(name: &str) -> bool {
+    ROLE_ESCAPE_PARAMS
+        .iter()
+        .any(|param| name.eq_ignore_ascii_case(param))
+}
+
+pub(super) fn role_escape_target(stmts: &pg_raw_parse::StmtList) -> Option<String> {
+    for node in stmts.stmts() {
+        match node {
+            Node::VariableSetStmt(stmt) => {
+                if let Some(name) = stmt.name()
+                    && is_role_escape(name)
+                {
+                    return Some(name.to_string());
+                }
+            }
+            Node::SelectStmt(stmt) => {
+                if let Some(fcall) = extract_set_config(stmt)
+                    && let Some(name) = fcall.args().first().and_then(Node::as_str)
+                    && is_role_escape(name)
+                {
+                    return Some(name.to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+
+    None
+}
+
 /// Returns None if the arguments could not be parsed
 fn parse_args(fcall: &nodes::FuncCall) -> Option<SetParam> {
     let name = parse_config_name(fcall.args().first()?)?;

--- a/pgdog/src/net/messages/error_response.rs
+++ b/pgdog/src/net/messages/error_response.rs
@@ -100,6 +100,19 @@ impl ErrorResponse {
         }
     }
 
+    pub fn role_locked(name: &str) -> ErrorResponse {
+        ErrorResponse {
+            severity: "ERROR".into(),
+            code: "42501".into(),
+            message: format!(
+                "\"SET {}\" is not allowed: this connection impersonates a fixed role",
+                name
+            ),
+            routine: Some("client::QueryEngine::set".into()),
+            ..Default::default()
+        }
+    }
+
     pub fn omni_in_direct_to_shard() -> ErrorResponse {
         ErrorResponse {
             severity: "ERROR".into(),

--- a/pgdog/src/net/messages/error_response.rs
+++ b/pgdog/src/net/messages/error_response.rs
@@ -115,6 +115,19 @@ impl ErrorResponse {
         }
     }
 
+    pub fn role_locked(name: &str) -> ErrorResponse {
+        ErrorResponse {
+            severity: "ERROR".into(),
+            code: "42501".into(),
+            message: format!(
+                "\"SET {}\" is not allowed: this connection impersonates a fixed role",
+                name
+            ),
+            routine: Some("client::QueryEngine::set".into()),
+            ..Default::default()
+        }
+    }
+
     pub fn omni_write_with_directive() -> ErrorResponse {
         ErrorResponse {
             severity: "ERROR".into(),

--- a/pgdog/src/net/stream.rs
+++ b/pgdog/src/net/stream.rs
@@ -453,6 +453,16 @@ mod tests {
         (Stream::plain(ours, 4096), peer.await.unwrap())
     }
 
+    async fn wait_for_liveness(stream: &mut Stream, expected: Liveness) {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while stream.liveness() != expected {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("socket did not reach expected liveness state");
+    }
+
     #[tokio::test]
     async fn test_liveness_clean_when_peer_idle() {
         let (mut stream, _peer) = connected_pair().await;
@@ -479,9 +489,8 @@ mod tests {
 
         peer.write_all(b"E").await.unwrap();
         peer.flush().await.unwrap();
-        tokio::task::yield_now().await;
 
-        assert_eq!(stream.liveness(), Liveness::DataPending);
+        wait_for_liveness(&mut stream, Liveness::DataPending).await;
     }
 
     #[tokio::test]
@@ -489,9 +498,8 @@ mod tests {
         let (mut stream, peer) = connected_pair().await;
 
         drop(peer);
-        tokio::task::yield_now().await;
 
-        assert_eq!(stream.liveness(), Liveness::Closed);
+        wait_for_liveness(&mut stream, Liveness::Closed).await;
     }
 
     #[tokio::test]
@@ -500,9 +508,8 @@ mod tests {
 
         peer.write_all(b"hello").await.unwrap();
         peer.flush().await.unwrap();
-        tokio::task::yield_now().await;
 
-        assert_eq!(stream.liveness(), Liveness::DataPending);
+        wait_for_liveness(&mut stream, Liveness::DataPending).await;
         assert_eq!(stream.liveness(), Liveness::DataPending);
 
         let mut buf = [0u8; 5];

--- a/pgdog/src/plugin/mod.rs
+++ b/pgdog/src/plugin/mod.rs
@@ -1,17 +1,17 @@
 //! pgDog plugins.
 
+use indexmap::IndexMap;
 use once_cell::sync::OnceCell;
 use pgdog_config::{Config, LogFormat};
 use pgdog_plugin::libloading;
 use pgdog_plugin::libloading::Library;
 use pgdog_plugin::{Config as PdConfig, PdStr, PluginVtable};
 use semver::Version;
-use std::collections::HashMap;
 use tokio::time::Instant;
 use tracing::{debug, error, info, warn};
 
-static LIBS: OnceCell<Vec<Library>> = OnceCell::new();
-pub static PLUGINS: OnceCell<HashMap<String, &'static PluginVtable>> = OnceCell::new();
+static LIBS: OnceCell<Vec<Option<Library>>> = OnceCell::new();
+pub static PLUGINS: OnceCell<IndexMap<String, &'static PluginVtable>> = OnceCell::new();
 
 // Compare semantic versions by major and minor only (ignore patch/bugfix).
 fn same_major_minor(a: &str, b: &str) -> bool {
@@ -39,7 +39,7 @@ pub fn load(config: &Config) -> Result<(), libloading::Error> {
 
     let libs = plugins
         .iter()
-        .filter_map(|plugin| {
+        .map(|plugin| {
             PluginVtable::library(&plugin.name)
                 .map_err(|err| error!("plugin \"{}\" failed to load: {:#?}", plugin.name, err))
                 .ok()
@@ -51,8 +51,12 @@ pub fn load(config: &Config) -> Result<(), libloading::Error> {
     let rustc_version = pgdog_plugin::RUSTC_VERSION;
     let pgdog_plugin_api_version = pgdog_plugin::VERSION;
 
-    let plugin_libs = plugins.iter().enumerate().filter_map(|(i, plugin)| {
-        if let Some(lib) = LIBS.get().unwrap().get(i) {
+    let Some(libs) = LIBS.get() else {
+        return Ok(());
+    };
+
+    let plugin_libs = plugins.iter().zip(libs).filter_map(|(plugin, lib)| {
+        if let Some(lib) = lib {
             let now = Instant::now();
             let Some(plugin_lib) = PluginVtable::load(lib) else {
                 warn!(
@@ -140,11 +144,11 @@ pub fn shutdown() {
 
 /// Get plugin by name.
 pub fn plugin(name: &str) -> Option<&PluginVtable> {
-    PLUGINS.get().unwrap().get(name).copied()
+    PLUGINS.get().and_then(|plugins| plugins.get(name).copied())
 }
 
 /// Get all loaded plugins.
-pub fn plugins() -> Option<&'static HashMap<String, &'static PluginVtable>> {
+pub fn plugins() -> Option<&'static IndexMap<String, &'static PluginVtable>> {
     PLUGINS.get()
 }
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -4,6 +4,15 @@ This directory contains plugins that ship with PgDog and are built by original a
 
 ## Plugins
 
+### `pgdog-google-auth`
+
+Authenticates PostgreSQL clients with Google OAuth 2.0 access tokens, including
+tokens printed by `gcloud auth print-access-token`. The plugin validates tokens
+with Google's `tokeninfo` endpoint and can restrict access by Google account,
+domain, OAuth audience, and scope.
+
+See the [`pgdog-google-auth` documentation](pgdog-google-auth/README.md).
+
 ### `pgdog-example-plugin`
 
 Example plugin that can be used as reference by the community. It currently records

--- a/plugins/pgdog-google-auth/Cargo.toml
+++ b/plugins/pgdog-google-auth/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "pgdog-google-auth"
+version = "0.1.0"
+edition.workspace = true
+description = "PgDog authentication plugin for Google OAuth 2.0 access tokens."
+license = "AGPL-3.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+once_cell = "1"
+parking_lot.workspace = true
+pgdog-plugin.workspace = true
+reqwest = { workspace = true, features = ["blocking", "json", "query"] }
+serde = { version = "1", features = ["derive"] }
+serde_json.workspace = true
+thiserror = "2"
+toml = "0.8"
+tracing = "0.1"
+url = "2"
+
+[dev-dependencies]
+tempfile = "3.23"

--- a/plugins/pgdog-google-auth/README.md
+++ b/plugins/pgdog-google-auth/README.md
@@ -1,0 +1,103 @@
+# Google access-token authentication
+
+`pgdog-google-auth` lets PostgreSQL clients authenticate to PgDog with Google
+OAuth 2.0 access tokens, including tokens produced by
+[`gcloud auth print-access-token`](https://docs.cloud.google.com/sdk/gcloud/reference/auth/print-access-token).
+
+The plugin sends the token to Google's HTTPS `tokeninfo` endpoint. It checks the
+token expiry and can enforce verified email, account, domain, OAuth audience,
+and scope restrictions. The token is never forwarded to PostgreSQL.
+
+> [!WARNING]
+> Access tokens are bearer credentials. Require TLS between clients and PgDog.
+> The plugin enforces TLS by default.
+
+## Build
+
+The main PgDog container build includes the plugin at
+`/usr/lib/libpgdog_google_auth.so`. To build it locally:
+
+```bash
+cargo build --release -p pgdog-google-auth
+```
+
+## Configure PgDog
+
+Enable plugin authentication and point PgDog at the plugin configuration:
+
+```toml
+[general]
+auth_type = "plugin"
+tls_client_required = true
+
+[[plugins]]
+name = "pgdog_google_auth"
+config = "google-auth.toml"
+```
+
+Start from [`config.example.toml`](config.example.toml). At minimum, restrict
+the accepted principals with `allowed_domains` or `allowed_emails`.
+
+By default, the verified Google email becomes the PostgreSQL user and must
+match the startup user. For example:
+
+```bash
+account="$(gcloud config get-value account)"
+PGPASSWORD="$(gcloud auth print-access-token)" \
+  psql "host=pgdog.example.com port=6432 dbname=app user=${account} sslmode=require"
+```
+
+For preconfigured pools, add the derived user to `users.toml`:
+
+```toml
+[[users]]
+name = "alice@example.com"
+database = "app"
+server_user = "pgdog_service"
+server_role = "alice"
+# Render server_password here from the approved secret manager.
+```
+
+Do not commit backend passwords. Render `users.toml` from the approved secret
+manager or use auto-provisioning with `server_password_env`.
+
+## Auto-provision users
+
+The plugin can create a pool after it validates a token:
+
+```toml
+allowed_domains = ["example.com"]
+provision = true
+impersonate = true
+server_user = "pgdog_service"
+server_password_env = "PGDOG_GOOGLE_AUTH_SERVER_PASSWORD"
+```
+
+Inject `PGDOG_GOOGLE_AUTH_SERVER_PASSWORD` into the PgDog process from the
+approved secret manager. PgDog uses `server_user` to connect to PostgreSQL and
+sets the derived Google identity as `server_role`.
+
+The PostgreSQL role must already exist, and the service account must be allowed
+to assume it:
+
+```sql
+GRANT "alice@example.com" TO pgdog_service;
+```
+
+Set `strip_email_domain = true` if PostgreSQL roles use the email local part.
+Set `username_claim = "user_id"` if stable numeric Google account IDs are
+preferred.
+
+## Security and operations
+
+- The token is sent only to the configured `tokeninfo_url`. Redirects are
+  disabled to prevent credential forwarding.
+- `tokeninfo_url` must use HTTPS. Plain HTTP is accepted only for loopback test
+  servers.
+- Request errors are sanitized so logs do not include the token-bearing URL.
+- `timeout_ms` bounds token validation. PgDog's `background_workers` setting
+  caps concurrent blocking authentication calls.
+- Google may rate-limit token introspection. Connection pooling reduces calls
+  because validation happens once per client connection.
+- A Google or network outage prevents new logins. Existing database sessions
+  remain active.

--- a/plugins/pgdog-google-auth/README.md
+++ b/plugins/pgdog-google-auth/README.md
@@ -77,9 +77,16 @@ For preconfigured pools, add the derived user to `users.toml`:
 name = "alice@example.com"
 database = "app"
 server_user = "pgdog_service"
-server_role = "alice"
 # Render server_password here from the approved secret manager.
 ```
+
+With `impersonate = true` (the default), the plugin's grant fills in
+`server_role` at login with the derived Google identity, so queries run as
+`alice@example.com` rather than as `pgdog_service`. The PostgreSQL role must
+already exist and be granted to the service account (see below); otherwise the
+backend refuses the `role` startup parameter and the login fails. An explicit
+`server_role` in `users.toml` takes precedence over the grant; PgDog logs a
+warning when they differ.
 
 Do not commit backend passwords. Render `users.toml` from the approved secret
 manager or use auto-provisioning with `server_password_env`.

--- a/plugins/pgdog-google-auth/README.md
+++ b/plugins/pgdog-google-auth/README.md
@@ -38,6 +38,29 @@ config = "google-auth.toml"
 Start from [`config.example.toml`](config.example.toml). At minimum, restrict
 the accepted principals with `allowed_domains` or `allowed_emails`.
 
+To let selected users authenticate with PostgreSQL passwords, enable PgDog's
+password or passthrough fallback:
+
+```toml
+# pgdog.toml
+[general]
+auth_type = "plugin"
+passthrough_auth = "enabled"
+tls_client_required = true
+```
+
+With `username_claim = "email"`, `strip_email_domain = false`, and
+`require_user_match = true`, the plugin claims only full email startup users
+matching `allowed_domains` or `allowed_emails`. A non-email user such as
+`postgres` returns `Skip` without sending its password to Google. Invalid Google
+tokens for claimed email users still return `Deny`, so they cannot downgrade to
+password authentication. For true backend passthrough, do not define the
+non-email user in `users.toml`.
+
+When `require_user_match = false`, `strip_email_domain = true`, or
+`username_claim = "user_id"`, PgDog cannot route by the startup email namespace.
+The plugin therefore claims the credential and preserves fail-closed behavior.
+
 By default, the verified Google email becomes the PostgreSQL user and must
 match the startup user. For example:
 

--- a/plugins/pgdog-google-auth/config.example.toml
+++ b/plugins/pgdog-google-auth/config.example.toml
@@ -17,6 +17,10 @@ require_verified_email = true
 allowed_domains = ["example.com"]
 allowed_emails = []
 
+# With the defaults above, startup users outside the allowed full-email
+# namespace (for example, "postgres") return Skip without sending their
+# credential to Google. PgDog can then use password or passthrough fallback.
+
 # Optional OAuth client and scope restrictions.
 allowed_audiences = []
 required_scopes = ["https://www.googleapis.com/auth/cloud-platform"]

--- a/plugins/pgdog-google-auth/config.example.toml
+++ b/plugins/pgdog-google-auth/config.example.toml
@@ -1,0 +1,31 @@
+# Google OAuth 2.0 token validation endpoint.
+tokeninfo_url = "https://oauth2.googleapis.com/tokeninfo"
+timeout_ms = 5000
+
+# Access tokens are credentials. Keep this enabled outside isolated loopback
+# tests so the PostgreSQL password exchange is encrypted.
+require_tls = true
+
+# Derive the PostgreSQL user from "email" or "user_id".
+username_claim = "email"
+strip_email_domain = false
+require_user_match = true
+require_verified_email = true
+
+# Restrict which Google identities may authenticate. If both lists are set,
+# matching either an exact email or a domain is sufficient.
+allowed_domains = ["example.com"]
+allowed_emails = []
+
+# Optional OAuth client and scope restrictions.
+allowed_audiences = []
+required_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+
+# Existing users.toml entries do not need provisioning. To create pools for
+# validated Google identities, enable provision and inject the backend password
+# into PgDog's environment from the approved secret manager.
+provision = false
+impersonate = true
+# server_user = "pgdog_service"
+# server_password_env = "PGDOG_GOOGLE_AUTH_SERVER_PASSWORD"
+# read_only = false

--- a/plugins/pgdog-google-auth/src/config.rs
+++ b/plugins/pgdog-google-auth/src/config.rs
@@ -1,0 +1,315 @@
+use std::{env, fs, path::Path, time::Duration};
+
+use reqwest::{Url, blocking::Client, redirect::Policy};
+use serde::Deserialize;
+use thiserror::Error;
+use url::Host;
+
+const DEFAULT_TOKENINFO_URL: &str = "https://oauth2.googleapis.com/tokeninfo";
+const DEFAULT_TIMEOUT_MS: u64 = 5_000;
+const MIN_TIMEOUT_MS: u64 = 100;
+const MAX_TIMEOUT_MS: u64 = 60_000;
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum UsernameClaim {
+    #[default]
+    Email,
+    UserId,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub(crate) struct Settings {
+    pub(crate) tokeninfo_url: String,
+    pub(crate) timeout_ms: u64,
+    pub(crate) require_tls: bool,
+    pub(crate) username_claim: UsernameClaim,
+    pub(crate) strip_email_domain: bool,
+    pub(crate) require_user_match: bool,
+    pub(crate) require_verified_email: bool,
+    pub(crate) allowed_audiences: Vec<String>,
+    pub(crate) allowed_domains: Vec<String>,
+    pub(crate) allowed_emails: Vec<String>,
+    pub(crate) required_scopes: Vec<String>,
+    pub(crate) provision: bool,
+    pub(crate) impersonate: bool,
+    pub(crate) server_user: Option<String>,
+    pub(crate) server_password_env: Option<String>,
+    pub(crate) read_only: Option<bool>,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            tokeninfo_url: DEFAULT_TOKENINFO_URL.into(),
+            timeout_ms: DEFAULT_TIMEOUT_MS,
+            require_tls: true,
+            username_claim: UsernameClaim::Email,
+            strip_email_domain: false,
+            require_user_match: true,
+            require_verified_email: true,
+            allowed_audiences: Vec::new(),
+            allowed_domains: Vec::new(),
+            allowed_emails: Vec::new(),
+            required_scopes: Vec::new(),
+            provision: false,
+            impersonate: true,
+            server_user: None,
+            server_password_env: None,
+            read_only: None,
+        }
+    }
+}
+
+pub(crate) struct RuntimeConfig {
+    pub(crate) settings: Settings,
+    pub(crate) endpoint: Url,
+    pub(crate) client: Client,
+    pub(crate) server_password: Option<String>,
+}
+
+impl RuntimeConfig {
+    pub(crate) fn load(path: Option<&Path>) -> Result<Self, ConfigError> {
+        let settings = match path {
+            Some(path) => {
+                let contents = fs::read_to_string(path).map_err(|source| ConfigError::Read {
+                    path: path.display().to_string(),
+                    source,
+                })?;
+                toml::from_str(&contents).map_err(|source| ConfigError::Parse {
+                    path: path.display().to_string(),
+                    source,
+                })?
+            }
+            None => Settings::default(),
+        };
+
+        Self::from_settings(settings)
+    }
+
+    pub(crate) fn from_settings(mut settings: Settings) -> Result<Self, ConfigError> {
+        if !(MIN_TIMEOUT_MS..=MAX_TIMEOUT_MS).contains(&settings.timeout_ms) {
+            return Err(ConfigError::Invalid(format!(
+                "timeout_ms must be between {MIN_TIMEOUT_MS} and {MAX_TIMEOUT_MS}"
+            )));
+        }
+
+        normalize_list(&mut settings.allowed_audiences, "allowed_audiences", false)?;
+        normalize_list(&mut settings.required_scopes, "required_scopes", false)?;
+        normalize_list(&mut settings.allowed_domains, "allowed_domains", true)?;
+        normalize_list(&mut settings.allowed_emails, "allowed_emails", true)?;
+
+        let endpoint = validate_endpoint(&settings.tokeninfo_url)?;
+        let timeout = Duration::from_millis(settings.timeout_ms);
+        let client = Client::builder()
+            .connect_timeout(timeout)
+            .timeout(timeout)
+            .redirect(Policy::none())
+            .user_agent(concat!("pgdog-google-auth/", env!("CARGO_PKG_VERSION")))
+            .build()
+            .map_err(ConfigError::Client)?;
+
+        let server_password = if settings.provision {
+            if settings.allowed_domains.is_empty() && settings.allowed_emails.is_empty() {
+                return Err(ConfigError::Invalid(
+                    "provision = true requires allowed_domains or allowed_emails".into(),
+                ));
+            }
+
+            let server_user = settings
+                .server_user
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .ok_or_else(|| {
+                    ConfigError::Invalid("provision = true requires server_user".into())
+                })?;
+            settings.server_user = Some(server_user.to_owned());
+
+            let variable = settings
+                .server_password_env
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .ok_or_else(|| {
+                    ConfigError::Invalid("provision = true requires server_password_env".into())
+                })?
+                .to_owned();
+            settings.server_password_env = Some(variable.clone());
+
+            let password = env::var(&variable).map_err(|_| ConfigError::MissingSecret {
+                variable: variable.clone(),
+            })?;
+            if password.is_empty() {
+                return Err(ConfigError::MissingSecret { variable });
+            }
+            Some(password)
+        } else {
+            None
+        };
+
+        Ok(Self {
+            settings,
+            endpoint,
+            client,
+            server_password,
+        })
+    }
+}
+
+fn normalize_list(
+    values: &mut [String],
+    field: &'static str,
+    lowercase: bool,
+) -> Result<(), ConfigError> {
+    for value in values {
+        *value = value.trim().to_owned();
+        if value.is_empty() {
+            return Err(ConfigError::Invalid(format!(
+                "{field} cannot contain empty values"
+            )));
+        }
+        if lowercase {
+            value.make_ascii_lowercase();
+        }
+    }
+    Ok(())
+}
+
+fn validate_endpoint(value: &str) -> Result<Url, ConfigError> {
+    let url = Url::parse(value).map_err(ConfigError::Url)?;
+
+    if !url.username().is_empty()
+        || url.password().is_some()
+        || url.query().is_some()
+        || url.fragment().is_some()
+    {
+        return Err(ConfigError::Invalid(
+            "tokeninfo_url cannot contain credentials, a query, or a fragment".into(),
+        ));
+    }
+
+    match url.scheme() {
+        "https" => Ok(url),
+        "http" if loopback(&url) => Ok(url),
+        _ => Err(ConfigError::Invalid(
+            "tokeninfo_url must use HTTPS; HTTP is allowed only for loopback tests".into(),
+        )),
+    }
+}
+
+fn loopback(url: &Url) -> bool {
+    match url.host() {
+        Some(Host::Domain(host)) => host.eq_ignore_ascii_case("localhost"),
+        Some(Host::Ipv4(address)) => address.is_loopback(),
+        Some(Host::Ipv6(address)) => address.is_loopback(),
+        None => false,
+    }
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum ConfigError {
+    #[error("failed to read Google auth config {path}: {source}")]
+    Read {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to parse Google auth config {path}: {source}")]
+    Parse {
+        path: String,
+        #[source]
+        source: toml::de::Error,
+    },
+    #[error("invalid tokeninfo_url: {0}")]
+    Url(#[source] url::ParseError),
+    #[error("failed to create Google tokeninfo client: {0}")]
+    Client(#[source] reqwest::Error),
+    #[error("missing backend password in environment variable {variable}")]
+    MissingSecret { variable: String },
+    #[error("invalid Google auth configuration: {0}")]
+    Invalid(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_are_secure() {
+        let settings = Settings::default();
+
+        assert!(settings.require_tls);
+        assert!(settings.require_user_match);
+        assert!(settings.require_verified_email);
+        assert!(settings.impersonate);
+        assert!(!settings.provision);
+        assert_eq!(settings.username_claim, UsernameClaim::Email);
+    }
+
+    #[test]
+    fn rejects_non_loopback_http_endpoint() {
+        let settings = Settings {
+            tokeninfo_url: "http://example.com/tokeninfo".into(),
+            ..Default::default()
+        };
+
+        assert!(RuntimeConfig::from_settings(settings).is_err());
+    }
+
+    #[test]
+    fn accepts_loopback_http_endpoint_for_tests() {
+        for tokeninfo_url in [
+            "http://127.0.0.1:12345/tokeninfo",
+            "http://[::1]:12345/tokeninfo",
+            "http://localhost:12345/tokeninfo",
+        ] {
+            let settings = Settings {
+                tokeninfo_url: tokeninfo_url.into(),
+                ..Default::default()
+            };
+
+            assert!(
+                RuntimeConfig::from_settings(settings).is_ok(),
+                "{tokeninfo_url}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_auto_provisioning_without_principal_allowlist() {
+        let settings = Settings {
+            provision: true,
+            server_user: Some("pgdog_service".into()),
+            server_password_env: Some("PGDOG_TEST_PASSWORD".into()),
+            ..Default::default()
+        };
+
+        let error = RuntimeConfig::from_settings(settings)
+            .err()
+            .expect("configuration should fail");
+        assert!(error.to_string().contains("allowed_domains"));
+    }
+
+    #[test]
+    fn parses_config_file() {
+        let directory = tempfile::tempdir().expect("create temp directory");
+        let path = directory.path().join("google-auth.toml");
+        fs::write(
+            &path,
+            r#"
+require_tls = true
+username_claim = "user_id"
+allowed_domains = ["Example.COM"]
+required_scopes = ["scope-a"]
+"#,
+        )
+        .expect("write config");
+
+        let runtime = RuntimeConfig::load(Some(&path)).expect("load config");
+        assert_eq!(runtime.settings.username_claim, UsernameClaim::UserId);
+        assert_eq!(runtime.settings.allowed_domains, ["example.com"]);
+        assert_eq!(runtime.settings.required_scopes, ["scope-a"]);
+    }
+}

--- a/plugins/pgdog-google-auth/src/config.rs
+++ b/plugins/pgdog-google-auth/src/config.rs
@@ -158,6 +158,40 @@ impl RuntimeConfig {
     }
 }
 
+impl Settings {
+    /// Whether the startup user belongs to the Google-authenticated namespace.
+    ///
+    /// A full email startup user can be routed before token introspection when
+    /// the token-derived email must match it. Other identity modes need the
+    /// token response before ownership can be determined, so the plugin claims
+    /// them and preserves fail-closed behavior.
+    pub(crate) fn claims_user(&self, user: &str) -> bool {
+        if !self.require_user_match
+            || self.username_claim != UsernameClaim::Email
+            || self.strip_email_domain
+        {
+            return true;
+        }
+
+        let normalized = user.to_ascii_lowercase();
+        let Some((local, domain)) = normalized.rsplit_once('@') else {
+            return false;
+        };
+        if local.is_empty() || domain.is_empty() {
+            return false;
+        }
+
+        if self.allowed_domains.is_empty() && self.allowed_emails.is_empty() {
+            return true;
+        }
+
+        self.allowed_emails
+            .iter()
+            .any(|allowed| allowed == &normalized)
+            || self.allowed_domains.iter().any(|allowed| allowed == domain)
+    }
+}
+
 fn normalize_list(
     values: &mut [String],
     field: &'static str,
@@ -311,5 +345,37 @@ required_scopes = ["scope-a"]
         assert_eq!(runtime.settings.username_claim, UsernameClaim::UserId);
         assert_eq!(runtime.settings.allowed_domains, ["example.com"]);
         assert_eq!(runtime.settings.required_scopes, ["scope-a"]);
+    }
+
+    #[test]
+    fn routes_only_matching_full_email_users_when_possible() {
+        let settings = Settings {
+            allowed_domains: vec!["example.com".into()],
+            allowed_emails: vec!["specific@other.test".into()],
+            ..Default::default()
+        };
+
+        assert!(settings.claims_user("alice@example.com"));
+        assert!(settings.claims_user("specific@other.test"));
+        assert!(!settings.claims_user("postgres"));
+        assert!(!settings.claims_user("alice@other.test"));
+
+        let derived_identity = Settings {
+            require_user_match: false,
+            ..settings.clone()
+        };
+        assert!(derived_identity.claims_user("postgres"));
+
+        let stripped_email = Settings {
+            strip_email_domain: true,
+            ..settings.clone()
+        };
+        assert!(stripped_email.claims_user("alice"));
+
+        let user_id = Settings {
+            username_claim: UsernameClaim::UserId,
+            ..settings
+        };
+        assert!(user_id.claims_user("1234567890"));
     }
 }

--- a/plugins/pgdog-google-auth/src/lib.rs
+++ b/plugins/pgdog-google-auth/src/lib.rs
@@ -44,6 +44,10 @@ impl Plugin for GoogleAuthPlugin {
             return AuthDecision::Deny("Google authentication plugin is not configured".into());
         };
 
+        if !runtime.settings.claims_user(&context.user) {
+            return AuthDecision::Skip;
+        }
+
         match token_info::authenticate(&runtime, &context.user, &context.credential, context.tls) {
             Ok(grant) => AuthDecision::Allow(grant),
             Err(err) => AuthDecision::Deny(err.to_string()),

--- a/plugins/pgdog-google-auth/src/lib.rs
+++ b/plugins/pgdog-google-auth/src/lib.rs
@@ -1,0 +1,52 @@
+//! Google OAuth 2.0 access-token authentication for PgDog.
+
+mod config;
+mod token_info;
+
+use std::{path::Path, sync::Arc};
+
+use config::RuntimeConfig;
+use once_cell::sync::Lazy;
+use parking_lot::RwLock;
+use pgdog_plugin::{AuthContext, AuthDecision, Config as PluginConfig, PdStr, Plugin, plugin};
+use tracing::{error, info};
+
+plugin!(GoogleAuthPlugin);
+
+struct GoogleAuthPlugin;
+
+static RUNTIME: Lazy<RwLock<Option<Arc<RuntimeConfig>>>> = Lazy::new(|| RwLock::new(None));
+
+impl Plugin for GoogleAuthPlugin {
+    extern "C-unwind" fn version() -> PdStr<'static> {
+        env!("CARGO_PKG_VERSION").into()
+    }
+
+    extern "C-unwind" fn config(config: PluginConfig<'_>) -> bool {
+        let path = (!config.plugin_config.is_empty()).then(|| Path::new(&*config.plugin_config));
+
+        match RuntimeConfig::load(path) {
+            Ok(runtime) => {
+                info!("[pgdog_google_auth] configured Google access-token authentication");
+                *RUNTIME.write() = Some(Arc::new(runtime));
+                true
+            }
+            Err(err) => {
+                error!("[pgdog_google_auth] configuration failed: {err}");
+                *RUNTIME.write() = None;
+                false
+            }
+        }
+    }
+
+    fn authenticate(context: AuthContext<'_>) -> AuthDecision {
+        let Some(runtime) = RUNTIME.read().clone() else {
+            return AuthDecision::Deny("Google authentication plugin is not configured".into());
+        };
+
+        match token_info::authenticate(&runtime, &context.user, &context.credential, context.tls) {
+            Ok(grant) => AuthDecision::Allow(grant),
+            Err(err) => AuthDecision::Deny(err.to_string()),
+        }
+    }
+}

--- a/plugins/pgdog-google-auth/src/token_info.rs
+++ b/plugins/pgdog-google-auth/src/token_info.rs
@@ -1,0 +1,465 @@
+use std::{
+    collections::HashSet,
+    io::{Read, Take},
+};
+
+use pgdog_plugin::AuthGrant;
+use serde::Deserialize;
+use thiserror::Error;
+
+use crate::config::{RuntimeConfig, Settings, UsernameClaim};
+
+const MAX_TOKEN_LENGTH: usize = 16 * 1024;
+const MAX_RESPONSE_LENGTH: u64 = 64 * 1024;
+const MAX_POSTGRES_USERNAME_LENGTH: usize = 63;
+
+#[derive(Debug, Deserialize)]
+struct TokenInfo {
+    #[serde(alias = "aud")]
+    audience: Option<String>,
+    #[serde(alias = "azp")]
+    issued_to: Option<String>,
+    #[serde(alias = "sub")]
+    user_id: Option<String>,
+    scope: Option<String>,
+    expires_in: Option<i64>,
+    email: Option<String>,
+    #[serde(alias = "email_verified")]
+    verified_email: Option<bool>,
+}
+
+pub(crate) fn authenticate(
+    runtime: &RuntimeConfig,
+    startup_user: &str,
+    credential: &str,
+    tls: bool,
+) -> Result<AuthGrant, AuthenticationError> {
+    if runtime.settings.require_tls && !tls {
+        return Err(AuthenticationError::TlsRequired);
+    }
+    if credential.is_empty() || credential.len() > MAX_TOKEN_LENGTH {
+        return Err(AuthenticationError::InvalidCredential);
+    }
+
+    let token_info = fetch(runtime, credential)?;
+    validate(&runtime.settings, startup_user, token_info).map(|username| AuthGrant {
+        derived_user: Some(username.clone()),
+        server_role: runtime.settings.impersonate.then_some(username),
+        server_user: runtime.settings.server_user.clone(),
+        server_password: runtime.server_password.clone(),
+        read_only: runtime.settings.read_only,
+        provision: runtime.settings.provision,
+    })
+}
+
+fn fetch(runtime: &RuntimeConfig, credential: &str) -> Result<TokenInfo, AuthenticationError> {
+    let response = runtime
+        .client
+        .get(runtime.endpoint.clone())
+        .query(&[("access_token", credential)])
+        .send()
+        .map_err(request_error)?;
+
+    if !response.status().is_success() {
+        return Err(AuthenticationError::Rejected);
+    }
+
+    let mut body = Vec::new();
+    let mut limited: Take<_> = response.take(MAX_RESPONSE_LENGTH + 1);
+    limited
+        .read_to_end(&mut body)
+        .map_err(|error| AuthenticationError::Request(error.to_string()))?;
+    if body.len() as u64 > MAX_RESPONSE_LENGTH {
+        return Err(AuthenticationError::ResponseTooLarge);
+    }
+
+    serde_json::from_slice(&body).map_err(AuthenticationError::InvalidResponse)
+}
+
+fn request_error(error: reqwest::Error) -> AuthenticationError {
+    AuthenticationError::Request(error.without_url().to_string())
+}
+
+fn validate(
+    settings: &Settings,
+    startup_user: &str,
+    token_info: TokenInfo,
+) -> Result<String, AuthenticationError> {
+    if token_info.expires_in.is_none_or(|seconds| seconds <= 0) {
+        return Err(AuthenticationError::Expired);
+    }
+
+    validate_audience(settings, &token_info)?;
+    validate_scopes(settings, &token_info)?;
+
+    let email = token_info
+        .email
+        .as_deref()
+        .map(str::trim)
+        .filter(|email| !email.is_empty())
+        .map(str::to_ascii_lowercase);
+    let email_required = settings.username_claim == UsernameClaim::Email
+        || !settings.allowed_domains.is_empty()
+        || !settings.allowed_emails.is_empty();
+
+    if email_required && email.is_none() {
+        return Err(AuthenticationError::MissingEmail);
+    }
+    if email_required && settings.require_verified_email && token_info.verified_email != Some(true)
+    {
+        return Err(AuthenticationError::UnverifiedEmail);
+    }
+    if email_required {
+        validate_email(email.as_deref().ok_or(AuthenticationError::MissingEmail)?)?;
+    }
+
+    if !settings.allowed_domains.is_empty() || !settings.allowed_emails.is_empty() {
+        let email = email.as_deref().ok_or(AuthenticationError::MissingEmail)?;
+        let (_, domain) = validate_email(email)?;
+        let allowed = settings
+            .allowed_emails
+            .iter()
+            .any(|allowed| allowed == email)
+            || settings
+                .allowed_domains
+                .iter()
+                .any(|allowed| allowed == domain);
+        if !allowed {
+            return Err(AuthenticationError::PrincipalNotAllowed);
+        }
+    }
+
+    let username = match settings.username_claim {
+        UsernameClaim::Email => {
+            let email = email.ok_or(AuthenticationError::MissingEmail)?;
+            if settings.strip_email_domain {
+                validate_email(&email)?.0.to_owned()
+            } else {
+                email
+            }
+        }
+        UsernameClaim::UserId => token_info
+            .user_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|user_id| !user_id.is_empty())
+            .map(str::to_owned)
+            .ok_or(AuthenticationError::MissingUserId)?,
+    };
+
+    if username.len() > MAX_POSTGRES_USERNAME_LENGTH {
+        return Err(AuthenticationError::UsernameTooLong);
+    }
+    if settings.require_user_match && startup_user != username {
+        return Err(AuthenticationError::UserMismatch);
+    }
+
+    Ok(username)
+}
+
+fn validate_email(email: &str) -> Result<(&str, &str), AuthenticationError> {
+    let (local, domain) = email
+        .rsplit_once('@')
+        .ok_or(AuthenticationError::InvalidEmail)?;
+
+    if local.is_empty() || domain.is_empty() {
+        return Err(AuthenticationError::InvalidEmail);
+    }
+
+    Ok((local, domain))
+}
+
+fn validate_audience(
+    settings: &Settings,
+    token_info: &TokenInfo,
+) -> Result<(), AuthenticationError> {
+    if settings.allowed_audiences.is_empty() {
+        return Ok(());
+    }
+
+    let accepted = token_info
+        .audience
+        .iter()
+        .chain(token_info.issued_to.iter())
+        .any(|audience| {
+            settings
+                .allowed_audiences
+                .iter()
+                .any(|allowed| allowed == audience)
+        });
+
+    accepted
+        .then_some(())
+        .ok_or(AuthenticationError::AudienceNotAllowed)
+}
+
+fn validate_scopes(settings: &Settings, token_info: &TokenInfo) -> Result<(), AuthenticationError> {
+    if settings.required_scopes.is_empty() {
+        return Ok(());
+    }
+
+    let scopes: HashSet<_> = token_info
+        .scope
+        .as_deref()
+        .unwrap_or_default()
+        .split_whitespace()
+        .collect();
+
+    settings
+        .required_scopes
+        .iter()
+        .all(|scope| scopes.contains(scope.as_str()))
+        .then_some(())
+        .ok_or(AuthenticationError::MissingScope)
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum AuthenticationError {
+    #[error("Google access tokens require a TLS client connection")]
+    TlsRequired,
+    #[error("invalid Google access token")]
+    InvalidCredential,
+    #[error("Google tokeninfo request failed: {0}")]
+    Request(String),
+    #[error("Google rejected the access token")]
+    Rejected,
+    #[error("Google tokeninfo response exceeded the size limit")]
+    ResponseTooLarge,
+    #[error("Google tokeninfo returned an invalid response: {0}")]
+    InvalidResponse(#[source] serde_json::Error),
+    #[error("Google access token is expired")]
+    Expired,
+    #[error("Google access token has no email identity")]
+    MissingEmail,
+    #[error("Google access token email is not verified")]
+    UnverifiedEmail,
+    #[error("Google access token contains an invalid email identity")]
+    InvalidEmail,
+    #[error("Google account is not allowed")]
+    PrincipalNotAllowed,
+    #[error("Google access token audience is not allowed")]
+    AudienceNotAllowed,
+    #[error("Google access token is missing a required scope")]
+    MissingScope,
+    #[error("Google access token has no user_id identity")]
+    MissingUserId,
+    #[error("Google identity exceeds PostgreSQL's 63-byte user-name limit")]
+    UsernameTooLong,
+    #[error("PostgreSQL startup user does not match the Google identity")]
+    UserMismatch,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        io::{Read, Write},
+        net::TcpListener,
+        thread,
+    };
+
+    use super::*;
+    use crate::config::Settings;
+
+    fn token_info() -> TokenInfo {
+        TokenInfo {
+            audience: Some("gcloud-client".into()),
+            issued_to: None,
+            user_id: Some("1234567890".into()),
+            scope: Some("scope-a scope-b".into()),
+            expires_in: Some(3_600),
+            email: Some("alice@example.com".into()),
+            verified_email: Some(true),
+        }
+    }
+
+    fn settings() -> Settings {
+        Settings {
+            require_tls: false,
+            allowed_audiences: vec!["gcloud-client".into()],
+            allowed_domains: vec!["example.com".into()],
+            required_scopes: vec!["scope-a".into()],
+            ..Default::default()
+        }
+    }
+
+    fn mock_server(
+        status: &'static str,
+        body: &'static str,
+    ) -> (String, thread::JoinHandle<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock server");
+        let address = listener.local_addr().expect("mock server address");
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            let mut request = [0u8; 4096];
+            let size = stream.read(&mut request).expect("read request");
+            let request = String::from_utf8_lossy(&request[..size]).into_owned();
+            let response = format!(
+                "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream
+                .write_all(response.as_bytes())
+                .expect("write response");
+            request
+        });
+
+        (format!("http://{address}/tokeninfo"), handle)
+    }
+
+    #[test]
+    fn accepts_verified_allowed_identity() {
+        let username = validate(&settings(), "alice@example.com", token_info())
+            .expect("token should validate");
+
+        assert_eq!(username, "alice@example.com");
+    }
+
+    #[test]
+    fn can_use_user_id_as_postgres_identity() {
+        let settings = Settings {
+            username_claim: UsernameClaim::UserId,
+            require_user_match: false,
+            require_verified_email: false,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            validate(&settings, "ignored", token_info()).expect("token should validate"),
+            "1234567890"
+        );
+    }
+
+    #[test]
+    fn rejects_expired_token() {
+        let mut token = token_info();
+        token.expires_in = Some(0);
+
+        assert!(matches!(
+            validate(&settings(), "alice@example.com", token),
+            Err(AuthenticationError::Expired)
+        ));
+    }
+
+    #[test]
+    fn rejects_unverified_email() {
+        let mut token = token_info();
+        token.verified_email = Some(false);
+
+        assert!(matches!(
+            validate(&settings(), "alice@example.com", token),
+            Err(AuthenticationError::UnverifiedEmail)
+        ));
+    }
+
+    #[test]
+    fn rejects_disallowed_audience_domain_and_scope() {
+        let mut audience = settings();
+        audience.allowed_audiences = vec!["different-client".into()];
+        assert!(matches!(
+            validate(&audience, "alice@example.com", token_info()),
+            Err(AuthenticationError::AudienceNotAllowed)
+        ));
+
+        let mut domain = settings();
+        domain.allowed_domains = vec!["other.example".into()];
+        assert!(matches!(
+            validate(&domain, "alice@example.com", token_info()),
+            Err(AuthenticationError::PrincipalNotAllowed)
+        ));
+
+        let mut scope = settings();
+        scope.required_scopes = vec!["scope-c".into()];
+        assert!(matches!(
+            validate(&scope, "alice@example.com", token_info()),
+            Err(AuthenticationError::MissingScope)
+        ));
+    }
+
+    #[test]
+    fn rejects_startup_user_mismatch() {
+        assert!(matches!(
+            validate(&settings(), "bob@example.com", token_info()),
+            Err(AuthenticationError::UserMismatch)
+        ));
+    }
+
+    #[test]
+    fn rejects_malformed_email_identity() {
+        for email in ["alice", "@example.com", "alice@"] {
+            let mut token = token_info();
+            token.email = Some(email.into());
+
+            assert!(matches!(
+                validate(&settings(), email, token),
+                Err(AuthenticationError::InvalidEmail)
+            ));
+        }
+    }
+
+    #[test]
+    fn accepts_oidc_tokeninfo_field_names() {
+        let token_info: TokenInfo = serde_json::from_str(
+            r#"{
+                "aud": "gcloud-client",
+                "azp": "authorized-party",
+                "sub": "1234567890",
+                "scope": "scope-a",
+                "expires_in": 3600,
+                "email": "alice@example.com",
+                "email_verified": true
+            }"#,
+        )
+        .expect("parse tokeninfo response");
+
+        assert_eq!(
+            validate(&settings(), "alice@example.com", token_info).expect("token should validate"),
+            "alice@example.com"
+        );
+    }
+
+    #[test]
+    fn calls_tokeninfo_without_leaking_token_in_errors() {
+        let body = r#"{
+            "audience": "gcloud-client",
+            "user_id": "1234567890",
+            "scope": "scope-a scope-b",
+            "expires_in": 3600,
+            "email": "alice@example.com",
+            "verified_email": true
+        }"#;
+        let (url, request) = mock_server("200 OK", body);
+        let runtime = RuntimeConfig::from_settings(Settings {
+            tokeninfo_url: url,
+            require_tls: false,
+            require_user_match: false,
+            ..Default::default()
+        })
+        .expect("create runtime");
+        let token = "ya29.a+b/c?";
+
+        let grant = authenticate(&runtime, "ignored", token, false).expect("authenticate");
+        assert_eq!(grant.derived_user.as_deref(), Some("alice@example.com"));
+
+        let request = request.join().expect("join mock server");
+        assert!(request.starts_with("GET /tokeninfo?access_token="));
+        assert!(!request.contains(token));
+    }
+
+    #[test]
+    fn rejects_non_success_response() {
+        let (url, request) = mock_server("400 Bad Request", r#"{"error":"invalid_token"}"#);
+        let runtime = RuntimeConfig::from_settings(Settings {
+            tokeninfo_url: url,
+            require_tls: false,
+            require_user_match: false,
+            ..Default::default()
+        })
+        .expect("create runtime");
+
+        assert!(matches!(
+            authenticate(&runtime, "ignored", "bad-token", false),
+            Err(AuthenticationError::Rejected)
+        ));
+        request.join().expect("join mock server");
+    }
+}

--- a/plugins/pgdog-google-auth/src/token_info.rs
+++ b/plugins/pgdog-google-auth/src/token_info.rs
@@ -24,8 +24,21 @@ struct TokenInfo {
     scope: Option<String>,
     expires_in: Option<String>,
     email: Option<String>,
-    #[serde(alias = "email_verified")]
+    #[serde(alias = "email_verified", deserialize_with = "deserialize_str_bool")]
     verified_email: Option<bool>,
+}
+
+fn deserialize_str_bool<'de, D>(deserializer: D) -> Result<Option<bool>, D::Error>
+where
+    D: serde::de::Deserializer<'de>,
+{
+    let s: &str = serde::de::Deserialize::deserialize(deserializer)?;
+
+    match s {
+        "true" => Ok(Some(true)),
+        "false" => Ok(Some(false)),
+        _ => Err(serde::de::Error::unknown_variant(s, &["true", "false"])),
+    }
 }
 
 pub(crate) fn authenticate(
@@ -411,7 +424,7 @@ mod tests {
                 "scope": "scope-a",
                 "expires_in": "3600",
                 "email": "alice@example.com",
-                "email_verified": true
+                "email_verified": "true"
             }"#,
         )
         .expect("parse tokeninfo response");
@@ -425,12 +438,15 @@ mod tests {
     #[test]
     fn calls_tokeninfo_without_leaking_token_in_errors() {
         let body = r#"{
-            "audience": "gcloud-client",
-            "user_id": "1234567890",
-            "scope": "scope-a scope-b",
-            "expires_in": "3600",
-            "email": "alice@example.com",
-            "verified_email": true
+          "azp": "42789329387.apps.googleusercontent.com",
+          "aud": "42789329387.apps.googleusercontent.com",
+          "sub": "427893293874278932938",
+          "scope": "email https://www.googleapis.com/auth/accounts.reauth https://www.googleapis.com/auth/appengine.admin https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/compute https://www.googleapis.com/auth/sqlservice.login https://www.googleapis.com/auth/userinfo.email openid",
+          "exp": "1787664074",
+          "expires_in": "2865",
+          "email": "marco.palmisano@examplecompany.com",
+          "email_verified": "true",
+          "access_type": "offline"
         }"#;
         let (url, request) = mock_server("200 OK", body);
         let runtime = RuntimeConfig::from_settings(Settings {
@@ -443,7 +459,7 @@ mod tests {
         let token = "ya29.a+b/c?";
 
         let grant = authenticate(&runtime, "ignored", token, false).expect("authenticate");
-        assert_eq!(grant.derived_user.as_deref(), Some("alice@example.com"));
+        assert_eq!(grant.derived_user.as_deref(), Some("marco.palmisano@examplecompany.com"));
 
         let request = request.join().expect("join mock server");
         assert!(request.starts_with("GET /tokeninfo?access_token="));

--- a/plugins/pgdog-google-auth/src/token_info.rs
+++ b/plugins/pgdog-google-auth/src/token_info.rs
@@ -98,7 +98,8 @@ fn validate(
     startup_user: &str,
     token_info: TokenInfo,
 ) -> Result<String, AuthenticationError> {
-    let parsed_secs: i64 = token_info.expires_in
+    let parsed_secs: i64 = token_info
+        .expires_in
         .as_deref()
         .unwrap_or("0")
         .parse()
@@ -459,7 +460,10 @@ mod tests {
         let token = "ya29.a+b/c?";
 
         let grant = authenticate(&runtime, "ignored", token, false).expect("authenticate");
-        assert_eq!(grant.derived_user.as_deref(), Some("marco.palmisano@examplecompany.com"));
+        assert_eq!(
+            grant.derived_user.as_deref(),
+            Some("marco.palmisano@examplecompany.com")
+        );
 
         let request = request.join().expect("join mock server");
         assert!(request.starts_with("GET /tokeninfo?access_token="));

--- a/plugins/pgdog-google-auth/src/token_info.rs
+++ b/plugins/pgdog-google-auth/src/token_info.rs
@@ -22,7 +22,7 @@ struct TokenInfo {
     #[serde(alias = "sub")]
     user_id: Option<String>,
     scope: Option<String>,
-    expires_in: Option<i64>,
+    expires_in: Option<String>,
     email: Option<String>,
     #[serde(alias = "email_verified")]
     verified_email: Option<bool>,
@@ -85,7 +85,12 @@ fn validate(
     startup_user: &str,
     token_info: TokenInfo,
 ) -> Result<String, AuthenticationError> {
-    if token_info.expires_in.is_none_or(|seconds| seconds <= 0) {
+    let parsed_secs: i64 = token_info.expires_in
+        .as_deref()
+        .unwrap_or("0")
+        .parse()
+        .unwrap();
+    if parsed_secs <= 0 {
         return Err(AuthenticationError::Expired);
     }
 
@@ -266,7 +271,7 @@ mod tests {
             issued_to: None,
             user_id: Some("1234567890".into()),
             scope: Some("scope-a scope-b".into()),
-            expires_in: Some(3_600),
+            expires_in: Some("3600".into()),
             email: Some("alice@example.com".into()),
             verified_email: Some(true),
         }
@@ -332,7 +337,7 @@ mod tests {
     #[test]
     fn rejects_expired_token() {
         let mut token = token_info();
-        token.expires_in = Some(0);
+        token.expires_in = Some("0".into());
 
         assert!(matches!(
             validate(&settings(), "alice@example.com", token),
@@ -404,7 +409,7 @@ mod tests {
                 "azp": "authorized-party",
                 "sub": "1234567890",
                 "scope": "scope-a",
-                "expires_in": 3600,
+                "expires_in": "3600",
                 "email": "alice@example.com",
                 "email_verified": true
             }"#,
@@ -423,7 +428,7 @@ mod tests {
             "audience": "gcloud-client",
             "user_id": "1234567890",
             "scope": "scope-a scope-b",
-            "expires_in": 3600,
+            "expires_in": "3600",
             "email": "alice@example.com",
             "verified_email": true
         }"#;

--- a/plugins/pgdog-google-auth/src/token_info.rs
+++ b/plugins/pgdog-google-auth/src/token_info.rs
@@ -24,21 +24,51 @@ struct TokenInfo {
     scope: Option<String>,
     expires_in: Option<String>,
     email: Option<String>,
-    #[serde(alias = "email_verified", deserialize_with = "deserialize_str_bool")]
+    #[serde(
+        default,
+        alias = "email_verified",
+        deserialize_with = "deserialize_str_bool"
+    )]
     verified_email: Option<bool>,
 }
 
+/// Google's tokeninfo endpoint stringifies booleans (`"email_verified":
+/// "true"`), while other identity endpoints use real JSON booleans; accept
+/// both. `deserialize_with` disables serde's implicit missing-field handling
+/// for `Option`, hence the explicit `default` on the field above.
 fn deserialize_str_bool<'de, D>(deserializer: D) -> Result<Option<bool>, D::Error>
 where
     D: serde::de::Deserializer<'de>,
 {
-    let s: &str = serde::de::Deserialize::deserialize(deserializer)?;
+    struct StrBool;
 
-    match s {
-        "true" => Ok(Some(true)),
-        "false" => Ok(Some(false)),
-        _ => Err(serde::de::Error::unknown_variant(s, &["true", "false"])),
+    impl serde::de::Visitor<'_> for StrBool {
+        type Value = bool;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str(r#"a boolean or "true"/"false""#)
+        }
+
+        fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(value)
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            match value {
+                "true" => Ok(true),
+                "false" => Ok(false),
+                _ => Err(E::unknown_variant(value, &["true", "false"])),
+            }
+        }
     }
+
+    deserializer.deserialize_any(StrBool).map(Some)
 }
 
 pub(crate) fn authenticate(
@@ -433,6 +463,26 @@ mod tests {
         assert_eq!(
             validate(&settings(), "alice@example.com", token_info).expect("token should validate"),
             "alice@example.com"
+        );
+    }
+
+    #[test]
+    fn accepts_boolean_and_missing_email_verified() {
+        // Other Google identity endpoints send a real JSON boolean.
+        let token_info: TokenInfo = serde_json::from_str(
+            r#"{"expires_in": "3600", "email": "alice@example.com", "email_verified": true}"#,
+        )
+        .expect("parse boolean email_verified");
+        assert_eq!(token_info.verified_email, Some(true));
+
+        // Tokens without the email scope omit the field entirely.
+        let token_info: TokenInfo =
+            serde_json::from_str(r#"{"expires_in": "3600"}"#).expect("parse missing field");
+        assert_eq!(token_info.verified_email, None);
+
+        assert!(
+            serde_json::from_str::<TokenInfo>(r#"{"expires_in": "3600", "email_verified": "yes"}"#)
+                .is_err()
         );
     }
 


### PR DESCRIPTION
## Summary

This is the first of two PRs reworking #1084 (JWT client auth) into a general extension point. It adds one new plugin hook, `pgdog_authenticate`, next to the existing `pgdog_route`, so a plugin can validate a client credential. There is no JWT anywhere in this PR; core only learns how to ask a plugin "is this credential good?". It also adds a per-user `server_role` option so a pool can impersonate a role on the backend, and a `background_workers` setting that caps how many auth plugin calls run at once.

Design was discussed first in an RFC (gist: https://gist.github.com/ziomarco/ad18e5c5f65472f13671958514b30c0d) and approved with a few adjustments, all of which are implemented here.

## Motivation

In #1084 I put JWT validation directly into `Client::check_password`. The feedback was that it belongs in a plugin, but the plugin system only had a query-routing hook, so there was nowhere for auth to plug in. This PR builds that missing seam.

Authentication is a multi-message exchange, so I did not try to hand the client socket to a plugin. pgdog keeps driving the wire exactly like passthrough auth does today: it sends `AuthenticationCleartextPassword`, reads the password message, and only then asks the plugins about the credential. Each plugin answers Skip, Allow, or Deny, and the first non-Skip answer wins, in `[[plugins]]` order. The same hook works for LDAP, OIDC introspection, RADIUS, Vault, or any custom check without touching core again.

The plugin call runs inside `tokio::task::spawn_blocking`, since auth happens once per connection and a plugin may need to block on I/O (a JWKS fetch, an LDAP bind). That is different from `route()`, which runs per query and has to stay fast.

## What's in this PR

- `pgdog-plugin`: the `PdAuthContext` / `PdAuthResult` FFI types, safe `AuthContext` / `AuthDecision` / `AuthGrant` wrappers, and the symbol resolution and call path. The result carries plugin-allocated strings, so there is a paired `pgdog_authenticate_free`: pgdog copies the strings out and the plugin frees its own allocations, which stays sound even if a plugin uses a custom allocator. A plugin that exports `pgdog_authenticate` without the free symbol is refused at load.
- `pgdog-macros`: an `#[authentication]` attribute, the same idea as `#[route]`. It generates both symbols and wraps the user function in `catch_unwind`, so a panicking plugin becomes a Deny rather than taking down the pooler.
- `pgdog-config`: the `auth_type = "plugin"` variant, the per-user `server_role`, and `background_workers`.
- `pgdog`: the `spawn_blocking` driver, one new branch in `Client::login`, `databases::add_authenticated` for auto-provisioning a pool on Allow (the existing `add()` compares the credential against the stored password, which cannot work with a per-login token), the `role` startup parameter, the guard that rejects client-issued role changes on impersonation pools, and load-time validation.

For `server_role`, the role is pushed as a `role` startup-packet parameter. Startup parameters are session defaults, so `RESET ALL` and `DISCARD ALL` restore the role instead of clearing it, and pgdog's connection cleanup between checkouts needs no special handling. The one thing that does need handling is a client trying to escape the role, so pgdog rejects `SET ROLE`, `RESET ROLE`, and `SET SESSION AUTHORIZATION` (including the multi-statement and `set_config()` spellings) on pools that set a `server_role`. The statement is refused with a normal Postgres error and the session stays open.

## Decisions from the RFC review

A few points were settled during review and are worth calling out:

- When every plugin skips, pgdog denies. There is no fallback to configured-password verification: `auth_type = "plugin"` is explicit, so if nothing claims the credential the login fails.
- `background_workers` (default 4) caps concurrent auth plugin calls, so a slow or stuck plugin cannot exhaust the blocking pool.
- `server_role` is a core per-user option, not something JWT-specific. A `[[users]]` entry that sets it has to supply a working backend credential (`server_password`, or a `server_auth` mechanism), since the user config no longer carries the Postgres password. pgdog warns at config load if that is missing.
- The credential travels in-band as a cleartext password, same exposure as `auth_type = "plain"` and passthrough. pgdog warns at startup when `tls_client_required = false`.
- `pgdog-plugin` goes from 0.3.0 to 0.4.0 so stale plugins are rejected cleanly by the existing version gate. The in-tree plugins are updated to match.

## Testing

`cargo nextest run --profile dev` is green (2260 tests). New unit tests cover the FFI round-trip (String to `PdString` and back, the Allow/Deny/Skip encoding, and free-once-then-safe semantics), the auth driver's ordering and all-skip-denies behavior, `add_authenticated`'s gap-filling and never-overwrite rules, and the role-escape guard across single-statement, multi-statement, and `set_config()` forms.

There is a new integration suite under `integration/plugins/auth` (run by `bash integration/plugins/run.sh`) with a small `test-plugin-auth` built through `#[authentication]`. It checks that a good credential connects and queries, that wrong / deny / panic / all-skip credentials all get the generic auth error while the deny reason stays in the pgdog log, that an impersonated role shows up in `SELECT current_user` and survives connection reuse and cleanup, that role-escape attempts are rejected, and that a read-only grant blocks INSERT. The existing routing-plugin spec runs unchanged as a regression check. I also walked through each auth scenario by hand with psql against a running pgdog.

## What's next

PR 2 is the JWT plugin itself: an in-tree `plugins/pgdog-jwt-auth` cdylib (the validator ported from #1084, with the JWKS cache made synchronous), built into the Docker image, plus the `integration/jwt` suite ported over and documentation for both the hook and the plugin. All of the JWT configuration moves out of `[general]` and into the plugin's own config file, which is what made the `jwt_user_suffix` hack from #1084 unnecessary.
