### PR TITLE
Compute SHA1 shard key from raw digest bytes

### DIFF
--- a/pgdog/src/frontend/router/sharding/hasher.rs
+++ b/pgdog/src/frontend/router/sharding/hasher.rs
@@ -38,10 +38,7 @@ impl Hasher {
         hasher.update(bytes);
         let hash = hasher.finalize();
 
-        let hex = format!("{:x}", hash);
-        let key = i64::from_str_radix(&hex[hex.len() - 8..], 16).unwrap();
-
-        key as u64
+        u32::from_be_bytes([hash[16], hash[17], hash[18], hash[19]]) as u64
     }
 }
 


### PR DESCRIPTION
The SHA1 sharding hash formatted the full 20-byte digest as a hex string, then parsed the last 8 hex characters back into an integer on every call. That allocated a string and ran a radix parse to recover bytes already sitting in the digest.

Read the last four bytes directly and assemble the key with u32::from_be_bytes. The last 8 hex characters map to bytes 16 through 19, so the shard assignment is unchanged; only the work to extract it goes away. This also drops the unwrap on the parse.