### PR TITLE
Generate a valid default node-id in UniqueId

### DIFF
--- a/pgdog/src/util.rs
+++ b/pgdog/src/util.rs
@@ -114,18 +114,13 @@ pub fn random_string(n: usize) -> String {
         .collect()
 }
 
-// Generate a unique 8-character hex instance ID on first access
+// Generate a random id on first access
 static INSTANCE_ID: Lazy<String> = Lazy::new(|| {
     if let Ok(node_id) = env::var("NODE_ID") {
         node_id
     } else {
         let mut rng = rand::rng();
-        (0..8)
-            .map(|_| {
-                let n: u8 = rng.random_range(0..16);
-                format!("{:x}", n)
-            })
-            .collect()
+        rng.random_range(0..1024).to_string()
     }
 });
 


### PR DESCRIPTION
This code clearly intended to have a fallback to a random number if the environment variable `NODE_ID` wasn't set. This was fundamentally broken as what it was generating was a hex string and it was trying to parse it as decimal. And even if it was parsing it correctly, the max node ID is
1023. So we generate a random number between 0 and 1023