### PR TITLE
Simplify constructing a ShardConfig

### DIFF
--- a/pgdog/src/backend/pool/cluster.rs
+++ b/pgdog/src/backend/pool/cluster.rs
@@ -298,7 +298,7 @@ impl Cluster {
                 .map(|(number, config)| {
                     Shard::new(ShardConfig {
                         number,
-                        primary: &config.primary,
+                        primary: config.primary.as_ref(),
                         replicas: &config.replicas,
                         lb_strategy,
                         rw_split,
@@ -671,7 +671,6 @@ mod test {
         ConfigAndUsers, OmnishardedTable, PoolerMode, QueryParserLevel, ShardedSchema,
     };
 
-    use crate::backend::schema::SchemaCache;
     use crate::frontend::router::sharding::ShardedTable;
     use crate::{
         backend::{
@@ -679,10 +678,7 @@ mod test {
             pool::{Address, Config, PoolConfig, ShardConfig},
             replication::ShardedSchemas,
         },
-        config::{
-            DataType, Hasher, LoadBalancingStrategy, MultiTenant, ReadWriteSplit,
-            ReadWriteStrategy, Role, config,
-        },
+        config::{DataType, Hasher, MultiTenant, ReadWriteSplit, ReadWriteStrategy, Role, config},
         frontend::ClientRequest,
         net::Query,
     };
@@ -695,7 +691,7 @@ mod test {
                 user: "pgdog".into(),
                 database: "pgdog".into(),
             });
-            let primary = &Some(PoolConfig {
+            let primary = Some(&PoolConfig {
                 address: Address::new_test(),
                 config: Config::default(),
             });
@@ -713,12 +709,9 @@ mod test {
                         number,
                         primary,
                         replicas,
-                        lb_strategy: LoadBalancingStrategy::Random,
-                        rw_split: ReadWriteSplit::IncludePrimary,
                         identifier: identifier.clone(),
                         lsn_check_interval: Duration::MAX,
-                        pub_sub_enabled: false,
-                        schema_cache: SchemaCache::default(),
+                        ..Default::default()
                     })
                 })
                 .collect::<Vec<_>>();
@@ -826,7 +819,7 @@ mod test {
             let shard1 = cluster.shards.last_mut().unwrap();
             *shard1 = Shard::new(ShardConfig {
                 number: 1,
-                primary: &Some(PoolConfig {
+                primary: Some(&PoolConfig {
                     address: Address {
                         database_name: "pgdog1".into(),
                         ..Address::new_test()
@@ -841,12 +834,9 @@ mod test {
                     },
                     config: Config::default(),
                 }],
-                lb_strategy: LoadBalancingStrategy::Random,
-                rw_split: ReadWriteSplit::IncludePrimary,
                 identifier: cluster.identifier.clone(),
                 lsn_check_interval: Duration::MAX,
-                pub_sub_enabled: false,
-                schema_cache: SchemaCache::default(),
+                ..Default::default()
             });
             cluster
         }
@@ -859,18 +849,12 @@ mod test {
 
             Cluster {
                 shards: vec![Shard::new(ShardConfig {
-                    number: 0,
-                    primary: &Some(PoolConfig {
+                    primary: Some(&PoolConfig {
                         address: Address::new_test(),
                         config: Config::default(),
                     }),
-                    replicas: &[],
-                    lb_strategy: LoadBalancingStrategy::default(),
-                    rw_split: ReadWriteSplit::default(),
                     identifier: identifier.clone(),
-                    lsn_check_interval: Duration::default(),
-                    pub_sub_enabled: false,
-                    schema_cache: SchemaCache::default(),
+                    ..Default::default()
                 })],
                 prepared_statements: config.config.general.prepared_statements,
                 dry_run: config.config.general.dry_run,
@@ -891,8 +875,6 @@ mod test {
             let mut cluster = Self::new_test_single_shard(config);
             let identifier = cluster.identifier.clone();
             cluster.shards[0] = Shard::new(ShardConfig {
-                number: 0,
-                primary: &None,
                 replicas: &[PoolConfig {
                     address: Address {
                         configured_role: Role::Replica,
@@ -900,12 +882,8 @@ mod test {
                     },
                     config: Config::default(),
                 }],
-                lb_strategy: LoadBalancingStrategy::default(),
-                rw_split: ReadWriteSplit::default(),
                 identifier,
-                lsn_check_interval: Duration::default(),
-                pub_sub_enabled: false,
-                schema_cache: SchemaCache::default(),
+                ..Default::default()
             });
 
             cluster

--- a/pgdog/src/backend/pool/shard/mod.rs
+++ b/pgdog/src/backend/pool/shard/mod.rs
@@ -27,11 +27,12 @@ pub mod role_detector;
 use monitor::*;
 use role_detector::*;
 
+#[derive(Default)]
 pub(super) struct ShardConfig<'a> {
     /// Shard number.
     pub(super) number: usize,
     /// Shard primary database, if any.
-    pub(super) primary: &'a Option<PoolConfig>,
+    pub(super) primary: Option<&'a PoolConfig>,
     /// Shard replica databases.
     pub(super) replicas: &'a [PoolConfig],
     /// Load balancing strategy for replicas.
@@ -343,7 +344,7 @@ impl ShardInner {
             pub_sub_enabled,
             schema_cache,
         } = shard;
-        let primary = primary.as_ref().map(Pool::new);
+        let primary = primary.map(Pool::new);
         let lb = LoadBalancer::new(&primary, replicas, lb_strategy, rw_split);
         let comms = Arc::new(ShardComms {
             shutdown: CancellationToken::new(),
@@ -375,7 +376,7 @@ mod test {
     async fn test_exclude_primary() {
         crate::logger();
 
-        let primary = &Some(PoolConfig {
+        let primary = Some(&PoolConfig {
             address: Address::new_test(),
             ..Default::default()
         });
@@ -389,18 +390,15 @@ mod test {
         }];
 
         let shard = Shard::new(ShardConfig {
-            number: 0,
             primary,
             replicas,
-            lb_strategy: LoadBalancingStrategy::Random,
             rw_split: ReadWriteSplit::ExcludePrimary,
             identifier: Arc::new(User {
                 user: "pgdog".into(),
                 database: "pgdog".into(),
             }),
             lsn_check_interval: Duration::MAX,
-            pub_sub_enabled: false,
-            schema_cache: SchemaCache::default(),
+            ..Default::default()
         });
         shard.launch();
 
@@ -418,7 +416,7 @@ mod test {
     async fn test_include_primary() {
         crate::logger();
 
-        let primary = &Some(PoolConfig {
+        let primary = Some(&PoolConfig {
             address: Address::new_test(),
             ..Default::default()
         });
@@ -429,18 +427,15 @@ mod test {
         }];
 
         let shard = Shard::new(ShardConfig {
-            number: 0,
             primary,
             replicas,
-            lb_strategy: LoadBalancingStrategy::Random,
             rw_split: ReadWriteSplit::IncludePrimary,
             identifier: Arc::new(User {
                 user: "pgdog".into(),
                 database: "pgdog".into(),
             }),
             lsn_check_interval: Duration::MAX,
-            pub_sub_enabled: false,
-            schema_cache: SchemaCache::default(),
+            ..Default::default()
         });
         shard.launch();
         let mut ids = BTreeSet::new();

--- a/pgdog/src/backend/pool/shard/mod.rs
+++ b/pgdog/src/backend/pool/shard/mod.rs
@@ -27,7 +27,7 @@ pub mod role_detector;
 use monitor::*;
 use role_detector::*;
 
-#[derive(Default)]
+#[cfg_attr(test, derive(Default))]
 pub(super) struct ShardConfig<'a> {
     /// Shard number.
     pub(super) number: usize,

--- a/pgdog/src/backend/pool/shard/monitor.rs
+++ b/pgdog/src/backend/pool/shard/monitor.rs
@@ -289,7 +289,7 @@ mod test {
         })];
 
         let shard = Shard::new(ShardConfig {
-            primary: primary,
+            primary,
             replicas: &replicas,
             rw_split: ReadWriteSplit::ExcludePrimary,
             identifier: Arc::new(User {

--- a/pgdog/src/backend/pool/shard/monitor.rs
+++ b/pgdog/src/backend/pool/shard/monitor.rs
@@ -163,7 +163,7 @@ mod test {
     use crate::backend::pool::lsn_monitor::LsnStats;
     use crate::backend::pool::{Address, Config, PoolConfig};
     use crate::backend::replication::publisher::Lsn;
-    use crate::config::{LoadBalancingStrategy, ReadWriteSplit, Role};
+    use crate::config::{ReadWriteSplit, Role};
     use pgdog_postgres_types::{Format, FromDataType, TimestampTz};
     use pgdog_stats::LsnStats as StatsLsnStats;
     use tokio::time::sleep;
@@ -282,17 +282,15 @@ mod test {
     async fn test_monitor_updates_roles_on_failover() {
         crate::logger();
 
-        let primary = Some(pool_config(Address::new_test()));
+        let primary = Some(&pool_config(Address::new_test()));
         let replicas = [pool_config(Address {
             configured_role: Role::Auto,
             ..Address::new_test()
         })];
 
         let shard = Shard::new(ShardConfig {
-            number: 0,
-            primary: &primary,
+            primary: primary,
             replicas: &replicas,
-            lb_strategy: LoadBalancingStrategy::Random,
             rw_split: ReadWriteSplit::ExcludePrimary,
             identifier: Arc::new(User {
                 user: "pgdog".into(),
@@ -301,8 +299,7 @@ mod test {
             // Disable the maintenance tick (interval → MAX) so the monitor only
             // wakes on the role-change notification we fire below.
             lsn_check_interval: Duration::MAX,
-            pub_sub_enabled: false,
-            schema_cache: SchemaCache::default(),
+            ..Default::default()
         });
 
         // index 0 = replica target, index 1 = primary target.

--- a/pgdog/src/backend/pool/shard/role_detector.rs
+++ b/pgdog/src/backend/pool/shard/role_detector.rs
@@ -46,8 +46,7 @@ mod test {
     use crate::backend::pool::lsn_monitor::LsnStats;
     use crate::backend::pool::{Address, Config, PoolConfig};
     use crate::backend::replication::publisher::Lsn;
-    use crate::backend::schema::SchemaCache;
-    use crate::config::{LoadBalancingStrategy, ReadWriteSplit, Role};
+    use crate::config::{ReadWriteSplit, Role};
     use pgdog_stats::LsnStats as StatsLsnStats;
 
     use super::super::ShardConfig;
@@ -77,20 +76,17 @@ mod test {
         }
     }
 
-    fn create_test_shard(primary: &Option<PoolConfig>, replicas: &[PoolConfig]) -> Shard {
+    fn create_test_shard(primary: Option<&PoolConfig>, replicas: &[PoolConfig]) -> Shard {
         Shard::new(ShardConfig {
-            number: 0,
             primary,
             replicas,
-            lb_strategy: LoadBalancingStrategy::Random,
             rw_split: ReadWriteSplit::ExcludePrimary,
             identifier: Arc::new(User {
                 user: "pgdog".into(),
                 database: "pgdog".into(),
             }),
             lsn_check_interval: Duration::MAX,
-            pub_sub_enabled: false,
-            schema_cache: SchemaCache::default(),
+            ..Default::default()
         })
     }
 
@@ -111,7 +107,7 @@ mod test {
     fn test_changed_returns_false_when_lsn_stats_invalid() {
         let primary = Some(create_test_pool_config("127.0.0.1", 5432, true));
         let replicas = [create_test_pool_config("localhost", 5432, true)];
-        let shard = create_test_shard(&primary, &replicas);
+        let shard = create_test_shard(primary.as_ref(), &replicas);
 
         let mut detector = RoleDetector::new(&shard);
 
@@ -123,7 +119,7 @@ mod test {
     fn test_changed_returns_false_when_roles_unchanged() {
         let primary = Some(create_test_pool_config("127.0.0.1", 5432, true));
         let replicas = [create_test_pool_config("localhost", 5432, true)];
-        let shard = create_test_shard(&primary, &replicas);
+        let shard = create_test_shard(primary.as_ref(), &replicas);
 
         set_lsn_stats(&shard, 0, true, 100);
         set_lsn_stats(&shard, 1, false, 200);
@@ -138,7 +134,7 @@ mod test {
     fn test_changed_returns_true_on_failover() {
         let primary = Some(create_test_pool_config("127.0.0.1", 5432, true));
         let replicas = [create_test_pool_config("localhost", 5432, true)];
-        let shard = create_test_shard(&primary, &replicas);
+        let shard = create_test_shard(primary.as_ref(), &replicas);
 
         set_lsn_stats(&shard, 0, true, 100);
         set_lsn_stats(&shard, 1, false, 200);
@@ -158,7 +154,7 @@ mod test {
     fn test_changed_returns_false_after_roles_stabilize() {
         let primary = Some(create_test_pool_config("127.0.0.1", 5432, true));
         let replicas = [create_test_pool_config("localhost", 5432, true)];
-        let shard = create_test_shard(&primary, &replicas);
+        let shard = create_test_shard(primary.as_ref(), &replicas);
 
         set_lsn_stats(&shard, 0, true, 100);
         set_lsn_stats(&shard, 1, false, 200);
@@ -179,7 +175,7 @@ mod test {
     fn test_disabled_when_not_all_roles_auto() {
         let primary = Some(create_test_pool_config("127.0.0.1", 5432, false));
         let replicas = [create_test_pool_config("localhost", 5432, true)];
-        let shard = create_test_shard(&primary, &replicas);
+        let shard = create_test_shard(primary.as_ref(), &replicas);
 
         set_lsn_stats(&shard, 0, true, 100);
         set_lsn_stats(&shard, 1, false, 200);


### PR DESCRIPTION
Adding fields to this struct has been common recently, and doing so is extremely painful and causes a ton of churn in tests that simply do not care about the field we've added. Deriving `Default` lets us decouple tests from the fields they aren't specifically interested in