### PR TITLE
Remove or cfg all remaining references to the old parser

### DIFF
--- a/pgdog/Cargo.toml
+++ b/pgdog/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 default-run = "pgdog"
 
 [features]
-default = ["pgdog-plugin/pg_query"]
+default = ["pg_query", "pgdog-plugin/pg_query"]
 tui = ["ratatui"]
 new_parser = ["pg_raw_parse", "pgdog-plugin/new_parser"]
 
@@ -46,7 +46,7 @@ base64 = "0.22"
 md5 = "0.7"
 futures = "0.3"
 csv-core = "0.1"
-pg_query = { git = "https://github.com/pgdogdev/pg_query.rs.git", rev = "97019d0c13ad0b888fe91ee5bed5448b5f409cdd" }
+pg_query = { git = "https://github.com/pgdogdev/pg_query.rs.git", rev = "97019d0c13ad0b888fe91ee5bed5448b5f409cdd", optional = true }
 regex = "1"
 memchr = "2"
 semver = "1"

--- a/pgdog/benches/comment_parser.rs
+++ b/pgdog/benches/comment_parser.rs
@@ -1,4 +1,5 @@
 use brunch::{Bench, benches};
+#[cfg(not(feature = "new_parser"))]
 use pg_query::scan_raw;
 use pgdog::backend::ShardingSchema;
 use pgdog::frontend::router::parser::comment::parse_edge_comment;
@@ -9,6 +10,16 @@ const QUERY_WITH_TRAILING: &str =
     "SELECT * FROM users WHERE id = $1 AND name = $2 /* pgdog_role: primary */";
 const QUERY_NO_COMMENT: &str = "SELECT * FROM users WHERE id = $1 AND name = $2";
 
+#[cfg(feature = "new_parser")]
+benches!(
+    Bench::new("parse_edge_comment(leading)")
+        .run(|| parse_edge_comment(QUERY_WITH_LEADING, &ShardingSchema::default())),
+    Bench::new("parse_edge_comment(trailing)")
+        .run(|| parse_edge_comment(QUERY_WITH_TRAILING, &ShardingSchema::default())),
+    Bench::new("parse_edge_comment(no comment)")
+        .run(|| parse_edge_comment(QUERY_NO_COMMENT, &ShardingSchema::default())),
+);
+#[cfg(not(feature = "new_parser"))]
 benches!(
     Bench::new("parse_edge_comment(leading)")
         .run(|| parse_edge_comment(QUERY_WITH_LEADING, &ShardingSchema::default())),

--- a/pgdog/src/backend/replication/error.rs
+++ b/pgdog/src/backend/replication/error.rs
@@ -29,9 +29,6 @@ pub enum Error {
 
     #[error("transaction required for copy")]
     CopyNoTransaction,
-
-    #[error("{0}")]
-    PgQuery(#[from] pg_query::Error),
 }
 
 impl From<backend::Error> for Error {

--- a/pgdog/src/backend/replication/logical/error.rs
+++ b/pgdog/src/backend/replication/logical/error.rs
@@ -103,6 +103,7 @@ pub enum Error {
     MissingData,
 
     #[error("pg_query: {0}")]
+    #[cfg(not(feature = "new_parser"))]
     PgQuery(#[from] pg_query::Error),
 
     #[error("copy error")]

--- a/pgdog/src/backend/replication/logical/publisher/table.rs
+++ b/pgdog/src/backend/replication/logical/publisher/table.rs
@@ -528,6 +528,10 @@ mod test {
         replication::logical::publisher::queries::{PublicationTableColumn, ReplicaIdentity},
         server::test::test_server,
     };
+    #[cfg(not(feature = "new_parser"))]
+    use pg_query::parse;
+    #[cfg(feature = "new_parser")]
+    use pg_raw_parse::parse;
 
     use crate::config::config;
     use crate::net::messages::replication::logical::tuple_data::{
@@ -588,16 +592,16 @@ mod test {
         let table = make_table(vec![("id", true), ("name", false), ("value", false)]);
 
         let insert = table.insert();
-        assert!(pg_query::parse(&insert).is_ok(), "insert: {}", insert);
+        assert!(parse(&insert).is_ok(), "insert: {}", insert);
 
         let upsert = table.upsert();
-        assert!(pg_query::parse(&upsert).is_ok(), "upsert: {}", upsert);
+        assert!(parse(&upsert).is_ok(), "upsert: {}", upsert);
 
         let update = table.update();
-        assert!(pg_query::parse(&update).is_ok(), "update: {}", update);
+        assert!(parse(&update).is_ok(), "update: {}", update);
 
         let delete = table.delete();
-        assert!(pg_query::parse(&delete).is_ok(), "delete: {}", delete);
+        assert!(parse(&delete).is_ok(), "delete: {}", delete);
     }
 
     #[test]
@@ -605,16 +609,16 @@ mod test {
         let table = make_table(vec![("id", true), ("has\"quote", false), ("normal", false)]);
 
         let insert = table.insert();
-        assert!(pg_query::parse(&insert).is_ok(), "insert: {}", insert);
+        assert!(parse(&insert).is_ok(), "insert: {}", insert);
 
         let upsert = table.upsert();
-        assert!(pg_query::parse(&upsert).is_ok(), "upsert: {}", upsert);
+        assert!(parse(&upsert).is_ok(), "upsert: {}", upsert);
 
         let update = table.update();
-        assert!(pg_query::parse(&update).is_ok(), "update: {}", update);
+        assert!(parse(&update).is_ok(), "update: {}", update);
 
         let delete = table.delete();
-        assert!(pg_query::parse(&delete).is_ok(), "delete: {}", delete);
+        assert!(parse(&delete).is_ok(), "delete: {}", delete);
     }
 
     #[test]
@@ -692,16 +696,16 @@ mod test {
         ]);
 
         let insert = table.insert();
-        assert!(pg_query::parse(&insert).is_ok(), "insert: {}", insert);
+        assert!(parse(&insert).is_ok(), "insert: {}", insert);
 
         let upsert = table.upsert();
-        assert!(pg_query::parse(&upsert).is_ok(), "upsert: {}", upsert);
+        assert!(parse(&upsert).is_ok(), "upsert: {}", upsert);
 
         let update = table.update();
-        assert!(pg_query::parse(&update).is_ok(), "update: {}", update);
+        assert!(parse(&update).is_ok(), "update: {}", update);
 
         let delete = table.delete();
-        assert!(pg_query::parse(&delete).is_ok(), "delete: {}", delete);
+        assert!(parse(&delete).is_ok(), "delete: {}", delete);
     }
 
     #[test]
@@ -711,16 +715,16 @@ mod test {
         table.table.schema = "schema\"quote".to_string();
 
         let insert = table.insert();
-        assert!(pg_query::parse(&insert).is_ok(), "insert: {}", insert);
+        assert!(parse(&insert).is_ok(), "insert: {}", insert);
 
         let upsert = table.upsert();
-        assert!(pg_query::parse(&upsert).is_ok(), "upsert: {}", upsert);
+        assert!(parse(&upsert).is_ok(), "upsert: {}", upsert);
 
         let update = table.update();
-        assert!(pg_query::parse(&update).is_ok(), "update: {}", update);
+        assert!(parse(&update).is_ok(), "update: {}", update);
 
         let delete = table.delete();
-        assert!(pg_query::parse(&delete).is_ok(), "delete: {}", delete);
+        assert!(parse(&delete).is_ok(), "delete: {}", delete);
     }
 
     #[test]
@@ -849,13 +853,13 @@ mod test {
 
         for table in tables {
             let upsert = table.upsert();
-            assert!(pg_query::parse(&upsert).is_ok());
+            assert!(parse(&upsert).is_ok());
 
             let update = table.update();
-            assert!(pg_query::parse(&update).is_ok());
+            assert!(parse(&update).is_ok());
 
             let delete = table.delete();
-            assert!(pg_query::parse(&delete).is_ok());
+            assert!(parse(&delete).is_ok());
         }
 
         publication.cleanup().await;
@@ -1003,7 +1007,7 @@ mod test {
             sql,
             format!("DELETE FROM {q}{s}{q}.{q}{t}{q} WHERE (tableoid, ctid) = {subq}")
         );
-        assert!(pg_query::parse(&sql).is_ok(), "delete_full_identity: {sql}");
+        assert!(parse(&sql).is_ok(), "delete_full_identity: {sql}");
     }
 
     #[test]
@@ -1018,10 +1022,7 @@ mod test {
             sql,
             format!("DELETE FROM {q}{s}{q}.{q}{t}{q} WHERE (tableoid, ctid) = {subq}")
         );
-        assert!(
-            pg_query::parse(&sql).is_ok(),
-            "delete_full_identity single: {sql}"
-        );
+        assert!(parse(&sql).is_ok(), "delete_full_identity single: {sql}");
     }
 
     #[test]
@@ -1040,7 +1041,7 @@ mod test {
             format!("UPDATE {q}{s}{q}.{q}{t}{q} SET {set}WHERE (tableoid, ctid) = {subq}")
         );
         assert!(
-            pg_query::parse(&sql).is_ok(),
+            parse(&sql).is_ok(),
             "update_full_identity all_present: {sql}"
         );
     }
@@ -1064,10 +1065,7 @@ mod test {
             sql,
             format!("UPDATE {q}{s}{q}.{q}{t}{q} SET {set}WHERE (tableoid, ctid) = {subq}")
         );
-        assert!(
-            pg_query::parse(&sql).is_ok(),
-            "update_full_identity partial: {sql}"
-        );
+        assert!(parse(&sql).is_ok(), "update_full_identity partial: {sql}");
     }
 
     #[test]
@@ -1090,7 +1088,7 @@ mod test {
             format!("UPDATE {q}{s}{q}.{q}{t}{q} SET {set}WHERE (tableoid, ctid) = {subq}")
         );
         assert!(
-            pg_query::parse(&sql).is_ok(),
+            parse(&sql).is_ok(),
             "update_full_identity first_toasted: {sql}"
         );
     }
@@ -1115,7 +1113,7 @@ mod test {
             format!("UPDATE {q}{s}{q}.{q}{t}{q} SET {set}WHERE (tableoid, ctid) = {subq}")
         );
         assert!(
-            pg_query::parse(&sql).is_ok(),
+            parse(&sql).is_ok(),
             "update_full_identity single col: {sql}"
         );
     }


### PR DESCRIPTION
After this commit, `pg_query` is no longer linked when we compile with `--no-default-features --features new_parser`, and this will be ready to ship to customers assuming green CI