### PR TITLE
Port rewrite_ast_limit_offset to the new parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3313,7 +3313,7 @@ dependencies = [
 [[package]]
 name = "pg_raw_parse"
 version = "0.1.0"
-source = "git+https://github.com/pgdogdev/pg_raw_parse.git?rev=576226d#576226dd9d9e86539bc0b9d9baeb16c3601b346d"
+source = "git+https://github.com/pgdogdev/pg_raw_parse.git?rev=7770583#7770583a2fc503ee3743d328e805345c7dc015da"
 dependencies = [
  "bindgen 0.72.1",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ edition = "2024"
 pgdog-plugin = { path = "./pgdog-plugin", version = "0.4.0" }
 pgdog-config = { path = "./pgdog-config", version = "0.1.0" }
 pgdog-postgres-types = { path = "./pgdog-postgres-types"}
+pg_raw_parse = { git = "https://github.com/pgdogdev/pg_raw_parse.git", rev = "7770583" }
 bon = "3.9"
 schemars = { version = "1.2.1", features = ["uuid1"] }
 serde_json = "1.0"

--- a/pgdog/Cargo.toml
+++ b/pgdog/Cargo.toml
@@ -81,7 +81,7 @@ smallvec = "1"
 reqwest.workspace = true
 hex = "0.4"
 x509-parser = "0.18"
-pg_raw_parse = { git = "https://github.com/pgdogdev/pg_raw_parse.git", rev = "576226d", optional = true }
+pg_raw_parse = { workspace = true, optional = true }
 itertools = "0.15.0"
 
 [target.'cfg(unix)'.dependencies]

--- a/pgdog/src/frontend/client/query_engine/test/rewrite_offset.rs
+++ b/pgdog/src/frontend/client/query_engine/test/rewrite_offset.rs
@@ -171,6 +171,12 @@ async fn test_offset_with_unique_id_simple() {
         final_sql.contains("LIMIT 15"),
         "LIMIT should be 10+5=15: {final_sql}"
     );
+    #[cfg(feature = "new_parser")]
+    assert!(
+        !final_sql.contains("OFFSET"),
+        "SQL should not contain OFFSET: {final_sql}",
+    );
+    #[cfg(not(feature = "new_parser"))]
     assert!(
         final_sql.contains("OFFSET 0"),
         "OFFSET should be 0: {final_sql}"

--- a/pgdog/src/frontend/router/parser/rewrite/statement/offset.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/offset.rs
@@ -1,9 +1,10 @@
-use pg_query::NodeEnum;
 #[cfg(not(feature = "new_parser"))]
-use pg_query::protobuf::ParamRef;
-use pg_query::protobuf::{AConst, Integer, ParseResult, a_const::Val};
+use pg_query::{
+    NodeEnum,
+    protobuf::{AConst, Integer, ParamRef, ParseResult, a_const::Val},
+};
 #[cfg(feature = "new_parser")]
-use pg_raw_parse::{Node, nodes};
+use pg_raw_parse::{ConstValue, Node, Owned, StmtList, nodes};
 
 use crate::frontend::ClientRequest;
 use crate::frontend::router::parser::Limit;
@@ -88,7 +89,9 @@ impl OffsetPlan {
         if self.limit.limit.is_some() || self.limit.offset.is_some() {
             let new_limit = (limit_val.unwrap_or(0) + offset_val.unwrap_or(0)) as i32;
             let ast = request.ast.as_ref().ok_or(Error::MissingAst)?;
+            #[cfg(not(feature = "new_parser"))]
             let mut protobuf = ast.ast.protobuf.clone();
+            #[cfg(not(feature = "new_parser"))]
             if rewrite_ast_limit_offset(&mut protobuf, new_limit) {
                 let result = pg_query::ParseResult::new(protobuf, "".into());
                 let new_sql = result.deparse()?;
@@ -96,6 +99,19 @@ impl OffsetPlan {
                     match message {
                         ProtocolMessage::Query(q) => q.set_query(&new_sql),
                         ProtocolMessage::Parse(p) => p.set_query(&new_sql),
+                        _ => {}
+                    }
+                }
+            }
+
+            #[cfg(feature = "new_parser")]
+            if let Some(rewritten) = rewrite_ast_limit_offset(&ast.new_ast, new_limit) {
+                let result = pg_raw_parse::deparse(&*rewritten)?;
+                let new_sql = result.as_str();
+                for message in request.messages.iter_mut() {
+                    match message {
+                        ProtocolMessage::Query(q) => q.set_query(new_sql),
+                        ProtocolMessage::Parse(p) => p.set_query(new_sql),
                         _ => {}
                     }
                 }
@@ -159,37 +175,58 @@ fn extract_limit_value(node: &Option<pg_query::NodeEnum>) -> Option<LimitValueIn
     }
 }
 
-fn rewrite_ast_limit_offset(ast: &mut ParseResult, new_limit: i32) -> bool {
-    let raw_stmt = match ast.stmts.first_mut() {
-        Some(s) => s,
-        None => return false,
-    };
-    let stmt = match raw_stmt.stmt.as_mut() {
-        Some(s) => s,
-        None => return false,
-    };
-    let select = match &mut stmt.node {
-        Some(NodeEnum::SelectStmt(s)) => s,
-        _ => return false,
+#[cfg(feature = "new_parser")]
+fn rewrite_ast_limit_offset(ast: &StmtList, new_limit: i32) -> Option<Owned<nodes::SelectStmt>> {
+    let Some(Node::SelectStmt(select)) = ast.stmts().next() else {
+        return None;
     };
 
-    select.limit_count = Some(Box::new(pg_query::Node {
-        node: Some(NodeEnum::AConst(AConst {
-            val: Some(Val::Ival(Integer { ival: new_limit })),
-            isnull: false,
-            location: -1i32,
-        })),
-    }));
+    Some(make::owned(|mem| {
+        let mut select = mem.make_unique(select);
+        select
+            .as_mut()
+            .set_limit_count(mem.make_a_const(ConstValue::Integer(new_limit)).uncast());
+        select.as_mut().set_limit_offset(mem.none());
+        select
+    }))
+}
 
-    select.limit_offset = Some(Box::new(pg_query::Node {
-        node: Some(NodeEnum::AConst(AConst {
-            val: Some(Val::Ival(Integer { ival: 0 })),
-            isnull: false,
-            location: -1i32,
-        })),
-    }));
+cfg_select! {
+    not(feature = "new_parser") => {
+        fn rewrite_ast_limit_offset(ast: &mut ParseResult, new_limit: i32) -> bool {
+            let raw_stmt = match ast.stmts.first_mut() {
+                Some(s) => s,
+                None => return false,
+            };
+            let stmt = match raw_stmt.stmt.as_mut() {
+                Some(s) => s,
+                None => return false,
+            };
+            let select = match &mut stmt.node {
+                Some(NodeEnum::SelectStmt(s)) => s,
+                _ => return false,
+            };
 
-    true
+            select.limit_count = Some(Box::new(pg_query::Node {
+                node: Some(NodeEnum::AConst(AConst {
+                    val: Some(Val::Ival(Integer { ival: new_limit })),
+                    isnull: false,
+                    location: -1i32,
+                })),
+            }));
+
+            select.limit_offset = Some(Box::new(pg_query::Node {
+                node: Some(NodeEnum::AConst(AConst {
+                    val: Some(Val::Ival(Integer { ival: 0 })),
+                    isnull: false,
+                    location: -1i32,
+                })),
+            }));
+
+            true
+        }
+    }
+    _ => {}
 }
 
 impl StatementRewrite<'_> {
@@ -431,6 +468,9 @@ mod tests {
             ProtocolMessage::Query(q) => q.query().to_owned(),
             _ => panic!("expected Query"),
         };
+        #[cfg(feature = "new_parser")]
+        assert_eq!(query, "SELECT * FROM t LIMIT 15");
+        #[cfg(not(feature = "new_parser"))]
         assert_eq!(query, "SELECT * FROM t LIMIT 15 OFFSET 0");
 
         let route = request.route.unwrap();
@@ -521,6 +561,9 @@ mod tests {
             ProtocolMessage::Parse(p) => p.query().to_owned(),
             _ => panic!("expected Parse"),
         };
+        #[cfg(feature = "new_parser")]
+        assert_eq!(sql, "SELECT * FROM t LIMIT 15");
+        #[cfg(not(feature = "new_parser"))]
         assert_eq!(sql, "SELECT * FROM t LIMIT 15 OFFSET 0");
 
         let route = request.route.unwrap();


### PR DESCRIPTION
This has a minor behavioral change of rewriting to `LIMIT x` instead of `LIMIT x OFFSET 0`