### PR TITLE
Port the plugin system to the new parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3313,7 +3313,7 @@ dependencies = [
 [[package]]
 name = "pg_raw_parse"
 version = "0.1.0"
-source = "git+https://github.com/pgdogdev/pg_raw_parse.git?rev=576226d#576226dd9d9e86539bc0b9d9baeb16c3601b346d"
+source = "git+https://github.com/pgdogdev/pg_raw_parse.git?rev=7770583#7770583a2fc503ee3743d328e805345c7dc015da"
 dependencies = [
  "bindgen 0.72.1",
  "cc",
@@ -3434,6 +3434,7 @@ version = "0.1.0"
 dependencies = [
  "once_cell",
  "parking_lot",
+ "pg_raw_parse",
  "pgdog-plugin",
  "thiserror 2.0.18",
 ]
@@ -3467,6 +3468,7 @@ dependencies = [
  "bindgen 0.71.1",
  "libloading",
  "pg_query",
+ "pg_raw_parse",
  "pgdog-postgres-types",
  "tracing",
  "tracing-subscriber",
@@ -3494,6 +3496,7 @@ dependencies = [
  "arc-swap",
  "once_cell",
  "parking_lot",
+ "pg_raw_parse",
  "pgdog-plugin",
  "serde",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,10 @@ members = [
 edition = "2024"
 
 [workspace.dependencies]
-pgdog-plugin = { path = "./pgdog-plugin", version = "0.4.0" }
+pgdog-plugin = { path = "./pgdog-plugin", version = "0.4.0", default-features = false }
 pgdog-config = { path = "./pgdog-config", version = "0.1.0" }
 pgdog-postgres-types = { path = "./pgdog-postgres-types"}
+pg_raw_parse = { git = "https://github.com/pgdogdev/pg_raw_parse.git", rev = "7770583" }
 bon = "3.9"
 schemars = { version = "1.2.1", features = ["uuid1"] }
 serde_json = "1.0"

--- a/integration/two_pc_crash_safety/wal_helper/Cargo.toml
+++ b/integration/two_pc_crash_safety/wal_helper/Cargo.toml
@@ -10,5 +10,5 @@ path = "src/main.rs"
 
 [dependencies]
 bytes = "1"
-pgdog = { path = "../../../pgdog" }
+pgdog = { path = "../../../pgdog", default-features = false }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/pgdog-plugin/Cargo.toml
+++ b/pgdog-plugin/Cargo.toml
@@ -15,7 +15,8 @@ crate-type = ["rlib", "cdylib"]
 
 [dependencies]
 libloading = "0.8"
-pg_query = { git = "https://github.com/pgdogdev/pg_query.rs.git", rev = "97019d0c13ad0b888fe91ee5bed5448b5f409cdd" }
+pg_query = { git = "https://github.com/pgdogdev/pg_query.rs.git", rev = "97019d0c13ad0b888fe91ee5bed5448b5f409cdd", optional = true }
+pg_raw_parse = { workspace = true, optional = true }
 pgdog-postgres-types.workspace = true
 
 tracing = "0.1"
@@ -23,3 +24,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 [build-dependencies]
 bindgen = "0.71.0"
+
+[features]
+default = ["pg_query"]
+new_parser = ["pg_raw_parse"]

--- a/pgdog-plugin/src/context.rs
+++ b/pgdog-plugin/src/context.rs
@@ -56,7 +56,11 @@ pub struct Context<'a> {
     // We are relying on an implemenation detail of the compiler that could
     // change at any time to make this work. There is no safe way to pass
     // this type, but this won't be an issue with the new parser
+    #[cfg(not(feature = "new_parser"))]
     pub query: &'a pg_query::protobuf::ParseResult,
+    #[cfg(feature = "new_parser")]
+    /// The parsed Abstract Syntax Tree of the statement(s).
+    pub query: &'a pg_raw_parse::StmtList,
     /// Bound parameters.
     pub params: Parameters<'a>,
 }
@@ -197,7 +201,9 @@ impl Context<'_> {
 impl Context<'_> {
     #[doc(hidden)]
     pub fn doc_test() -> Self {
+        #[cfg(not(feature = "new_parser"))]
         use pg_query::protobuf::ParseResult;
+        #[cfg(not(feature = "new_parser"))]
         static EMPTY_PARSE_RESULT: ParseResult = ParseResult {
             version: 0,
             stmts: Vec::new(),
@@ -208,7 +214,10 @@ impl Context<'_> {
             has_primary: true,
             in_transaction: false,
             write_override: false,
+            #[cfg(not(feature = "new_parser"))]
             query: &EMPTY_PARSE_RESULT,
+            #[cfg(feature = "new_parser")]
+            query: pg_raw_parse::list::empty_list(),
             params: Parameters::default(),
         }
     }

--- a/pgdog-plugin/src/lib.rs
+++ b/pgdog-plugin/src/lib.rs
@@ -182,6 +182,13 @@
 //! ```
 //!
 
+#[cfg(all(feature = "pg_query", feature = "pg_raw_parse"))]
+compile_error!("Cannot build with both the old and new parser");
+#[cfg(not(any(feature = "pg_query", feature = "pg_raw_parse")))]
+compile_error!(
+    r#"pg-plugin must be built with either default features, or features = "new_parser""#
+);
+
 mod config;
 pub mod context;
 pub mod logging;
@@ -200,6 +207,7 @@ pub use string::PdStr;
 
 pub use libloading;
 
+#[cfg(feature = "pg_query")]
 pub use pg_query;
 
 pub const RUSTC_VERSION: &str = env!("RUSTC_VERSION");

--- a/pgdog-plugin/src/plugin.rs
+++ b/pgdog-plugin/src/plugin.rs
@@ -37,6 +37,17 @@ pub struct PluginVtable {
     /// Configure plugin.
     config: extern "C-unwind" fn(Config<'_>) -> bool,
     /// Route query.
+    #[cfg(feature = "new_parser")]
+    route: extern "C-unwind" fn(
+        u64,
+        bool,
+        bool,
+        bool,
+        bool,
+        &pg_raw_parse::StmtList,
+        RawParameters<'_>,
+    ) -> Route,
+    #[cfg(not(feature = "new_parser"))]
     route: extern "C-unwind" fn(
         u64,
         bool,
@@ -82,7 +93,8 @@ pub trait Plugin {
         has_primary: bool,
         in_transaction: bool,
         write_override: bool,
-        query: &pg_query::protobuf::ParseResult,
+        #[cfg(not(feature = "new_parser"))] query: &pg_query::protobuf::ParseResult,
+        #[cfg(feature = "new_parser")] query: &pg_raw_parse::StmtList,
         params: RawParameters<'_>,
     ) -> Route {
         let context = Context {

--- a/pgdog-plugin/src/prelude.rs
+++ b/pgdog-plugin/src/prelude.rs
@@ -1,5 +1,6 @@
 //! Commonly used structs and re-exports.
 
+#[cfg(feature = "pg_query")]
 pub use crate::pg_query;
 pub use crate::{
     Context, ParameterFormat, PdStr, Plugin, ReadWrite, Route, Shard,

--- a/pgdog/Cargo.toml
+++ b/pgdog/Cargo.toml
@@ -11,8 +11,9 @@ readme = "README.md"
 default-run = "pgdog"
 
 [features]
+default = ["pgdog-plugin/pg_query"]
 tui = ["ratatui"]
-new_parser = ["pg_raw_parse"]
+new_parser = ["pg_raw_parse", "pgdog-plugin/new_parser"]
 
 [dependencies]
 bon.workspace = true
@@ -81,7 +82,7 @@ smallvec = "1"
 reqwest.workspace = true
 hex = "0.4"
 x509-parser = "0.18"
-pg_raw_parse = { git = "https://github.com/pgdogdev/pg_raw_parse.git", rev = "576226d", optional = true }
+pg_raw_parse = { workspace = true, optional = true }
 itertools = "0.15.0"
 
 [target.'cfg(unix)'.dependencies]

--- a/pgdog/src/frontend/router/parser/query/plugins.rs
+++ b/pgdog/src/frontend/router/parser/query/plugins.rs
@@ -76,7 +76,10 @@ impl QueryParser {
             has_primary: !context.write_only,
             in_transaction: context.router_context.in_transaction(),
             write_override: self.write_override || !read, // This is set inside `QueryParser::plugins`.
+            #[cfg(not(feature = "new_parser"))]
             query: &statement.parse_result().protobuf,
+            #[cfg(feature = "new_parser")]
+            query: &statement.new_ast,
             params,
         };
 

--- a/pgdog/src/frontend/router/parser/query/update.rs
+++ b/pgdog/src/frontend/router/parser/query/update.rs
@@ -64,7 +64,7 @@ mod tests {
 
     #[test]
     fn update_preserves_decimal_values() {
-        let parsed = pgdog_plugin::pg_query::parse(
+        let parsed = pg_query::parse(
             "UPDATE transactions SET amount = 50.00, status = 'completed' WHERE id = 1",
         )
         .expect("parse");
@@ -110,9 +110,8 @@ mod tests {
 
     #[test]
     fn update_with_quoted_decimal() {
-        let parsed =
-            pgdog_plugin::pg_query::parse("UPDATE transactions SET amount = '50.00' WHERE id = 1")
-                .expect("parse");
+        let parsed = pg_query::parse("UPDATE transactions SET amount = '50.00' WHERE id = 1")
+            .expect("parse");
 
         let stmt = parsed
             .protobuf

--- a/plugins/pgdog-example-plugin/Cargo.toml
+++ b/plugins/pgdog-example-plugin/Cargo.toml
@@ -11,3 +11,8 @@ pgdog-plugin.workspace = true
 once_cell = "1"
 parking_lot = "0.12"
 thiserror = "2"
+pg_raw_parse = { workspace = true, optional = true }
+
+[features]
+default = ["pgdog-plugin/pg_query"]
+new_parser = ["pg_raw_parse", "pgdog-plugin/new_parser"]

--- a/plugins/pgdog-example-plugin/src/plugin.rs
+++ b/plugins/pgdog-example-plugin/src/plugin.rs
@@ -5,14 +5,22 @@ use std::{
 
 use once_cell::sync::Lazy;
 use parking_lot::Mutex;
+#[cfg(not(feature = "new_parser"))]
 use pg_query::{NodeEnum, protobuf::RangeVar};
+#[cfg(feature = "new_parser")]
+use pg_raw_parse::Node;
 use pgdog_plugin::prelude::*;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum PluginError {
     #[error("{0}")]
+    #[cfg(not(feature = "new_parser"))]
     PgQuery(#[from] pg_query::Error),
+
+    #[error("{0}")]
+    #[cfg(feature = "pg_raw_parse")]
+    Parser(#[from] pg_raw_parse::Error),
 
     #[error("empty query")]
     EmptyQuery,
@@ -23,7 +31,8 @@ static WRITE_TIMES: Lazy<Mutex<HashMap<String, Instant>>> =
 
 /// Route query to a replica or a primary, depending on when was the last time
 /// we wrote to the table.
-pub(crate) fn route_query(context: Context) -> Result<Route, PluginError> {
+#[cfg(feature = "new_parser")]
+pub(crate) fn route_query(context: Context<'_>) -> Result<Route, PluginError> {
     // PgDog really thinks this should be a write.
     // This could be because there is an INSERT statement in a CTE,
     // or something else. You could override its decision here, but make
@@ -32,30 +41,26 @@ pub(crate) fn route_query(context: Context) -> Result<Route, PluginError> {
 
     let root = context
         .query
-        .stmts
-        .first()
-        .ok_or(PluginError::EmptyQuery)?
-        .stmt
-        .as_ref()
+        .stmts()
+        .next()
         .ok_or(PluginError::EmptyQuery)?;
 
-    match root.node.as_ref() {
-        Some(NodeEnum::SelectStmt(stmt)) => {
+    match root {
+        Node::SelectStmt(stmt) => {
             if write_override {
                 return Ok(Route::unknown());
             }
 
-            let table_name = stmt
-                .from_clause
-                .first()
-                .ok_or(PluginError::EmptyQuery)?
-                .node
-                .as_ref()
-                .ok_or(PluginError::EmptyQuery)?;
+            let table_name = stmt.from_clause().first().ok_or(PluginError::EmptyQuery)?;
 
-            if let NodeEnum::RangeVar(RangeVar { relname, .. }) = table_name {
+            if let Node::RangeVar(range_var) = table_name {
                 // Got info on last write.
-                if let Some(last_write) = { WRITE_TIMES.lock().get(relname).cloned() } {
+                if let Some(last_write) = {
+                    WRITE_TIMES
+                        .lock()
+                        .get(range_var.relname().unwrap())
+                        .cloned()
+                } {
                     if last_write.elapsed() > Duration::from_secs(5) && context.has_replicas() {
                         return Ok(Route::new(Shard::Unknown, ReadWrite::Read));
                     }
@@ -64,25 +69,25 @@ pub(crate) fn route_query(context: Context) -> Result<Route, PluginError> {
                 }
             }
         }
-        Some(NodeEnum::InsertStmt(stmt)) => {
-            if let Some(ref relation) = stmt.relation {
+        Node::InsertStmt(stmt) => {
+            if let Some(relation) = stmt.relation() {
                 WRITE_TIMES
                     .lock()
-                    .insert(relation.relname.clone(), Instant::now());
+                    .insert(relation.relname().unwrap().to_owned(), Instant::now());
             }
         }
-        Some(NodeEnum::UpdateStmt(stmt)) => {
-            if let Some(ref relation) = stmt.relation {
+        Node::UpdateStmt(stmt) => {
+            if let Some(relation) = stmt.relation() {
                 WRITE_TIMES
                     .lock()
-                    .insert(relation.relname.clone(), Instant::now());
+                    .insert(relation.relname().unwrap().to_owned(), Instant::now());
             }
         }
-        Some(NodeEnum::DeleteStmt(stmt)) => {
-            if let Some(ref relation) = stmt.relation {
+        Node::DeleteStmt(stmt) => {
+            if let Some(relation) = stmt.relation() {
                 WRITE_TIMES
                     .lock()
-                    .insert(relation.relname.clone(), Instant::now());
+                    .insert(relation.relname().unwrap().to_owned(), Instant::now());
             }
         }
         _ => {}
@@ -106,6 +111,94 @@ pub(crate) fn route_query(context: Context) -> Result<Route, PluginError> {
     Ok(Route::unknown())
 }
 
+cfg_select! {
+    not(feature = "new_parser") => {
+        pub(crate) fn route_query(context: Context<'_>) -> Result<Route, PluginError> {
+            // PgDog really thinks this should be a write.
+            // This could be because there is an INSERT statement in a CTE,
+            // or something else. You could override its decision here, but make
+            // sure you checked the AST first.
+            let write_override = context.write_override();
+
+            let root = context
+                .query
+                .stmts
+                .first()
+                .ok_or(PluginError::EmptyQuery)?
+                .stmt
+                .as_ref()
+                .ok_or(PluginError::EmptyQuery)?;
+
+            match root.node.as_ref() {
+                Some(NodeEnum::SelectStmt(stmt)) => {
+                    if write_override {
+                        return Ok(Route::unknown());
+                    }
+
+                    let table_name = stmt
+                        .from_clause
+                        .first()
+                        .ok_or(PluginError::EmptyQuery)?
+                        .node
+                        .as_ref()
+                        .ok_or(PluginError::EmptyQuery)?;
+
+                    if let NodeEnum::RangeVar(RangeVar { relname, .. }) = table_name {
+                        // Got info on last write.
+                        if let Some(last_write) = { WRITE_TIMES.lock().get(relname).cloned() } {
+                            if last_write.elapsed() > Duration::from_secs(5) && context.has_replicas() {
+                                return Ok(Route::new(Shard::Unknown, ReadWrite::Read));
+                            }
+                        } else if context.has_replicas() {
+                            return Ok(Route::new(Shard::Unknown, ReadWrite::Read));
+                        }
+                    }
+                }
+                Some(NodeEnum::InsertStmt(stmt)) => {
+                    if let Some(ref relation) = stmt.relation {
+                        WRITE_TIMES
+                            .lock()
+                            .insert(relation.relname.clone(), Instant::now());
+                    }
+                }
+                Some(NodeEnum::UpdateStmt(stmt)) => {
+                    if let Some(ref relation) = stmt.relation {
+                        WRITE_TIMES
+                            .lock()
+                            .insert(relation.relname.clone(), Instant::now());
+                    }
+                }
+                Some(NodeEnum::DeleteStmt(stmt)) => {
+                    if let Some(ref relation) = stmt.relation {
+                        WRITE_TIMES
+                            .lock()
+                            .insert(relation.relname.clone(), Instant::now());
+                    }
+                }
+                _ => {}
+            }
+
+            // Get prepared statement parameters.
+            let params = context.parameters();
+            if params.parameters.is_empty() {
+                // No params bound.
+            } else {
+                let param = params
+                    .parameters
+                    .first()
+                    .and_then(|p| p.decode(params.parameter_format(0)));
+                if let Some(param) = param {
+                    println!("Decoded parameter 0 ($1): {:?}", param);
+                }
+            }
+
+            // Let PgDog decide.
+            Ok(Route::unknown())
+        }
+    }
+    _ => {}
+}
+
 #[cfg(test)]
 mod test {
     use pgdog_plugin::parameters::Parameters;
@@ -115,14 +208,17 @@ mod test {
     #[test]
     fn test_routing_plugin() {
         // Keep protobuf in memory.
-        let proto = pg_query::parse("SELECT * FROM users").unwrap().protobuf;
+        #[cfg(not(feature = "new_parser"))]
+        let query = pg_query::parse("SELECT * FROM users").unwrap().protobuf;
+        #[cfg(feature = "new_parser")]
+        let query = pg_raw_parse::parse("SELECT * FROM users").unwrap();
         let context = pgdog_plugin::Context {
             shards: 1,
             has_replicas: true,
             has_primary: true,
             in_transaction: false,
             write_override: false,
-            query: &proto,
+            query: &query,
             params: Parameters::default(),
         };
         let route = route_query(context).unwrap();

--- a/plugins/pgdog-primary-only-tables/Cargo.toml
+++ b/plugins/pgdog-primary-only-tables/Cargo.toml
@@ -15,3 +15,8 @@ toml = "0.8"
 serde = { version = "1", features = ["derive"]}
 arc-swap = "1"
 tracing = "0.1"
+pg_raw_parse = { workspace = true, optional = true }
+
+[features]
+default = ["pgdog-plugin/pg_query"]
+new_parser = ["pg_raw_parse", "pgdog-plugin/new_parser"]

--- a/plugins/pgdog-primary-only-tables/src/lib.rs
+++ b/plugins/pgdog-primary-only-tables/src/lib.rs
@@ -7,11 +7,16 @@ use std::{
 
 use arc_swap::ArcSwap;
 use once_cell::sync::Lazy;
-use pgdog_plugin::{
-    Config as PluginConfig, Context, PdStr, Plugin, ReadWrite, Route, Shard,
-    pg_query::{NodeEnum, NodeRef},
-};
+#[cfg(feature = "new_parser")]
+use pg_raw_parse::Node;
+#[cfg(feature = "new_parser")]
+use pg_raw_parse::walk::{self, Recurse};
+#[cfg(not(feature = "new_parser"))]
+use pgdog_plugin::pg_query::{NodeEnum, NodeRef};
+use pgdog_plugin::{Config as PluginConfig, Context, PdStr, Plugin, ReadWrite, Route, Shard};
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "new_parser")]
+use std::ops::ControlFlow;
 use tracing::{error, info};
 
 static CONFIG: Lazy<ArcSwap<Config>> = Lazy::new(|| ArcSwap::from_pointee(Config::default()));
@@ -26,7 +31,7 @@ impl Plugin for PrimaryOnlyTables {
     }
 
     fn route(context: Context<'_>) -> Route {
-        route_query(context).unwrap_or(Route::unknown())
+        route_query(context)
     }
 
     extern "C-unwind" fn config(config: PluginConfig<'_>) -> bool {
@@ -75,46 +80,84 @@ fn read_config(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn route_query(context: Context<'_>) -> Result<Route, Box<dyn std::error::Error>> {
+#[cfg(feature = "new_parser")]
+fn route_query(context: Context<'_>) -> Route {
     let ast = &context.query;
 
-    let root_node = ast
-        .stmts
-        .first()
-        .and_then(|s| s.stmt.as_ref())
-        .and_then(|s| s.node.as_ref());
-
-    let is_select = root_node.is_some_and(|node| match node {
-        NodeEnum::SelectStmt(_) => true,
-        NodeEnum::ExplainStmt(stmt) => stmt
-            .query
-            .as_ref()
-            .and_then(|q| q.node.as_ref())
-            .is_some_and(|n| matches!(n, NodeEnum::SelectStmt(_))),
-        _ => false,
-    });
-
-    if !is_select {
-        return Ok(Route::default());
-    }
+    let select = match ast.stmts().next() {
+        Some(Node::SelectStmt(s)) => s,
+        Some(Node::ExplainStmt(stmt)) if let Node::SelectStmt(s) = stmt.query() => s,
+        _ => return Route::default(),
+    };
 
     let config = CONFIG.load().clone();
 
-    for node in ast.nodes() {
-        if let NodeRef::RangeVar(range_var) = node.0 {
+    let route = walk::walk_manual(select.into(), |node| match node {
+        Node::RangeVar(range_var) => {
             for table in &config.tables {
-                let name_matches = table.name == range_var.relname;
+                let name_matches = Some(table.name.as_str()) == range_var.relname();
                 let schema_matches = match &table.schema {
-                    Some(schema) => schema == &range_var.schemaname,
+                    Some(schema) => Some(schema.as_str()) == range_var.schemaname(),
                     None => true,
                 };
 
                 if name_matches && schema_matches {
-                    return Ok(Route::new(Shard::Unknown, ReadWrite::Write));
+                    return ControlFlow::Break(Route::new(Shard::Unknown, ReadWrite::Write));
                 }
             }
+            Recurse::yes()
+        }
+        _ => Recurse::yes(),
+    });
+
+    route.unwrap_or_default()
+}
+
+cfg_select! {
+    not(feature = "new_parser") => {
+        fn route_query(context: Context<'_>) -> Route {
+            let ast = &context.query;
+
+            let root_node = ast
+                .stmts
+                .first()
+                .and_then(|s| s.stmt.as_ref())
+                .and_then(|s| s.node.as_ref());
+
+            let is_select = root_node.is_some_and(|node| match node {
+                NodeEnum::SelectStmt(_) => true,
+                NodeEnum::ExplainStmt(stmt) => stmt
+                    .query
+                    .as_ref()
+                    .and_then(|q| q.node.as_ref())
+                    .is_some_and(|n| matches!(n, NodeEnum::SelectStmt(_))),
+                _ => false,
+            });
+
+            if !is_select {
+                return Route::default();
+            }
+
+            let config = CONFIG.load().clone();
+
+            for node in ast.nodes() {
+                if let NodeRef::RangeVar(range_var) = node.0 {
+                    for table in &config.tables {
+                        let name_matches = table.name == range_var.relname;
+                        let schema_matches = match &table.schema {
+                            Some(schema) => schema == &range_var.schemaname,
+                            None => true,
+                        };
+
+                        if name_matches && schema_matches {
+                            return Route::new(Shard::Unknown, ReadWrite::Write);
+                        }
+                    }
+                }
+            }
+
+            Route::default()
         }
     }
-
-    Ok(Route::default())
+    _ => {}
 }


### PR DESCRIPTION
This ports both the plugin system, and the in-tree plugins to use the new parser. Since `pgdog-plugin` is small enough to port the whole crate at once, I've ensured that if `new_parser` is enabled, `pg_query` isn't linked at all (at least not by that crate)