### PR TITLE
fix: crash in new parser handling partitioned table DDL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3313,7 +3313,7 @@ dependencies = [
 [[package]]
 name = "pg_raw_parse"
 version = "0.1.0"
-source = "git+https://github.com/pgdogdev/pg_raw_parse.git?rev=457b7c9#457b7c91b72b2d4b55be991707dbdf0e784127a4"
+source = "git+https://github.com/pgdogdev/pg_raw_parse.git?rev=4843f8bb01c1b7f844d2b8c43de551d3a493d333#4843f8bb01c1b7f844d2b8c43de551d3a493d333"
 dependencies = [
  "bindgen 0.72.1",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ edition = "2024"
 pgdog-plugin = { path = "./pgdog-plugin", version = "0.4.0", default-features = false }
 pgdog-config = { path = "./pgdog-config", version = "0.1.0" }
 pgdog-postgres-types = { path = "./pgdog-postgres-types"}
-pg_raw_parse = { git = "https://github.com/pgdogdev/pg_raw_parse.git", rev = "457b7c9" }
+pg_raw_parse = { git = "https://github.com/pgdogdev/pg_raw_parse.git", rev = "4843f8bb01c1b7f844d2b8c43de551d3a493d333" }
 bon = "3.9"
 schemars = { version = "1.2.1", features = ["uuid1"] }
 serde_json = "1.0"


### PR DESCRIPTION
New parser was incorrectly labeling nodes in partitioned tables DDL:

```
[...]
FOR VALUES FROM ('2007-12-01') TO ('2008-01-01')
[...]
```