### PR TITLE
fix: lsn detector needs to correctly identify replica-only deployments

### DIFF
--- a/pgdog/src/backend/pool/lb/mod.rs
+++ b/pgdog/src/backend/pool/lb/mod.rs
@@ -149,6 +149,7 @@ impl LoadBalancer {
     /// return new primary (if any), and replicas.
     pub fn redetect_roles(&self) -> bool {
         let mut promoted = false;
+        let roles_detected_before = self.roles_detected();
 
         let mut targets = self
             .targets
@@ -186,14 +187,14 @@ impl LoadBalancer {
                 .for_each(|(_, target)| {
                     target.1.set_role(Role::Replica);
                 });
-        } else {
+        } else if targets.iter().all(|target| target.0.valid()) {
             // All targets are replicas until we get a primary.
             targets.iter().for_each(|target| {
                 target.1.set_role(Role::Replica);
             });
         }
 
-        if promoted {
+        if promoted || (!roles_detected_before && self.roles_detected()) {
             self.role_detection.notify_one();
         }
 

--- a/pgdog/src/backend/pool/lb/mod.rs
+++ b/pgdog/src/backend/pool/lb/mod.rs
@@ -186,6 +186,11 @@ impl LoadBalancer {
                 .for_each(|(_, target)| {
                     target.1.set_role(Role::Replica);
                 });
+        } else {
+            // All targets are replicas until we get a primary.
+            targets.iter().for_each(|target| {
+                target.1.set_role(Role::Replica);
+            });
         }
 
         if promoted {

--- a/pgdog/src/backend/pool/lb/test.rs
+++ b/pgdog/src/backend/pool/lb/test.rs
@@ -1283,7 +1283,7 @@ async fn test_redetect_roles_marks_added_auto_target_replica_when_primary_unchan
 }
 
 #[tokio::test]
-async fn test_redetect_roles_marks_auto_targets_replicas_when_no_primary_discovered() {
+async fn test_redetect_roles_leaves_auto_targets_pending_when_stats_are_invalid() {
     let mut config1 = create_test_pool_config("127.0.0.1", 5432);
     config1.address.configured_role = Role::Auto;
 
@@ -1303,6 +1303,37 @@ async fn test_redetect_roles_marks_auto_targets_replicas_when_no_primary_discove
     assert!(
         !lb.redetect_roles(),
         "no valid primary was discovered, so no promotion is reported"
+    );
+
+    assert!(lb.targets.iter().all(|target| target.role() == Role::Auto));
+    assert!(!lb.roles_detected());
+    assert!(lb.has_replicas());
+}
+
+#[tokio::test]
+async fn test_redetect_roles_marks_auto_targets_replicas_when_all_valid_targets_are_replicas() {
+    let mut config1 = create_test_pool_config("127.0.0.1", 5432);
+    config1.address.configured_role = Role::Auto;
+
+    let mut config2 = create_test_pool_config("localhost", 5432);
+    config2.address.configured_role = Role::Auto;
+
+    let lb = LoadBalancer::new(
+        &None,
+        &[config1, config2],
+        LoadBalancingStrategy::Random,
+        ReadWriteSplit::IncludePrimary,
+    );
+
+    set_lsn_stats(&lb.targets[0], true, 100);
+    set_lsn_stats(&lb.targets[1], true, 90);
+
+    assert!(lb.targets.iter().all(|target| target.role() == Role::Auto));
+    assert!(!lb.roles_detected());
+
+    assert!(
+        !lb.redetect_roles(),
+        "no primary was discovered, so no promotion is reported"
     );
 
     assert!(

--- a/pgdog/src/backend/pool/lb/test.rs
+++ b/pgdog/src/backend/pool/lb/test.rs
@@ -1283,6 +1283,38 @@ async fn test_redetect_roles_marks_added_auto_target_replica_when_primary_unchan
 }
 
 #[tokio::test]
+async fn test_redetect_roles_marks_auto_targets_replicas_when_no_primary_discovered() {
+    let mut config1 = create_test_pool_config("127.0.0.1", 5432);
+    config1.address.configured_role = Role::Auto;
+
+    let mut config2 = create_test_pool_config("localhost", 5432);
+    config2.address.configured_role = Role::Auto;
+
+    let lb = LoadBalancer::new(
+        &None,
+        &[config1, config2],
+        LoadBalancingStrategy::Random,
+        ReadWriteSplit::IncludePrimary,
+    );
+
+    assert!(lb.targets.iter().all(|target| target.role() == Role::Auto));
+    assert!(!lb.roles_detected());
+
+    assert!(
+        !lb.redetect_roles(),
+        "no valid primary was discovered, so no promotion is reported"
+    );
+
+    assert!(
+        lb.targets
+            .iter()
+            .all(|target| target.role() == Role::Replica)
+    );
+    assert!(lb.roles_detected());
+    assert!(lb.has_replicas());
+}
+
+#[tokio::test]
 async fn test_can_move_conns_to_different_addresses() {
     let pool_config1 = create_test_pool_config("127.0.0.1", 5432);
     let pool_config2 = create_test_pool_config("localhost", 5432);


### PR DESCRIPTION
The role detector would leave the cluster in an unusable state with all roles set to `auto` if there was no primary configured. This is not necessary -- it's perfectly valid to have replica-only clusters with `role = "auto"` especially when combined with `replicas_only` here: https://docs.pgdog.dev/enterprise_edition/autodiscovery/#replicas-only