### PR TITLE
Port some tests over to the new parser

### DIFF
--- a/pgdog/src/frontend/router/parser/query/test/mod.rs
+++ b/pgdog/src/frontend/router/parser/query/test/mod.rs
@@ -688,12 +688,6 @@ fn test_any() {
 }
 
 #[test]
-fn test_commit_prepared() {
-    let stmt = pg_query::parse("COMMIT PREPARED 'test'").unwrap();
-    println!("{:?}", stmt);
-}
-
-#[test]
 fn test_set_comments() {
     // let command = query_parser!(
     //     QueryParser::default(),
@@ -708,39 +702,4 @@ fn test_set_comments() {
         true
     );
     assert!(matches!(command, Command::Set { .. }));
-}
-
-#[test]
-fn test_subqueries() {
-    println!(
-        "{:#?}",
-        pg_query::parse(r#"
-        SELECT
-            count(*) AS "count"
-        FROM
-        (
-            SELECT "companies".* FROM
-            (
-                 SELECT "companies".*
-                 FROM "companies"
-                 INNER JOIN "organizations_relevant_companies" ON
-                 ("organizations_relevant_companies"."company_id" = "companies"."id")
-                 WHERE
-                 (
-                     ("organizations_relevant_companies"."org_id" = 1)
-                     AND NOT
-                     (
-                        EXISTS
-                        (
-                           SELECT * FROM "hidden_globals"
-                           WHERE
-                           (
-                               ("hidden_globals"."org_id" = 1)
-                               AND ("hidden_globals"."global_company_id" = "organizations_relevant_companies"."company_id")
-                           )
-                     )
-                )
-            )
-        ) AS "companies" OFFSET 0) AS "t1" LIMIT 1"#).unwrap()
-    );
 }

--- a/pgdog/src/frontend/router/parser/query/update.rs
+++ b/pgdog/src/frontend/router/parser/query/update.rs
@@ -59,86 +59,152 @@ impl QueryParser {
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(feature = "new_parser")]
+    #[cfg(not(feature = "new_parser"))]
     use pg_query::NodeEnum;
 
     #[test]
+    #[cfg(feature = "new_parser")]
     fn update_preserves_decimal_values() {
-        let parsed = pg_query::parse(
+        let parsed = pg_raw_parse::parse(
             "UPDATE transactions SET amount = 50.00, status = 'completed' WHERE id = 1",
         )
-        .expect("parse");
+        .unwrap();
 
-        let stmt = parsed
-            .protobuf
-            .stmts
-            .first()
-            .and_then(|node| node.stmt.as_ref())
-            .and_then(|node| node.node.as_ref())
-            .expect("statement node");
-
-        let update = match stmt {
-            NodeEnum::UpdateStmt(update) => update,
-            _ => panic!("expected update stmt"),
+        let Some(Node::UpdateStmt(update)) = parsed.stmts().next() else {
+            panic!("expected update stmt");
         };
 
         // Check that we can extract assignment values including decimals
         let mut found_decimal = false;
         let mut found_string = false;
 
-        for target in &update.target_list {
-            if let Some(NodeEnum::ResTarget(res)) = &target.node
-                && let Some(val) = &res.val
-            {
-                let value = Value::try_from(&val.node).unwrap();
-                match value {
-                    Value::Float(f) => {
-                        assert_eq!(f, 50.0);
-                        found_decimal = true;
-                    }
-                    Value::String(s) => {
-                        assert_eq!(s, "completed");
-                        found_string = true;
-                    }
-                    _ => {}
+        for target in update.target_list() {
+            let value = Value::try_from(target.val()).unwrap();
+            match value {
+                Value::Float(f) => {
+                    assert_eq!(f, 50.0);
+                    found_decimal = true;
                 }
+                Value::String(s) => {
+                    assert_eq!(s, "completed");
+                    found_string = true;
+                }
+                _ => {}
             }
         }
         assert!(found_decimal, "Should have found decimal value");
         assert!(found_string, "Should have found string value");
     }
 
+    cfg_select! {
+        not(feature = "new_parser") => {
+            #[test]
+            fn update_preserves_decimal_values() {
+                let parsed = pg_query::parse(
+                    "UPDATE transactions SET amount = 50.00, status = 'completed' WHERE id = 1",
+                )
+                .expect("parse");
+
+                let stmt = parsed
+                    .protobuf
+                    .stmts
+                    .first()
+                    .and_then(|node| node.stmt.as_ref())
+                    .and_then(|node| node.node.as_ref())
+                    .expect("statement node");
+
+                let update = match stmt {
+                    NodeEnum::UpdateStmt(update) => update,
+                    _ => panic!("expected update stmt"),
+                };
+
+                // Check that we can extract assignment values including decimals
+                let mut found_decimal = false;
+                let mut found_string = false;
+
+                for target in &update.target_list {
+                    if let Some(NodeEnum::ResTarget(res)) = &target.node
+                        && let Some(val) = &res.val
+                    {
+                        let value = Value::try_from(&val.node).unwrap();
+                        match value {
+                            Value::Float(f) => {
+                                assert_eq!(f, 50.0);
+                                found_decimal = true;
+                            }
+                            Value::String(s) => {
+                                assert_eq!(s, "completed");
+                                found_string = true;
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                assert!(found_decimal, "Should have found decimal value");
+                assert!(found_string, "Should have found string value");
+            }
+        }
+        _ => {}
+    }
+
     #[test]
+    #[cfg(feature = "new_parser")]
     fn update_with_quoted_decimal() {
-        let parsed = pg_query::parse("UPDATE transactions SET amount = '50.00' WHERE id = 1")
-            .expect("parse");
+        let parsed =
+            pg_raw_parse::parse("UPDATE transactions SET amount = '50.00' WHERE id = 1").unwrap();
 
-        let stmt = parsed
-            .protobuf
-            .stmts
-            .first()
-            .and_then(|node| node.stmt.as_ref())
-            .and_then(|node| node.node.as_ref())
-            .expect("statement node");
-
-        let update = match stmt {
-            NodeEnum::UpdateStmt(update) => update,
-            _ => panic!("expected update stmt"),
+        let Some(Node::UpdateStmt(update)) = parsed.stmts().next() else {
+            panic!("expected update stmt");
         };
 
         // Quoted decimals should be treated as strings
         let mut found_string = false;
-        for target in &update.target_list {
-            if let Some(NodeEnum::ResTarget(res)) = &target.node
-                && let Some(val) = &res.val
-            {
-                let value = Value::try_from(&val.node).unwrap();
-                if let Value::String(s) = value {
-                    assert_eq!(s, "50.00");
-                    found_string = true;
-                }
+        for target in update.target_list() {
+            let value = Value::try_from(target.val()).unwrap();
+            if let Value::String(s) = value {
+                assert_eq!(s, "50.00");
+                found_string = true;
             }
         }
         assert!(found_string, "Should have found string value");
+    }
+
+    cfg_select! {
+        not(feature = "new_parser") => {
+            #[test]
+            fn update_with_quoted_decimal() {
+                let parsed = pg_query::parse("UPDATE transactions SET amount = '50.00' WHERE id = 1")
+                    .expect("parse");
+
+                let stmt = parsed
+                    .protobuf
+                    .stmts
+                    .first()
+                    .and_then(|node| node.stmt.as_ref())
+                    .and_then(|node| node.node.as_ref())
+                    .expect("statement node");
+
+                let update = match stmt {
+                    NodeEnum::UpdateStmt(update) => update,
+                    _ => panic!("expected update stmt"),
+                };
+
+                // Quoted decimals should be treated as strings
+                let mut found_string = false;
+                for target in &update.target_list {
+                    if let Some(NodeEnum::ResTarget(res)) = &target.node
+                        && let Some(val) = &res.val
+                    {
+                        let value = Value::try_from(&val.node).unwrap();
+                        if let Value::String(s) = value {
+                            assert_eq!(s, "50.00");
+                            found_string = true;
+                        }
+                    }
+                }
+                assert!(found_string, "Should have found string value");
+            }
+        }
+        _ => {}
     }
 }

--- a/pgdog/src/frontend/router/parser/rewrite/statement/visitor.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/visitor.rs
@@ -1,10 +1,11 @@
+#![cfg(not(feature = "new_parser"))]
 //! AST visitor utilities for statement rewriting.
 
 use pg_query::protobuf::ParseResult;
 use pg_query::{Node, NodeEnum};
 
 /// Count the maximum parameter number ($1, $2, etc.) in the parse result.
-pub fn count_params(ast: &mut ParseResult) -> u16 {
+pub(crate) fn count_params(ast: &mut ParseResult) -> u16 {
     let mut max_param = 0i32;
     let _: Result<(), std::convert::Infallible> = visit_and_mutate_nodes(ast, |node| {
         if let Some(NodeEnum::ParamRef(param)) = &node.node {


### PR DESCRIPTION
Our parameter counter is dead code now so it's CFG'd out. Two of these tests were testing nothing so they've been removed (don't start... We don't need to test whether PostgreSQL is capable of parsing the PostgreSQL grammar), the other two were straight ports but with far fewer checks needed since the new parser keeps more type info than the old one