### PR TITLE
fix: validate message length before widening it to a size

### DIFF
--- a/pgdog/src/net/error.rs
+++ b/pgdog/src/net/error.rs
@@ -117,6 +117,11 @@ pub enum Error {
 
     #[error("message size {size} bytes exceeds query_size_limit of {limit} bytes")]
     MessageTooLarge { size: usize, limit: usize },
+
+    /// The length field counts itself, so it can never be below 4. A message
+    /// declaring less than that can't be framed, and the peer is out of sync.
+    #[error("malformed message: declared length {0} is below the minimum of 4 bytes")]
+    MalformedMessageLength(i32),
 }
 
 impl Error {
@@ -127,6 +132,12 @@ impl Error {
         match self {
             Self::MessageTooLarge { size, limit } => Some(
                 super::messages::ErrorResponse::query_too_large(*size, *limit),
+            ),
+            Self::MalformedMessageLength(len) => Some(
+                super::messages::ErrorResponse::protocol_violation(&format!(
+                    "declared message length {} is below the minimum of 4 bytes",
+                    len
+                )),
             ),
             _ => None,
         }
@@ -159,5 +170,17 @@ mod tests {
         assert!(!Error::UnexpectedMessage('Z', 'Q').is_retryable());
         assert!(!Error::NotTextEncoding.is_retryable());
         assert!(!Error::UnexpectedPayload.is_retryable());
+    }
+
+    #[test]
+    fn malformed_message_length_is_permanent() {
+        // Re-reading a peer that framed a message wrongly just re-reads the
+        // same bytes, so this must not be treated as a transient fault.
+        let err = Error::MalformedMessageLength(-1);
+        assert!(!err.is_retryable());
+
+        // The client gets told why before it is disconnected.
+        let response = err.as_fatal_error_response().unwrap();
+        assert_eq!(response.code, "08P01");
     }
 }

--- a/pgdog/src/net/messages/buffer.rs
+++ b/pgdog/src/net/messages/buffer.rs
@@ -56,7 +56,7 @@ impl MessageBuffer {
         stream: &mut (impl Unpin + AsyncReadExt),
     ) -> Result<Message, Error> {
         loop {
-            if let Some(size) = self.message_size() {
+            if let Some(size) = self.message_size()? {
                 if let Some(limit) = self.size_limit_block
                     && size > limit
                     && self.is_query_message()
@@ -75,7 +75,7 @@ impl MessageBuffer {
                     return Err(Error::MessageTooLarge { size, limit });
                 }
 
-                if self.have_message() {
+                if self.buffer.len() >= size {
                     return Ok(Message::new(self.buffer.split_to(size).freeze()));
                 }
 
@@ -116,7 +116,7 @@ impl MessageBuffer {
     /// will see: Query ('Q', simple protocol) or Parse ('P', extended).
     /// The size limit protects the parser, so only these are subject to it.
     ///
-    /// Invariant: only called when `message_size()` returned `Some`, which
+    /// Invariant: only called when `message_size()` returned `Ok(Some)`, which
     /// requires at least the 5-byte header in the buffer, so indexing the
     /// message code byte can't panic.
     fn is_query_message(&self) -> bool {
@@ -138,20 +138,21 @@ impl MessageBuffer {
         }
     }
 
-    fn have_message(&self) -> bool {
-        self.message_size()
-            .map(|len| self.buffer.len() >= len)
-            .unwrap_or(false)
-    }
-
-    fn message_size(&self) -> Option<usize> {
+    fn message_size(&self) -> Result<Option<usize>, Error> {
         if self.buffer.len() >= HEADER_SIZE {
             let mut cur = Cursor::new(&self.buffer);
             let _code = cur.get_u8();
-            let len = cur.get_i32() as usize + 1;
-            Some(len)
+            let len = cur.get_i32();
+            // The length counts itself but not the message code, so 4 is the
+            // floor. Validating before the `as usize` widening below matters:
+            // it sign-extends a negative length into a huge size, which then
+            // panics the connection task in `reserve`.
+            if len < 4 {
+                return Err(Error::MalformedMessageLength(len));
+            }
+            Ok(Some(len as usize + 1))
         } else {
-            None
+            Ok(None)
         }
     }
 
@@ -446,13 +447,64 @@ mod test {
             .unwrap();
         assert_eq!(msg.code(), 'S');
 
-        // Malformed query header declaring size < HEADER_SIZE: the
-        // log-sample slice must clamp to HEADER_SIZE and not panic.
+        // Smallest legal query header, still over the limit: the log-sample
+        // slice has no payload to read and must not panic.
         let mut buf = MessageBuffer::new(4096, Some(3));
         let err = buf
-            .read(&mut Cursor::new(vec![b'Q', 0, 0, 0, 3]))
+            .read(&mut Cursor::new(vec![b'Q', 0, 0, 0, 4]))
             .await
             .unwrap_err();
         assert!(matches!(err, Error::MessageTooLarge { limit: 3, .. }));
+    }
+
+    #[tokio::test]
+    async fn test_malformed_message_length_rejected() {
+        // Lengths below 4 are unframable. Before they were validated, the
+        // `as usize` widening turned them into enormous sizes: -1 wrapped to
+        // a size of 0 under the release profile's disabled overflow checks,
+        // yielding empty messages forever, and -2 reserved usize::MAX.
+        for len in [-1_i32, -2, i32::MIN, 0, 3] {
+            let mut data = BytesMut::new();
+            data.put_u8(b'Q');
+            data.put_i32(len);
+
+            let mut buf = MessageBuffer::new(4096, None);
+            let err = buf.read(&mut Cursor::new(data.to_vec())).await.unwrap_err();
+
+            assert!(
+                matches!(err, Error::MalformedMessageLength(got) if got == len),
+                "length {} should be rejected as malformed, got {:?}",
+                len,
+                err
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_minimum_message_length_accepted() {
+        // 4 is legal: the length counts itself and Sync carries no payload.
+        let mut buf = MessageBuffer::new(4096, None);
+        let msg = buf
+            .read(&mut Cursor::new(Sync.to_bytes().to_vec()))
+            .await
+            .unwrap();
+        assert_eq!(msg.code(), 'S');
+        assert_eq!(msg.len(), HEADER_SIZE);
+    }
+
+    #[tokio::test]
+    async fn test_malformed_length_does_not_stall_the_buffer() {
+        // The malformed header used to stay in the buffer and be re-read
+        // forever. It must surface as an error instead of an empty message.
+        let mut data = BytesMut::new();
+        data.put_u8(b'Q');
+        data.put_i32(-1);
+        data.extend_from_slice(&Sync.to_bytes());
+
+        let mut buf = MessageBuffer::new(4096, None);
+        assert!(matches!(
+            buf.read(&mut Cursor::new(data.to_vec())).await,
+            Err(Error::MalformedMessageLength(-1))
+        ));
     }
 }


### PR DESCRIPTION
Fixes #1226.

`MessageBuffer::message_size()` read the Postgres length field off the wire and widened it to a `usize` without validating it:

```rust
let len = cur.get_i32() as usize + 1;
```

`get_i32()` returns an `i32`, so a negative length sign-extends. Two failure modes, both post-auth:

- **`len == -1`** → `(-1 as usize) + 1` wraps to `0` when overflow checks are off, i.e. the release profile. `buffer.len() >= 0` is trivially true, so `split_to(0)` consumes nothing and yields an **empty message**; the malformed header stays in the buffer and the next read does the same thing, so it never drains. (With overflow checks on, the addition panics outright.)
- **`len <= -2`** → no wrap; the size lands near `usize::MAX` (`-2` gives exactly `usize::MAX`) and `ensure_capacity` panics in `BytesMut::reserve`.

Small non-negative lengths (`0..4`) were accepted too, producing sizes below the 5-byte header.

## The fix

Validate before widening, mirroring the check the sibling `Stream::read_buf()` path already does. 4 is the floor: the length field counts itself but not the message code.

## Judgement calls worth your eye

**A new error variant instead of reusing `UnexpectedEof`.** `stream.rs` returns `UnexpectedEof` for this exact condition, so consistency argued for reusing it — but `Error::is_retryable()` lists `UnexpectedEof` as retryable, and the replication paths (`parallel_sync.rs:69`, `publisher_impl.rs:315`) act on that. A peer that framed a message wrongly will just re-send the same bytes, so a retry is pointless. `MalformedMessageLength` is permanent by default, and `as_fatal_error_response()` maps it to an `08P01` protocol violation so the client is told why before being disconnected — the same path `MessageTooLarge` already uses. Happy to collapse it into `UnexpectedEof` if you'd rather the two read paths stay identical.

**`message_size()` now returns `Result<Option<usize>, Error>`.** That rippled into `have_message()`, whose only caller already had `size` in scope and was recomputing it. Rather than have it swallow the new error, I inlined it to `self.buffer.len() >= size` and dropped the function. Both it and `message_size()` are private and used only in this file.

**One existing assertion changed.** `test_size_limit` fed `[b'Q', 0, 0, 0, 3]` and expected `MessageTooLarge`; that input is now rejected earlier as malformed. I kept the log-sample clamp covered with the smallest legal header (`len = 4`) and moved the malformed case into the new test.

## Tests

- `test_malformed_message_length_rejected` — `-1`, `-2`, `i32::MIN`, `0`, `3` all rejected.
- `test_malformed_length_does_not_stall_the_buffer` — the `-1` empty-message loop now surfaces as an error.
- `test_minimum_message_length_accepted` — `len = 4` (`Sync`) still reads, guarding against an off-by-one in the floor.
- `malformed_message_length_is_permanent` — not retryable, maps to `08P01`.

`cargo fmt --all -- --check` and `cargo clippy --all-targets -- -D warnings` are both clean.
