### PR TITLE
Update the parser to support PG 18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3313,7 +3313,7 @@ dependencies = [
 [[package]]
 name = "pg_raw_parse"
 version = "0.1.0"
-source = "git+https://github.com/pgdogdev/pg_raw_parse.git?rev=b818856#b818856acce89a1f5d8231c694d1c2de22d51fdf"
+source = "git+https://github.com/pgdogdev/pg_raw_parse.git?rev=457b7c9#457b7c91b72b2d4b55be991707dbdf0e784127a4"
 dependencies = [
  "bindgen 0.72.1",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ edition = "2024"
 pgdog-plugin = { path = "./pgdog-plugin", version = "0.4.0", default-features = false }
 pgdog-config = { path = "./pgdog-config", version = "0.1.0" }
 pgdog-postgres-types = { path = "./pgdog-postgres-types"}
-pg_raw_parse = { git = "https://github.com/pgdogdev/pg_raw_parse.git", rev = "b818856" }
+pg_raw_parse = { git = "https://github.com/pgdogdev/pg_raw_parse.git", rev = "457b7c9" }
 bon = "3.9"
 schemars = { version = "1.2.1", features = ["uuid1"] }
 serde_json = "1.0"

--- a/pgdog/src/backend/schema/sync/pg_dump.rs
+++ b/pgdog/src/backend/schema/sync/pg_dump.rs
@@ -2193,6 +2193,12 @@ ALTER TABLE child ADD CONSTRAINT child_parent_fk FOREIGN KEY (parent_id) REFEREN
             statements[1].deref(),
             "CREATE TABLE IF NOT EXISTS child (id int, parent_id bigint)"
         );
+        #[cfg(feature = "new_parser")]
+        assert_eq!(
+            statements[2].deref(),
+            "ALTER TABLE parent ADD CONSTRAINT parent_pkey PRIMARY KEY (id)"
+        );
+        #[cfg(not(feature = "new_parser"))]
         assert_eq!(
             statements[2].deref(),
             "\nALTER TABLE parent ADD CONSTRAINT parent_pkey PRIMARY KEY (id)"

--- a/pgdog/src/backend/schema/sync/pg_dump.rs
+++ b/pgdog/src/backend/schema/sync/pg_dump.rs
@@ -2158,6 +2158,12 @@ ALTER TABLE test ADD CONSTRAINT id_pkey PRIMARY KEY (id);"#,
             statements[0].deref(),
             "CREATE TABLE IF NOT EXISTS test (id bigint, value text)"
         );
+        #[cfg(feature = "new_parser")]
+        assert_eq!(
+            statements[1].deref(),
+            "ALTER TABLE test ADD CONSTRAINT id_pkey PRIMARY KEY (id)"
+        );
+        #[cfg(not(feature = "new_parser"))]
         assert_eq!(
             statements[1].deref(),
             "\nALTER TABLE test ADD CONSTRAINT id_pkey PRIMARY KEY (id)"

--- a/pgdog/src/frontend/router/parser/rewrite/statement/update.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/update.rs
@@ -284,7 +284,7 @@ impl Inner {
     #[cfg(feature = "new_parser")]
     /// Do we have to return the rows to the client?
     pub(crate) fn is_returning(&self) -> bool {
-        self.from_update.returning_clause().is_none()
+        self.from_update.returning_clause().is_some()
     }
 
     #[cfg(not(feature = "new_parser"))]

--- a/pgdog/src/frontend/router/parser/rewrite/statement/update.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/update.rs
@@ -248,7 +248,7 @@ impl Inner {
             insert.as_mut().set_select_stmt(select.uncast());
             insert
                 .as_mut()
-                .set_returning_list(mem.make_unique(self.from_update.returning_list()));
+                .set_returning_clause(mem.make_unique(self.from_update.returning_clause()));
             Ok(mem.make_list(&[mem.make_raw_stmt(insert.uncast())]))
         })?;
         let stmt = deparse(insert.first().unwrap())?;
@@ -284,7 +284,7 @@ impl Inner {
     #[cfg(feature = "new_parser")]
     /// Do we have to return the rows to the client?
     pub(crate) fn is_returning(&self) -> bool {
-        !self.from_update.returning_list().is_empty()
+        self.from_update.returning_clause().is_none()
     }
 
     #[cfg(not(feature = "new_parser"))]


### PR DESCRIPTION
RETURNING clauses now allow accessing both OLD and NEW values.