### PR TITLE
fix: switch to alternative Tokio timer for >2 workers

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,6 +2,10 @@
 linker = "/usr/bin/clang"
 rustflags = ["-C", "link-arg=--ld-path=/usr/bin/mold", "--cfg", "tokio_unstable"]
 
+[target.aarch64-unknown-linux-gnu]
+linker = "/usr/bin/clang"
+rustflags = ["-C", "link-arg=--ld-path=/usr/bin/mold", "--cfg", "tokio_unstable"]
+
 # Bump reserved stack size size to 2 MB (from default 1 MB) on
 # Windows to buid pg_query. This setting applies to all binaries,
 # not just build scripts but should be harmless because the bumped

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,6 @@
 [target.x86_64-unknown-linux-gnu]
 linker = "/usr/bin/clang"
-rustflags = ["-C", "link-arg=--ld-path=/usr/bin/mold"]
+rustflags = ["-C", "link-arg=--ld-path=/usr/bin/mold", "--cfg", "tokio_unstable"]
 
 # Bump reserved stack size size to 2 MB (from default 1 MB) on
 # Windows to buid pg_query. This setting applies to all binaries,
@@ -8,15 +8,15 @@ rustflags = ["-C", "link-arg=--ld-path=/usr/bin/mold"]
 # stack size is the reserved memory not committed memory.
 #
 # /STACK docs: https://learn.microsoft.com/en-us/cpp/build/reference/stack-stack-allocations?view=msvc-170
-# 
+#
 # Without this the build fails on Windows with an error similar to the following:
 #
 # error: failed to run custom build command for `pg_query v6.1.1 (https://github.com/pgdogdev/pg_query.rs.git?rev=97019d0c13ad0b888fe91ee5bed5448b5f409cdd#97019d0c)`
-# 
+#
 # Caused by:
 #  process didn't exit successfully: `d:\src\rust\pgdog\target\debug\build\pg_query-63c4edfb7d8ae57a\build-script-build` (exit code: 0xc00000fd, STATUS_STACK_OVERFLOW)
 #  --- stderr
-# 
+#
 #  thread 'main' (12096) has overflowed its stack
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "link-arg=/STACK:2097152"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,10 +1,13 @@
+[target.'cfg(all())']
+rustflags = ["--cfg", "tokio_unstable"]
+
 [target.x86_64-unknown-linux-gnu]
 linker = "/usr/bin/clang"
-rustflags = ["-C", "link-arg=--ld-path=/usr/bin/mold", "--cfg", "tokio_unstable"]
+rustflags = ["-C", "link-arg=--ld-path=/usr/bin/mold"]
 
 [target.aarch64-unknown-linux-gnu]
 linker = "/usr/bin/clang"
-rustflags = ["-C", "link-arg=--ld-path=/usr/bin/mold", "--cfg", "tokio_unstable"]
+rustflags = ["-C", "link-arg=--ld-path=/usr/bin/mold"]
 
 # Bump reserved stack size size to 2 MB (from default 1 MB) on
 # Windows to buid pg_query. This setting applies to all binaries,

--- a/.github/workflows/tests-new-parser.yml
+++ b/.github/workflows/tests-new-parser.yml
@@ -20,7 +20,7 @@ jobs:
         run: bash integration/ci/setup.sh --with-toxi
       - name: Run tests with coverage
         env:
-          RUSTFLAGS: "-C link-dead-code"
+          RUSTFLAGS: "--cfg tokio_unstable -C link-dead-code"
         run: |
           cargo llvm-cov clean --workspace
           cargo llvm-cov nextest --lcov --output-path lcov.info --no-fail-fast --test-threads=1 --package pgdog --package pgdog-config --package pgdog-vector --package pgdog-stats --package pgdog-postgres-types --no-default-features --features new_parser --filter-expr "package(pgdog) | package(pgdog-config) | package(pgdog-vector) | package(pgdog-stats) | package(pgdog-postgres-types)"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
         run: bash integration/ci/setup.sh --with-toxi
       - name: Run tests with coverage
         env:
-          RUSTFLAGS: "-C link-dead-code"
+          RUSTFLAGS: "--cfg tokio_unstable -C link-dead-code"
         run: |
           cargo llvm-cov clean --workspace
           cargo llvm-cov nextest --lcov --output-path lcov.info --no-fail-fast --test-threads=1 --filter-expr "package(pgdog) | package(pgdog-config) | package(pgdog-vector) | package(pgdog-stats) | package(pgdog-postgres-types)"

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,6 @@ WORKDIR /build
 
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 RUN source ~/.cargo/env && \
-    if [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "arm64" ]; then \
-        export RUSTFLAGS="-Ctarget-feature=+lse"; \
-    fi && \
     cargo_features=(); \
     if [ -n "${FEATURES}" ]; then \
         cargo_features=(--no-default-features --features "${FEATURES}"); \

--- a/integration/complex/shutdown.sh
+++ b/integration/complex/shutdown.sh
@@ -12,7 +12,7 @@ pushd ${SCRIPT_DIR}
 python shutdown.py pgdog
 popd
 
-sleep 1
+sleep 3
 
 if pgrep pgdog; then
     echo "Shutdown failed"
@@ -26,7 +26,7 @@ pushd ${SCRIPT_DIR}
 python shutdown.py pgdog_sharded
 popd
 
-sleep 1
+sleep 3
 
 if pgrep pgdog; then
     echo "Shutdown failed"

--- a/integration/complex/shutdown.sh
+++ b/integration/complex/shutdown.sh
@@ -12,7 +12,7 @@ pushd ${SCRIPT_DIR}
 python shutdown.py pgdog
 popd
 
-sleep 3
+sleep 1
 
 if pgrep pgdog; then
     echo "Shutdown failed"
@@ -26,7 +26,7 @@ pushd ${SCRIPT_DIR}
 python shutdown.py pgdog_sharded
 popd
 
-sleep 3
+sleep 1
 
 if pgrep pgdog; then
     echo "Shutdown failed"

--- a/integration/pgdog.toml
+++ b/integration/pgdog.toml
@@ -26,6 +26,7 @@ reload_schema_on_ddl = false
 # idle_healthcheck_delay = 50000000
 unique_id_function = "standard"
 auth_type = "scram"
+workers = 4
 # log_dedup_window = 30_000
 # log_dedup_threshold =
 

--- a/pgdog/src/api/async_task.rs
+++ b/pgdog/src/api/async_task.rs
@@ -16,6 +16,8 @@ use tokio::time::timeout;
 use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, Span, error, info, info_span, warn};
 
+use crate::tasks;
+
 /// Represent the ID of the async task.
 #[derive(Copy, Clone, Debug, Display, FromStr, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct AsyncTaskId(u64);
@@ -379,12 +381,12 @@ fn run_task<P: Task, T: Task>(
         task: entry.clone(),
     };
 
-    let mut handle = tokio::spawn(task.run(ctx.clone()).instrument(span));
+    let mut handle = tasks::spawn(task.run(ctx.clone()).instrument(span));
     let (sender, receiver) = oneshot::channel();
 
     let cancellation_token = entry.cancellation_token.clone();
 
-    tokio::spawn(async move {
+    tasks::spawn(async move {
         let res = select! {
             _ = cancellation_token.cancelled() => {
                 ctx.transition(TaskStatus::Cancelling);

--- a/pgdog/src/api/async_task.rs
+++ b/pgdog/src/api/async_task.rs
@@ -381,12 +381,12 @@ fn run_task<P: Task, T: Task>(
         task: entry.clone(),
     };
 
-    let mut handle = tasks::spawn(task.run(ctx.clone()).instrument(span));
+    let mut handle = tasks::spawn("async task", task.run(ctx.clone()).instrument(span));
     let (sender, receiver) = oneshot::channel();
 
     let cancellation_token = entry.cancellation_token.clone();
 
-    tasks::spawn(async move {
+    tasks::spawn("async task_waiter", async move {
         let res = select! {
             _ = cancellation_token.cancelled() => {
                 ctx.transition(TaskStatus::Cancelling);

--- a/pgdog/src/api/async_task.rs
+++ b/pgdog/src/api/async_task.rs
@@ -386,7 +386,7 @@ fn run_task<P: Task, T: Task>(
 
     let cancellation_token = entry.cancellation_token.clone();
 
-    tasks::spawn("async task_waiter", async move {
+    tasks::spawn("async task waiter", async move {
         let res = select! {
             _ = cancellation_token.cancelled() => {
                 ctx.transition(TaskStatus::Cancelling);

--- a/pgdog/src/api/copy_data.rs
+++ b/pgdog/src/api/copy_data.rs
@@ -8,6 +8,8 @@ use crate::api::Task;
 use crate::api::async_task::{AsyncTaskContext, Empty};
 use crate::backend::replication::logical::Error;
 use crate::backend::replication::logical::orchestrator::Orchestrator;
+use crate::tasks;
+use tokio::select;
 
 /// Bulk-copy table data from a source database to a target, returning the
 /// orchestrator so the composing task can thread it into the next phase.
@@ -25,6 +27,7 @@ impl Task for CopyDataTask {
     async fn run(self, ctx: AsyncTaskContext<Self>) -> Result<Orchestrator, Error> {
         let token = ctx.cancellation_token();
         let orchestrator = self.orchestrator;
+        let shutdown = tasks::shutdown_signal();
 
         // Don't start a sync that's already cancelled. Once it's running, the
         // token is threaded into the copy workers, which abort their COPY loops
@@ -33,7 +36,10 @@ impl Task for CopyDataTask {
             return Err(Error::DataSyncAborted);
         }
 
-        orchestrator.data_sync(&token).await?;
+        select! {
+            _ = shutdown.cancelled() => return Ok(orchestrator),
+            res = orchestrator.data_sync(&token) => res?,
+        }
 
         Ok(orchestrator)
     }

--- a/pgdog/src/api/copy_data.rs
+++ b/pgdog/src/api/copy_data.rs
@@ -8,8 +8,6 @@ use crate::api::Task;
 use crate::api::async_task::{AsyncTaskContext, Empty};
 use crate::backend::replication::logical::Error;
 use crate::backend::replication::logical::orchestrator::Orchestrator;
-use crate::tasks;
-use tokio::select;
 
 /// Bulk-copy table data from a source database to a target, returning the
 /// orchestrator so the composing task can thread it into the next phase.
@@ -27,7 +25,6 @@ impl Task for CopyDataTask {
     async fn run(self, ctx: AsyncTaskContext<Self>) -> Result<Orchestrator, Error> {
         let token = ctx.cancellation_token();
         let orchestrator = self.orchestrator;
-        let shutdown = tasks::shutdown_signal();
 
         // Don't start a sync that's already cancelled. Once it's running, the
         // token is threaded into the copy workers, which abort their COPY loops
@@ -36,10 +33,7 @@ impl Task for CopyDataTask {
             return Err(Error::DataSyncAborted);
         }
 
-        select! {
-            _ = shutdown.cancelled() => return Ok(orchestrator),
-            res = orchestrator.data_sync(&token) => res?,
-        }
+        orchestrator.data_sync(&token).await?;
 
         Ok(orchestrator)
     }

--- a/pgdog/src/api/schema_sync.rs
+++ b/pgdog/src/api/schema_sync.rs
@@ -7,8 +7,6 @@ use crate::api::async_task::AsyncTaskContext;
 use crate::backend::replication::logical::Error;
 use crate::backend::replication::logical::orchestrator::Orchestrator;
 use crate::backend::schema::sync::pg_dump::SyncState;
-use crate::tasks;
-use tokio::select;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Display, FromStr)]
 pub enum SchemaSyncPhase {
@@ -66,44 +64,37 @@ impl Task for SchemaSyncTask {
 
     #[allow(clippy::print_stdout)]
     async fn run(self, ctx: AsyncTaskContext<Self>) -> Result<Orchestrator, Error> {
-        let shutdown = tasks::shutdown_signal();
         let mut orchestrator = self.orchestrator;
-        let shutdown_orchestrator = orchestrator.clone();
 
-        select! {
-            _ = shutdown.cancelled() => Ok(shutdown_orchestrator),
-            res = async {
-                if orchestrator.schema().is_err() {
-                    ctx.set_status(SchemaSyncStatus::LoadingSchema);
-                    orchestrator.load_schema().await?;
-                }
-
-                if self.dry_run {
-                    let schema = orchestrator.schema()?;
-                    for statement in schema.statements(self.phase.into())? {
-                        println!("{}", statement.deref());
-                    }
-                    return Ok(orchestrator);
-                }
-
-                match self.phase {
-                    SchemaSyncPhase::Pre => {
-                        ctx.set_status(SchemaSyncStatus::SyncingTables);
-                        orchestrator.schema_sync_pre(self.ignore_errors).await?;
-                    }
-                    SchemaSyncPhase::Post => {
-                        ctx.set_status(SchemaSyncStatus::CreatingIndexes);
-                        orchestrator.schema_sync_post(self.ignore_errors).await?;
-                    }
-                    SchemaSyncPhase::Cutover => {
-                        ctx.set_status(SchemaSyncStatus::Cutover);
-                        orchestrator.schema_sync_cutover(self.ignore_errors).await?;
-                    }
-                }
-
-                Ok(orchestrator)
-            } => res,
+        if orchestrator.schema().is_err() {
+            ctx.set_status(SchemaSyncStatus::LoadingSchema);
+            orchestrator.load_schema().await?;
         }
+
+        if self.dry_run {
+            let schema = orchestrator.schema()?;
+            for statement in schema.statements(self.phase.into())? {
+                println!("{}", statement.deref());
+            }
+            return Ok(orchestrator);
+        }
+
+        match self.phase {
+            SchemaSyncPhase::Pre => {
+                ctx.set_status(SchemaSyncStatus::SyncingTables);
+                orchestrator.schema_sync_pre(self.ignore_errors).await?;
+            }
+            SchemaSyncPhase::Post => {
+                ctx.set_status(SchemaSyncStatus::CreatingIndexes);
+                orchestrator.schema_sync_post(self.ignore_errors).await?;
+            }
+            SchemaSyncPhase::Cutover => {
+                ctx.set_status(SchemaSyncStatus::Cutover);
+                orchestrator.schema_sync_cutover(self.ignore_errors).await?;
+            }
+        }
+
+        Ok(orchestrator)
     }
 }
 

--- a/pgdog/src/api/schema_sync.rs
+++ b/pgdog/src/api/schema_sync.rs
@@ -7,6 +7,8 @@ use crate::api::async_task::AsyncTaskContext;
 use crate::backend::replication::logical::Error;
 use crate::backend::replication::logical::orchestrator::Orchestrator;
 use crate::backend::schema::sync::pg_dump::SyncState;
+use crate::tasks;
+use tokio::select;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Display, FromStr)]
 pub enum SchemaSyncPhase {
@@ -64,37 +66,44 @@ impl Task for SchemaSyncTask {
 
     #[allow(clippy::print_stdout)]
     async fn run(self, ctx: AsyncTaskContext<Self>) -> Result<Orchestrator, Error> {
+        let shutdown = tasks::shutdown_signal();
         let mut orchestrator = self.orchestrator;
+        let shutdown_orchestrator = orchestrator.clone();
 
-        if orchestrator.schema().is_err() {
-            ctx.set_status(SchemaSyncStatus::LoadingSchema);
-            orchestrator.load_schema().await?;
+        select! {
+            _ = shutdown.cancelled() => Ok(shutdown_orchestrator),
+            res = async {
+                if orchestrator.schema().is_err() {
+                    ctx.set_status(SchemaSyncStatus::LoadingSchema);
+                    orchestrator.load_schema().await?;
+                }
+
+                if self.dry_run {
+                    let schema = orchestrator.schema()?;
+                    for statement in schema.statements(self.phase.into())? {
+                        println!("{}", statement.deref());
+                    }
+                    return Ok(orchestrator);
+                }
+
+                match self.phase {
+                    SchemaSyncPhase::Pre => {
+                        ctx.set_status(SchemaSyncStatus::SyncingTables);
+                        orchestrator.schema_sync_pre(self.ignore_errors).await?;
+                    }
+                    SchemaSyncPhase::Post => {
+                        ctx.set_status(SchemaSyncStatus::CreatingIndexes);
+                        orchestrator.schema_sync_post(self.ignore_errors).await?;
+                    }
+                    SchemaSyncPhase::Cutover => {
+                        ctx.set_status(SchemaSyncStatus::Cutover);
+                        orchestrator.schema_sync_cutover(self.ignore_errors).await?;
+                    }
+                }
+
+                Ok(orchestrator)
+            } => res,
         }
-
-        if self.dry_run {
-            let schema = orchestrator.schema()?;
-            for statement in schema.statements(self.phase.into())? {
-                println!("{}", statement.deref());
-            }
-            return Ok(orchestrator);
-        }
-
-        match self.phase {
-            SchemaSyncPhase::Pre => {
-                ctx.set_status(SchemaSyncStatus::SyncingTables);
-                orchestrator.schema_sync_pre(self.ignore_errors).await?;
-            }
-            SchemaSyncPhase::Post => {
-                ctx.set_status(SchemaSyncStatus::CreatingIndexes);
-                orchestrator.schema_sync_post(self.ignore_errors).await?;
-            }
-            SchemaSyncPhase::Cutover => {
-                ctx.set_status(SchemaSyncStatus::Cutover);
-                orchestrator.schema_sync_cutover(self.ignore_errors).await?;
-            }
-        }
-
-        Ok(orchestrator)
     }
 }
 

--- a/pgdog/src/backend/pool/cluster.rs
+++ b/pgdog/src/backend/pool/cluster.rs
@@ -13,10 +13,10 @@ use std::{
     },
     time::Duration,
 };
-use tokio::spawn;
 use tracing::error;
 
 use crate::frontend::router::sharding::ShardedTable;
+use crate::tasks;
 use crate::{
     backend::{
         Schema, ShardedTables,
@@ -654,7 +654,7 @@ impl Cluster {
             let identifier = self.identifier();
             let shard = shard.clone();
 
-            spawn(async move {
+            tasks::spawn(async move {
                 use tokio::time::sleep;
 
                 loop {

--- a/pgdog/src/backend/pool/cluster.rs
+++ b/pgdog/src/backend/pool/cluster.rs
@@ -654,7 +654,7 @@ impl Cluster {
             let identifier = self.identifier();
             let shard = shard.clone();
 
-            tasks::spawn(async move {
+            tasks::spawn("cluster schema sync", async move {
                 use tokio::time::sleep;
 
                 loop {

--- a/pgdog/src/backend/pool/comms.rs
+++ b/pgdog/src/backend/pool/comms.rs
@@ -1,4 +1,5 @@
 use tokio::sync::Notify;
+use tokio_util::sync::CancellationToken;
 
 /// Internal pool notifications.
 pub(super) struct Comms {
@@ -8,7 +9,7 @@ pub(super) struct Comms {
     /// or waiting for one to be returned to the pool.
     pub(super) request: Notify,
     /// Pool is shutting down.
-    pub(super) shutdown: Notify,
+    pub(super) shutdown: CancellationToken,
 }
 
 impl Comms {
@@ -17,7 +18,7 @@ impl Comms {
         Self {
             ready: Notify::new(),
             request: Notify::new(),
-            shutdown: Notify::new(),
+            shutdown: CancellationToken::new(),
         }
     }
 }

--- a/pgdog/src/backend/pool/connection/mirror/mod.rs
+++ b/pgdog/src/backend/pool/connection/mirror/mod.rs
@@ -115,7 +115,7 @@ impl Mirror {
         let handler = MirrorHandler::new(tx, &mirror_config, cluster.stats());
 
         let stats_for_errors = cluster.stats();
-        tasks::spawn(async move {
+        tasks::spawn("mirror", async move {
             loop {
                 select! {
                     req = rx.recv() => {

--- a/pgdog/src/backend/pool/connection/mirror/mod.rs
+++ b/pgdog/src/backend/pool/connection/mirror/mod.rs
@@ -5,8 +5,8 @@ use std::time::Duration;
 use pgdog_config::MirroringLevel;
 use rand::{Rng, rng};
 use tokio::select;
+use tokio::sync::mpsc::*;
 use tokio::time::{Instant, sleep};
-use tokio::{spawn, sync::mpsc::*};
 use tracing::{debug, error, warn};
 
 use crate::backend::Cluster;
@@ -16,6 +16,7 @@ use crate::frontend::client::query_engine::{QueryEngine, QueryEngineContext};
 use crate::frontend::client::timeouts::Timeouts;
 use crate::frontend::{ClientComms, PreparedStatements};
 use crate::net::{FrontendPid, Parameter, Parameters, Stream};
+use crate::tasks;
 
 use super::Error;
 
@@ -114,7 +115,7 @@ impl Mirror {
         let handler = MirrorHandler::new(tx, &mirror_config, cluster.stats());
 
         let stats_for_errors = cluster.stats();
-        spawn(async move {
+        tasks::spawn(async move {
             loop {
                 select! {
                     req = rx.recv() => {

--- a/pgdog/src/backend/pool/lb/mod.rs
+++ b/pgdog/src/backend/pool/lb/mod.rs
@@ -12,7 +12,7 @@ use rand::seq::SliceRandom;
 use tokio::{sync::Notify, time::timeout};
 use tracing::warn;
 
-use crate::net::messages::FrontendPid;
+use crate::{config::config, net::messages::FrontendPid};
 use crate::{
     config::{LoadBalancingStrategy, ReadWriteSplit, Role},
     net::Parameters,
@@ -74,9 +74,8 @@ impl Target {
 pub struct LoadBalancer {
     /// Read/write targets.
     pub(super) targets: Vec<Target>,
-
+    /// Connection checkout timeout.
     checkout_timeout: Duration,
-
     /// Round robin atomic counter.
     pub(super) round_robin: Arc<AtomicUsize>,
     /// Chosen load balancing strategy.
@@ -104,7 +103,9 @@ impl LoadBalancer {
                 addrs
                     .first()
                     .map(|addr| addr.config.checkout_timeout)
-                    .unwrap_or(Duration::MAX),
+                    .unwrap_or(Duration::from_millis(
+                        config().config.general.checkout_timeout,
+                    )),
             );
 
         let mut targets: Vec<_> = addrs
@@ -309,7 +310,10 @@ impl LoadBalancer {
     /// callers will block until their `checkout_timeout` fires.
     async fn wait_roles_detected(&self) -> Result<(), Error> {
         if !self.roles_detected() {
-            if let Err(_) = timeout(self.checkout_timeout, self.role_detection.notified()).await {
+            if timeout(self.checkout_timeout, self.role_detection.notified())
+                .await
+                .is_err()
+            {
                 return Err(Error::CheckoutTimeout);
             };
             // Chain the wakeup so any other waiter that arrived after us

--- a/pgdog/src/backend/pool/lb/mod.rs
+++ b/pgdog/src/backend/pool/lb/mod.rs
@@ -74,8 +74,9 @@ impl Target {
 pub struct LoadBalancer {
     /// Read/write targets.
     pub(super) targets: Vec<Target>,
-    /// Checkout timeout.
-    pub(super) checkout_timeout: Duration,
+
+    checkout_timeout: Duration,
+
     /// Round robin atomic counter.
     pub(super) round_robin: Arc<AtomicUsize>,
     /// Chosen load balancing strategy.
@@ -98,12 +99,13 @@ impl LoadBalancer {
     ) -> LoadBalancer {
         let checkout_timeout = primary
             .as_ref()
-            .map(|primary| primary.config().checkout_timeout)
-            .unwrap_or(Duration::ZERO)
-            + addrs
-                .iter()
-                .map(|c| c.config.checkout_timeout)
-                .sum::<Duration>();
+            .map(|pool| pool.config().checkout_timeout)
+            .unwrap_or(
+                addrs
+                    .first()
+                    .map(|addr| addr.config.checkout_timeout)
+                    .unwrap_or(Duration::MAX),
+            );
 
         let mut targets: Vec<_> = addrs
             .iter()
@@ -214,11 +216,7 @@ impl LoadBalancer {
 
     /// Get a live connection from the pool.
     pub async fn get(&self, request: &Request) -> Result<Guard, Error> {
-        match timeout(self.checkout_timeout, self.get_internal(request)).await {
-            Ok(Ok(conn)) => Ok(conn),
-            Ok(Err(err)) => Err(err),
-            Err(_) => Err(Error::ReplicaCheckoutTimeout),
-        }
+        self.get_internal(request).await
     }
 
     /// Get parameters from first non-banned connection pool.
@@ -309,13 +307,17 @@ impl LoadBalancer {
     /// `Primary` or `Replica`. The wakeup is driven by `pick_primary`, so
     /// if no primary is ever elected (e.g. LSN stats never populate),
     /// callers will block until their `checkout_timeout` fires.
-    async fn wait_roles_detected(&self) {
+    async fn wait_roles_detected(&self) -> Result<(), Error> {
         if !self.roles_detected() {
-            self.role_detection.notified().await;
+            if let Err(_) = timeout(self.checkout_timeout, self.role_detection.notified()).await {
+                return Err(Error::CheckoutTimeout);
+            };
             // Chain the wakeup so any other waiter that arrived after us
             // also gets released without needing another promotion event.
             self.role_detection.notify_one();
         }
+
+        Ok(())
     }
 
     /// True once no target is still in the `Auto` state.
@@ -327,15 +329,11 @@ impl LoadBalancer {
     }
 
     pub(super) async fn get_primary(&self, request: &Request) -> Result<Guard, Error> {
-        match timeout(self.checkout_timeout, self.get_primary_internal(request)).await {
-            Ok(Ok(guard)) => Ok(guard),
-            Err(_) => Err(Error::CheckoutTimeout),
-            Ok(Err(err)) => Err(err),
-        }
+        self.get_primary_internal(request).await
     }
 
     async fn get_primary_internal(&self, request: &Request) -> Result<Guard, Error> {
-        self.wait_roles_detected().await;
+        self.wait_roles_detected().await?;
         self.primary_target()
             .ok_or(Error::NoPrimary)?
             .pool

--- a/pgdog/src/backend/pool/lb/monitor.rs
+++ b/pgdog/src/backend/pool/lb/monitor.rs
@@ -1,11 +1,11 @@
 use std::time::Instant;
 
-use crate::config::config;
+use crate::{config::config, tasks};
 
 use super::*;
 
 use pgdog_stats::ReplicaLag;
-use tokio::{select, spawn, task::JoinHandle, time::interval};
+use tokio::{select, task::JoinHandle, time::interval};
 use tracing::debug;
 
 static MAINTENANCE: Duration = Duration::from_millis(333);
@@ -22,7 +22,7 @@ impl Monitor {
             replicas: replicas.clone(),
         };
 
-        spawn(async move {
+        tasks::spawn(async move {
             monitor.run().await;
         })
     }

--- a/pgdog/src/backend/pool/lb/monitor.rs
+++ b/pgdog/src/backend/pool/lb/monitor.rs
@@ -22,7 +22,7 @@ impl Monitor {
             replicas: replicas.clone(),
         };
 
-        tasks::spawn(async move {
+        tasks::spawn("lb monitor", async move {
             monitor.run().await;
         })
     }

--- a/pgdog/src/backend/pool/lsn_monitor.rs
+++ b/pgdog/src/backend/pool/lsn_monitor.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use tokio::{
-    select, spawn,
+    select,
     time::{interval, sleep, timeout},
 };
 use tracing::{debug, error, trace};
@@ -12,6 +12,7 @@ use tracing::{debug, error, trace};
 use crate::{
     backend::{ConnectReason, Server},
     net::DataRow,
+    tasks,
 };
 
 use super::*;
@@ -134,7 +135,7 @@ impl LsnMonitor {
     pub(super) fn run(pool: &Pool) {
         let monitor = Self { pool: pool.clone() };
 
-        spawn(async move {
+        tasks::spawn(async move {
             monitor.spawn().await;
         });
     }

--- a/pgdog/src/backend/pool/lsn_monitor.rs
+++ b/pgdog/src/backend/pool/lsn_monitor.rs
@@ -135,7 +135,7 @@ impl LsnMonitor {
     pub(super) fn run(pool: &Pool) {
         let monitor = Self { pool: pool.clone() };
 
-        tasks::spawn(async move {
+        tasks::spawn("pool lsn monitor", async move {
             monitor.spawn().await;
         });
     }

--- a/pgdog/src/backend/pool/lsn_monitor.rs
+++ b/pgdog/src/backend/pool/lsn_monitor.rs
@@ -187,7 +187,7 @@ impl LsnMonitor {
     async fn spawn(&self) {
         select! {
             _ = sleep(self.pool.config().lsn_check_delay) => {},
-            _ = self.pool.comms().shutdown.notified() => { return; }
+            _ = self.pool.comms().shutdown.cancelled() => { return; }
         }
 
         debug!("lsn monitor loop is running [{}]", self.pool.addr());
@@ -198,7 +198,7 @@ impl LsnMonitor {
         loop {
             select! {
                 _ = interval.tick() => {},
-                _ = self.pool.comms().shutdown.notified() => { break; }
+                _ = self.pool.comms().shutdown.cancelled() => { break; }
             }
 
             match self.run_check(aurora_detected).await {

--- a/pgdog/src/backend/pool/monitor.rs
+++ b/pgdog/src/backend/pool/monitor.rs
@@ -74,7 +74,7 @@ impl Monitor {
     pub(super) fn run(pool: &Pool) {
         let monitor = Self { pool: pool.clone() };
 
-        tasks::spawn(async move {
+        tasks::spawn("pool monitor", async move {
             monitor.spawn().await;
         });
     }
@@ -85,9 +85,12 @@ impl Monitor {
 
         // Maintenance loop.
         let pool = self.pool.clone();
-        tasks::spawn(async move { Self::maintenance(pool).await });
+        tasks::spawn(
+            "pool maintenance",
+            async move { Self::maintenance(pool).await },
+        );
         let pool = self.pool.clone();
-        tasks::spawn(async move { Self::stats(pool).await });
+        tasks::spawn("pool stats", async move { Self::stats(pool).await });
 
         // Delay starting health checks to give
         // time for the pool to spin up.
@@ -103,7 +106,7 @@ impl Monitor {
         };
 
         if !replication_mode && interval > Duration::ZERO {
-            tasks::spawn(async move {
+            tasks::spawn("pool healthchecks", async move {
                 select! {
                     _ = sleep(delay) => {}
                     _ = pool.comms().shutdown.cancelled() => return,
@@ -116,7 +119,9 @@ impl Monitor {
         // Only spawned for pools that use an external identity provider.
         if self.pool.addr().server_auth.is_external_identity() {
             let pool = self.pool.clone();
-            tasks::spawn(async move { Self::token_refresh(pool).await });
+            tasks::spawn("pool token refresh", async move {
+                Self::token_refresh(pool).await
+            });
         }
 
         loop {

--- a/pgdog/src/backend/pool/monitor.rs
+++ b/pgdog/src/backend/pool/monitor.rs
@@ -106,7 +106,7 @@ impl Monitor {
             tasks::spawn(async move {
                 select! {
                     _ = sleep(delay) => {}
-                    _ = pool.comms().shutdown.notified() => return,
+                    _ = pool.comms().shutdown.cancelled() => return,
                 }
                 Self::healthchecks(pool).await
             });
@@ -163,7 +163,7 @@ impl Monitor {
                 }
 
                 // Pool is shutting down.
-                _ = comms.shutdown.notified() => {
+                _ = comms.shutdown.cancelled() => {
                     break;
                 }
             }
@@ -239,7 +239,7 @@ impl Monitor {
                     }
                 }
 
-                _ = comms.shutdown.notified() => break,
+                _ = comms.shutdown.cancelled() => break,
             }
         }
 
@@ -276,7 +276,7 @@ impl Monitor {
                 }
 
 
-                _ = comms.shutdown.notified() => break,
+                _ = comms.shutdown.cancelled() => break,
             }
         }
 
@@ -317,7 +317,7 @@ impl Monitor {
                     guard.close_old(now);
                 }
 
-                _ = comms.shutdown.notified() => break,
+                _ = comms.shutdown.cancelled() => break,
             }
         }
 
@@ -427,7 +427,7 @@ impl Monitor {
                     }
                 }
 
-                _ = comms.shutdown.notified() => {
+                _ = comms.shutdown.cancelled() => {
                     break;
                 }
             }

--- a/pgdog/src/backend/pool/monitor.rs
+++ b/pgdog/src/backend/pool/monitor.rs
@@ -51,9 +51,10 @@ use crate::backend::pool::inner::ShouldCreate;
 use crate::backend::pool::token_cache::TokenCache;
 use crate::backend::{ConnectReason, DisconnectReason, Server};
 use crate::config::ServerAuth;
+use crate::tasks;
 
+use tokio::select;
 use tokio::time::{Instant, interval, sleep, timeout};
-use tokio::{select, task::spawn};
 use tracing::{debug, error, info, warn};
 
 static MAINTENANCE: Duration = Duration::from_millis(333);
@@ -73,7 +74,7 @@ impl Monitor {
     pub(super) fn run(pool: &Pool) {
         let monitor = Self { pool: pool.clone() };
 
-        spawn(async move {
+        tasks::spawn(async move {
             monitor.spawn().await;
         });
     }
@@ -84,9 +85,9 @@ impl Monitor {
 
         // Maintenance loop.
         let pool = self.pool.clone();
-        spawn(async move { Self::maintenance(pool).await });
+        tasks::spawn(async move { Self::maintenance(pool).await });
         let pool = self.pool.clone();
-        spawn(async move { Self::stats(pool).await });
+        tasks::spawn(async move { Self::stats(pool).await });
 
         // Delay starting health checks to give
         // time for the pool to spin up.
@@ -102,8 +103,11 @@ impl Monitor {
         };
 
         if !replication_mode && interval > Duration::ZERO {
-            spawn(async move {
-                sleep(delay).await;
+            tasks::spawn(async move {
+                select! {
+                    _ = sleep(delay) => {}
+                    _ = pool.comms().shutdown.notified() => return,
+                }
                 Self::healthchecks(pool).await
             });
         }
@@ -112,7 +116,7 @@ impl Monitor {
         // Only spawned for pools that use an external identity provider.
         if self.pool.addr().server_auth.is_external_identity() {
             let pool = self.pool.clone();
-            spawn(async move { Self::token_refresh(pool).await });
+            tasks::spawn(async move { Self::token_refresh(pool).await });
         }
 
         loop {

--- a/pgdog/src/backend/pool/pool_impl.rs
+++ b/pgdog/src/backend/pool/pool_impl.rs
@@ -384,7 +384,7 @@ impl Pool {
         guard.online = false;
         guard.dump_idle();
         guard.close_waiters(Error::Offline);
-        self.comms().shutdown.notify_waiters();
+        self.comms().shutdown.cancel();
         self.comms().ready.notify_waiters();
     }
 

--- a/pgdog/src/backend/pool/shard/mod.rs
+++ b/pgdog/src/backend/pool/shard/mod.rs
@@ -4,8 +4,9 @@ use arc_swap::ArcSwap;
 use std::ops::Deref;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::OnceCell;
-use tokio::{select, sync::Notify};
+use tokio::select;
+use tokio::sync::{Notify, OnceCell};
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, info};
 
 use crate::backend::PubSubListener;
@@ -230,7 +231,7 @@ impl Shard {
 
     /// Shutdown every pool and maintenance task in this shard.
     pub fn shutdown(&self) {
-        self.comms.shutdown.notify_waiters();
+        self.comms.shutdown.cancel();
         self.shutdown_pub_sub();
         self.lb.shutdown();
     }
@@ -329,7 +330,7 @@ impl ShardInner {
         let primary = primary.as_ref().map(Pool::new);
         let lb = LoadBalancer::new(&primary, replicas, lb_strategy, rw_split);
         let comms = Arc::new(ShardComms {
-            shutdown: Notify::new(),
+            shutdown: CancellationToken::new(),
             lsn_check_interval,
         });
 

--- a/pgdog/src/backend/pool/shard/mod.rs
+++ b/pgdog/src/backend/pool/shard/mod.rs
@@ -5,7 +5,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::OnceCell;
-use tokio::{select, spawn, sync::Notify};
+use tokio::{select, sync::Notify};
 use tracing::{debug, info};
 
 use crate::backend::PubSubListener;

--- a/pgdog/src/backend/pool/shard/monitor.rs
+++ b/pgdog/src/backend/pool/shard/monitor.rs
@@ -41,7 +41,7 @@ impl ShardMonitor {
             shard: shard.clone(),
         };
 
-        tasks::spawn(async move { monitor.spawn().await });
+        tasks::spawn("shard monitor", async move { monitor.spawn().await });
     }
 }
 

--- a/pgdog/src/backend/pool/shard/monitor.rs
+++ b/pgdog/src/backend/pool/shard/monitor.rs
@@ -1,4 +1,7 @@
-use crate::backend::pool::lsn_monitor::{LsnStats, ReplicaLag};
+use crate::{
+    backend::pool::lsn_monitor::{LsnStats, ReplicaLag},
+    tasks,
+};
 
 use super::*;
 
@@ -37,7 +40,7 @@ impl ShardMonitor {
             shard: shard.clone(),
         };
 
-        spawn(async move { monitor.spawn().await });
+        tasks::spawn(async move { monitor.spawn().await });
     }
 }
 

--- a/pgdog/src/backend/pool/shard/monitor.rs
+++ b/pgdog/src/backend/pool/shard/monitor.rs
@@ -7,19 +7,20 @@ use super::*;
 
 use futures::stream::{FuturesUnordered, StreamExt};
 use tokio::time::interval;
+use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 /// Shard communication primitives.
 #[derive(Debug)]
 pub(super) struct ShardComms {
-    pub(super) shutdown: Notify,
+    pub(super) shutdown: CancellationToken,
     pub(super) lsn_check_interval: Duration,
 }
 
 impl Default for ShardComms {
     fn default() -> Self {
         Self {
-            shutdown: Notify::new(),
+            shutdown: CancellationToken::new(),
             lsn_check_interval: Duration::MAX,
         }
     }
@@ -82,7 +83,7 @@ impl ShardMonitor {
                 },
                 // Role change needs us to run this asap.
                 _ = role_changes.next() => {}
-                _ = self.shard.comms().shutdown.notified() => {
+                _ = self.shard.comms().shutdown.cancelled() => {
                     break;
                 },
             }

--- a/pgdog/src/backend/pub_sub/listener.rs
+++ b/pgdog/src/backend/pub_sub/listener.rs
@@ -188,7 +188,7 @@ impl PubSubListener {
         let channels = listener.channels.clone();
         let pool = listener.pool.clone();
         let comms = listener.comms.clone();
-        tasks::spawn(async move {
+        tasks::spawn("pub sub", async move {
             loop {
                 select! {
                     _ = comms.start.notified() => {}

--- a/pgdog/src/backend/pub_sub/listener.rs
+++ b/pgdog/src/backend/pub_sub/listener.rs
@@ -17,6 +17,7 @@ use tokio::{
     sync::{Notify, broadcast, mpsc},
     time::sleep,
 };
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info};
 
 use super::{Stats, StatsSnapshot, channel_size};
@@ -151,7 +152,7 @@ pub(crate) mod test_support {
 #[derive(Debug)]
 struct Comms {
     start: Notify,
-    shutdown: Notify,
+    shutdown: CancellationToken,
 }
 
 /// Notification listener.
@@ -179,7 +180,7 @@ impl PubSubListener {
             channels,
             comms: Arc::new(Comms {
                 start: Notify::new(),
-                shutdown: Notify::new(),
+                shutdown: CancellationToken::new(),
             }),
         };
 
@@ -189,10 +190,19 @@ impl PubSubListener {
         let comms = listener.comms.clone();
         tasks::spawn(async move {
             loop {
-                comms.start.notified().await;
+                select! {
+                    _ = comms.start.notified() => {}
+                    _ = comms.shutdown.cancelled() => {
+                        rx.close();
+                    }
+                }
+
+                if rx.is_closed() {
+                    break;
+                }
 
                 select! {
-                    _ = comms.shutdown.notified() => {
+                    _ = comms.shutdown.cancelled() => {
                         rx.close(); // Drain remaining messages.
                     }
 
@@ -203,7 +213,7 @@ impl PubSubListener {
                             // to avoid connection storms during incidents.
                             select! {
                                 _ = sleep(Duration::from_millis(config().config.general.connect_attempt_delay)) => {}
-                                _ = comms.shutdown.notified() => rx.close(),
+                                _ = comms.shutdown.cancelled() => rx.close(),
                             }
                         }
                     }
@@ -225,7 +235,7 @@ impl PubSubListener {
 
     /// Shutdown the listener.
     pub fn shutdown(&self) {
-        self.comms.shutdown.notify_one();
+        self.comms.shutdown.cancel();
     }
 
     /// Listen on a channel.
@@ -368,7 +378,7 @@ mod test {
                 channels: Arc::new(Mutex::new(HashMap::new())),
                 comms: Arc::new(Comms {
                     start: Notify::new(),
-                    shutdown: Notify::new(),
+                    shutdown: CancellationToken::new(),
                 }),
             },
             rx,

--- a/pgdog/src/backend/pub_sub/listener.rs
+++ b/pgdog/src/backend/pub_sub/listener.rs
@@ -13,7 +13,7 @@ use std::{
 use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 use tokio::{
-    select, spawn,
+    select,
     sync::{Notify, broadcast, mpsc},
     time::sleep,
 };
@@ -27,6 +27,7 @@ use crate::{
         FromBytes, FrontendPid, NotificationResponse, Parameter, Parameters, Protocol,
         ProtocolMessage, Query, ToBytes,
     },
+    tasks,
 };
 
 #[derive(Debug, Clone)]
@@ -186,7 +187,7 @@ impl PubSubListener {
         let channels = listener.channels.clone();
         let pool = listener.pool.clone();
         let comms = listener.comms.clone();
-        spawn(async move {
+        tasks::spawn(async move {
             loop {
                 comms.start.notified().await;
 
@@ -200,7 +201,10 @@ impl PubSubListener {
                             error!("pub/sub error: {} [{}]", err, pool.addr());
                             // Don't reconnect for another connect attempt delay
                             // to avoid connection storms during incidents.
-                            sleep(Duration::from_millis(config().config.general.connect_attempt_delay)).await;
+                            select! {
+                                _ = sleep(Duration::from_millis(config().config.general.connect_attempt_delay)) => {}
+                                _ = comms.shutdown.notified() => rx.close(),
+                            }
                         }
                     }
                 }

--- a/pgdog/src/backend/replication/logical/publisher/parallel_sync.rs
+++ b/pgdog/src/backend/replication/logical/publisher/parallel_sync.rs
@@ -5,7 +5,7 @@
 //!
 use std::sync::Arc;
 
-use tokio::{spawn, sync::Semaphore, task::JoinHandle, time::sleep};
+use tokio::{sync::Semaphore, task::JoinHandle, time::sleep};
 use tracing::{info, warn};
 
 use super::super::Error;
@@ -16,6 +16,7 @@ use crate::backend::{
 };
 use crate::frontend::client::query_engine::two_pc::Manager;
 use crate::net::messages::Protocol;
+use crate::tasks;
 use crate::util::escape_identifier;
 use futures::{StreamExt, stream::FuturesUnordered};
 use tokio_util::sync::CancellationToken;
@@ -31,7 +32,7 @@ struct ParallelSync {
 impl ParallelSync {
     // Run parallel sync.
     pub fn run(self) -> JoinHandle<Result<Table, Error>> {
-        spawn(async move {
+        tasks::spawn(async move {
             // Record copy in queue before waiting for permit.
             let tracker = TableCopy::new(&self.table.table.schema, &self.table.table.name);
 

--- a/pgdog/src/backend/replication/logical/publisher/parallel_sync.rs
+++ b/pgdog/src/backend/replication/logical/publisher/parallel_sync.rs
@@ -32,7 +32,7 @@ struct ParallelSync {
 impl ParallelSync {
     // Run parallel sync.
     pub fn run(self) -> JoinHandle<Result<Table, Error>> {
-        tasks::spawn(async move {
+        tasks::spawn("parallel sync", async move {
             // Record copy in queue before waiting for permit.
             let tracker = TableCopy::new(&self.table.table.schema, &self.table.table.name);
 

--- a/pgdog/src/backend/replication/logical/publisher/progress.rs
+++ b/pgdog/src/backend/replication/logical/publisher/progress.rs
@@ -2,12 +2,13 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicI64, AtomicUsize, Ordering};
 use std::time::Duration;
 
+use tokio::select;
 use tokio::sync::Notify;
 use tokio::time::sleep;
-use tokio::{select, spawn};
 use tracing::info;
 
 use crate::backend::replication::publisher::{Lsn, PublicationTable};
+use crate::tasks;
 
 #[derive(Debug)]
 struct Inner {
@@ -53,7 +54,7 @@ impl Progress {
 
         let notify = inner.clone();
 
-        spawn(async move {
+        tasks::spawn(async move {
             let mut prev = 0;
             let table = if let Some(ref table) = notify.table {
                 format!(" for table \"{}\".\"{}\"", table.schema, table.name)

--- a/pgdog/src/backend/replication/logical/publisher/progress.rs
+++ b/pgdog/src/backend/replication/logical/publisher/progress.rs
@@ -54,7 +54,7 @@ impl Progress {
 
         let notify = inner.clone();
 
-        tasks::spawn(async move {
+        tasks::spawn("logical publisher progress", async move {
             let mut prev = 0;
             let table = if let Some(ref table) = notify.table {
                 format!(" for table \"{}\".\"{}\"", table.schema, table.name)

--- a/pgdog/src/backend/replication/logical/publisher/publisher_impl.rs
+++ b/pgdog/src/backend/replication/logical/publisher/publisher_impl.rs
@@ -240,7 +240,7 @@ impl Publisher {
             let dest = dest.clone();
 
             // Replicate in parallel.
-            let handle = tasks::spawn(async move {
+            let handle = tasks::spawn("replication", async move {
                 slot.start_replication().await?;
                 let progress = Progress::new_stream();
                 let max_attempts = dest.resharding_replication_retry_max_attempts();
@@ -445,7 +445,7 @@ impl Publisher {
 
             let dest = dest.clone();
             let cancel = cancel.clone();
-            handles.push(tasks::spawn(async move {
+            handles.push(tasks::spawn("parallel sync manager", async move {
                 let manager = ParallelSyncManager::new(tables, replicas, dest)?;
                 let tables = manager.run(cancel).await?;
 

--- a/pgdog/src/backend/replication/logical/publisher/publisher_impl.rs
+++ b/pgdog/src/backend/replication/logical/publisher/publisher_impl.rs
@@ -8,7 +8,7 @@ use pgdog_config::QueryParserEngine;
 use tokio::task::JoinHandle;
 use tokio::time::{Instant, sleep};
 use tokio::try_join;
-use tokio::{select, spawn, time::interval};
+use tokio::{select, time::interval};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
@@ -25,6 +25,7 @@ use crate::backend::replication::{
 use crate::backend::{Cluster, pool::Request};
 use crate::config::Role;
 use crate::net::replication::ReplicationMeta;
+use crate::tasks;
 
 fn merge_table_lsns(
     tables: Vec<Table>,
@@ -239,7 +240,7 @@ impl Publisher {
             let dest = dest.clone();
 
             // Replicate in parallel.
-            let handle = spawn(async move {
+            let handle = tasks::spawn(async move {
                 slot.start_replication().await?;
                 let progress = Progress::new_stream();
                 let max_attempts = dest.resharding_replication_retry_max_attempts();
@@ -444,7 +445,7 @@ impl Publisher {
 
             let dest = dest.clone();
             let cancel = cancel.clone();
-            handles.push(spawn(async move {
+            handles.push(tasks::spawn(async move {
                 let manager = ParallelSyncManager::new(tables, replicas, dest)?;
                 let tables = manager.run(cancel).await?;
 

--- a/pgdog/src/backend/schema/sync/progress.rs
+++ b/pgdog/src/backend/schema/sync/progress.rs
@@ -1,8 +1,10 @@
 use std::fmt::Display;
+use tokio::select;
 use tokio::sync::mpsc;
 use tokio::time::Instant;
-use tokio::{select, spawn};
 use tracing::info;
+
+use crate::tasks;
 
 use super::Statement;
 
@@ -129,7 +131,7 @@ impl Progress {
         let (tx, rx) = mpsc::unbounded_channel();
         let timer = Instant::now();
 
-        spawn(async move {
+        tasks::spawn(async move {
             Self::listen(rx, total).await;
         });
 

--- a/pgdog/src/backend/schema/sync/progress.rs
+++ b/pgdog/src/backend/schema/sync/progress.rs
@@ -131,7 +131,7 @@ impl Progress {
         let (tx, rx) = mpsc::unbounded_channel();
         let timer = Instant::now();
 
-        tasks::spawn(async move {
+        tasks::spawn("schema sync progress", async move {
             Self::listen(rx, total).await;
         });
 

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 
 use pgdog_config::users::PasswordKind;
 use timeouts::Timeouts;
-use tokio::{select, spawn, time::timeout};
+use tokio::{select, spawn};
 use tracing::{Level as LogLevel, debug, enabled, error, info, trace, warn};
 
 use super::{ClientRequest, Error, PreparedStatements};
@@ -32,7 +32,7 @@ use crate::net::messages::{
 use crate::net::{MessageBuffer, ProtocolMessage, Stream, parameter::Parameters};
 use crate::state::State;
 use crate::stats::memory::MemoryUsage;
-use crate::util::user_database_from_params;
+use crate::util::{safe_timeout, user_database_from_params};
 
 pub mod query_engine;
 pub mod sticky;
@@ -118,7 +118,7 @@ impl Client {
     ) -> Result<(), Error> {
         let login_timeout = Duration::from_millis(config.config.general.client_login_timeout);
 
-        match timeout(
+        match safe_timeout(
             login_timeout,
             Self::login(stream, params, addr, config, protocol_version),
         )
@@ -608,7 +608,7 @@ impl Client {
                 .client_idle_timeout(&state, &self.client_request);
 
             let message =
-                match timeout(idle_timeout, self.stream_buffer.read(&mut self.stream)).await {
+                match safe_timeout(idle_timeout, self.stream_buffer.read(&mut self.stream)).await {
                     Err(_) => {
                         self.stream
                             .fatal(ErrorResponse::client_idle_timeout(idle_timeout, &state))

--- a/pgdog/src/frontend/client/query_engine/connect.rs
+++ b/pgdog/src/frontend/client/query_engine/connect.rs
@@ -1,6 +1,5 @@
-use tokio::time::timeout;
-
 use crate::frontend::router::parser::{ShardWithPriority, route::ShardSource};
+use crate::util::safe_timeout;
 
 use super::*;
 
@@ -44,7 +43,7 @@ impl QueryEngine {
                 let begin_stmt = self.begin_stmt.take();
 
                 // We may need to sync params with the server and that reads from the socket.
-                timeout(
+                safe_timeout(
                     query_timeout,
                     self.backend.link_client(
                         context.id,

--- a/pgdog/src/frontend/client/query_engine/query.rs
+++ b/pgdog/src/frontend/client/query_engine/query.rs
@@ -1,4 +1,3 @@
-use tokio::time::timeout;
 use tracing::{info, trace};
 
 use crate::{
@@ -11,6 +10,7 @@ use crate::{
         RowDescription, ToBytes, TransactionState,
     },
     state::State,
+    util::safe_timeout,
 };
 
 use tracing::{debug, error};
@@ -58,7 +58,7 @@ impl QueryEngine {
             }
         }
 
-        match timeout(
+        match safe_timeout(
             context.timeouts.query_timeout(&State::Active),
             self.client_server_exchange(context),
         )

--- a/pgdog/src/frontend/client/query_engine/route_query.rs
+++ b/pgdog/src/frontend/client/query_engine/route_query.rs
@@ -1,8 +1,8 @@
 use pgdog_config::PoolerMode;
-use tokio::time::timeout;
 use tracing::trace;
 
 use crate::backend::Cluster;
+use crate::util::safe_timeout;
 
 use super::*;
 
@@ -53,7 +53,7 @@ impl QueryEngine {
             // Make sure schema is loaded before we throw traffic
             // at it. This matters for sharded deployments only.
             if let Ok(cluster) = self.backend.cluster() {
-                timeout(
+                safe_timeout(
                     context.timeouts.query_timeout(&State::Active),
                     cluster.wait_schema_loaded(),
                 )

--- a/pgdog/src/frontend/client/query_engine/two_pc/manager.rs
+++ b/pgdog/src/frontend/client/query_engine/two_pc/manager.rs
@@ -75,7 +75,7 @@ impl Manager {
         };
 
         let monitor = manager.clone();
-        tasks::spawn(async move {
+        tasks::spawn("2pc monitor", async move {
             Self::monitor(monitor).await;
         });
 
@@ -93,7 +93,7 @@ impl Manager {
             Ok(wal) => {
                 self.wal.store(Some(Arc::new(wal)));
                 info!("[2pc] wal enabled");
-                tasks::spawn(Self::checkpoint_loop());
+                tasks::spawn("2pc wal", Self::checkpoint_loop());
             }
             Err(err) => {
                 warn!(

--- a/pgdog/src/frontend/client/query_engine/two_pc/manager.rs
+++ b/pgdog/src/frontend/client/query_engine/two_pc/manager.rs
@@ -13,7 +13,7 @@ use std::{
     time::Duration,
 };
 use tokio::{
-    select, spawn,
+    select,
     sync::Notify,
     time::{Instant, interval, sleep},
 };
@@ -35,6 +35,7 @@ use crate::{
             parser::{Shard, ShardWithPriority},
         },
     },
+    tasks,
 };
 
 use super::Error;
@@ -66,6 +67,7 @@ impl Manager {
             notify: Arc::new(InnerNotify {
                 notify: Notify::new(),
                 offline: AtomicBool::new(false),
+                done_flag: AtomicBool::new(false),
                 done: Notify::new(),
             }),
             wal: Arc::new(ArcSwapOption::const_empty()),
@@ -73,7 +75,7 @@ impl Manager {
         };
 
         let monitor = manager.clone();
-        spawn(async move {
+        tasks::spawn(async move {
             Self::monitor(monitor).await;
         });
 
@@ -91,7 +93,7 @@ impl Manager {
             Ok(wal) => {
                 self.wal.store(Some(Arc::new(wal)));
                 info!("[2pc] wal enabled");
-                spawn(Self::checkpoint_loop());
+                tasks::spawn(Self::checkpoint_loop());
             }
             Err(err) => {
                 warn!(
@@ -326,6 +328,7 @@ impl Manager {
                 notify.notify.notify_one();
             } else if notify.offline.load(Ordering::Relaxed) {
                 // No more transactions to cleanup.
+                notify.done_flag.store(true, Ordering::Relaxed);
                 notify.done.notify_waiters();
                 break;
             }
@@ -386,8 +389,13 @@ impl Manager {
     /// Once the monitor has drained the cleanup queue, the WAL is shut
     /// down too so any final End records make it to disk before exit.
     pub async fn shutdown(&self) {
+        if self.notify.done_flag.load(Ordering::Relaxed) {
+            return;
+        }
+
         let waiter = self.notify.done.notified();
         self.notify.offline.store(true, Ordering::Relaxed);
+        self.notify.notify.notify_one();
         let transactions = self.inner.lock().queue.len();
 
         info!("cleaning up {} two-phase transactions", transactions);
@@ -416,5 +424,6 @@ struct Inner {
 struct InnerNotify {
     notify: Notify,
     offline: AtomicBool,
+    done_flag: AtomicBool,
     done: Notify,
 }

--- a/pgdog/src/frontend/client/query_engine/two_pc/wal/writer.rs
+++ b/pgdog/src/frontend/client/query_engine/two_pc/wal/writer.rs
@@ -159,7 +159,7 @@ impl Wal {
         let (tx, rx) = mpsc::channel::<WriteRequest>(CHANNEL_CAPACITY);
         let shutdown = Arc::new(WalShutdown::default());
 
-        tasks::spawn({
+        tasks::spawn("2pc wal writer", {
             let shutdown = Arc::clone(&shutdown);
 
             async move {
@@ -331,7 +331,7 @@ async fn run(
                 // the previous one before starting.
                 let prev = gc_handle.take();
                 let wal_dir = wal_dir.clone();
-                gc_handle = Some(tasks::spawn(async move {
+                gc_handle = Some(tasks::spawn("2pc wal gc", async move {
                     if let Some(prev) = prev {
                         let _ = prev.await;
                     }

--- a/pgdog/src/frontend/client/query_engine/two_pc/wal/writer.rs
+++ b/pgdog/src/frontend/client/query_engine/two_pc/wal/writer.rs
@@ -37,8 +37,8 @@ use super::error::Error;
 use super::record::{BeginPayload, CheckpointEntry, CheckpointPayload, Record, TxnPayload};
 use super::recovery;
 use super::segment::{Segment, gc_before_lsn};
-use crate::config::config;
 use crate::frontend::client::query_engine::two_pc::{Manager, TwoPcTransaction};
+use crate::{config::config, tasks};
 
 /// Acquire an exclusive flock on `<dir>/.lock` and stamp it with our
 /// PID + start time. Returns the locked `File`; dropping it releases
@@ -159,7 +159,7 @@ impl Wal {
         let (tx, rx) = mpsc::channel::<WriteRequest>(CHANNEL_CAPACITY);
         let shutdown = Arc::new(WalShutdown::default());
 
-        tokio::spawn({
+        tasks::spawn({
             let shutdown = Arc::clone(&shutdown);
 
             async move {
@@ -331,7 +331,7 @@ async fn run(
                 // the previous one before starting.
                 let prev = gc_handle.take();
                 let wal_dir = wal_dir.clone();
-                gc_handle = Some(tokio::spawn(async move {
+                gc_handle = Some(tasks::spawn(async move {
                     if let Some(prev) = prev {
                         let _ = prev.await;
                     }

--- a/pgdog/src/frontend/prepared_statements/mod.rs
+++ b/pgdog/src/frontend/prepared_statements/mod.rs
@@ -177,7 +177,7 @@ pub fn start_maintenance() {
         loop {
             tokio::select! {
                 _ = sleep(Duration::from_secs(1)) => {}
-                _ = shutdown.notified() => break,
+                _ = shutdown.cancelled() => break,
             }
             run_maintenance();
         }

--- a/pgdog/src/frontend/prepared_statements/mod.rs
+++ b/pgdog/src/frontend/prepared_statements/mod.rs
@@ -171,7 +171,7 @@ impl PreparedStatements {
 /// Run prepared statements maintenance task
 /// every second.
 pub fn start_maintenance() {
-    crate::tasks::spawn(async move {
+    crate::tasks::spawn("prepared statements cache", async move {
         debug!("prepared statements cache maintenance started");
         let shutdown = crate::tasks::shutdown_signal();
         loop {

--- a/pgdog/src/frontend/prepared_statements/mod.rs
+++ b/pgdog/src/frontend/prepared_statements/mod.rs
@@ -4,7 +4,7 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use once_cell::sync::Lazy;
 use parking_lot::RwLock;
-use tokio::{spawn, time::sleep};
+use tokio::time::sleep;
 use tracing::debug;
 
 use crate::{
@@ -171,10 +171,14 @@ impl PreparedStatements {
 /// Run prepared statements maintenance task
 /// every second.
 pub fn start_maintenance() {
-    spawn(async move {
+    crate::tasks::spawn(async move {
         debug!("prepared statements cache maintenance started");
+        let shutdown = crate::tasks::shutdown_signal();
         loop {
-            sleep(Duration::from_secs(1)).await;
+            tokio::select! {
+                _ = sleep(Duration::from_secs(1)) => {}
+                _ = shutdown.notified() => break,
+            }
             run_maintenance();
         }
     });

--- a/pgdog/src/healthcheck.rs
+++ b/pgdog/src/healthcheck.rs
@@ -26,13 +26,18 @@ pub async fn server(port: u16) -> std::io::Result<()> {
             _ = shutdown.cancelled() => break,
         };
         let io = TokioIo::new(stream);
+        let shutdown = shutdown.clone();
 
         tasks::spawn("http healthcheck", async move {
-            if let Err(err) = http1::Builder::new()
-                .serve_connection(io, service_fn(healthcheck))
-                .await
-            {
-                eprintln!("Healthcheck endpoint error: {:?}", err);
+            let connection = http1::Builder::new().serve_connection(io, service_fn(healthcheck));
+
+            tokio::select! {
+                result = connection => {
+                    if let Err(err) = result {
+                        eprintln!("Healthcheck endpoint error: {:?}", err);
+                    }
+                }
+                _ = shutdown.cancelled() => {}
             }
         });
     }

--- a/pgdog/src/healthcheck.rs
+++ b/pgdog/src/healthcheck.rs
@@ -8,20 +8,26 @@ use hyper::service::service_fn;
 use hyper::{Request, Response};
 use hyper_util::rt::TokioIo;
 use tokio::net::TcpListener;
+use tokio::select;
 use tracing::info;
 
 use crate::backend::databases::{Databases, databases};
+use crate::tasks;
 
 pub async fn server(port: u16) -> std::io::Result<()> {
     info!("healthcheck endpoint http://0.0.0.0:{}", port);
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
     let listener = TcpListener::bind(addr).await?;
+    let shutdown = tasks::shutdown_signal();
 
     loop {
-        let (stream, _) = listener.accept().await?;
+        let (stream, _) = select! {
+            result = listener.accept() => result?,
+            _ = shutdown.notified() => break,
+        };
         let io = TokioIo::new(stream);
 
-        tokio::task::spawn(async move {
+        tasks::spawn(async move {
             if let Err(err) = http1::Builder::new()
                 .serve_connection(io, service_fn(healthcheck))
                 .await
@@ -30,6 +36,8 @@ pub async fn server(port: u16) -> std::io::Result<()> {
             }
         });
     }
+
+    Ok(())
 }
 
 async fn healthcheck(

--- a/pgdog/src/healthcheck.rs
+++ b/pgdog/src/healthcheck.rs
@@ -27,7 +27,7 @@ pub async fn server(port: u16) -> std::io::Result<()> {
         };
         let io = TokioIo::new(stream);
 
-        tasks::spawn(async move {
+        tasks::spawn("http healthcheck", async move {
             if let Err(err) = http1::Builder::new()
                 .serve_connection(io, service_fn(healthcheck))
                 .await

--- a/pgdog/src/healthcheck.rs
+++ b/pgdog/src/healthcheck.rs
@@ -23,7 +23,7 @@ pub async fn server(port: u16) -> std::io::Result<()> {
     loop {
         let (stream, _) = select! {
             result = listener.accept() => result?,
-            _ = shutdown.notified() => break,
+            _ = shutdown.cancelled() => break,
         };
         let io = TokioIo::new(stream);
 

--- a/pgdog/src/lib.rs
+++ b/pgdog/src/lib.rs
@@ -18,6 +18,7 @@ pub mod plugin;
 pub mod sighup;
 pub mod state;
 pub mod stats;
+pub mod tasks;
 #[cfg(test)]
 pub mod test_utils;
 #[cfg(feature = "tui")]

--- a/pgdog/src/main.rs
+++ b/pgdog/src/main.rs
@@ -101,6 +101,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     runtime.block_on(async move { pgdog(args.command).await })?;
 
+    databases::shutdown();
+
     Ok(())
 }
 
@@ -193,19 +195,34 @@ async fn pgdog(command: Option<Commands>) -> Result<(), Box<dyn std::error::Erro
 
             if let Commands::Setup { database } = command {
                 info!("🔄 entering setup mode");
-                cli::setup(database).await?;
+                let result = cli::setup(database).await;
+
+                Manager::get().shutdown().await;
+                databases::shutdown();
+
+                result?;
             }
 
             if let Commands::ReplicateAndCutover { .. } = command {
                 info!("🔄 entering test mode");
-                cli::replicate_and_cutover(command.clone()).await?;
+                let result = cli::replicate_and_cutover(command.clone()).await;
+
+                Manager::get().shutdown().await;
+                databases::shutdown();
+
+                result?;
             }
 
-            if let Commands::Route { .. } = command
-                && let Err(err) = cli::route(command.clone()).await
-            {
-                error!("{}", err);
-                return Err(err);
+            if let Commands::Route { .. } = command {
+                let result = cli::route(command.clone()).await;
+
+                Manager::get().shutdown().await;
+                databases::shutdown();
+
+                if let Err(err) = result {
+                    error!("{}", err);
+                    return Err(err);
+                }
             }
         }
     }

--- a/pgdog/src/main.rs
+++ b/pgdog/src/main.rs
@@ -200,10 +200,10 @@ async fn pgdog(command: Option<Commands>) -> Result<(), Box<dyn std::error::Erro
     info!("🐕 PgDog is shutting down");
     stats_logger.shutdown();
     Manager::get().shutdown().await;
+    pgdog::tasks::shutdown().await;
 
     // Any shutdown routines go below.
     plugin::shutdown();
-    pgdog::tasks::shutdown().await;
 
     Ok(())
 }

--- a/pgdog/src/main.rs
+++ b/pgdog/src/main.rs
@@ -126,15 +126,19 @@ async fn pgdog(command: Option<Commands>) -> Result<(), Box<dyn std::error::Erro
     }
 
     if let Some(openmetrics_port) = general.openmetrics_port {
-        pgdog::tasks::spawn(async move { stats::http_server::server(openmetrics_port).await });
+        pgdog::tasks::spawn("openmetrics server", async move {
+            stats::http_server::server(openmetrics_port).await
+        });
     }
 
     if config::config().config.otel.endpoint.is_some() {
-        pgdog::tasks::spawn(stats::otel_exporter::run());
+        pgdog::tasks::spawn("otel publisher", stats::otel_exporter::run());
     }
 
     if let Some(healthcheck_port) = general.healthcheck_port {
-        pgdog::tasks::spawn(async move { healthcheck::server(healthcheck_port).await });
+        pgdog::tasks::spawn("http healthcheck server", async move {
+            healthcheck::server(healthcheck_port).await
+        });
     }
 
     let stats_logger = stats::StatsLogger::new();
@@ -169,6 +173,8 @@ async fn pgdog(command: Option<Commands>) -> Result<(), Box<dyn std::error::Erro
                 // Wait for the 2PC monitor to drain any in-flight cleanup
                 // before the process exits, even on error.
                 Manager::get().shutdown().await;
+                databases::shutdown();
+
                 if let Err(err) = result {
                     error!("{}", err);
                     return Err(err);
@@ -177,7 +183,14 @@ async fn pgdog(command: Option<Commands>) -> Result<(), Box<dyn std::error::Erro
 
             if let Commands::SchemaSync { .. } = command {
                 info!("🔄 entering schema sync mode");
-                if let Err(err) = cli::schema_sync(command.clone()).await {
+                let result = cli::schema_sync(command.clone()).await;
+
+                // Wait for the 2PC monitor to drain any in-flight cleanup
+                // before the process exits, even on error.
+                Manager::get().shutdown().await;
+                databases::shutdown();
+
+                if let Err(err) = result {
                     error!("{}", err);
                     return Err(err);
                 }
@@ -203,8 +216,8 @@ async fn pgdog(command: Option<Commands>) -> Result<(), Box<dyn std::error::Erro
     }
 
     stats_logger.shutdown();
-    Manager::get().shutdown().await;
     pgdog::tasks::shutdown().await;
+    println!("tasks shutdown");
 
     // Any shutdown routines go below.
     plugin::shutdown();

--- a/pgdog/src/main.rs
+++ b/pgdog/src/main.rs
@@ -214,6 +214,7 @@ fn build_runtime(workers: usize, stack_size: usize) -> std::io::Result<tokio::ru
             .build(),
         workers => Builder::new_multi_thread()
             .worker_threads(workers)
+            .enable_alt_timer()
             .enable_all()
             .thread_stack_size(stack_size)
             .build(),

--- a/pgdog/src/main.rs
+++ b/pgdog/src/main.rs
@@ -101,12 +101,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     runtime.block_on(async move { pgdog(args.command).await })?;
 
-    // FIXME(lev): The runtime won't shut down rn
-    // because of some stuck background tasks
-    // and enable_alt_timer. The regular timer doesn't care
-    // if we leave stuff behind, but the thread-local one blocks
-    // until all tasks are done.
-    std::process::exit(0);
+    Ok(())
 }
 
 async fn pgdog(command: Option<Commands>) -> Result<(), Box<dyn std::error::Error>> {

--- a/pgdog/src/main.rs
+++ b/pgdog/src/main.rs
@@ -100,9 +100,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     runtime.block_on(async move { pgdog(args.command).await })?;
-    runtime.shutdown_background();
 
-    Ok(())
+    // FIXME(lev): The runtime won't shut down rn
+    // because of some stuck background tasks
+    // and enable_alt_timer. The regular timer doesn't care
+    // if we leave stuff behind, but the thread-local one blocks
+    // until all tasks are done.
+    std::process::exit(0);
 }
 
 async fn pgdog(command: Option<Commands>) -> Result<(), Box<dyn std::error::Error>> {
@@ -198,13 +202,14 @@ async fn pgdog(command: Option<Commands>) -> Result<(), Box<dyn std::error::Erro
         }
     }
 
-    info!("🐕 PgDog is shutting down");
     stats_logger.shutdown();
     Manager::get().shutdown().await;
     pgdog::tasks::shutdown().await;
 
     // Any shutdown routines go below.
     plugin::shutdown();
+
+    info!("🐕 PgDog is shutting down");
 
     Ok(())
 }

--- a/pgdog/src/main.rs
+++ b/pgdog/src/main.rs
@@ -101,8 +101,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     runtime.block_on(async move { pgdog(args.command).await })?;
 
-    databases::shutdown();
-
     Ok(())
 }
 

--- a/pgdog/src/main.rs
+++ b/pgdog/src/main.rs
@@ -247,6 +247,7 @@ fn build_runtime(workers: usize, stack_size: usize) -> std::io::Result<tokio::ru
             builder.worker_threads(workers);
 
             if workers > 2 {
+                info!("🚀 using alternative Tokio timer");
                 builder.enable_alt_timer();
             }
 

--- a/pgdog/src/main.rs
+++ b/pgdog/src/main.rs
@@ -244,12 +244,16 @@ fn build_runtime(workers: usize, stack_size: usize) -> std::io::Result<tokio::ru
             .enable_all()
             .thread_stack_size(stack_size)
             .build(),
-        workers => Builder::new_multi_thread()
-            .worker_threads(workers)
-            .enable_alt_timer()
-            .enable_all()
-            .thread_stack_size(stack_size)
-            .build(),
+        workers => {
+            let mut builder = Builder::new_multi_thread();
+            builder.worker_threads(workers);
+
+            if workers > 2 {
+                builder.enable_alt_timer();
+            }
+
+            builder.enable_all().thread_stack_size(stack_size).build()
+        }
     }
 }
 

--- a/pgdog/src/main.rs
+++ b/pgdog/src/main.rs
@@ -121,15 +121,15 @@ async fn pgdog(command: Option<Commands>) -> Result<(), Box<dyn std::error::Erro
     }
 
     if let Some(openmetrics_port) = general.openmetrics_port {
-        tokio::spawn(async move { stats::http_server::server(openmetrics_port).await });
+        pgdog::tasks::spawn(async move { stats::http_server::server(openmetrics_port).await });
     }
 
     if config::config().config.otel.endpoint.is_some() {
-        tokio::spawn(stats::otel_exporter::run());
+        pgdog::tasks::spawn(stats::otel_exporter::run());
     }
 
     if let Some(healthcheck_port) = general.healthcheck_port {
-        tokio::spawn(async move { healthcheck::server(healthcheck_port).await });
+        pgdog::tasks::spawn(async move { healthcheck::server(healthcheck_port).await });
     }
 
     let stats_logger = stats::StatsLogger::new();
@@ -199,9 +199,11 @@ async fn pgdog(command: Option<Commands>) -> Result<(), Box<dyn std::error::Erro
 
     info!("🐕 PgDog is shutting down");
     stats_logger.shutdown();
+    Manager::get().shutdown().await;
 
     // Any shutdown routines go below.
     plugin::shutdown();
+    pgdog::tasks::shutdown().await;
 
     Ok(())
 }

--- a/pgdog/src/main.rs
+++ b/pgdog/src/main.rs
@@ -212,7 +212,6 @@ async fn pgdog(command: Option<Commands>) -> Result<(), Box<dyn std::error::Erro
 
     stats_logger.shutdown();
     pgdog::tasks::shutdown().await;
-    println!("tasks shutdown");
 
     // Any shutdown routines go below.
     plugin::shutdown();

--- a/pgdog/src/main.rs
+++ b/pgdog/src/main.rs
@@ -100,6 +100,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     runtime.block_on(async move { pgdog(args.command).await })?;
+    runtime.shutdown_background();
 
     Ok(())
 }

--- a/pgdog/src/net/discovery/listener.rs
+++ b/pgdog/src/net/discovery/listener.rs
@@ -11,10 +11,11 @@ use std::sync::Arc;
 use std::time::SystemTime;
 
 use tokio::net::UdpSocket;
+use tokio::select;
 use tokio::time::{Duration, interval};
-use tokio::{select, spawn};
 
 use super::{Error, Message, Payload};
+use crate::tasks;
 
 /// Service discovery listener.
 #[derive(Clone, Debug)]
@@ -63,7 +64,7 @@ impl Listener {
     pub fn run(&self, address: Ipv4Addr, port: u16) {
         let listener = self.clone();
         info!("launching service discovery ({}:{})", address, port);
-        spawn(async move {
+        tasks::spawn(async move {
             if let Err(err) = listener.spawn(address, port).await {
                 error!("crashed: {:?}", err);
             }
@@ -78,9 +79,11 @@ impl Listener {
 
         let mut buf = vec![0u8; 1024];
         let mut interval = interval(Duration::from_secs(1));
+        let shutdown = tasks::shutdown_signal();
 
         loop {
             select! {
+                _ = shutdown.notified() => return Ok(self.clone()),
                 result = socket.recv_from(&mut buf) => {
                     let (len, addr) = result?;
                     let message = Message::from_bytes(&buf[..len]).ok();

--- a/pgdog/src/net/discovery/listener.rs
+++ b/pgdog/src/net/discovery/listener.rs
@@ -83,7 +83,7 @@ impl Listener {
 
         loop {
             select! {
-                _ = shutdown.notified() => return Ok(self.clone()),
+                _ = shutdown.cancelled() => return Ok(self.clone()),
                 result = socket.recv_from(&mut buf) => {
                     let (len, addr) = result?;
                     let message = Message::from_bytes(&buf[..len]).ok();

--- a/pgdog/src/net/discovery/listener.rs
+++ b/pgdog/src/net/discovery/listener.rs
@@ -64,7 +64,7 @@ impl Listener {
     pub fn run(&self, address: Ipv4Addr, port: u16) {
         let listener = self.clone();
         info!("launching service discovery ({}:{})", address, port);
-        tasks::spawn(async move {
+        tasks::spawn("service discovery", async move {
             if let Err(err) = listener.spawn(address, port).await {
                 error!("crashed: {:?}", err);
             }

--- a/pgdog/src/stats/http_server.rs
+++ b/pgdog/src/stats/http_server.rs
@@ -8,9 +8,11 @@ use hyper::service::service_fn;
 use hyper::{Request, Response};
 use hyper_util::rt::TokioIo;
 use tokio::net::TcpListener;
+use tokio::select;
 use tracing::{info, warn};
 
 use super::{Clients, Listeners, MirrorStatsMetrics, Pools, QueryCache, TwoPc};
+use crate::tasks;
 
 async fn metrics(_: Request<hyper::body::Incoming>) -> Result<Response<Full<Bytes>>, Infallible> {
     let clients = Clients::load();
@@ -58,12 +60,16 @@ pub async fn server(port: u16) -> std::io::Result<()> {
     info!("OpenMetrics endpoint http://0.0.0.0:{}", port);
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
     let listener = TcpListener::bind(addr).await?;
+    let shutdown = tasks::shutdown_signal();
 
     loop {
-        let (stream, _) = listener.accept().await?;
+        let (stream, _) = select! {
+            result = listener.accept() => result?,
+            _ = shutdown.notified() => break,
+        };
         let io = TokioIo::new(stream);
 
-        tokio::task::spawn(async move {
+        tasks::spawn(async move {
             if let Err(err) = http1::Builder::new()
                 .serve_connection(io, service_fn(metrics))
                 .await
@@ -78,4 +84,6 @@ pub async fn server(port: u16) -> std::io::Result<()> {
             }
         });
     }
+
+    Ok(())
 }

--- a/pgdog/src/stats/http_server.rs
+++ b/pgdog/src/stats/http_server.rs
@@ -68,19 +68,24 @@ pub async fn server(port: u16) -> std::io::Result<()> {
             _ = shutdown.cancelled() => break,
         };
         let io = TokioIo::new(stream);
+        let shutdown = shutdown.clone();
 
         tasks::spawn("openmetrics http server", async move {
-            if let Err(err) = http1::Builder::new()
-                .serve_connection(io, service_fn(metrics))
-                .await
-            {
-                // Clients (TCP health probes, scrapers that disconnect
-                // mid-request, keep-alive teardown) routinely close the socket
-                // before sending a complete request. That surfaces as
-                // IncompleteMessage and is benign.
-                if !err.is_incomplete_message() {
-                    warn!("OpenMetrics endpoint error: {:?}", err);
+            let connection = http1::Builder::new().serve_connection(io, service_fn(metrics));
+
+            tokio::select! {
+                result = connection => {
+                    if let Err(err) = result {
+                        // Clients (TCP health probes, scrapers that disconnect
+                        // mid-request, keep-alive teardown) routinely close the socket
+                        // before sending a complete request. That surfaces as
+                        // IncompleteMessage and is benign.
+                        if !err.is_incomplete_message() {
+                            warn!("OpenMetrics endpoint error: {:?}", err);
+                        }
+                    }
                 }
+                _ = shutdown.cancelled() => {}
             }
         });
     }

--- a/pgdog/src/stats/http_server.rs
+++ b/pgdog/src/stats/http_server.rs
@@ -65,7 +65,7 @@ pub async fn server(port: u16) -> std::io::Result<()> {
     loop {
         let (stream, _) = select! {
             result = listener.accept() => result?,
-            _ = shutdown.notified() => break,
+            _ = shutdown.cancelled() => break,
         };
         let io = TokioIo::new(stream);
 

--- a/pgdog/src/stats/http_server.rs
+++ b/pgdog/src/stats/http_server.rs
@@ -69,7 +69,7 @@ pub async fn server(port: u16) -> std::io::Result<()> {
         };
         let io = TokioIo::new(stream);
 
-        tasks::spawn(async move {
+        tasks::spawn("openmetrics http server", async move {
             if let Err(err) = http1::Builder::new()
                 .serve_connection(io, service_fn(metrics))
                 .await

--- a/pgdog/src/stats/logger.rs
+++ b/pgdog/src/stats/logger.rs
@@ -46,7 +46,7 @@ impl Logger {
                         );
                     }
                     _ = me.shutdown.notified() => break,
-                    _ = shutdown.notified() => break,
+                    _ = shutdown.cancelled() => break,
                 }
             }
         });

--- a/pgdog/src/stats/logger.rs
+++ b/pgdog/src/stats/logger.rs
@@ -1,9 +1,10 @@
 use std::{sync::Arc, time::Duration};
 
-use tokio::{select, spawn, sync::Notify, time::sleep};
+use tokio::{select, sync::Notify, time::sleep};
 use tracing::info;
 
 use crate::frontend::router::parser::Cache;
+use crate::tasks;
 
 #[derive(Debug, Clone)]
 pub struct Logger {
@@ -32,7 +33,8 @@ impl Logger {
     pub fn spawn(&self) {
         let me = self.clone();
 
-        spawn(async move {
+        tasks::spawn(async move {
+            let shutdown = tasks::shutdown_signal();
             loop {
                 select! {
                     _ = sleep(me.interval) => {
@@ -44,6 +46,7 @@ impl Logger {
                         );
                     }
                     _ = me.shutdown.notified() => break,
+                    _ = shutdown.notified() => break,
                 }
             }
         });

--- a/pgdog/src/stats/logger.rs
+++ b/pgdog/src/stats/logger.rs
@@ -33,7 +33,7 @@ impl Logger {
     pub fn spawn(&self) {
         let me = self.clone();
 
-        tasks::spawn(async move {
+        tasks::spawn("stats logger", async move {
             let shutdown = tasks::shutdown_signal();
             loop {
                 select! {

--- a/pgdog/src/stats/otel_exporter.rs
+++ b/pgdog/src/stats/otel_exporter.rs
@@ -10,7 +10,7 @@ use tracing::{info, warn};
 
 use super::otel;
 use super::{Clients, Listeners, MirrorStatsMetrics, Pools, QueryCache, TwoPc};
-use crate::config::config;
+use crate::{config::config, tasks};
 
 /// Maximum number of metrics per OTLP request to stay under endpoint payload limits.
 const BATCH_SIZE: usize = 10;
@@ -32,8 +32,13 @@ pub async fn run() {
         interval.as_secs_f64(),
     );
 
+    let shutdown = tasks::shutdown_signal();
+
     loop {
-        sleep(interval).await;
+        tokio::select! {
+            _ = sleep(interval) => {}
+            _ = shutdown.notified() => break,
+        }
 
         let clients = Clients::load();
         let pools = Pools::load().into_metrics();

--- a/pgdog/src/stats/otel_exporter.rs
+++ b/pgdog/src/stats/otel_exporter.rs
@@ -37,7 +37,7 @@ pub async fn run() {
     loop {
         tokio::select! {
             _ = sleep(interval) => {}
-            _ = shutdown.notified() => break,
+            _ = shutdown.cancelled() => break,
         }
 
         let clients = Clients::load();

--- a/pgdog/src/tasks.rs
+++ b/pgdog/src/tasks.rs
@@ -1,0 +1,49 @@
+//! Process-wide background task tracking.
+
+use std::{
+    future::Future,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+};
+
+use once_cell::sync::Lazy;
+use tokio::{sync::Notify, task::JoinHandle};
+use tokio_util::task::TaskTracker;
+
+static TASKS: Lazy<BackgroundTasks> = Lazy::new(BackgroundTasks::default);
+
+#[derive(Debug, Default)]
+struct BackgroundTasks {
+    tracker: TaskTracker,
+    shutdown: Arc<Notify>,
+    shutting_down: AtomicBool,
+}
+
+/// Spawn a process background task that must finish before runtime teardown.
+pub fn spawn<F>(future: F) -> JoinHandle<F::Output>
+where
+    F: Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    TASKS.tracker.spawn(future)
+}
+
+/// Shared shutdown signal for background tasks that are not tied to a pool/client signal.
+pub fn shutdown_signal() -> Arc<Notify> {
+    TASKS.shutdown.clone()
+}
+
+/// True once process background tasks have been asked to stop.
+pub fn shutting_down() -> bool {
+    TASKS.shutting_down.load(Ordering::Relaxed)
+}
+
+/// Ask all tracked background tasks to stop and wait for them.
+pub async fn shutdown() {
+    TASKS.shutting_down.store(true, Ordering::Relaxed);
+    TASKS.shutdown.notify_waiters();
+    TASKS.tracker.close();
+    TASKS.tracker.wait().await;
+}

--- a/pgdog/src/tasks.rs
+++ b/pgdog/src/tasks.rs
@@ -2,14 +2,12 @@
 
 use std::{
     future::Future,
-    sync::{
-        Arc,
-        atomic::{AtomicBool, Ordering},
-    },
+    sync::atomic::{AtomicBool, Ordering},
 };
 
 use once_cell::sync::Lazy;
-use tokio::{sync::Notify, task::JoinHandle};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
 
 static TASKS: Lazy<BackgroundTasks> = Lazy::new(BackgroundTasks::default);
@@ -17,7 +15,7 @@ static TASKS: Lazy<BackgroundTasks> = Lazy::new(BackgroundTasks::default);
 #[derive(Debug, Default)]
 struct BackgroundTasks {
     tracker: TaskTracker,
-    shutdown: Arc<Notify>,
+    shutdown: CancellationToken,
     shutting_down: AtomicBool,
 }
 
@@ -31,7 +29,7 @@ where
 }
 
 /// Shared shutdown signal for background tasks that are not tied to a pool/client signal.
-pub fn shutdown_signal() -> Arc<Notify> {
+pub fn shutdown_signal() -> CancellationToken {
     TASKS.shutdown.clone()
 }
 
@@ -43,7 +41,7 @@ pub fn shutting_down() -> bool {
 /// Ask all tracked background tasks to stop and wait for them.
 pub async fn shutdown() {
     TASKS.shutting_down.store(true, Ordering::Relaxed);
-    TASKS.shutdown.notify_waiters();
+    TASKS.shutdown.cancel();
     TASKS.tracker.close();
     TASKS.tracker.wait().await;
 }

--- a/pgdog/src/tasks.rs
+++ b/pgdog/src/tasks.rs
@@ -7,10 +7,12 @@ use std::{
 
 use dashmap::DashMap;
 use once_cell::sync::Lazy;
-use tokio::task::JoinHandle;
+use tokio::{task::JoinHandle, time::timeout};
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
-use tracing::info;
+use tracing::{error, info};
+
+use crate::config::config;
 
 static TASKS: Lazy<BackgroundTasks> = Lazy::new(BackgroundTasks::default);
 
@@ -65,5 +67,13 @@ pub async fn shutdown() {
     TASKS.tracker.close();
 
     info!("waiting on {} background tasks", TASKS.tracker.len());
-    TASKS.tracker.wait().await;
+
+    let wait = timeout(
+        config().config.general.shutdown_timeout(),
+        TASKS.tracker.wait(),
+    );
+
+    if wait.await.is_err() {
+        error!("unterminated background tasks: {:?}", TASKS.counter);
+    }
 }

--- a/pgdog/src/tasks.rs
+++ b/pgdog/src/tasks.rs
@@ -5,10 +5,12 @@ use std::{
     sync::atomic::{AtomicBool, Ordering},
 };
 
+use dashmap::DashMap;
 use once_cell::sync::Lazy;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
+use tracing::info;
 
 static TASKS: Lazy<BackgroundTasks> = Lazy::new(BackgroundTasks::default);
 
@@ -17,15 +19,33 @@ struct BackgroundTasks {
     tracker: TaskTracker,
     shutdown: CancellationToken,
     shutting_down: AtomicBool,
+    counter: DashMap<&'static str, usize>,
 }
 
 /// Spawn a process background task that must finish before runtime teardown.
-pub fn spawn<F>(future: F) -> JoinHandle<F::Output>
+pub fn spawn<F>(name: &'static str, future: F) -> JoinHandle<F::Output>
 where
     F: Future + Send + 'static,
     F::Output: Send + 'static,
 {
-    TASKS.tracker.spawn(future)
+    let mut counter = TASKS.counter.entry(name).or_insert(0);
+    *counter += 1;
+
+    TASKS.tracker.spawn(async move {
+        let res = future.await;
+        let mut remove = false;
+
+        if let Some(mut counter) = TASKS.counter.get_mut(name) {
+            *counter = counter.saturating_sub(1);
+            remove = *counter == 0;
+        }
+
+        if remove {
+            TASKS.counter.remove(name);
+        }
+
+        res
+    })
 }
 
 /// Shared shutdown signal for background tasks that are not tied to a pool/client signal.
@@ -43,5 +63,7 @@ pub async fn shutdown() {
     TASKS.shutting_down.store(true, Ordering::Relaxed);
     TASKS.shutdown.cancel();
     TASKS.tracker.close();
+
+    info!("waiting on {} background tasks", TASKS.tracker.len());
     TASKS.tracker.wait().await;
 }

--- a/pgdog/src/util.rs
+++ b/pgdog/src/util.rs
@@ -282,11 +282,14 @@ pub fn sanitize_log_sample(s: &str, limit: usize) -> String {
     truncate_utf8(s, limit).replace(|c: char| c.is_control(), " ")
 }
 
-/// Wait for `future` to complete, unless `duration` elapses.
+/// Avoid calling [`tokio::time::timeout`] on [`Duration`] that lasts effectively forever.
 ///
-/// `Duration::MAX` is treated as an unlimited timeout. Tokio's timeout
-/// converts the duration to an instant internally, so skip it for the sentinel
-/// value to avoid overflowing that conversion.
+/// The Tokio timers can run hot and, if we can, we should avoid that mutex.
+///
+/// We did switch to the experimental timer that uses thread-locals, so
+/// this shouldn't be a problem anymore, but I still would like to avoid
+/// calling into time runtime if we don't have to.
+///
 pub(crate) async fn safe_timeout<F>(
     duration: Duration,
     future: F,

--- a/pgdog/src/util.rs
+++ b/pgdog/src/util.rs
@@ -5,7 +5,7 @@ use once_cell::sync::Lazy;
 use rand::{Rng, distr::Alphanumeric};
 #[cfg(feature = "new_parser")]
 use std::ops::ControlFlow;
-use std::{env, num::ParseIntError, time::Duration};
+use std::{env, future::Future, num::ParseIntError, time::Duration};
 
 use crate::net::Parameters; // 0.8
 
@@ -281,6 +281,25 @@ pub fn sanitize_log_sample(s: &str, limit: usize) -> String {
     truncate_utf8(s, limit).replace(|c: char| c.is_control(), " ")
 }
 
+/// Wait for `future` to complete, unless `duration` elapses.
+///
+/// `Duration::MAX` is treated as an unlimited timeout. Tokio's timeout
+/// converts the duration to an instant internally, so skip it for the sentinel
+/// value to avoid overflowing that conversion.
+pub(crate) async fn safe_timeout<F>(
+    duration: Duration,
+    future: F,
+) -> Result<F::Output, tokio::time::error::Elapsed>
+where
+    F: Future,
+{
+    if duration == Duration::MAX {
+        Ok(future.await)
+    } else {
+        tokio::time::timeout(duration, future).await
+    }
+}
+
 #[cfg(feature = "new_parser")]
 pub(crate) trait ResultControlFlowExt<T, E> {
     fn break_err<B>(self) -> ControlFlow<Result<B, E>, T>;
@@ -308,6 +327,17 @@ mod test {
         assert_eq!(human_duration(Duration::from_millis(2000)), "2s");
         assert_eq!(human_duration(Duration::from_millis(1000 * 60 * 2)), "2m");
         assert_eq!(human_duration(Duration::from_millis(1000 * 3600)), "1h");
+    }
+
+    #[tokio::test]
+    async fn test_safe_timeout_allows_duration_max() {
+        assert_eq!(safe_timeout(Duration::MAX, async { 42 }).await.unwrap(), 42);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_safe_timeout_times_out() {
+        let result = safe_timeout(Duration::from_millis(1), std::future::pending::<()>()).await;
+        assert!(result.is_err());
     }
 
     #[test]

--- a/pgdog/src/util.rs
+++ b/pgdog/src/util.rs
@@ -2,6 +2,7 @@
 
 use chrono::{DateTime, Local, Utc};
 use once_cell::sync::Lazy;
+use pgdog_config::MAX_DURATION;
 use rand::{Rng, distr::Alphanumeric};
 #[cfg(feature = "new_parser")]
 use std::ops::ControlFlow;
@@ -293,7 +294,7 @@ pub(crate) async fn safe_timeout<F>(
 where
     F: Future,
 {
-    if duration == Duration::MAX {
+    if duration == Duration::MAX || duration == MAX_DURATION {
         Ok(future.await)
     } else {
         tokio::time::timeout(duration, future).await


### PR DESCRIPTION
- fix: switch to alternative Tokio timer to reduce mutex contention when using `timeout`. This was causing the Tokio runtime mutex to burn hot with multiple workers and scaled with the number of connected clients, since they were all fighting for that mutex while waiting on the connection from the pool.
- fix: avoid calling `timeout` at all when the duration is infinite
- fix: use global task tracker for `spawn`ed tasks. This was actually a bug that just worked but got exposed by the alt timer: we were not waiting on tasks to exit on shutdown

