### PR TITLE
Feat/multi statement query support

### DIFF
--- a/integration/js/pg_tests/test/sequelize.js
+++ b/integration/js/pg_tests/test/sequelize.js
@@ -200,20 +200,11 @@ describe("Sequelize multi-statement SET", function () {
     await seq.close();
   });
 
-  it("mixed SET and non-SET returns error", async function () {
+  it("mixed SET and non-SET succeeds and applies SET", async function () {
     const seq = createSequelize();
 
-    try {
-      await seq.query("SET statement_timeout TO '10s'; SELECT 1");
-      assert.fail("expected error for mixed SET + SELECT");
-    } catch (err) {
-      assert.ok(
-        err.message.includes(
-          "multi-statement queries cannot mix SET with other commands",
-        ),
-        `unexpected error: ${err.message}`,
-      );
-    }
+    // Should succeed: PgDog intercepts the SET and forwards SELECT to the backend.
+    await seq.query("SET statement_timeout TO '10s'; SELECT 1");
 
     const [rows] = await seq.query("SELECT 1 AS val");
     assert.strictEqual(rows[0].val, 1);

--- a/integration/rust/tests/integration/multi_set.rs
+++ b/integration/rust/tests/integration/multi_set.rs
@@ -61,7 +61,7 @@ async fn test_multi_set_mixed_succeeds() {
 async fn test_multi_statement_select() {
     for conn in connections_tokio().await {
         let msgs = conn.simple_query("SELECT 1; SELECT 2").await.unwrap();
-        let values: Vec<String> = msgs
+        let mut values: Vec<String> = msgs
             .iter()
             .filter_map(|m| {
                 if let tokio_postgres::SimpleQueryMessage::Row(row) = m {
@@ -71,6 +71,10 @@ async fn test_multi_statement_select() {
                 }
             })
             .collect();
+        // On a sharded connection, each scalar SELECT fans out to all shards, so
+        // "SELECT 1; SELECT 2" may yield ["1","1","2","2"]. Dedup consecutive
+        // duplicates to assert ordering: all SELECT 1 results before SELECT 2.
+        values.dedup();
         assert_eq!(values, vec!["1", "2"]);
     }
 }
@@ -78,8 +82,11 @@ async fn test_multi_statement_select() {
 #[tokio::test]
 async fn test_multi_statement_transaction_batch() {
     for conn in connections_tokio().await {
+        // Use a real table (not TEMP) — transaction-mode pooling may route the setup
+        // query to a different backend than the BEGIN/COMMIT batch, so TEMP tables
+        // (which are session-scoped) would not be visible.
         conn.batch_execute(
-            "CREATE TEMP TABLE IF NOT EXISTS locks (
+            "CREATE TABLE IF NOT EXISTS pgdog_multi_stmt_locks (
                 key  TEXT PRIMARY KEY,
                 owner TEXT NOT NULL,
                 ttl  TIMESTAMPTZ NOT NULL
@@ -88,10 +95,14 @@ async fn test_multi_statement_transaction_batch() {
         .await
         .unwrap();
 
+        conn.batch_execute("TRUNCATE pgdog_multi_stmt_locks")
+            .await
+            .unwrap();
+
         conn.batch_execute(
             "BEGIN;\
-             DELETE FROM locks WHERE ttl < CURRENT_TIMESTAMP AT TIME ZONE 'UTC';\
-             INSERT INTO locks (key, owner, ttl) \
+             DELETE FROM pgdog_multi_stmt_locks WHERE ttl < CURRENT_TIMESTAMP AT TIME ZONE 'UTC';\
+             INSERT INTO pgdog_multi_stmt_locks (key, owner, ttl) \
                VALUES ('test-key', 'test-owner', NOW() + INTERVAL '1 hour') \
                ON CONFLICT DO NOTHING;\
              COMMIT;",
@@ -100,10 +111,48 @@ async fn test_multi_statement_transaction_batch() {
         .unwrap();
 
         let rows = conn
-            .simple_query("SELECT owner FROM locks WHERE key = 'test-key'")
+            .simple_query("SELECT owner FROM pgdog_multi_stmt_locks WHERE key = 'test-key'")
             .await
             .unwrap();
         let owner = extract_simple_query_value(&rows);
         assert_eq!(owner, "test-owner");
+    }
+}
+
+/// PostgreSQL normally wraps a multi-statement simple query in an implicit transaction,
+/// so a failure in any statement rolls back all preceding ones. PgDog splits the batch
+/// into individual requests, meaning each statement runs with its own auto-commit.
+/// This test documents that behavior: the first INSERT succeeds even when the second fails.
+#[tokio::test]
+async fn test_multi_statement_implicit_transaction_behavior() {
+    for conn in connections_tokio().await {
+        // Use a real table (not TEMP) — transaction-mode pooling may route the setup
+        // query to a different backend than the INSERT batch, so TEMP tables
+        // (which are session-scoped) would not be visible.
+        conn.batch_execute(
+            "CREATE TABLE IF NOT EXISTS pgdog_multi_stmt_implicit (id INT PRIMARY KEY)",
+        )
+        .await
+        .unwrap();
+
+        conn.batch_execute("TRUNCATE pgdog_multi_stmt_implicit")
+            .await
+            .unwrap();
+
+        // Second INSERT violates the primary key. In standard PostgreSQL simple query
+        // protocol both would roll back; with per-statement routing the first commits.
+        let _ = conn
+            .batch_execute(
+                "INSERT INTO pgdog_multi_stmt_implicit VALUES (1); INSERT INTO pgdog_multi_stmt_implicit VALUES (1)",
+            )
+            .await;
+
+        let rows = conn
+            .simple_query("SELECT count(*) FROM pgdog_multi_stmt_implicit WHERE id = 1")
+            .await
+            .unwrap();
+        let count = extract_simple_query_value(&rows);
+        // The first INSERT committed; the second failed independently.
+        assert_eq!(count, "1");
     }
 }

--- a/integration/rust/tests/integration/multi_set.rs
+++ b/integration/rust/tests/integration/multi_set.rs
@@ -74,3 +74,36 @@ async fn test_multi_statement_select() {
         assert_eq!(values, vec!["1", "2"]);
     }
 }
+
+#[tokio::test]
+async fn test_multi_statement_transaction_batch() {
+    for conn in connections_tokio().await {
+        conn.batch_execute(
+            "CREATE TEMP TABLE IF NOT EXISTS locks (
+                key  TEXT PRIMARY KEY,
+                owner TEXT NOT NULL,
+                ttl  TIMESTAMPTZ NOT NULL
+            )",
+        )
+        .await
+        .unwrap();
+
+        conn.batch_execute(
+            "BEGIN;\
+             DELETE FROM locks WHERE ttl < CURRENT_TIMESTAMP AT TIME ZONE 'UTC';\
+             INSERT INTO locks (key, owner, ttl) \
+               VALUES ('test-key', 'test-owner', NOW() + INTERVAL '1 hour') \
+               ON CONFLICT DO NOTHING;\
+             COMMIT;",
+        )
+        .await
+        .unwrap();
+
+        let rows = conn
+            .simple_query("SELECT owner FROM locks WHERE key = 'test-key'")
+            .await
+            .unwrap();
+        let owner = extract_simple_query_value(&rows);
+        assert_eq!(owner, "test-owner");
+    }
+}

--- a/integration/rust/tests/integration/multi_set.rs
+++ b/integration/rust/tests/integration/multi_set.rs
@@ -46,17 +46,31 @@ async fn test_multi_set_with_timezone_interval() {
 }
 
 #[tokio::test]
-async fn test_multi_set_mixed_returns_error() {
+async fn test_multi_set_mixed_succeeds() {
     for conn in connections_tokio().await {
-        let err = conn
-            .batch_execute("SET statement_timeout TO '10s'; SELECT 1")
+        conn.batch_execute("SET statement_timeout TO '10s'; SELECT 1")
             .await
-            .unwrap_err();
-        let db_err = err.as_db_error().expect("Expected a DbError");
-        let msg = db_err.message();
-        assert!(
-            msg.contains("multi-statement queries cannot mix SET with other commands"),
-            "unexpected error: {msg}",
-        );
+            .unwrap();
+
+        let rows = conn.simple_query("SHOW statement_timeout").await.unwrap();
+        assert_eq!(extract_simple_query_value(&rows), "10s");
+    }
+}
+
+#[tokio::test]
+async fn test_multi_statement_select() {
+    for conn in connections_tokio().await {
+        let msgs = conn.simple_query("SELECT 1; SELECT 2").await.unwrap();
+        let values: Vec<String> = msgs
+            .iter()
+            .filter_map(|m| {
+                if let tokio_postgres::SimpleQueryMessage::Row(row) = m {
+                    row.get(0).map(|s| s.to_string())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        assert_eq!(values, vec!["1", "2"]);
     }
 }

--- a/integration/rust/tests/sqlx/multi_set.rs
+++ b/integration/rust/tests/sqlx/multi_set.rs
@@ -72,25 +72,18 @@ async fn test_multi_set_in_transaction() {
 }
 
 #[tokio::test]
-async fn test_multi_set_mixed_returns_error() {
+async fn test_multi_set_mixed_succeeds() {
     for pool in connections_sqlx().await {
         let mut conn = pool.acquire().await.unwrap();
 
-        let err = conn
-            .execute("SET statement_timeout TO '10s'; SELECT 1")
+        conn.execute("SET statement_timeout TO '10s'; SELECT 1")
             .await
-            .unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("multi-statement queries cannot mix SET with other commands"),
-            "unexpected error: {err}",
-        );
+            .unwrap();
 
-        // Connection should still be usable after the error.
-        let val: String = sqlx::query_scalar("SHOW server_version")
+        let timeout: String = sqlx::query_scalar("SHOW statement_timeout")
             .fetch_one(&mut *conn)
             .await
             .unwrap();
-        assert!(!val.is_empty());
+        assert_eq!(timeout, "10s");
     }
 }

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -543,11 +543,13 @@ impl Client {
         }
 
         // If client sent multiple requests, split them up and execute individually.
-        let spliced = self.client_request.spliced()?;
-        let spliced = if spliced.is_empty() {
-            self.client_request.spliced_simple()
+        let extended = self.client_request.spliced()?;
+        let (spliced, is_simple_splice) = if extended.is_empty() {
+            let simple = self.client_request.spliced_simple();
+            let is_simple = !simple.is_empty();
+            (simple, is_simple)
         } else {
-            spliced
+            (extended, false)
         };
         if spliced.is_empty() {
             let mut context = QueryEngineContext::new(self);
@@ -556,10 +558,21 @@ impl Client {
         } else {
             let total = spliced.len();
             let mut reqs = spliced.into_iter().enumerate();
-            self.transaction.get_or_insert(TransactionType::Implicit);
+            // For extended protocol pipelining, mark the client as being in an implicit
+            // transaction so the backend connection is kept across statements in the pipeline.
+            // For simple query splicing, each statement routes independently — don't force
+            // Implicit here; the requests_left mechanism in cleanup_backend handles connection
+            // reuse without affecting shard routing.
+            if !is_simple_splice {
+                self.transaction.get_or_insert(TransactionType::Implicit);
+            }
             while let Some((num, mut req)) = reqs.next() {
                 debug!("processing spliced request {}/{}", num + 1, total);
-                let mut context = QueryEngineContext::new(self).spliced(&mut req, reqs.len());
+                let mut context = if is_simple_splice {
+                    QueryEngineContext::new(self).spliced_simple_query(&mut req, reqs.len())
+                } else {
+                    QueryEngineContext::new(self).spliced(&mut req, reqs.len())
+                };
                 query_engine.handle(&mut context).await?;
                 self.transaction = context.transaction();
 

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -544,6 +544,11 @@ impl Client {
 
         // If client sent multiple requests, split them up and execute individually.
         let spliced = self.client_request.spliced()?;
+        let spliced = if spliced.is_empty() {
+            self.client_request.spliced_simple()
+        } else {
+            spliced
+        };
         if spliced.is_empty() {
             let mut context = QueryEngineContext::new(self);
             query_engine.handle(&mut context).await?;

--- a/pgdog/src/frontend/client/query_engine/context.rs
+++ b/pgdog/src/frontend/client/query_engine/context.rs
@@ -43,6 +43,9 @@ pub struct QueryEngineContext<'a> {
     pub(super) query_log_stdout: bool,
     /// Maximum query message size before a warning is logged.
     pub(super) query_size_limit: Option<usize>,
+    /// Spliced simple query: suppress intermediate ReadyForQuery messages so the
+    /// client (which sent one Q) sees exactly one ReadyForQuery at the end.
+    pub(super) simple_query_splice: bool,
 }
 
 impl<'a> QueryEngineContext<'a> {
@@ -66,12 +69,24 @@ impl<'a> QueryEngineContext<'a> {
             rewrite_result: None,
             query_log_stdout: client.query_log_stdout,
             query_size_limit: client.query_size_limit,
+            simple_query_splice: false,
         }
     }
 
     pub fn spliced(mut self, req: &'a mut ClientRequest, request_left: usize) -> Self {
         self.client_request = req;
         self.requests_left = request_left;
+        self
+    }
+
+    pub fn spliced_simple_query(
+        mut self,
+        req: &'a mut ClientRequest,
+        requests_left: usize,
+    ) -> Self {
+        self.client_request = req;
+        self.requests_left = requests_left;
+        self.simple_query_splice = true;
         self
     }
 
@@ -94,6 +109,7 @@ impl<'a> QueryEngineContext<'a> {
             rewrite_result: None,
             query_log_stdout: false,
             query_size_limit: None,
+            simple_query_splice: false,
         }
     }
 

--- a/pgdog/src/frontend/client/query_engine/end_transaction.rs
+++ b/pgdog/src/frontend/client/query_engine/end_transaction.rs
@@ -24,7 +24,10 @@ impl QueryEngine {
                 vec![]
             };
             messages.push(cmd.message()?);
-            messages.push(ReadyForQuery::idle().message()?);
+            let suppress_rfq = context.simple_query_splice && context.requests_left > 0;
+            if !suppress_rfq {
+                messages.push(ReadyForQuery::idle().message()?);
+            }
 
             context.stream.send_many(&messages).await?
         };

--- a/pgdog/src/frontend/client/query_engine/end_transaction.rs
+++ b/pgdog/src/frontend/client/query_engine/end_transaction.rs
@@ -159,4 +159,22 @@ mod tests {
             context.transaction
         );
     }
+
+    #[tokio::test]
+    async fn test_end_not_connected_suppress_rfq() {
+        load_test();
+
+        let mut client =
+            crate::frontend::Client::new_test(Stream::dev_null(), Parameters::default());
+        client.transaction = Some(TransactionType::ReadWrite);
+
+        let mut engine = QueryEngine::from_client(&client).unwrap();
+        let mut context = QueryEngineContext::new(&mut client);
+        context.simple_query_splice = true;
+        context.requests_left = 1;
+
+        let result = engine.end_not_connected(&mut context, false, false).await;
+        assert!(result.is_ok());
+        assert_eq!(context.transaction, None);
+    }
 }

--- a/pgdog/src/frontend/client/query_engine/fake.rs
+++ b/pgdog/src/frontend/client/query_engine/fake.rs
@@ -61,16 +61,22 @@ impl QueryEngine {
                         .await?
                 }
                 ProtocolMessage::Query(_) => {
-                    (if let Some(row) = data_row.as_ref() {
+                    let suppress_rfq =
+                        context.simple_query_splice && context.requests_left > 0;
+                    let cc = (if let Some(row) = data_row.as_ref() {
                         context.stream.send(&row_description).await?
                             + context.stream.send(row).await?
                     } else {
                         0
-                    }) + context.stream.send(&CommandComplete::new(command)).await?
-                        + context
+                    }) + context.stream.send(&CommandComplete::new(command)).await?;
+                    if suppress_rfq {
+                        cc
+                    } else {
+                        cc + context
                             .stream
                             .send(&ReadyForQuery::in_transaction(context.in_transaction()))
                             .await?
+                    }
                 }
                 // TODO(lev): Elixir closes the statement it just asked us to prepare.
                 // That's very memory-conscious of it, and we appreciate it.

--- a/pgdog/src/frontend/client/query_engine/query.rs
+++ b/pgdog/src/frontend/client/query_engine/query.rs
@@ -243,10 +243,16 @@ impl QueryEngine {
 
         trace!("{:#?} >>> {:?}", message, context.stream.peer_addr());
 
-        if flush {
-            context.stream.send_flush(&message).await?;
-        } else {
-            context.stream.send(&message).await?;
+        // For spliced simple queries the client sent one Q and expects one ReadyForQuery.
+        // Suppress intermediate ones; only the final statement's ReadyForQuery is forwarded.
+        let suppress_rfq = code == 'Z' && context.simple_query_splice && context.requests_left > 0;
+
+        if !suppress_rfq {
+            if flush {
+                context.stream.send_flush(&message).await?;
+            } else {
+                context.stream.send(&message).await?;
+            }
         }
 
         if code == 'Z' {

--- a/pgdog/src/frontend/client/query_engine/start_transaction.rs
+++ b/pgdog/src/frontend/client/query_engine/start_transaction.rs
@@ -26,13 +26,15 @@ impl QueryEngine {
                 self.extended_transaction_reply(context, true, false)
                     .await?
             } else {
-                context
-                    .stream
-                    .send_many(&[
-                        CommandComplete::new_begin().message()?,
+                let suppress_rfq =
+                    context.simple_query_splice && context.requests_left > 0;
+                let mut msgs = vec![CommandComplete::new_begin().message()?];
+                if !suppress_rfq {
+                    msgs.push(
                         ReadyForQuery::in_transaction(context.in_transaction()).message()?,
-                    ])
-                    .await?
+                    );
+                }
+                context.stream.send_many(&msgs).await?
             };
 
             self.stats.sent(bytes_sent);

--- a/pgdog/src/frontend/client_request.rs
+++ b/pgdog/src/frontend/client_request.rs
@@ -7,11 +7,6 @@ use std::ops::{Deref, DerefMut};
 use lazy_static::lazy_static;
 use regex::Regex;
 
-#[cfg(not(feature = "new_parser"))]
-use pg_query;
-#[cfg(feature = "new_parser")]
-use pg_raw_parse;
-
 use crate::{
     frontend::router::Ast,
     net::{
@@ -25,40 +20,26 @@ use super::{PreparedStatements, router::Route};
 
 pub use super::BufferedQuery;
 
-#[cfg(feature = "new_parser")]
-fn split_statements(query: &str) -> Vec<(usize, usize)> {
-    let Ok(parsed) = pg_raw_parse::parse(query) else {
-        return vec![];
-    };
-    let inner = parsed.into_inner();
-    if inner.len() <= 1 {
-        return vec![];
-    }
-    inner
-        .into_iter()
-        .map(|stmt| {
-            let loc = stmt.stmt_location.max(0) as usize;
-            let len = stmt.stmt_len as usize;
-            (loc, len)
-        })
-        .collect()
-}
-
-#[cfg(not(feature = "new_parser"))]
-fn split_statements(query: &str) -> Vec<(usize, usize)> {
+/// Split a multi-statement simple query string into individual statement slices.
+/// Returns an empty vec if parsing fails or the query contains only one statement.
+fn split_statements(query: &str) -> Vec<&str> {
     let Ok(parsed) = pg_query::parse(query) else {
         return vec![];
     };
-    let stmts = &parsed.protobuf.stmts;
+    let stmts = parsed.protobuf.stmts;
     if stmts.len() <= 1 {
         return vec![];
     }
     stmts
         .iter()
-        .map(|stmt| {
+        .filter_map(|stmt| {
             let loc = stmt.stmt_location.max(0) as usize;
-            let len = stmt.stmt_len as usize;
-            (loc, len)
+            let end = if stmt.stmt_len == 0 {
+                query.len()
+            } else {
+                loc + stmt.stmt_len as usize
+            };
+            query.get(loc..end).map(str::trim).filter(|s| !s.is_empty())
         })
         .collect()
 }
@@ -419,29 +400,17 @@ impl ClientRequest {
     /// the request is not a simple Query, contains only one statement, or parsing fails.
     /// In all those cases the caller falls through to the normal query engine path.
     pub fn spliced_simple(&self) -> Vec<Self> {
-        let Some(ProtocolMessage::Query(q)) = self.messages.iter().find(|m| m.code() == 'Q') else {
+        let Some(ProtocolMessage::Query(q)) = self.messages.iter().find(|m| m.code() == 'Q')
+        else {
             return vec![];
         };
-        let query_text = q.query();
-
-        split_statements(query_text)
+        split_statements(q.query())
             .into_iter()
-            .filter_map(|(offset, len)| {
-                let end = if len == 0 {
-                    query_text.len()
-                } else {
-                    offset + len
-                };
-                let text = query_text.get(offset..end)?.trim();
-                if text.is_empty() {
-                    return None;
-                }
-                Some(Self {
-                    messages: vec![ProtocolMessage::Query(Query::new(text))],
-                    route: None,
-                    ast: None,
-                    last_parse: None,
-                })
+            .map(|text| Self {
+                messages: vec![ProtocolMessage::Query(Query::new(text))],
+                route: None,
+                ast: None,
+                last_parse: None,
             })
             .collect()
     }

--- a/pgdog/src/frontend/client_request.rs
+++ b/pgdog/src/frontend/client_request.rs
@@ -465,6 +465,13 @@ mod test {
 
     use super::*;
 
+    #[cfg(not(feature = "new_parser"))]
+    #[test]
+    fn test_spliced_simple_returns_empty_without_new_parser() {
+        let req = ClientRequest::from(vec![Query::new("SELECT 1; SELECT 2").into()]);
+        assert!(req.spliced_simple().is_empty());
+    }
+
     #[cfg(feature = "new_parser")]
     #[test]
     fn test_spliced_simple_two_selects() {

--- a/pgdog/src/frontend/client_request.rs
+++ b/pgdog/src/frontend/client_request.rs
@@ -7,14 +7,19 @@ use std::ops::{Deref, DerefMut};
 use lazy_static::lazy_static;
 use regex::Regex;
 
+#[cfg(feature = "new_parser")]
+use pg_raw_parse;
+
 use crate::{
     frontend::router::Ast,
     net::{
         Error, Flush, Parse, ProtocolMessage,
-        messages::{Bind, CopyData, Protocol, Query},
+        messages::{Bind, CopyData, Protocol},
     },
     stats::memory::MemoryUsage,
 };
+#[cfg(feature = "new_parser")]
+use crate::net::messages::Query;
 
 use super::{PreparedStatements, router::Route};
 
@@ -22,18 +27,19 @@ pub use super::BufferedQuery;
 
 /// Split a multi-statement simple query string into individual statement slices.
 /// Returns an empty vec if parsing fails or the query contains only one statement.
+#[cfg(feature = "new_parser")]
 fn split_statements(query: &str) -> Vec<&str> {
-    let Ok(parsed) = pg_query::parse(query) else {
+    let Ok(parsed) = pg_raw_parse::parse(query) else {
         return vec![];
     };
-    let stmts = parsed.protobuf.stmts;
+    let stmts = parsed.into_inner();
     if stmts.len() <= 1 {
         return vec![];
     }
     stmts
         .iter()
         .filter_map(|stmt| {
-            let loc = stmt.stmt_location.max(0) as usize;
+            let loc = stmt.stmt_location as usize;
             let end = if stmt.stmt_len == 0 {
                 query.len()
             } else {
@@ -399,6 +405,7 @@ impl ClientRequest {
     /// Analogous to `spliced()` for extended protocol. Returns empty vec when
     /// the request is not a simple Query, contains only one statement, or parsing fails.
     /// In all those cases the caller falls through to the normal query engine path.
+    #[cfg(feature = "new_parser")]
     pub fn spliced_simple(&self) -> Vec<Self> {
         let Some(ProtocolMessage::Query(q)) = self.messages.iter().find(|m| m.code() == 'Q')
         else {
@@ -413,6 +420,11 @@ impl ClientRequest {
                 last_parse: None,
             })
             .collect()
+    }
+
+    #[cfg(not(feature = "new_parser"))]
+    pub fn spliced_simple(&self) -> Vec<Self> {
+        vec![]
     }
 }
 
@@ -453,6 +465,7 @@ mod test {
 
     use super::*;
 
+    #[cfg(feature = "new_parser")]
     #[test]
     fn test_spliced_simple_two_selects() {
         let req = ClientRequest::from(vec![Query::new("SELECT 1; SELECT 2").into()]);
@@ -469,12 +482,14 @@ mod test {
         assert!(texts[1].contains("SELECT 2"), "second: {}", texts[1]);
     }
 
+    #[cfg(feature = "new_parser")]
     #[test]
     fn test_spliced_simple_single_statement_no_split() {
         let req = ClientRequest::from(vec![Query::new("SELECT 1").into()]);
         assert!(req.spliced_simple().is_empty());
     }
 
+    #[cfg(feature = "new_parser")]
     #[test]
     fn test_spliced_simple_non_query_no_split() {
         let req = ClientRequest::from(vec![
@@ -486,6 +501,7 @@ mod test {
         assert!(req.spliced_simple().is_empty());
     }
 
+    #[cfg(feature = "new_parser")]
     #[test]
     fn test_spliced_simple_transaction_batch() {
         let req = ClientRequest::from(vec![

--- a/pgdog/src/frontend/client_request.rs
+++ b/pgdog/src/frontend/client_request.rs
@@ -7,11 +7,16 @@ use std::ops::{Deref, DerefMut};
 use lazy_static::lazy_static;
 use regex::Regex;
 
+#[cfg(not(feature = "new_parser"))]
+use pg_query;
+#[cfg(feature = "new_parser")]
+use pg_raw_parse;
+
 use crate::{
     frontend::router::Ast,
     net::{
         Error, Flush, Parse, ProtocolMessage,
-        messages::{Bind, CopyData, Protocol},
+        messages::{Bind, CopyData, Protocol, Query},
     },
     stats::memory::MemoryUsage,
 };
@@ -19,6 +24,44 @@ use crate::{
 use super::{PreparedStatements, router::Route};
 
 pub use super::BufferedQuery;
+
+#[cfg(feature = "new_parser")]
+fn split_statements(query: &str) -> Vec<(usize, usize)> {
+    let Ok(parsed) = pg_raw_parse::parse(query) else {
+        return vec![];
+    };
+    let inner = parsed.into_inner();
+    if inner.len() <= 1 {
+        return vec![];
+    }
+    inner
+        .into_iter()
+        .map(|stmt| {
+            let loc = stmt.stmt_location.max(0) as usize;
+            let len = stmt.stmt_len as usize;
+            (loc, len)
+        })
+        .collect()
+}
+
+#[cfg(not(feature = "new_parser"))]
+fn split_statements(query: &str) -> Vec<(usize, usize)> {
+    let Ok(parsed) = pg_query::parse(query) else {
+        return vec![];
+    };
+    let stmts = &parsed.protobuf.stmts;
+    if stmts.len() <= 1 {
+        return vec![];
+    }
+    stmts
+        .iter()
+        .map(|stmt| {
+            let loc = stmt.stmt_location.max(0) as usize;
+            let len = stmt.stmt_len as usize;
+            (loc, len)
+        })
+        .collect()
+}
 
 /// Client request, containing exactly one query.
 #[derive(Debug, Clone)]
@@ -369,6 +412,39 @@ impl ClientRequest {
 
         Ok(requests)
     }
+
+    /// Split a multi-statement simple Query into individual single-statement requests.
+    ///
+    /// Analogous to `spliced()` for extended protocol. Returns empty vec when
+    /// the request is not a simple Query, contains only one statement, or parsing fails.
+    /// In all those cases the caller falls through to the normal query engine path.
+    pub fn spliced_simple(&self) -> Vec<Self> {
+        let Some(ProtocolMessage::Query(q)) = self.messages.iter().find(|m| m.code() == 'Q') else {
+            return vec![];
+        };
+        let query_text = q.query();
+
+        split_statements(query_text)
+            .into_iter()
+            .filter_map(|(offset, len)| {
+                let end = if len == 0 {
+                    query_text.len()
+                } else {
+                    offset + len
+                };
+                let text = query_text.get(offset..end)?.trim();
+                if text.is_empty() {
+                    return None;
+                }
+                Some(Self {
+                    messages: vec![ProtocolMessage::Query(Query::new(text))],
+                    route: None,
+                    ast: None,
+                    last_parse: None,
+                })
+            })
+            .collect()
+    }
 }
 
 impl From<ClientRequest> for Vec<ProtocolMessage> {
@@ -407,6 +483,65 @@ mod test {
     use crate::net::{Describe, Execute, Parse, Query, Sync};
 
     use super::*;
+
+    #[test]
+    fn test_spliced_simple_two_selects() {
+        let req = ClientRequest::from(vec![Query::new("SELECT 1; SELECT 2").into()]);
+        let split = req.spliced_simple();
+        assert_eq!(split.len(), 2, "expected 2 split requests");
+        let texts: Vec<&str> = split
+            .iter()
+            .map(|r| match r.messages.first().unwrap() {
+                ProtocolMessage::Query(q) => q.query(),
+                _ => panic!("expected Query"),
+            })
+            .collect();
+        assert!(texts[0].contains("SELECT 1"), "first: {}", texts[0]);
+        assert!(texts[1].contains("SELECT 2"), "second: {}", texts[1]);
+    }
+
+    #[test]
+    fn test_spliced_simple_single_statement_no_split() {
+        let req = ClientRequest::from(vec![Query::new("SELECT 1").into()]);
+        assert!(req.spliced_simple().is_empty());
+    }
+
+    #[test]
+    fn test_spliced_simple_non_query_no_split() {
+        let req = ClientRequest::from(vec![
+            Parse::named("s", "SELECT $1").into(),
+            Bind::new_statement("s").into(),
+            Execute::new().into(),
+            Sync::new().into(),
+        ]);
+        assert!(req.spliced_simple().is_empty());
+    }
+
+    #[test]
+    fn test_spliced_simple_transaction_batch() {
+        let req = ClientRequest::from(vec![
+            Query::new(
+                "BEGIN;\
+                 DELETE FROM locks WHERE ttl < CURRENT_TIMESTAMP AT TIME ZONE 'UTC';\
+                 INSERT INTO locks (key, owner, ttl) VALUES ('k', 'o', NOW() + INTERVAL '1 min') ON CONFLICT DO NOTHING;\
+                 COMMIT;"
+            ).into(),
+        ]);
+        let split = req.spliced_simple();
+        assert_eq!(
+            split.len(),
+            4,
+            "expected BEGIN/DELETE/INSERT/COMMIT as 4 requests"
+        );
+        let codes: Vec<char> = split
+            .iter()
+            .map(|r| r.messages.first().unwrap().code())
+            .collect();
+        assert!(
+            codes.iter().all(|&c| c == 'Q'),
+            "all should be simple Query messages"
+        );
+    }
 
     #[test]
     fn test_request_splice() {

--- a/pgdog/src/frontend/router/parser/error.rs
+++ b/pgdog/src/frontend/router/parser/error.rs
@@ -101,7 +101,4 @@ pub enum Error {
 
     #[error("sharded databases require the query parser to be enabled")]
     QueryParserRequired,
-
-    #[error("multi-statement queries cannot mix SET with other commands")]
-    MultiStatementMixedSet,
 }

--- a/pgdog/src/frontend/router/parser/query/mod.rs
+++ b/pgdog/src/frontend/router/parser/query/mod.rs
@@ -290,19 +290,18 @@ impl QueryParser {
             .run()?;
         }
 
-        // Handle multi-statement SET commands (e.g. "SET x TO 1; SET y TO 2").
-        if stmts.len() > 1
-            && let Some(command) = self.try_multi_set(&**stmts, context)?
-        {
-            return Ok(command);
+        // Handle multi-statement queries.
+        if stmts.len() > 1 {
+            // All-SET batch: intercepted for parameter tracking.
+            if let Some(command) = self.try_multi_set(&**stmts, context)? {
+                return Ok(command);
+            }
+            // Mixed or non-SET batch: forward the full query to the write primary.
+            return Ok(Command::Query(Route::write(
+                context.shards_calculator.shard(),
+            )));
         }
 
-        //
-        // Get the root AST node.
-        //
-        // We don't expect clients to send multiple queries. If they do
-        // only the first one is used for routing.
-        //
         let root = stmts.first();
 
         let Some(root) = root else {
@@ -555,19 +554,18 @@ impl QueryParser {
 
                 let stmts = &statement.parse_result().protobuf.stmts;
 
-                // Handle multi-statement SET commands (e.g. "SET x TO 1; SET y TO 2").
-                if stmts.len() > 1
-                    && let Some(command) = self.try_multi_set(stmts, context)?
-                {
-                    return Ok(command);
+                // Handle multi-statement queries.
+                if stmts.len() > 1 {
+                    // All-SET batch: intercepted for parameter tracking.
+                    if let Some(command) = self.try_multi_set(stmts, context)? {
+                        return Ok(command);
+                    }
+                    // Mixed or non-SET batch: forward the full query to the write primary.
+                    return Ok(Command::Query(Route::write(
+                        context.shards_calculator.shard(),
+                    )));
                 }
 
-                //
-                // Get the root AST node.
-                //
-                // We don't expect clients to send multiple queries. If they do
-                // only the first one is used for routing.
-                //
                 let root = stmts.first();
 
                 let root = if let Some(root) = root {

--- a/pgdog/src/frontend/router/parser/query/set.rs
+++ b/pgdog/src/frontend/router/parser/query/set.rs
@@ -118,8 +118,7 @@ impl QueryParser {
     /// Try to handle multi-statement queries containing SET commands.
     ///
     /// - All SETs → returns `Ok(Some(Command::Set { .. }))`
-    /// - No SETs → returns `Ok(None)`, caller falls through to default parsing
-    /// - Mix of SET + non-SET → returns `Err(MultiStatementMixedSet)`
+    /// - No SETs or mixed SET + non-SET → returns `Ok(None)`, caller routes to write primary
     ///
     /// In session mode, returns `Ok(Some(Command::Query(..)))` immediately so that
     /// all multi-statement queries are forwarded to the server verbatim.
@@ -151,10 +150,8 @@ impl QueryParser {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        if params.is_empty() {
+        if params.is_empty() || has_other {
             Ok(None)
-        } else if has_other {
-            Err(Error::MultiStatementMixedSet)
         } else {
             Ok(Some(Command::Set {
                 params,
@@ -204,7 +201,7 @@ impl QueryParser {
                     }
 
                     if has_set && has_other {
-                        return Err(Error::MultiStatementMixedSet);
+                        return Ok(None);
                     }
                 }
 

--- a/pgdog/src/frontend/router/parser/query/test/test_set.rs
+++ b/pgdog/src/frontend/router/parser/query/test/test_set.rs
@@ -29,15 +29,15 @@ fn test_mixed_set_passthrough_in_session_mode() {
 }
 
 #[test]
-fn test_mixed_set_rejected_in_transaction_mode() {
+fn test_mixed_set_routes_to_write_in_transaction_mode() {
     let mut test = QueryParserTest::new();
 
-    let result = test.try_execute(vec![
+    let command = test.execute(vec![
         Query::new("SET DateStyle='ISO'; show transaction_isolation").into(),
     ]);
     assert!(
-        result.is_err(),
-        "expected error for mixed SET in transaction mode, got {result:#?}",
+        matches!(command, Command::Query(ref r) if r.is_write()),
+        "expected write Command::Query for mixed SET in transaction mode, got {command:#?}",
     );
 }
 
@@ -121,23 +121,26 @@ fn test_set_multi_statement_mixed_local() {
 }
 
 #[test]
-fn test_set_multi_statement_mixed_returns_error() {
+fn test_set_multi_statement_mixed_routes_to_write() {
     let mut test = QueryParserTest::new();
 
-    let result = test.try_execute(vec![
+    let command = test.execute(vec![
         Query::new("SET statement_timeout TO 1; SELECT 1").into(),
     ]);
-    assert!(result.is_err());
+    assert!(
+        matches!(command, Command::Query(ref r) if r.is_write()),
+        "expected write Command::Query for mixed SET+SELECT, got {command:#?}",
+    );
 }
 
 #[test]
-fn test_multi_statement_no_set_falls_through() {
+fn test_multi_statement_no_set_routes_to_write() {
     let mut test = QueryParserTest::new();
 
     let command = test.execute(vec![Query::new("SELECT 1; SELECT 2").into()]);
     assert!(
-        matches!(command, Command::Query(_)),
-        "multi-statement without SET should fall through, got {command:#?}",
+        matches!(command, Command::Query(ref r) if r.is_write()),
+        "multi-statement should route to write primary, got {command:#?}",
     );
 }
 


### PR DESCRIPTION
## Context and motivation


At my company we're using PgDog as part of a PostgreSQL version upgrade migration strategy. We have a polyglot environment with services across different languages, ORMs, query builders, and driver versions. Some have hard dependencies we can't control (in our case, Kong) that generate raw multi-statement simple queries we couldn't inspect or modify. The goal was safety in the read path without having to audit every query generated across every language and library. We're not using sharding, so the intention was to keep changes minimal there.

## What changed

- Removed `MultiStatementMixedSet` — mixed batches no longer error
- Router routes multi-statement non-SET batches to the write primary instead of only using the first statement for routing
- Added `ClientRequest::spliced_simple()` behind `#[cfg(feature = "new_parser")]` that splits a `Q` message into per-statement requests using `stmt_location`/`stmt_len` from `pg_raw_parse`
- Wired `spliced_simple()` into the client loop after `spliced()`, so simple-query batches go through the same splice processing path as extended-protocol pipelines when the new parser is enabled
- Added `simple_query_splice` context flag and `suppress_rfq` logic in four places (`query.rs`, `fake.rs`, `start_transaction.rs`, `end_transaction.rs`) to hold back intermediate `ReadyForQuery` messages so the client sees exactly one `Z` at the end, matching simple query protocol semantics
- All-`SET` batches continue to be intercepted by PgDog's parameter tracking; single-statement queries and parse failures fall through unchanged

**Default builds** (without `new_parser`): multi-statement batches route to the write primary as a whole. `spliced_simple()` returns empty vec and callers fall through.

**`new_parser` builds**: full per-statement splitting with `SET` interception and correct `ReadyForQuery` handling.

## On the complexity

The `suppress_rfq` work across four handlers is more invasive than I originally wanted. It was necessary because `SET`, `BEGIN`, and `COMMIT` all have code paths that generate synthetic `ReadyForQuery` responses without going through the backend, so each one needed the same fix. The motivation for splitting rather than forwarding verbatim is that libraries we can't control frequently send batches like `SET statement_timeout TO '30s'; SELECT ...` as part of connection setup. If PgDog forwards the whole `Q` verbatim it never sees the `SET`, and when that backend connection gets returned to the pool the next client inherits stale parameter state silently.

If you feel this is too much complexity for what's being solved, or there are implications for the broader codebase I'm not seeing, happy to scale this back to just the routing fix.

## On @sgrif's review comments

- **Old parser / `new_parser` feature flag**: `spliced_simple()`, `split_statements()`, and the related unit tests are now all gated behind `#[cfg(feature = "new_parser")]` using `pg_raw_parse`. Default builds fall through unchanged.
- **`&str -> Vec<&str>` signature**: done, `split_statements` returns slices directly now
- **Error propagation in `split_statements`**: parse failures fall through to the single-statement path, which forwards to the backend and lets Postgres return the error to the client. Feels safer than surfacing a proxy-level parse error for something the backend might handle fine
- **Should router error if it sees more than one statement**: with the latest changes this code path no longer sees multi-statement batches directly when `new_parser` is enabled. `spliced_simple()` handles the split upstream before routing runs so each statement routes individually. The `stmts.len() > 1` guard in the router is now just a fallback for parse failures, session mode, and default builds
- **Implicit transactional behavior**: this was the right concern to raise. Added tests documenting the behavior. PgDog splits the batch so each statement gets its own auto-commit rather than an implicit transaction wrapping the whole thing. `test_multi_statement_implicit_transaction_behavior` documents this as a known divergence from standard PostgreSQL behavior

## Testing

I don't have permissions to run CI on this repo so I iterated locally. I ran the full Rust integration suite (`cargo nextest run --profile integration`) and the Go, Python, and SQL suites directly against a locally built binary. It took a bit of work to get local integration testing set up properly but wanted to make sure I wasn't breaking anything as I iterated. The failures I saw were all pre-existing environment issues (sharded pool config, unique_id node config, bundler version mismatch) and unrelated to these changes. The 9 new multi-statement tests all pass and I didn't see regressions in the suites I was able to run.

Note: the splitting behavior and new tests only activate under `new_parser`. The default build integration tests exercise the routing-only path.