### PR TITLE
Don't attempt to construct a unique_id generator eagerly

### DIFF
--- a/pgdog/src/frontend/router/parser/rewrite/statement/mod.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/mod.rs
@@ -150,26 +150,28 @@ impl<'a> StatementRewrite<'a> {
 
         // Track the next parameter number to use
         let mut next_param = plan.params as i32 + 1;
-        let generator = crate::unique_id::UniqueId::generator()?;
+        let mut err = None;
         transform::transform_node(
             stmt.stmt_mut(),
             &mut transform::TransformClosure::new(|node| {
-                if let Some(replacement) = Self::rewrite_unique_id(
-                    node.as_ref(),
-                    mem,
-                    generator,
-                    self.extended,
-                    &mut next_param,
-                ) {
-                    plan.unique_ids += 1;
-                    self.rewritten = true;
-                    node.replace(replacement);
-                    None
-                } else {
-                    Some(node)
+                match Self::rewrite_unique_id(node.as_ref(), mem, self.extended, &mut next_param) {
+                    Ok(Some(replacement)) => {
+                        plan.unique_ids += 1;
+                        self.rewritten = true;
+                        node.replace(replacement);
+                        None
+                    }
+                    Err(e) => {
+                        err = Some(e);
+                        None
+                    }
+                    Ok(None) => Some(node),
                 }
             }),
         );
+        if let Some(err) = err {
+            return Err(err);
+        }
 
         if let NodeMut::SelectStmt(mut select) = stmt.stmt_mut() {
             self.rewrite_aggregates(&mut select, mem, &mut plan, self.db_schema)?;

--- a/pgdog/src/frontend/router/parser/rewrite/statement/unique_id.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/unique_id.rs
@@ -17,12 +17,11 @@ impl StatementRewrite<'_> {
     pub(super) fn rewrite_unique_id<'mem>(
         node: Node<'_>,
         mem: make::MemoryToken<'mem>,
-        generator: &UniqueId,
         extended: bool,
         next_param: &mut i32,
-    ) -> Option<make::Unique<'mem, Node<'mem>>> {
+    ) -> Result<Option<make::Unique<'mem, Node<'mem>>>, super::Error> {
         if !Self::is_unique_id(node) {
-            return None;
+            return Ok(None);
         }
 
         let replacement = if extended {
@@ -32,12 +31,12 @@ impl StatementRewrite<'_> {
         } else {
             use pg_raw_parse::ConstValue;
 
-            let unique_id = generator.next_id();
+            let unique_id = crate::unique_id::UniqueId::generator()?.next_id();
             mem.make_a_const(ConstValue::Float(&unique_id.to_string()))
                 .uncast()
         };
 
-        Some(
+        Ok(Some(
             mem.make_type_cast(
                 replacement,
                 mem.make_list(&[
@@ -46,7 +45,7 @@ impl StatementRewrite<'_> {
                 ]),
             )
             .uncast(),
-        )
+        ))
     }
 
     cfg_select! {


### PR DESCRIPTION
We had lifted the construction of the generator out of the `transform` block because that function needs to be infallible. Unfortunately, that is where the error from the lack of a NODE_ID variable being set occurs, and moving that to the unique_id generation would have the same problem but require changing more code.

So we construct the generator at the last moment, as the old code did, rather than injecting it.