### PR TITLE
cfg out most remaining references to the old parser

### DIFF
--- a/pgdog/src/frontend/router/parser/cache/test.rs
+++ b/pgdog/src/frontend/router/parser/cache/test.rs
@@ -1,6 +1,9 @@
 #![allow(clippy::print_stdout)]
 
-use pg_query::{normalize, parse};
+#[cfg(not(feature = "new_parser"))]
+use pg_query::parse;
+#[cfg(feature = "new_parser")]
+use pg_raw_parse::parse;
 use tokio::spawn;
 
 use crate::{
@@ -356,11 +359,4 @@ fn test_truncated_query_non_ascii_char_boundary() {
     let buffered = BufferedQuery::Query(Query::new("SELECT '€'"));
     let ast_query = AstQuery::from_query(&buffered);
     assert_eq!(ast_query.truncated_query(9), "SELECT '€");
-}
-
-#[test]
-fn test_normalize() {
-    let q = "SELECT * FROM users WHERE id = 1";
-    let normalized = normalize(q).unwrap();
-    assert_eq!(normalized, "SELECT * FROM users WHERE id = $1");
 }

--- a/pgdog/src/frontend/router/parser/column.rs
+++ b/pgdog/src/frontend/router/parser/column.rs
@@ -1,5 +1,6 @@
 //! Column name reference.
 
+#[cfg(not(feature = "new_parser"))]
 use pg_query::{Node, NodeEnum, protobuf::String as PgQueryString};
 #[cfg(feature = "new_parser")]
 use pg_raw_parse::{list, nodes};
@@ -137,6 +138,7 @@ impl<'a> TryFrom<&'a list::NodeList> for Column<'a> {
     }
 }
 
+#[cfg(not(feature = "new_parser"))]
 impl<'a> TryFrom<&'a Node> for Column<'a> {
     type Error = Error;
 
@@ -145,6 +147,7 @@ impl<'a> TryFrom<&'a Node> for Column<'a> {
     }
 }
 
+#[cfg(not(feature = "new_parser"))]
 impl<'a> TryFrom<&'a Option<NodeEnum>> for Column<'a> {
     type Error = Error;
 
@@ -231,6 +234,7 @@ impl<'a> TryFrom<&'a Option<NodeEnum>> for Column<'a> {
     }
 }
 
+#[cfg(not(feature = "new_parser"))]
 impl<'a> TryFrom<&Option<&'a Node>> for Column<'a> {
     type Error = Error;
 

--- a/pgdog/src/frontend/router/parser/error.rs
+++ b/pgdog/src/frontend/router/parser/error.rs
@@ -8,6 +8,7 @@ use crate::frontend::router::sharding;
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("{0}")]
+    #[cfg(not(feature = "new_parser"))]
     PgQuery(#[from] pg_query::Error),
 
     #[cfg(feature = "new_parser")]

--- a/pgdog/src/frontend/router/parser/rewrite/statement/error.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/error.rs
@@ -6,6 +6,7 @@ pub enum Error {
     UniqueId(#[from] crate::unique_id::Error),
 
     #[error("pg_query: {0}")]
+    #[cfg(not(feature = "new_parser"))]
     PgQuery(#[from] pg_query::Error),
 
     #[error("parser: {0}")]

--- a/pgdog/src/frontend/router/parser/statement.rs
+++ b/pgdog/src/frontend/router/parser/statement.rs
@@ -12,7 +12,7 @@ use pg_query::Node as PgNode;
 use pg_query::Node;
 #[cfg(all(test, not(feature = "new_parser")))]
 use pg_query::protobuf::RawStmt;
-#[cfg_attr(feature = "new_parser", allow(unused))]
+#[cfg(not(feature = "new_parser"))]
 use pg_query::{
     NodeEnum,
     protobuf::{
@@ -634,7 +634,7 @@ impl<'a> SearchResult<'a> {
     }
 }
 
-#[cfg_attr(feature = "new_parser", allow(unused))]
+#[cfg(not(feature = "new_parser"))]
 enum Statement<'a> {
     Select(&'a SelectStmt),
     Update(&'a UpdateStmt),


### PR DESCRIPTION
This removes all traces of the old parser when compiling with the new one, outside of logical replication