### PR TITLE
fix: don't drop the Describe response on deferred transactions

### DIFF
--- a/integration/rust/tests/tokio_postgres/mod.rs
+++ b/integration/rust/tests/tokio_postgres/mod.rs
@@ -2,3 +2,4 @@ pub mod copy;
 pub mod nulls;
 pub mod prepared;
 pub mod select;
+pub mod transaction;

--- a/integration/rust/tests/tokio_postgres/transaction.rs
+++ b/integration/rust/tests/tokio_postgres/transaction.rs
@@ -1,0 +1,19 @@
+use crate::setup::connections_tokio;
+
+#[tokio::test]
+async fn test_transaction_control() {
+    let conns = connections_tokio().await;
+    for conn in conns {
+        let begin = conn.prepare("BEGIN").await.unwrap();
+        assert!(begin.params().is_empty());
+        assert!(begin.columns().is_empty());
+
+        for _ in 0..25 {
+            conn.execute("BEGIN", &[]).await.unwrap();
+            conn.execute("COMMIT", &[]).await.unwrap();
+
+            conn.execute("BEGIN", &[]).await.unwrap();
+            conn.execute("ROLLBACK", &[]).await.unwrap();
+        }
+    }
+}

--- a/pgdog/src/frontend/client/query_engine/start_transaction.rs
+++ b/pgdog/src/frontend/client/query_engine/start_transaction.rs
@@ -1,6 +1,9 @@
 use crate::{
     frontend::client::TransactionType,
-    net::{BindComplete, CommandComplete, NoticeResponse, ParseComplete, Protocol, ReadyForQuery},
+    net::{
+        BindComplete, CommandComplete, NoData, NoticeResponse, ParameterDescription, ParseComplete,
+        Protocol, ProtocolMessage, ReadyForQuery,
+    },
 };
 
 use super::*;
@@ -50,7 +53,13 @@ impl QueryEngine {
             match message.code() {
                 'P' => reply.push(ParseComplete.message()?),
                 'B' => reply.push(BindComplete.message()?),
-                'D' | 'H' => (),
+                'D' => {
+                    if matches!(message, ProtocolMessage::Describe(d) if d.is_statement()) {
+                        reply.push(ParameterDescription::empty().message()?);
+                    }
+                    reply.push(NoData.message()?);
+                }
+                'H' => (),
                 'E' => reply.push(if in_transaction {
                     CommandComplete::new_begin().message()?
                 } else if !rollback {

--- a/pgdog/src/frontend/client/query_engine/test/extended_transaction.rs
+++ b/pgdog/src/frontend/client/query_engine/test/extended_transaction.rs
@@ -1,0 +1,142 @@
+use crate::{
+    expect_message,
+    frontend::client::TransactionType,
+    net::{
+        BindComplete, CommandComplete, NoData, NoticeResponse, ParameterDescription, ParseComplete,
+        ReadyForQuery,
+    },
+};
+
+use super::prelude::*;
+
+/// Deferred BEGIN with a statement Describe replies with ParameterDescription + NoData.
+#[tokio::test]
+async fn begin_statement_describe() {
+    let mut client = TestClient::new_replicas(Parameters::default()).await;
+
+    client.send(Parse::named("tx", "BEGIN")).await;
+    client.send(Bind::new_statement("tx")).await;
+    client.send(Describe::new_statement("tx")).await;
+    client.send(Execute::new()).await;
+    client.send(Sync).await;
+    client.try_process().await.unwrap();
+
+    assert!(!client.backend_connected());
+    assert!(client.client().transaction.is_some());
+
+    expect_message!(client.read().await, ParseComplete);
+    expect_message!(client.read().await, BindComplete);
+    expect_message!(client.read().await, ParameterDescription);
+    expect_message!(client.read().await, NoData);
+    expect_message!(client.read().await, CommandComplete);
+    let rfq = expect_message!(client.read().await, ReadyForQuery);
+    assert_eq!(rfq.status, 'T');
+}
+
+/// Deferred BEGIN with a portal Describe replies with NoData only.
+#[tokio::test]
+async fn begin_portal_describe() {
+    let mut client = TestClient::new_replicas(Parameters::default()).await;
+
+    client.send(Parse::named("tx", "BEGIN")).await;
+    client.send(Bind::new_statement("tx")).await;
+    client.send(Describe::new_portal("")).await;
+    client.send(Execute::new()).await;
+    client.send(Sync).await;
+    client.try_process().await.unwrap();
+
+    assert!(!client.backend_connected());
+
+    expect_message!(client.read().await, ParseComplete);
+    expect_message!(client.read().await, BindComplete);
+    expect_message!(client.read().await, NoData);
+    expect_message!(client.read().await, CommandComplete);
+    let rfq = expect_message!(client.read().await, ReadyForQuery);
+    assert_eq!(rfq.status, 'T');
+}
+
+/// A statement and a portal Describe in one batch are answered independently.
+#[tokio::test]
+async fn begin_multiple_describes() {
+    let mut client = TestClient::new_replicas(Parameters::default()).await;
+
+    client.send(Parse::named("tx", "BEGIN")).await;
+    client.send(Describe::new_statement("tx")).await;
+    client.send(Bind::new_statement("tx")).await;
+    client.send(Describe::new_portal("")).await;
+    client.send(Execute::new()).await;
+    client.send(Sync).await;
+    client.try_process().await.unwrap();
+
+    assert!(!client.backend_connected());
+
+    expect_message!(client.read().await, ParseComplete);
+    expect_message!(client.read().await, ParameterDescription);
+    expect_message!(client.read().await, NoData);
+    expect_message!(client.read().await, BindComplete);
+    expect_message!(client.read().await, NoData);
+    expect_message!(client.read().await, CommandComplete);
+    let rfq = expect_message!(client.read().await, ReadyForQuery);
+    assert_eq!(rfq.status, 'T');
+}
+
+/// Deferred COMMIT with a statement Describe, driven through end_not_connected.
+#[tokio::test]
+async fn commit_statement_describe() {
+    let mut client = TestClient::new_replicas(Parameters::default()).await;
+    client.client.transaction = Some(TransactionType::ReadWrite);
+    client.client.client_request = ClientRequest::from(vec![
+        Parse::named("c", "COMMIT").into(),
+        Bind::new_statement("c").into(),
+        Describe::new_statement("c").into(),
+        Execute::new().into(),
+        Sync.into(),
+    ]);
+
+    let mut context = QueryEngineContext::new(&mut client.client);
+    client
+        .engine
+        .end_not_connected(&mut context, false, true)
+        .await
+        .unwrap();
+    drop(context);
+
+    expect_message!(client.read().await, ParseComplete);
+    expect_message!(client.read().await, BindComplete);
+    expect_message!(client.read().await, ParameterDescription);
+    expect_message!(client.read().await, NoData);
+    expect_message!(client.read().await, CommandComplete);
+    let rfq = expect_message!(client.read().await, ReadyForQuery);
+    assert_eq!(rfq.status, 'I');
+}
+
+/// Deferred ROLLBACK outside a transaction keeps the no-transaction notice.
+#[tokio::test]
+async fn rollback_without_transaction_describe() {
+    let mut client = TestClient::new_replicas(Parameters::default()).await;
+    client.client.transaction = None;
+    client.client.client_request = ClientRequest::from(vec![
+        Parse::named("r", "ROLLBACK").into(),
+        Bind::new_statement("r").into(),
+        Describe::new_statement("r").into(),
+        Execute::new().into(),
+        Sync.into(),
+    ]);
+
+    let mut context = QueryEngineContext::new(&mut client.client);
+    client
+        .engine
+        .end_not_connected(&mut context, true, true)
+        .await
+        .unwrap();
+    drop(context);
+
+    expect_message!(client.read().await, ParseComplete);
+    expect_message!(client.read().await, BindComplete);
+    expect_message!(client.read().await, ParameterDescription);
+    expect_message!(client.read().await, NoData);
+    expect_message!(client.read().await, CommandComplete);
+    expect_message!(client.read().await, NoticeResponse);
+    let rfq = expect_message!(client.read().await, ReadyForQuery);
+    assert_eq!(rfq.status, 'I');
+}

--- a/pgdog/src/frontend/client/query_engine/test/mod.rs
+++ b/pgdog/src/frontend/client/query_engine/test/mod.rs
@@ -13,6 +13,7 @@ mod close_parse_global_cache;
 mod cross_shard_disabled;
 mod extended;
 mod extended_anonymous;
+mod extended_transaction;
 mod fatal_error;
 mod graceful_disconnect;
 mod graceful_shutdown;


### PR DESCRIPTION
Fixes #1196.

## Problem

When the query parser defers a transaction-control statement (`BEGIN`/`COMMIT`/`ROLLBACK`) because no server is attached yet, `extended_transaction_reply` builds the reply but ignores the client's `Describe`. Extended-protocol clients (tokio-postgres and friends) get no `ParameterDescription`/`NoData` and abort with `unexpected message from server`.

## Fix

Answer the `Describe`. Always sending `NoData` isn't enough: a **statement** describe (`'S'`) must be answered with `ParameterDescription` first. tokio-postgres sends one while preparing and expects `ParameterDescription` before anything else. 
So:

- statement `Describe` → `ParameterDescription` + `NoData`
- portal `Describe` → `NoData`

matching the [extended-query protocol][pg-ext] for utility statements (no params, no rows).

[pg-ext]: https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY


## Tests

The existing `tokio_postgres` tests only run `SELECT`/`INSERT`/`COPY`, so nothing exercised transaction control over the extended protocol. Added `tokio_postgres/transaction.rs`, plus protocol-level unit tests in `query_engine/test/extended_transaction.rs`.
