### PR TITLE
fix: psycopg2 in admin db

### DIFF
--- a/integration/python/test_psycopg2.py
+++ b/integration/python/test_psycopg2.py
@@ -129,3 +129,12 @@ def test_transaction_reads_explicit(conn_reads, conn_writes):
         cursor.execute("ROLLBACK")
 
     admin().execute("SET query_parser TO 'on'")
+
+
+def test_admin_db_connection():
+    conn = psycopg2.connect("host=127.0.0.1 port=6432 user=admin password=pgdog dbname=admin")
+    conn.autocommit = True
+    cur = conn.cursor()
+    cur.execute("SHOW POOLS")
+    rows = cur.fetchall()
+    assert len(rows) > 0

--- a/pgdog/src/admin/set.rs
+++ b/pgdog/src/admin/set.rs
@@ -180,7 +180,7 @@ impl Command for Set {
                 config.config.general.connect_timeout = self.value.parse()?;
             }
 
-            _ => return Err(Error::Syntax),
+            _ => return Ok(vec![]),
         }
 
         config::set(config)?;


### PR DESCRIPTION
psycopg2 sends a bunch of `SET` commands when it connects to the DB and our admin DB was getting mad (returning syntax error).