### PR TITLE
Port MultiTenantCheck to new parser

### DIFF
--- a/pgdog/src/frontend/router/parser/from_clause.rs
+++ b/pgdog/src/frontend/router/parser/from_clause.rs
@@ -1,68 +1,127 @@
+#[cfg(not(feature = "new_parser"))]
 use pg_query::{Node, NodeEnum};
+#[cfg(feature = "new_parser")]
+use pg_raw_parse::{Node, list::NodeList};
 
 use super::*;
 
 /// Handle FROM <table/join> clause.
 #[derive(Copy, Clone, Debug)]
 pub(crate) struct FromClause<'a> {
+    #[cfg(feature = "new_parser")]
+    nodes: &'a NodeList,
+    #[cfg(not(feature = "new_parser"))]
     nodes: &'a [Node],
 }
 
 impl<'a> FromClause<'a> {
     /// Create new FROM clause parser.
-    #[cfg(any(not(feature = "new_parser"), test))]
-    pub(crate) fn new(nodes: &'a [Node]) -> Self {
+    #[cfg(all(feature = "new_parser", test))]
+    pub(crate) fn new(nodes: &'a NodeList) -> Self {
         Self { nodes }
+    }
+
+    cfg_select! {
+        not(feature = "new_parser") => {
+            pub(crate) fn new(nodes: &'a [Node]) -> Self {
+                Self { nodes }
+            }
+        }
+        _ => {}
     }
 
     /// Get actual table name from an alias specified in the FROM clause.
     /// If no alias is specified, the table name is returned as-is.
-    pub(crate) fn resolve_alias(&'a self, name: &'a str) -> Option<&'a str> {
-        for node in self.nodes {
-            if let Some(ref node) = node.node
-                && let Some(name) = Self::resolve(name, node)
-            {
-                return Some(name);
-            }
-        }
-
-        None
+    #[cfg(feature = "new_parser")]
+    pub(crate) fn resolve_alias(&self, name: &str) -> Option<&'a str> {
+        self.nodes.iter().find_map(|node| Self::resolve(name, node))
     }
 
-    fn resolve(name: &'a str, node: &'a NodeEnum) -> Option<&'a str> {
-        match node {
-            NodeEnum::JoinExpr(join) => {
-                for arg in [&join.larg, &join.rarg].into_iter().flatten() {
-                    if let Some(ref node) = arg.node
+    cfg_select! {
+        not(feature = "new_parser") => {
+            pub(crate) fn resolve_alias(&self, name: &str) -> Option<&'a str> {
+                for node in self.nodes {
+                    if let Some(ref node) = node.node
                         && let Some(name) = Self::resolve(name, node)
                     {
                         return Some(name);
                     }
                 }
-            }
 
-            NodeEnum::RangeVar(range_var) => {
-                let table = Table::from(range_var);
-                if table.name_match(name) {
-                    return Some(table.name);
-                }
+                None
             }
-
-            _ => (),
         }
+        _ => {}
+    }
 
-        None
+    #[cfg(feature = "new_parser")]
+    fn resolve(name: &str, node: Node<'a>) -> Option<&'a str> {
+        match node {
+            Node::JoinExpr(join) => {
+                Self::resolve(name, join.larg()).or_else(|| Self::resolve(name, join.rarg()))
+            }
+
+            Node::RangeVar(range_var) => {
+                let table = Table::from(range_var);
+                table.name_match(name).then_some(table.name)
+            }
+
+            _ => None,
+        }
+    }
+
+    cfg_select! {
+        not(feature = "new_parser") => {
+            fn resolve(name: &str, node: &'a NodeEnum) -> Option<&'a str> {
+                match node {
+                    NodeEnum::JoinExpr(join) => {
+                        for arg in [&join.larg, &join.rarg].into_iter().flatten() {
+                            if let Some(ref node) = arg.node
+                                && let Some(name) = Self::resolve(name, node)
+                            {
+                                return Some(name);
+                            }
+                        }
+                    }
+
+                    NodeEnum::RangeVar(range_var) => {
+                        let table = Table::from(range_var);
+                        if table.name_match(name) {
+                            return Some(table.name);
+                        }
+                    }
+
+                    _ => (),
+                }
+
+                None
+            }
+        }
+        _ => {}
     }
 
     /// Get table name if the FROM clause contains only one table.
-    pub(crate) fn table_name(&'a self) -> Option<&'a str> {
-        if let Some(node) = self.nodes.first()
-            && let Some(NodeEnum::RangeVar(ref range_var)) = node.node
-        {
-            let table = Table::from(range_var);
-            return Some(table.name);
-        }
+    #[cfg(feature = "new_parser")]
+    pub(crate) fn table_name(&self) -> Option<&'a str> {
+        self.nodes.first().and_then(|node| match node {
+            Node::RangeVar(r) => Some(Table::from(r).name),
+            _ => None,
+        })
+    }
 
-        None
+    cfg_select! {
+        not(feature = "new_parser") => {
+            pub(crate) fn table_name(&self) -> Option<&'a str> {
+                if let Some(node) = self.nodes.first()
+                    && let Some(NodeEnum::RangeVar(ref range_var)) = node.node
+                {
+                    let table = Table::from(range_var);
+                    return Some(table.name);
+                }
+
+                None
+            }
+        }
+        _ => {}
     }
 }

--- a/pgdog/src/frontend/router/parser/multi_tenant.rs
+++ b/pgdog/src/frontend/router/parser/multi_tenant.rs
@@ -1,4 +1,7 @@
+#[cfg(not(feature = "new_parser"))]
 use pg_query::{NodeEnum, ParseResult};
+#[cfg(feature = "new_parser")]
+use pg_raw_parse::Node;
 
 use super::Error;
 use crate::{
@@ -15,6 +18,9 @@ pub struct MultiTenantCheck<'a> {
     user: &'a str,
     config: &'a MultiTenant,
     schema: Schema,
+    #[cfg(feature = "new_parser")]
+    ast: Node<'a>,
+    #[cfg(not(feature = "new_parser"))]
     ast: &'a ParseResult,
     search_path: Option<&'a ParameterValue>,
 }
@@ -24,7 +30,8 @@ impl<'a> MultiTenantCheck<'a> {
         user: &'a str,
         config: &'a MultiTenant,
         schema: Schema,
-        ast: &'a ParseResult,
+        #[cfg(feature = "new_parser")] ast: Node<'a>,
+        #[cfg(not(feature = "new_parser"))] ast: &'a ParseResult,
         search_path: Option<&'a ParameterValue>,
     ) -> Self {
         Self {
@@ -36,39 +43,33 @@ impl<'a> MultiTenantCheck<'a> {
         }
     }
 
+    #[cfg(feature = "new_parser")]
     pub fn run(&self) -> Result<(), Error> {
-        let stmt = self
-            .ast
-            .protobuf
-            .stmts
-            .first()
-            .and_then(|s| s.stmt.as_ref());
-
-        match stmt.and_then(|n| n.node.as_ref()) {
-            Some(NodeEnum::UpdateStmt(stmt)) => {
-                let table = stmt.relation.as_ref().map(Table::from);
+        match self.ast {
+            Node::UpdateStmt(stmt) => {
+                let table = stmt.relation().map(Table::from);
 
                 if let Some(table) = table {
                     let source = TablesSource::from(table);
-                    let where_clause = WhereClause::new(&source, &stmt.where_clause);
+                    let where_clause = WhereClause::new(&source, stmt.where_clause());
                     self.check(table, where_clause)?;
                 }
             }
-            Some(NodeEnum::SelectStmt(stmt)) => {
-                let table = Table::try_from(&stmt.from_clause).ok();
+            Node::SelectStmt(stmt) => {
+                let table = Table::try_from(stmt.from_clause()).ok();
 
                 if let Some(table) = table {
                     let source = TablesSource::from(table);
-                    let where_clause = WhereClause::new(&source, &stmt.where_clause);
+                    let where_clause = WhereClause::new(&source, stmt.where_clause());
                     self.check(table, where_clause)?;
                 }
             }
-            Some(NodeEnum::DeleteStmt(stmt)) => {
-                let table = stmt.relation.as_ref().map(Table::from);
+            Node::DeleteStmt(stmt) => {
+                let table = stmt.relation().map(Table::from);
 
                 if let Some(table) = table {
                     let source = TablesSource::from(table);
-                    let where_clause = WhereClause::new(&source, &stmt.where_clause);
+                    let where_clause = WhereClause::new(&source, stmt.where_clause());
                     self.check(table, where_clause)?;
                 }
             }
@@ -76,6 +77,53 @@ impl<'a> MultiTenantCheck<'a> {
             _ => (),
         }
         Ok(())
+    }
+
+    cfg_select! {
+        not(feature = "new_parser") => {
+            pub fn run(&self) -> Result<(), Error> {
+                let stmt = self
+                    .ast
+                    .protobuf
+                    .stmts
+                    .first()
+                    .and_then(|s| s.stmt.as_ref());
+
+                match stmt.and_then(|n| n.node.as_ref()) {
+                    Some(NodeEnum::UpdateStmt(stmt)) => {
+                        let table = stmt.relation.as_ref().map(Table::from);
+
+                        if let Some(table) = table {
+                            let source = TablesSource::from(table);
+                            let where_clause = WhereClause::new(&source, &stmt.where_clause);
+                            self.check(table, where_clause)?;
+                        }
+                    }
+                    Some(NodeEnum::SelectStmt(stmt)) => {
+                        let table = Table::try_from(&stmt.from_clause).ok();
+
+                        if let Some(table) = table {
+                            let source = TablesSource::from(table);
+                            let where_clause = WhereClause::new(&source, &stmt.where_clause);
+                            self.check(table, where_clause)?;
+                        }
+                    }
+                    Some(NodeEnum::DeleteStmt(stmt)) => {
+                        let table = stmt.relation.as_ref().map(Table::from);
+
+                        if let Some(table) = table {
+                            let source = TablesSource::from(table);
+                            let where_clause = WhereClause::new(&source, &stmt.where_clause);
+                            self.check(table, where_clause)?;
+                        }
+                    }
+
+                    _ => (),
+                }
+                Ok(())
+            }
+        }
+        _ => {}
     }
 
     fn check(&self, table: Table, where_clause: Option<WhereClause>) -> Result<(), Error> {
@@ -139,33 +187,76 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "new_parser")]
     fn multi_tenant_check_passes_with_matching_filter() {
         let schema = schema_with_tenant_column("tenant_id");
-        let ast = pg_query::parse("SELECT * FROM accounts WHERE tenant_id = 1")
-            .expect("parse select statement");
+        let ast = pg_raw_parse::parse("SELECT * FROM accounts WHERE tenant_id = 1").unwrap();
+        let stmt = ast.stmts().next().unwrap();
         let config = MultiTenant {
             column: "tenant_id".into(),
         };
 
-        let check = MultiTenantCheck::new("alice", &config, schema, &ast, None);
+        let check = MultiTenantCheck::new("alice", &config, schema, stmt, None);
         assert!(check.run().is_ok());
     }
 
+    cfg_select! {
+        not(feature = "new_parser") => {
+            #[test]
+            fn multi_tenant_check_passes_with_matching_filter() {
+                let schema = schema_with_tenant_column("tenant_id");
+                let ast = pg_query::parse("SELECT * FROM accounts WHERE tenant_id = 1")
+                    .expect("parse select statement");
+                let config = MultiTenant {
+                    column: "tenant_id".into(),
+                };
+
+                let check = MultiTenantCheck::new("alice", &config, schema, &ast, None);
+                assert!(check.run().is_ok());
+            }
+        }
+        _ => {}
+    }
+
     #[test]
+    #[cfg(feature = "new_parser")]
     fn multi_tenant_check_requires_tenant_column_in_filter() {
         let schema = schema_with_tenant_column("tenant_id");
-        let ast = pg_query::parse("SELECT * FROM accounts WHERE other_id = 1")
-            .expect("parse select statement");
+        let ast = pg_raw_parse::parse("SELECT * FROM accounts WHERE other_id = 1").unwrap();
+        let stmt = ast.stmts().next().unwrap();
         let config = MultiTenant {
             column: "tenant_id".into(),
         };
 
-        let check = MultiTenantCheck::new("alice", &config, schema, &ast, None);
+        let check = MultiTenantCheck::new("alice", &config, schema, stmt, None);
         let err = check
             .run()
             .expect_err("expected tenant id validation error");
         matches!(err, Error::MultiTenantId)
             .then_some(())
             .expect("should return multi-tenant id error");
+    }
+
+    cfg_select! {
+        not(feature = "new_parser") => {
+            #[test]
+            fn multi_tenant_check_requires_tenant_column_in_filter() {
+                let schema = schema_with_tenant_column("tenant_id");
+                let ast = pg_query::parse("SELECT * FROM accounts WHERE other_id = 1")
+                    .expect("parse select statement");
+                let config = MultiTenant {
+                    column: "tenant_id".into(),
+                };
+
+                let check = MultiTenantCheck::new("alice", &config, schema, &ast, None);
+                let err = check
+                    .run()
+                    .expect_err("expected tenant id validation error");
+                matches!(err, Error::MultiTenantId)
+                    .then_some(())
+                    .expect("should return multi-tenant id error");
+            }
+        }
+        _ => {}
     }
 }

--- a/pgdog/src/frontend/router/parser/query/mod.rs
+++ b/pgdog/src/frontend/router/parser/query/mod.rs
@@ -273,20 +273,22 @@ impl QueryParser {
         debug!("{}", context.query()?.query());
         trace!("{:#?}", statement);
 
-        if let Some(multi_tenant) = context.multi_tenant() {
+        let stmts = &statement.new_ast;
+
+        if let Some(multi_tenant) = context.multi_tenant()
+            && let Some(stmt) = stmts.stmts().next()
+        {
             debug!("running multi-tenant check");
 
             MultiTenantCheck::new(
                 context.router_context.cluster.user(),
                 multi_tenant,
                 context.router_context.cluster.schema(),
-                statement.parse_result(),
+                stmt,
                 context.router_context.parameter_hints.search_path,
             )
             .run()?;
         }
-
-        let stmts = &statement.new_ast;
 
         // Handle multi-statement SET commands (e.g. "SET x TO 1; SET y TO 2").
         if stmts.len() > 1

--- a/pgdog/src/frontend/router/parser/table.rs
+++ b/pgdog/src/frontend/router/parser/table.rs
@@ -194,6 +194,7 @@ impl<'a> TryFrom<&'a NodeList> for Table<'a> {
         let name = match list.next() {
             Some(Node::String(s)) => s.sval(),
             Some(Node::NodeList(l)) if value.len() == 1 => return Self::try_from(l),
+            Some(Node::RangeVar(rv)) if value.len() == 1 => return Ok(Self::from(rv)),
             _ => None,
         }
         .ok_or(Error::TableDecode)?;

--- a/pgdog/src/frontend/router/parser/where_clause.rs
+++ b/pgdog/src/frontend/router/parser/where_clause.rs
@@ -1,9 +1,12 @@
 //! WHERE clause of a UPDATE/SELECT/DELETE query.
 
+#[cfg(not(feature = "new_parser"))]
 use pg_query::{
     NodeEnum,
     protobuf::{a_const::Val, *},
 };
+#[cfg(feature = "new_parser")]
+use pg_raw_parse::{ConstValue, Node, nodes};
 use std::string::String;
 
 use crate::frontend::router::parser::{FromClause, Table};
@@ -29,7 +32,7 @@ impl<'a> From<FromClause<'a>> for TablesSource<'a> {
 }
 
 impl<'a> TablesSource<'a> {
-    pub(crate) fn resolve_alias(&'a self, name: &'a str) -> &'a str {
+    pub(crate) fn resolve_alias(&self, name: &'a str) -> &'a str {
         match self {
             Self::Table(table) => {
                 if table.name_match(name) {
@@ -48,7 +51,7 @@ impl<'a> TablesSource<'a> {
         }
     }
 
-    pub(crate) fn table_name(&'a self) -> Option<&'a str> {
+    pub(crate) fn table_name(&self) -> Option<&'a str> {
         match self {
             Self::Table(table) => Some(table.name),
             Self::FromClause(fc) => fc.table_name(),
@@ -84,17 +87,33 @@ pub(crate) struct WhereClause<'a> {
 impl<'a> WhereClause<'a> {
     /// Parse the `WHERE` clause of a statement and extract
     /// all possible sharding keys.
-    pub(crate) fn new(
-        source: &'a TablesSource<'a>,
-        where_clause: &'a Option<Box<Node>>,
-    ) -> Option<WhereClause<'a>> {
-        let Some(where_clause) = where_clause else {
+    #[cfg(feature = "new_parser")]
+    pub(crate) fn new(source: &TablesSource<'a>, where_clause: Node<'a>) -> Option<Self> {
+        if let Node::None = where_clause {
             return None;
         };
 
         let output = Self::parse(source, where_clause, false);
 
         Some(Self { output })
+    }
+
+    cfg_select! {
+        not(feature = "new_parser") => {
+            pub(crate) fn new(
+                source: &TablesSource<'a>,
+                where_clause: &'a Option<Box<Node>>,
+            ) -> Option<WhereClause<'a>> {
+                let Some(where_clause) = where_clause else {
+                    return None;
+                };
+
+                let output = Self::parse(source, where_clause, false);
+
+                Some(Self { output })
+            }
+        }
+        _ => {}
     }
 
     pub(crate) fn keys(&self, table_name: Option<&str>, column_name: &str) -> Vec<Key> {
@@ -184,6 +203,7 @@ impl<'a> WhereClause<'a> {
         keys
     }
 
+    #[cfg(not(feature = "new_parser"))]
     fn string(node: Option<&Node>) -> Option<&str> {
         if let Some(node) = node
             && let Some(NodeEnum::String(ref string)) = node.node
@@ -194,121 +214,215 @@ impl<'a> WhereClause<'a> {
         None
     }
 
-    fn parse(source: &'a TablesSource<'a>, node: &'a Node, array: bool) -> Vec<Output<'a>> {
-        let mut keys = vec![];
-
-        match node.node {
-            Some(NodeEnum::NullTest(ref null_test))
-                // Only check for IS NULL, IS NOT NULL definitely doesn't help.
-                if NullTestType::try_from(null_test.nulltesttype) == Ok(NullTestType::IsNull) => {
-                    let left = null_test
-                        .arg
-                        .as_ref()
-                        .and_then(|node| Self::parse(source, node, array).pop());
-
-                    if let Some(Output::Column(c)) = left {
-                        keys.push(Output::NullCheck(c));
-                    }
-                }
-
-            Some(NodeEnum::BoolExpr(ref expr)) => {
-                // Only AND expressions can really be asserted.
-                // OR needs both sides to be evaluated and either one
-                // can direct to a shard. Most cases, this will end up on all shards.
-                if expr.boolop() != BoolExprType::AndExpr {
-                    return keys;
-                }
-
-                for arg in &expr.args {
-                    keys.extend(Self::parse(source, arg, array));
-                }
+    #[cfg(feature = "new_parser")]
+    fn parse(source: &TablesSource<'a>, node: Node<'a>, array: bool) -> Vec<Output<'a>> {
+        match node {
+            // Only check for IS NULL, IS NOT NULL definitely doesn't help.
+            Node::NullTest(null_test) if null_test.nulltesttype == nodes::NullTestType::IS_NULL => {
+                Self::parse(source, null_test.arg(), array)
+                    .into_iter()
+                    .filter_map(|arg| match arg {
+                        Output::Column(c) => Some(Output::NullCheck(c)),
+                        _ => None,
+                    })
+                    .collect()
             }
 
-            Some(NodeEnum::AExpr(ref expr)) => {
-                let kind = expr.kind();
+            // Only AND expressions can really be asserted.
+            // OR needs both sides to be evaluated and either one
+            // can direct to a shard. Most cases, this will end up on all shards.
+            Node::BoolExpr(expr) if expr.boolop != nodes::BoolExprType::AND_EXPR => expr
+                .args()
+                .iter()
+                .flat_map(|arg| Self::parse(source, arg, array))
+                .collect(),
+
+            Node::A_Expr(expr) => {
+                use nodes::A_Expr_Kind;
                 if matches!(
-                    kind,
-                    AExprKind::AexprOp | AExprKind::AexprIn | AExprKind::AexprOpAny
+                    expr.kind,
+                    A_Expr_Kind::AEXPR_OP | A_Expr_Kind::AEXPR_IN | A_Expr_Kind::AEXPR_OP_ANY
                 ) {
-                    let op = Self::string(expr.name.first());
-                    if let Some(op) = op
-                        && op != "=" {
-                            return keys;
-                        }
-                }
-                let array = matches!(kind, AExprKind::AexprOpAny);
-                if let Some(ref left) = expr.lexpr
-                    && let Some(ref right) = expr.rexpr {
-                        let left = Self::parse(source, left, array);
-                        let right = Self::parse(source, right, array);
-
-                        keys.push(Output::Filter(left, right));
-                    }
-            }
-
-            Some(NodeEnum::AConst(ref value)) => {
-                if let Some(ref val) = value.val {
-                    match val {
-                        Val::Ival(int) => keys.push(Output::Int {
-                            value: int.ival,
-                            array,
-                        }),
-                        Val::Sval(sval) => keys.push(Output::Value {
-                            value: sval.sval.clone(),
-                            array,
-                        }),
-                        Val::Fval(fval) => keys.push(Output::Value {
-                            value: fval.fval.clone(),
-                            array,
-                        }),
-                        _ => (),
+                    if expr.name().first().and_then(Node::as_str) != Some("=") {
+                        return Vec::new();
                     }
                 }
+                let array = matches!(expr.kind, A_Expr_Kind::AEXPR_OP_ANY);
+                let left = Self::parse(source, expr.lexpr(), array);
+                let right = Self::parse(source, expr.rexpr(), array);
+
+                vec![Output::Filter(left, right)]
             }
 
-            Some(NodeEnum::ColumnRef(ref column)) => {
-                let name = Self::string(column.fields.last());
-                let table = Self::string(column.fields.iter().rev().nth(1));
+            Node::A_Const(value) => value
+                .val()
+                .into_iter()
+                .filter_map(|val| match val {
+                    ConstValue::Integer(value) => Some(Output::Int { value, array }),
+                    ConstValue::String(s) | ConstValue::Float(s) => Some(Output::Value {
+                        value: s.to_owned(),
+                        array,
+                    }),
+                    _ => None,
+                })
+                .collect(),
+
+            Node::ColumnRef(column) => {
+                let mut fields = column.fields().into_iter().rev();
+                let name = fields.next().and_then(Node::as_str);
+                let table = fields.next().and_then(Node::as_str);
                 let table = if let Some(table) = table {
                     Some(source.resolve_alias(table))
                 } else {
                     source.table_name()
                 };
 
-                if let Some(name) = name {
-                    return vec![Output::Column(Column { name, table })];
-                }
+                name.into_iter()
+                    .map(|name| Output::Column(Column { name, table }))
+                    .collect()
             }
 
-            Some(NodeEnum::ParamRef(ref param)) => {
-                keys.push(Output::Parameter {
+            Node::ParamRef(param) => {
+                vec![Output::Parameter {
                     pos: param.number,
                     array,
-                });
+                }]
             }
 
-            Some(NodeEnum::List(ref list)) => {
-                for node in &list.items {
-                    keys.extend(Self::parse(source, node, array));
-                }
+            Node::NodeList(list) => list
+                .iter()
+                .flat_map(|node| Self::parse(source, node, array))
+                .collect(),
+
+            Node::TypeCast(cast) => Self::parse(source, cast.arg(), array),
+
+            _ => Vec::new(),
+        }
+    }
+
+    cfg_select! {
+        not(feature = "new_parser") => {
+            fn parse(source: &TablesSource<'a>, node: &'a Node, array: bool) -> Vec<Output<'a>> {
+                let mut keys = vec![];
+
+                match node.node {
+                    Some(NodeEnum::NullTest(ref null_test))
+                        // Only check for IS NULL, IS NOT NULL definitely doesn't help.
+                        if NullTestType::try_from(null_test.nulltesttype) == Ok(NullTestType::IsNull) => {
+                            let left = null_test
+                                .arg
+                                .as_ref()
+                                .and_then(|node| Self::parse(source, node, array).pop());
+
+                            if let Some(Output::Column(c)) = left {
+                                keys.push(Output::NullCheck(c));
+                            }
+                        }
+
+                    Some(NodeEnum::BoolExpr(ref expr)) => {
+                        // Only AND expressions can really be asserted.
+                        // OR needs both sides to be evaluated and either one
+                        // can direct to a shard. Most cases, this will end up on all shards.
+                        if expr.boolop() != BoolExprType::AndExpr {
+                            return keys;
+                        }
+
+                        for arg in &expr.args {
+                            keys.extend(Self::parse(source, arg, array));
+                        }
+                    }
+
+                    Some(NodeEnum::AExpr(ref expr)) => {
+                        let kind = expr.kind();
+                        if matches!(
+                            kind,
+                            AExprKind::AexprOp | AExprKind::AexprIn | AExprKind::AexprOpAny
+                        ) {
+                            let op = Self::string(expr.name.first());
+                            if let Some(op) = op
+                                && op != "=" {
+                                    return keys;
+                                }
+                        }
+                        let array = matches!(kind, AExprKind::AexprOpAny);
+                        if let Some(ref left) = expr.lexpr
+                            && let Some(ref right) = expr.rexpr {
+                                let left = Self::parse(source, left, array);
+                                let right = Self::parse(source, right, array);
+
+                                keys.push(Output::Filter(left, right));
+                            }
+                    }
+
+                    Some(NodeEnum::AConst(ref value)) => {
+                        if let Some(ref val) = value.val {
+                            match val {
+                                Val::Ival(int) => keys.push(Output::Int {
+                                    value: int.ival,
+                                    array,
+                                }),
+                                Val::Sval(sval) => keys.push(Output::Value {
+                                    value: sval.sval.clone(),
+                                    array,
+                                }),
+                                Val::Fval(fval) => keys.push(Output::Value {
+                                    value: fval.fval.clone(),
+                                    array,
+                                }),
+                                _ => (),
+                            }
+                        }
+                    }
+
+                    Some(NodeEnum::ColumnRef(ref column)) => {
+                        let name = Self::string(column.fields.last());
+                        let table = Self::string(column.fields.iter().rev().nth(1));
+                        let table = if let Some(table) = table {
+                            Some(source.resolve_alias(table))
+                        } else {
+                            source.table_name()
+                        };
+
+                        if let Some(name) = name {
+                            return vec![Output::Column(Column { name, table })];
+                        }
+                    }
+
+                    Some(NodeEnum::ParamRef(ref param)) => {
+                        keys.push(Output::Parameter {
+                            pos: param.number,
+                            array,
+                        });
+                    }
+
+                    Some(NodeEnum::List(ref list)) => {
+                        for node in &list.items {
+                            keys.extend(Self::parse(source, node, array));
+                        }
+                    }
+
+                    Some(NodeEnum::TypeCast(ref cast)) => {
+                        if let Some(ref arg) = cast.arg {
+                            keys.extend(Self::parse(source, arg, array));
+                        }
+                    }
+
+                    _ => (),
+                };
+
+                keys
             }
-
-            Some(NodeEnum::TypeCast(ref cast)) => {
-                if let Some(ref arg) = cast.arg {
-                    keys.extend(Self::parse(source, arg, array));
-                }
-            }
-
-            _ => (),
-        };
-
-        keys
+        }
+        _ => {}
     }
 }
 
 #[cfg(test)]
 mod test {
-    use pg_query::parse;
+    #[cfg(not(feature = "new_parser"))]
+    use pg_query::{ParseResult, parse};
+    #[cfg(feature = "new_parser")]
+    use pg_raw_parse::{ParseResult, parse};
 
     use super::*;
 
@@ -317,21 +431,15 @@ mod test {
         let query =
             "SELECT * FROM sharded WHERE id = 5 AND (something_else != 6 OR column_a = 'test')";
         let ast = parse(query).unwrap();
-        let stmt = ast.protobuf.stmts.first().cloned().unwrap().stmt.unwrap();
-
-        if let Some(NodeEnum::SelectStmt(stmt)) = stmt.node {
-            let from_clause = FromClause::new(&stmt.from_clause);
-            let source = TablesSource::from(from_clause);
-            let where_ = WhereClause::new(&source, &stmt.where_clause).unwrap();
-            let mut keys = where_.keys(Some("sharded"), "id");
-            assert_eq!(
-                keys.pop().unwrap(),
-                Key::Constant {
-                    value: "5".into(),
-                    array: false
-                }
-            );
-        }
+        let where_ = where_clause(&ast);
+        let mut keys = where_.keys(Some("sharded"), "id");
+        assert_eq!(
+            keys.pop().unwrap(),
+            Key::Constant {
+                value: "5".into(),
+                array: false
+            }
+        );
     }
 
     #[test]
@@ -339,90 +447,55 @@ mod test {
         let query = "SELECT * FROM users WHERE tenant_id IS NULL";
         let ast = parse(query).unwrap();
 
-        let stmt = ast.protobuf.stmts.first().cloned().unwrap().stmt.unwrap();
-
-        if let Some(NodeEnum::SelectStmt(stmt)) = stmt.node {
-            let from_clause = FromClause::new(&stmt.from_clause);
-            let source = TablesSource::from(from_clause);
-            let where_ = WhereClause::new(&source, &stmt.where_clause).unwrap();
-            assert_eq!(
-                where_.keys(Some("users"), "tenant_id").pop(),
-                Some(Key::Null)
-            );
-        }
+        let where_ = where_clause(&ast);
+        assert_eq!(
+            where_.keys(Some("users"), "tenant_id").pop(),
+            Some(Key::Null)
+        );
 
         //  NOT NULL check is basically everyone, so no!
         let query = "SELECT * FROM users WHERE tenant_id IS NOT NULL";
         let ast = parse(query).unwrap();
 
-        let stmt = ast.protobuf.stmts.first().cloned().unwrap().stmt.unwrap();
-
-        if let Some(NodeEnum::SelectStmt(stmt)) = stmt.node {
-            let from_clause = FromClause::new(&stmt.from_clause);
-            let source = TablesSource::from(from_clause);
-            let where_ = WhereClause::new(&source, &stmt.where_clause).unwrap();
-            assert!(where_.keys(Some("users"), "tenant_id").is_empty());
-        }
+        let where_ = where_clause(&ast);
+        assert!(where_.keys(Some("users"), "tenant_id").is_empty());
     }
 
     #[test]
     fn test_in_clause() {
         let query = "SELECT * FROM users WHERE tenant_id IN ($1, $2, $3, $4)";
         let ast = parse(query).unwrap();
-        let stmt = ast.protobuf.stmts.first().cloned().unwrap().stmt.unwrap();
+        let where_ = where_clause(&ast);
 
-        if let Some(NodeEnum::SelectStmt(stmt)) = stmt.node {
-            let from_clause = FromClause::new(&stmt.from_clause);
-            let source = TablesSource::from(from_clause);
-            let where_ = WhereClause::new(&source, &stmt.where_clause).unwrap();
-            let keys = where_.keys(Some("users"), "tenant_id");
-            assert_eq!(keys.len(), 4);
-        } else {
-            panic!("not a select");
-        }
+        let keys = where_.keys(Some("users"), "tenant_id");
+        assert_eq!(keys.len(), 4);
     }
 
     #[test]
     fn test_any() {
         let query = "SELECT * FROM users WHERE tenant_id = ANY($1)";
         let ast = parse(query).unwrap();
-        let stmt = ast.protobuf.stmts.first().cloned().unwrap().stmt.unwrap();
-
-        if let Some(NodeEnum::SelectStmt(stmt)) = stmt.node {
-            let from_clause = FromClause::new(&stmt.from_clause);
-            let source = TablesSource::from(from_clause);
-            let where_ = WhereClause::new(&source, &stmt.where_clause).unwrap();
-            let keys = where_.keys(Some("users"), "tenant_id");
-            assert_eq!(
-                keys[0],
-                Key::Parameter {
-                    pos: 0,
-                    array: true
-                }
-            );
-        } else {
-            panic!("not a select");
-        }
+        let where_ = where_clause(&ast);
+        let keys = where_.keys(Some("users"), "tenant_id");
+        assert_eq!(
+            keys[0],
+            Key::Parameter {
+                pos: 0,
+                array: true
+            }
+        );
 
         let query = "SELECT * FROM users WHERE tenant_id = ANY('{1, 2, 3}')";
         let ast = parse(query).unwrap();
-        let stmt = ast.protobuf.stmts.first().cloned().unwrap().stmt.unwrap();
-
-        if let Some(NodeEnum::SelectStmt(stmt)) = stmt.node {
-            let from_clause = FromClause::new(&stmt.from_clause);
-            let source = TablesSource::from(from_clause);
-            let where_ = WhereClause::new(&source, &stmt.where_clause).unwrap();
-            let keys = where_.keys(Some("users"), "tenant_id");
-            assert_eq!(
-                keys[0],
-                Key::Constant {
-                    value: "{1, 2, 3}".to_string(),
-                    array: true
-                },
-            );
-        } else {
-            panic!("not a select");
-        }
+        let where_ = where_clause(&ast);
+        let keys = where_.keys(Some("users"), "tenant_id");
+        assert_eq!(
+            keys[0],
+            Key::Constant {
+                value: "{1, 2, 3}".to_string(),
+                array: true
+            },
+        );
     }
 
     #[test]
@@ -433,58 +506,68 @@ mod test {
                      JOIN categories c ON p.category_id = c.id
                      WHERE u.tenant_id = $1 AND o.status = 'shipped' AND p.price > 100";
         let ast = parse(query).unwrap();
-        let stmt = ast.protobuf.stmts.first().cloned().unwrap().stmt.unwrap();
+        let where_ = where_clause(&ast);
 
-        if let Some(NodeEnum::SelectStmt(stmt)) = stmt.node {
-            let from_clause = FromClause::new(&stmt.from_clause);
-            let source = TablesSource::from(from_clause);
-            let where_ = WhereClause::new(&source, &stmt.where_clause).unwrap();
+        // Test that we can extract keys for the users table with alias 'u'
+        let keys = where_.keys(Some("users"), "tenant_id");
+        assert_eq!(keys.len(), 1);
+        assert_eq!(
+            keys[0],
+            Key::Parameter {
+                pos: 0,
+                array: false
+            }
+        );
 
-            // Test that we can extract keys for the users table with alias 'u'
-            let keys = where_.keys(Some("users"), "tenant_id");
-            assert_eq!(keys.len(), 1);
-            assert_eq!(
-                keys[0],
-                Key::Parameter {
-                    pos: 0,
-                    array: false
-                }
-            );
-
-            // Test that we can extract keys for the orders table with alias 'o'
-            let status_keys = where_.keys(Some("orders"), "status");
-            assert_eq!(status_keys.len(), 1);
-            assert_eq!(
-                status_keys[0],
-                Key::Constant {
-                    value: "shipped".to_string(),
-                    array: false
-                }
-            );
-        } else {
-            panic!("not a select");
-        }
+        // Test that we can extract keys for the orders table with alias 'o'
+        let status_keys = where_.keys(Some("orders"), "status");
+        assert_eq!(status_keys.len(), 1);
+        assert_eq!(
+            status_keys[0],
+            Key::Constant {
+                value: "shipped".to_string(),
+                array: false
+            }
+        );
     }
 
     #[test]
     fn test_as_alias() {
         let query = r#"SELECT "id", "email", "createdAt", "updatedAt" FROM "Users" AS "User" WHERE "User"."id" = 24 ORDER BY "User"."id" LIMIT 1;"#;
         let ast = parse(query).unwrap();
-        let stmt = ast.protobuf.stmts.first().cloned().unwrap().stmt.unwrap();
-        if let Some(NodeEnum::SelectStmt(stmt)) = stmt.node {
-            let from_clause = FromClause::new(&stmt.from_clause);
-            let source = TablesSource::from(from_clause);
-            let where_ = WhereClause::new(&source, &stmt.where_clause).unwrap();
-            let keys = where_.keys(Some("Users"), "id");
-            assert_eq!(
-                keys[0],
-                Key::Constant {
-                    value: "24".to_string(),
-                    array: false
-                },
-            );
-        } else {
-            panic!("not a select");
+        let where_ = where_clause(&ast);
+        let keys = where_.keys(Some("Users"), "id");
+        assert_eq!(
+            keys[0],
+            Key::Constant {
+                value: "24".to_string(),
+                array: false
+            },
+        );
+    }
+
+    #[cfg(feature = "new_parser")]
+    fn where_clause(ast: &ParseResult) -> WhereClause<'_> {
+        let Some(Node::SelectStmt(stmt)) = ast.stmts().next() else {
+            panic!("Not a select");
+        };
+        let from_clause = FromClause::new(stmt.from_clause());
+        let source = TablesSource::from(from_clause);
+        WhereClause::new(&source, stmt.where_clause()).unwrap()
+    }
+
+    cfg_select! {
+        not(feature = "new_parser") => {
+            fn where_clause(ast: &ParseResult) -> WhereClause<'_> {
+                let stmt = ast.protobuf.stmts.first().as_ref().unwrap().stmt.as_ref().unwrap();
+                let Some(NodeEnum::SelectStmt(stmt)) = &stmt.node else {
+                    panic!("Not a select");
+                };
+                let from_clause = FromClause::new(&stmt.from_clause);
+                let source = TablesSource::from(from_clause);
+                WhereClause::new(&source, &stmt.where_clause).unwrap()
+            }
         }
+        _ => {}
     }
 }

--- a/pgdog/src/frontend/router/parser/where_clause.rs
+++ b/pgdog/src/frontend/router/parser/where_clause.rs
@@ -231,7 +231,7 @@ impl<'a> WhereClause<'a> {
             // Only AND expressions can really be asserted.
             // OR needs both sides to be evaluated and either one
             // can direct to a shard. Most cases, this will end up on all shards.
-            Node::BoolExpr(expr) if expr.boolop != nodes::BoolExprType::AND_EXPR => expr
+            Node::BoolExpr(expr) if expr.boolop == nodes::BoolExprType::AND_EXPR => expr
                 .args()
                 .iter()
                 .flat_map(|arg| Self::parse(source, arg, array))


### PR DESCRIPTION
Note that a good bit of this is actually dead code, as our code currently appears to incorrectly only ever be running this check for queries with a single table in the from clause. We have no test coverage for this, and I'm not familiar enough with this part of the code to be able to quickly fill that test coverage in, so I've left the bug in place for the time being with the intention to come back to it in the near future.

I left the dead code in place because I don't want to get bogged down by a major refactor while in the middle of a port