### PR TITLE
fix(memory): prepared statements cache retains gigabytes after statement spike

### DIFF
--- a/pgdog/src/frontend/prepared_statements/global_cache.rs
+++ b/pgdog/src/frontend/prepared_statements/global_cache.rs
@@ -239,6 +239,8 @@ impl GlobalCache {
         // unused will hold the remaining elements that was not extracted above
         self.unused = unused;
 
+        self.maybe_shrink();
+
         removed
     }
 
@@ -250,6 +252,23 @@ impl GlobalCache {
     /// Get all prepared statements in the global cache, keyed by global unique key.
     pub(crate) fn statements(&self) -> &HashMap<CacheKey, CachedStmt> {
         &self.statements
+    }
+
+    /// Return table memory to the allocator after a spike of unique
+    /// statements. Hysteresis (mostly-empty table, above a minimum size)
+    /// avoids rehashing on every sweep; shrinking to twice the current
+    /// len leaves headroom for new statements.
+    fn maybe_shrink(&mut self) {
+        const SHRINK_FACTOR: usize = 8;
+        const MIN_CAPACITY: usize = 4096;
+
+        if self.statements.capacity() > MIN_CAPACITY
+            && self.statements.capacity() / SHRINK_FACTOR > self.statements.len()
+        {
+            self.statements.shrink_to(self.statements.len() * 2);
+            self.names.shrink_to(self.names.len() * 2);
+            self.unused.shrink_to(self.unused.len() * 2);
+        }
     }
 
     /// Remove statement from global cache.
@@ -629,22 +648,81 @@ mod test {
         let spike_capacity = cache.capacity();
         assert!(spike_capacity >= 10_000);
 
-        for i in 1..=10_000 {
-            cache.close(&global_name(i));
-        }
-        cache.close_unused(100);
-        assert_eq!(cache.len(), 100);
-
-        // The table holds on to its allocation after the spike (capacity()
-        // may dip slightly due to tombstones); the accounting must report
-        // that memory.
-        assert!(cache.capacity() * 2 >= spike_capacity);
-        let table_floor = cache.capacity() * (std::mem::size_of::<(CacheKey, CachedStmt)>() + 1);
+        // The table allocates capacity, not len; the accounting
+        // must report that memory.
+        let table_floor = spike_capacity * (std::mem::size_of::<(CacheKey, CachedStmt)>() + 1);
         assert!(
             cache.memory_usage() >= table_floor,
             "memory_usage {} must include table capacity {}",
             cache.memory_usage(),
             table_floor
         );
+    }
+
+    #[test]
+    fn test_close_unused_shrinks_tables_after_spike() {
+        let mut cache = GlobalCache::default();
+        for i in 0..10_000 {
+            let parse = Parse::named("s", format!("SELECT {}", i));
+            cache.insert(&parse);
+        }
+        let spike_capacity = cache.capacity();
+        let spike_memory = cache.memory_usage();
+
+        for i in 1..=10_000 {
+            cache.close(&global_name(i));
+        }
+        cache.close_unused(100);
+        assert_eq!(cache.len(), 100);
+
+        // The sweep returns table memory to the allocator.
+        assert!(
+            cache.capacity() < spike_capacity / 8,
+            "capacity {} must shrink well below spike {}",
+            cache.capacity(),
+            spike_capacity
+        );
+        assert!(cache.memory_usage() < spike_memory / 8);
+
+        // Statements that survived the sweep are still usable.
+        let survivors: Vec<String> = cache.names().keys().cloned().collect();
+        assert_eq!(survivors.len(), 100);
+        for name in survivors {
+            assert!(cache.parse(&name).is_some());
+        }
+    }
+
+    #[test]
+    fn test_no_shrink_below_min_capacity() {
+        let mut cache = GlobalCache::default();
+        for i in 0..1_000 {
+            let parse = Parse::named("s", format!("SELECT {}", i));
+            cache.insert(&parse);
+        }
+        let capacity = cache.capacity();
+
+        for i in 1..=1_000 {
+            cache.close(&global_name(i));
+        }
+        cache.close_unused(10);
+
+        // Small tables are not worth rehashing.
+        assert!(cache.capacity() >= capacity / 2);
+    }
+
+    #[test]
+    fn test_no_shrink_when_mostly_full() {
+        let mut cache = GlobalCache::default();
+        for i in 0..10_000 {
+            let parse = Parse::named("s", format!("SELECT {}", i));
+            cache.insert(&parse);
+        }
+        let capacity = cache.capacity();
+
+        cache.close_unused(20_000);
+
+        // Nothing was removed; the table must not shrink.
+        assert_eq!(cache.len(), 10_000);
+        assert!(cache.capacity() >= capacity / 2);
     }
 }

--- a/pgdog/src/frontend/prepared_statements/global_cache.rs
+++ b/pgdog/src/frontend/prepared_statements/global_cache.rs
@@ -676,8 +676,6 @@ mod test {
         let spike_capacity = cache.capacity();
         assert!(spike_capacity >= 10_000);
 
-        // The table allocates capacity, not len; the accounting
-        // must report that memory.
         let table_floor = spike_capacity * (std::mem::size_of::<(CacheKey, CachedStmt)>() + 1);
         let usage = cache.memory_usage();
         assert!(usage >= table_floor);
@@ -703,7 +701,6 @@ mod test {
         assert!(shrunk_capacity < spike_capacity / 8);
         assert!(cache.memory_usage() < spike_memory / 8);
 
-        // Statements that survived the sweep are still usable.
         let survivors: Vec<String> = cache.names().keys().cloned().collect();
         assert_eq!(survivors.len(), 100);
         for name in survivors {
@@ -725,7 +722,6 @@ mod test {
         }
         cache.close_unused(10);
 
-        // Small tables are not worth rehashing.
         assert!(cache.capacity() >= capacity / 2);
     }
 

--- a/pgdog/src/frontend/prepared_statements/global_cache.rs
+++ b/pgdog/src/frontend/prepared_statements/global_cache.rs
@@ -654,11 +654,10 @@ mod test {
         // The table allocates capacity, not len; the accounting
         // must report that memory.
         let table_floor = spike_capacity * (std::mem::size_of::<(CacheKey, CachedStmt)>() + 1);
+        let usage = cache.memory_usage();
         assert!(
-            cache.memory_usage() >= table_floor,
-            "memory_usage {} must include table capacity {}",
-            cache.memory_usage(),
-            table_floor
+            usage >= table_floor,
+            "memory_usage {usage} must include table capacity {table_floor}"
         );
     }
 
@@ -678,11 +677,10 @@ mod test {
         cache.close_unused(100);
         assert_eq!(cache.len(), 100);
 
+        let shrunk_capacity = cache.capacity();
         assert!(
-            cache.capacity() < spike_capacity / 8,
-            "capacity {} must shrink well below spike {}",
-            cache.capacity(),
-            spike_capacity
+            shrunk_capacity < spike_capacity / 8,
+            "capacity {shrunk_capacity} must shrink well below spike {spike_capacity}"
         );
         assert!(cache.memory_usage() < spike_memory / 8);
 

--- a/pgdog/src/frontend/prepared_statements/global_cache.rs
+++ b/pgdog/src/frontend/prepared_statements/global_cache.rs
@@ -40,7 +40,7 @@ impl MemoryUsage for GlobalCache {
         self.statements.memory_usage()
             + self.names.memory_usage()
             + self.counter.memory_usage()
-            + self.unused.capacity() * 1usize.memory_usage()
+            + self.unused.memory_usage()
     }
 }
 
@@ -184,6 +184,12 @@ impl GlobalCache {
     /// Number of prepared statements in the local cache.
     pub(crate) fn len(&self) -> usize {
         self.statements.len()
+    }
+
+    /// Number of slots allocated by the statements table. A capacity far
+    /// above `len` means the cache is holding on to memory from a past spike.
+    pub fn capacity(&self) -> usize {
+        self.statements.capacity()
     }
 
     /// True if the local cache is empty.
@@ -611,5 +617,34 @@ mod test {
         assert!(cache.statements.is_empty());
         assert!(cache.names.is_empty());
         assert!(cache.unused.is_empty());
+    }
+
+    #[test]
+    fn test_memory_usage_counts_table_capacity() {
+        let mut cache = GlobalCache::default();
+        for i in 0..10_000 {
+            let parse = Parse::named("s", format!("SELECT {}", i));
+            cache.insert(&parse);
+        }
+        let spike_capacity = cache.capacity();
+        assert!(spike_capacity >= 10_000);
+
+        for i in 1..=10_000 {
+            cache.close(&global_name(i));
+        }
+        cache.close_unused(100);
+        assert_eq!(cache.len(), 100);
+
+        // The table holds on to its allocation after the spike (capacity()
+        // may dip slightly due to tombstones); the accounting must report
+        // that memory.
+        assert!(cache.capacity() * 2 >= spike_capacity);
+        let table_floor = cache.capacity() * (std::mem::size_of::<(CacheKey, CachedStmt)>() + 1);
+        assert!(
+            cache.memory_usage() >= table_floor,
+            "memory_usage {} must include table capacity {}",
+            cache.memory_usage(),
+            table_floor
+        );
     }
 }

--- a/pgdog/src/frontend/prepared_statements/global_cache.rs
+++ b/pgdog/src/frontend/prepared_statements/global_cache.rs
@@ -675,7 +675,6 @@ mod test {
         cache.close_unused(100);
         assert_eq!(cache.len(), 100);
 
-        // The sweep returns table memory to the allocator.
         assert!(
             cache.capacity() < spike_capacity / 8,
             "capacity {} must shrink well below spike {}",
@@ -721,7 +720,6 @@ mod test {
 
         cache.close_unused(20_000);
 
-        // Nothing was removed; the table must not shrink.
         assert_eq!(cache.len(), 10_000);
         assert!(cache.capacity() >= capacity / 2);
     }

--- a/pgdog/src/frontend/prepared_statements/global_cache.rs
+++ b/pgdog/src/frontend/prepared_statements/global_cache.rs
@@ -349,7 +349,7 @@ impl GlobalCache {
         const MIN_CAPACITY: usize = 4096;
 
         if self.statements.capacity() > MIN_CAPACITY
-            && self.statements.capacity() / SHRINK_FACTOR > self.statements.len()
+            && self.statements.capacity() > self.statements.len() * SHRINK_FACTOR
         {
             self.statements.shrink_to(self.statements.len() * 2);
             self.names.shrink_to(self.names.len() * 2);

--- a/pgdog/src/frontend/prepared_statements/global_cache.rs
+++ b/pgdog/src/frontend/prepared_statements/global_cache.rs
@@ -263,7 +263,7 @@ impl GlobalCache {
         const MIN_CAPACITY: usize = 4096;
 
         if self.statements.capacity() > MIN_CAPACITY
-            && self.statements.capacity() / SHRINK_FACTOR > self.statements.len()
+            && self.statements.capacity() > self.statements.len() * SHRINK_FACTOR
         {
             self.statements.shrink_to(self.statements.len() * 2);
             self.names.shrink_to(self.names.len() * 2);

--- a/pgdog/src/frontend/prepared_statements/global_cache.rs
+++ b/pgdog/src/frontend/prepared_statements/global_cache.rs
@@ -678,7 +678,6 @@ mod test {
         cache.close_unused(100);
         assert_eq!(cache.len(), 100);
 
-        // The sweep returns table memory to the allocator.
         assert!(
             cache.capacity() < spike_capacity / 8,
             "capacity {} must shrink well below spike {}",
@@ -724,7 +723,6 @@ mod test {
 
         cache.close_unused(20_000);
 
-        // Nothing was removed; the table must not shrink.
         assert_eq!(cache.len(), 10_000);
         assert!(cache.capacity() >= capacity / 2);
     }

--- a/pgdog/src/frontend/prepared_statements/global_cache.rs
+++ b/pgdog/src/frontend/prepared_statements/global_cache.rs
@@ -28,20 +28,27 @@ pub struct Statement {
 impl MemoryUsage for Statement {
     #[inline]
     fn memory_usage(&self) -> usize {
-        self.parse.len()
-            + if let Some(ref row_description) = self.row_description {
-                row_description.memory_usage()
-            } else {
-                0
-            }
-            + self.cache_key.memory_usage()
-            + self.evict_on_close.memory_usage()
+        // Same content accounting the cache aggregates in content_bytes,
+        // so SHOW PREPARED STATEMENTS agrees with the metric.
+        self.content_bytes() + self.cache_key.memory_usage() + self.evict_on_close.memory_usage()
     }
 }
 
 impl Statement {
     pub fn query(&self) -> &str {
         self.parse.query()
+    }
+
+    /// Heap bytes owned by this statement; tracked incrementally
+    /// in the cache's `content_bytes`.
+    fn content_bytes(&self) -> usize {
+        self.parse.len()
+            + self.rewrite.as_ref().map(|p| p.len()).unwrap_or(0)
+            + self
+                .row_description
+                .as_ref()
+                .map(|r| r.memory_usage())
+                .unwrap_or(0)
     }
 
     fn cache_key(&self) -> CacheKey {
@@ -115,16 +122,20 @@ pub struct GlobalCache {
     unused: HashSet<usize>,
     counter: usize,
     versions: usize,
+    /// Heap bytes owned by cached statements, maintained on
+    /// insert/remove so memory reporting stays O(1).
+    content_bytes: usize,
 }
 
 impl MemoryUsage for GlobalCache {
     #[inline]
     fn memory_usage(&self) -> usize {
-        self.statements.memory_usage()
-            + self.names.memory_usage()
-            + self.counter.memory_usage()
-            + self.versions.memory_usage()
-            + self.unused.memory_usage()
+        // O(1): tables report their allocation via capacity, entry
+        // contents are tracked incrementally as statements come and go.
+        self.statements.capacity() * (std::mem::size_of::<(CacheKey, CachedStmt)>() + 1)
+            + self.names.capacity() * (std::mem::size_of::<(String, Statement)>() + 1)
+            + self.unused.capacity() * (std::mem::size_of::<usize>() + 1)
+            + self.content_bytes
     }
 }
 
@@ -166,14 +177,14 @@ impl GlobalCache {
                 },
             );
 
-            self.names.insert(
-                name.clone(),
-                Statement {
-                    parse,
-                    cache_key,
-                    ..Default::default()
-                },
-            );
+            let key = name.clone();
+            let statement = Statement {
+                parse,
+                cache_key,
+                ..Default::default()
+            };
+            self.content_bytes += key.capacity() + statement.content_bytes();
+            self.names.insert(key, statement);
 
             (true, name)
         }
@@ -202,15 +213,15 @@ impl GlobalCache {
             },
         );
 
-        self.names.insert(
-            name.clone(),
-            Statement {
-                parse,
-                version: self.versions,
-                cache_key: key,
-                ..Default::default()
-            },
-        );
+        let name_key = name.clone();
+        let statement = Statement {
+            parse,
+            version: self.versions,
+            cache_key: key,
+            ..Default::default()
+        };
+        self.content_bytes += name_key.capacity() + statement.content_bytes();
+        self.names.insert(name_key, statement);
 
         name
     }
@@ -218,7 +229,9 @@ impl GlobalCache {
     /// Rewrite prepared statement in the global cache.
     pub fn rewrite(&mut self, parse: &Parse) {
         if let Some(stmt) = self.names.get_mut(parse.name()) {
+            let old = stmt.rewrite.as_ref().map(|p| p.len()).unwrap_or(0);
             stmt.rewrite = Some(parse.clone());
+            self.content_bytes = self.content_bytes.saturating_sub(old) + parse.len();
         }
     }
 
@@ -229,6 +242,7 @@ impl GlobalCache {
             && entry.row_description.is_none()
         {
             entry.row_description = Some(row_description.clone());
+            self.content_bytes += row_description.memory_usage();
         }
     }
 
@@ -242,6 +256,7 @@ impl GlobalCache {
         self.unused.shrink_to_fit();
         self.counter = 0;
         self.versions = 0;
+        self.content_bytes = 0;
     }
 
     /// Get the query string stored in the global cache
@@ -342,8 +357,7 @@ impl GlobalCache {
 
     /// Return table memory to the allocator after a spike of unique
     /// statements. Hysteresis (mostly-empty table, above a minimum size)
-    /// avoids rehashing on every sweep; shrinking to twice the current
-    /// len leaves headroom for new statements.
+    /// avoids rehashing on every sweep.
     fn maybe_shrink(&mut self) {
         const SHRINK_FACTOR: usize = 8;
         const MIN_CAPACITY: usize = 4096;
@@ -351,16 +365,19 @@ impl GlobalCache {
         if self.statements.capacity() > MIN_CAPACITY
             && self.statements.capacity() > self.statements.len() * SHRINK_FACTOR
         {
-            self.statements.shrink_to(self.statements.len() * 2);
-            self.names.shrink_to(self.names.len() * 2);
-            self.unused.shrink_to(self.unused.len() * 2);
+            self.statements.shrink_to_fit();
+            self.names.shrink_to_fit();
+            self.unused.shrink_to_fit();
         }
     }
 
     /// Remove statement from global cache.
     fn remove(&mut self, name: &str) {
-        if let Some(stmt) = self.names.remove(name) {
+        if let Some((key, stmt)) = self.names.remove_entry(name) {
             self.statements.remove(&stmt.cache_key());
+            self.content_bytes = self
+                .content_bytes
+                .saturating_sub(key.capacity() + stmt.content_bytes());
         }
     }
 
@@ -383,6 +400,16 @@ impl GlobalCache {
 
     pub fn statements(&self) -> &HashMap<CacheKey, CachedStmt> {
         &self.statements
+    }
+
+    /// Recompute content bytes from scratch; used by tests to verify
+    /// the incremental counter never drifts.
+    #[cfg(test)]
+    fn recomputed_content_bytes(&self) -> usize {
+        self.names
+            .iter()
+            .map(|(k, v)| k.capacity() + v.content_bytes())
+            .sum()
     }
 }
 
@@ -717,5 +744,43 @@ mod test {
 
         assert_eq!(cache.len(), 10_000);
         assert!(cache.capacity() >= capacity / 2);
+    }
+
+    #[test]
+    fn test_content_bytes_tracks_all_mutations() {
+        use crate::net::messages::Field;
+
+        let mut cache = GlobalCache::default();
+        for i in 0..500 {
+            let parse = Parse::named("s", format!("SELECT {}", i));
+            cache.insert(&parse);
+            cache.insert(&parse); // duplicate must not grow the counter
+        }
+        for i in 0..50 {
+            let parse = Parse::named("v", format!("SELECT 'v{}'", i));
+            cache.insert_anyway(&parse);
+        }
+        let rewrite = Parse::named("__pgdog_1", "SELECT 1, 2, 3");
+        cache.rewrite(&rewrite);
+        cache.rewrite(&rewrite); // replacing a rewrite must not double-count
+        let rd = RowDescription::new(&[Field::text("name"), Field::bigint("id")]);
+        cache.insert_row_description("__pgdog_2", &rd);
+        cache.insert_row_description("__pgdog_2", &rd); // second call is a no-op
+        assert_eq!(cache.content_bytes, cache.recomputed_content_bytes());
+
+        for i in 1..=500 {
+            // inserted twice, so close twice
+            cache.close(&global_name(i));
+            cache.close(&global_name(i));
+        }
+        for i in 501..=550 {
+            cache.close(&global_name(i));
+        }
+        cache.close_unused(10);
+        assert_eq!(cache.len(), 10);
+        assert_eq!(cache.content_bytes, cache.recomputed_content_bytes());
+
+        cache.close_unused(0);
+        assert_eq!(cache.content_bytes, 0);
     }
 }

--- a/pgdog/src/frontend/prepared_statements/global_cache.rs
+++ b/pgdog/src/frontend/prepared_statements/global_cache.rs
@@ -237,6 +237,9 @@ impl GlobalCache {
         self.statements.clear();
         self.names.clear();
         self.unused.clear();
+        self.statements.shrink_to_fit();
+        self.names.shrink_to_fit();
+        self.unused.shrink_to_fit();
         self.counter = 0;
         self.versions = 0;
     }
@@ -332,7 +335,26 @@ impl GlobalCache {
             self.remove(&global_name(*counter));
         }
 
+        self.maybe_shrink();
+
         remove.len()
+    }
+
+    /// Return table memory to the allocator after a spike of unique
+    /// statements. Hysteresis (mostly-empty table, above a minimum size)
+    /// avoids rehashing on every sweep; shrinking to twice the current
+    /// len leaves headroom for new statements.
+    fn maybe_shrink(&mut self) {
+        const SHRINK_FACTOR: usize = 8;
+        const MIN_CAPACITY: usize = 4096;
+
+        if self.statements.capacity() > MIN_CAPACITY
+            && self.statements.capacity() / SHRINK_FACTOR > self.statements.len()
+        {
+            self.statements.shrink_to(self.statements.len() * 2);
+            self.names.shrink_to(self.names.len() * 2);
+            self.unused.shrink_to(self.unused.len() * 2);
+        }
     }
 
     /// Remove statement from global cache.
@@ -629,22 +651,81 @@ mod test {
         let spike_capacity = cache.capacity();
         assert!(spike_capacity >= 10_000);
 
-        for i in 1..=10_000 {
-            cache.close(&global_name(i));
-        }
-        cache.close_unused(100);
-        assert_eq!(cache.len(), 100);
-
-        // The table holds on to its allocation after the spike (capacity()
-        // may dip slightly due to tombstones); the accounting must report
-        // that memory.
-        assert!(cache.capacity() * 2 >= spike_capacity);
-        let table_floor = cache.capacity() * (std::mem::size_of::<(CacheKey, CachedStmt)>() + 1);
+        // The table allocates capacity, not len; the accounting
+        // must report that memory.
+        let table_floor = spike_capacity * (std::mem::size_of::<(CacheKey, CachedStmt)>() + 1);
         assert!(
             cache.memory_usage() >= table_floor,
             "memory_usage {} must include table capacity {}",
             cache.memory_usage(),
             table_floor
         );
+    }
+
+    #[test]
+    fn test_close_unused_shrinks_tables_after_spike() {
+        let mut cache = GlobalCache::default();
+        for i in 0..10_000 {
+            let parse = Parse::named("s", format!("SELECT {}", i));
+            cache.insert(&parse);
+        }
+        let spike_capacity = cache.capacity();
+        let spike_memory = cache.memory_usage();
+
+        for i in 1..=10_000 {
+            cache.close(&global_name(i));
+        }
+        cache.close_unused(100);
+        assert_eq!(cache.len(), 100);
+
+        // The sweep returns table memory to the allocator.
+        assert!(
+            cache.capacity() < spike_capacity / 8,
+            "capacity {} must shrink well below spike {}",
+            cache.capacity(),
+            spike_capacity
+        );
+        assert!(cache.memory_usage() < spike_memory / 8);
+
+        // Statements that survived the sweep are still usable.
+        let survivors: Vec<String> = cache.names().keys().cloned().collect();
+        assert_eq!(survivors.len(), 100);
+        for name in survivors {
+            assert!(cache.parse(&name).is_some());
+        }
+    }
+
+    #[test]
+    fn test_no_shrink_below_min_capacity() {
+        let mut cache = GlobalCache::default();
+        for i in 0..1_000 {
+            let parse = Parse::named("s", format!("SELECT {}", i));
+            cache.insert(&parse);
+        }
+        let capacity = cache.capacity();
+
+        for i in 1..=1_000 {
+            cache.close(&global_name(i));
+        }
+        cache.close_unused(10);
+
+        // Small tables are not worth rehashing.
+        assert!(cache.capacity() >= capacity / 2);
+    }
+
+    #[test]
+    fn test_no_shrink_when_mostly_full() {
+        let mut cache = GlobalCache::default();
+        for i in 0..10_000 {
+            let parse = Parse::named("s", format!("SELECT {}", i));
+            cache.insert(&parse);
+        }
+        let capacity = cache.capacity();
+
+        cache.close_unused(20_000);
+
+        // Nothing was removed; the table must not shrink.
+        assert_eq!(cache.len(), 10_000);
+        assert!(cache.capacity() >= capacity / 2);
     }
 }

--- a/pgdog/src/frontend/prepared_statements/global_cache.rs
+++ b/pgdog/src/frontend/prepared_statements/global_cache.rs
@@ -652,10 +652,7 @@ mod test {
         // must report that memory.
         let table_floor = spike_capacity * (std::mem::size_of::<(CacheKey, CachedStmt)>() + 1);
         let usage = cache.memory_usage();
-        assert!(
-            usage >= table_floor,
-            "memory_usage {usage} < table {table_floor}"
-        );
+        assert!(usage >= table_floor);
     }
 
     #[test]
@@ -675,10 +672,7 @@ mod test {
         assert_eq!(cache.len(), 100);
 
         let shrunk_capacity = cache.capacity();
-        assert!(
-            shrunk_capacity < spike_capacity / 8,
-            "capacity {shrunk_capacity} not shrunk"
-        );
+        assert!(shrunk_capacity < spike_capacity / 8);
         assert!(cache.memory_usage() < spike_memory / 8);
 
         // Statements that survived the sweep are still usable.

--- a/pgdog/src/frontend/prepared_statements/global_cache.rs
+++ b/pgdog/src/frontend/prepared_statements/global_cache.rs
@@ -654,7 +654,7 @@ mod test {
         let usage = cache.memory_usage();
         assert!(
             usage >= table_floor,
-            "memory_usage {usage} must include table capacity {table_floor}"
+            "memory_usage {usage} < table {table_floor}"
         );
     }
 
@@ -677,7 +677,7 @@ mod test {
         let shrunk_capacity = cache.capacity();
         assert!(
             shrunk_capacity < spike_capacity / 8,
-            "capacity {shrunk_capacity} must shrink well below spike {spike_capacity}"
+            "capacity {shrunk_capacity} not shrunk"
         );
         assert!(cache.memory_usage() < spike_memory / 8);
 

--- a/pgdog/src/frontend/prepared_statements/global_cache.rs
+++ b/pgdog/src/frontend/prepared_statements/global_cache.rs
@@ -124,7 +124,7 @@ impl MemoryUsage for GlobalCache {
             + self.names.memory_usage()
             + self.counter.memory_usage()
             + self.versions.memory_usage()
-            + self.unused.len() * std::mem::size_of::<usize>()
+            + self.unused.memory_usage()
     }
 }
 
@@ -287,6 +287,12 @@ impl GlobalCache {
     /// Number of prepared statements in the local cache.
     pub fn len(&self) -> usize {
         self.statements.len()
+    }
+
+    /// Number of slots allocated by the statements table. A capacity far
+    /// above `len` means the cache is holding on to memory from a past spike.
+    pub fn capacity(&self) -> usize {
+        self.statements.capacity()
     }
 
     /// True if the local cache is empty.
@@ -611,5 +617,34 @@ mod test {
         assert!(cache.statements.is_empty());
         assert!(cache.names.is_empty());
         assert!(cache.unused.is_empty());
+    }
+
+    #[test]
+    fn test_memory_usage_counts_table_capacity() {
+        let mut cache = GlobalCache::default();
+        for i in 0..10_000 {
+            let parse = Parse::named("s", format!("SELECT {}", i));
+            cache.insert(&parse);
+        }
+        let spike_capacity = cache.capacity();
+        assert!(spike_capacity >= 10_000);
+
+        for i in 1..=10_000 {
+            cache.close(&global_name(i));
+        }
+        cache.close_unused(100);
+        assert_eq!(cache.len(), 100);
+
+        // The table holds on to its allocation after the spike (capacity()
+        // may dip slightly due to tombstones); the accounting must report
+        // that memory.
+        assert!(cache.capacity() * 2 >= spike_capacity);
+        let table_floor = cache.capacity() * (std::mem::size_of::<(CacheKey, CachedStmt)>() + 1);
+        assert!(
+            cache.memory_usage() >= table_floor,
+            "memory_usage {} must include table capacity {}",
+            cache.memory_usage(),
+            table_floor
+        );
     }
 }

--- a/pgdog/src/frontend/prepared_statements/global_cache.rs
+++ b/pgdog/src/frontend/prepared_statements/global_cache.rs
@@ -32,15 +32,17 @@ pub struct GlobalCache {
     names: HashMap<String, Statement>,
     unused: HashSet<Counter>,
     counter: Counter,
+    content_bytes: usize,
 }
 
 impl MemoryUsage for GlobalCache {
     #[inline]
     fn memory_usage(&self) -> usize {
-        self.statements.memory_usage()
-            + self.names.memory_usage()
+        self.statements.capacity() * (std::mem::size_of::<(CacheKey, CachedStmt)>() + 1)
+            + self.names.capacity() * (std::mem::size_of::<(String, Statement)>() + 1)
+            + self.unused.capacity() * (std::mem::size_of::<Counter>() + 1)
             + self.counter.memory_usage()
-            + self.unused.memory_usage()
+            + self.content_bytes
     }
 }
 
@@ -119,18 +121,32 @@ impl GlobalCache {
 
     /// Rewrite prepared statement in the global cache.
     pub(crate) fn rewrite(&mut self, parse: &Parse) {
-        if let Some(stmt) = self.names.get_mut(parse.name()) {
+        let delta = self.names.get_mut(parse.name()).map(|stmt| {
+            let before = stmt.content_bytes();
             stmt.set_rewrite(parse);
+            (before, stmt.content_bytes())
+        });
+
+        if let Some((before, after)) = delta {
+            self.content_bytes = self.content_bytes.saturating_sub(before) + after;
         }
     }
 
     /// Client sent a Describe for a prepared statement and received a RowDescription.
     /// We record the RowDescription for later use by the results decoder.
     pub fn insert_row_description(&mut self, name: &str, row_description: RowDescription) {
-        if let Some(entry) = self.names.get_mut(name)
-            && entry.row_description.is_none()
-        {
-            entry.row_description = Some(row_description);
+        let added = self
+            .names
+            .get_mut(name)
+            .filter(|entry| entry.row_description.is_none())
+            .map(|entry| {
+                let added = row_description.memory_usage();
+                entry.row_description = Some(row_description);
+                added
+            });
+
+        if let Some(added) = added {
+            self.content_bytes += added;
         }
     }
     /// Get the Parse message for a globally unique prepared statement
@@ -256,8 +272,7 @@ impl GlobalCache {
 
     /// Return table memory to the allocator after a spike of unique
     /// statements. Hysteresis (mostly-empty table, above a minimum size)
-    /// avoids rehashing on every sweep; shrinking to twice the current
-    /// len leaves headroom for new statements.
+    /// avoids rehashing on every sweep.
     fn maybe_shrink(&mut self) {
         const SHRINK_FACTOR: usize = 8;
         const MIN_CAPACITY: usize = 4096;
@@ -265,15 +280,26 @@ impl GlobalCache {
         if self.statements.capacity() > MIN_CAPACITY
             && self.statements.capacity() > self.statements.len() * SHRINK_FACTOR
         {
-            self.statements.shrink_to(self.statements.len() * 2);
-            self.names.shrink_to(self.names.len() * 2);
-            self.unused.shrink_to(self.unused.len() * 2);
+            self.statements.shrink_to_fit();
+            self.names.shrink_to_fit();
+            self.unused.shrink_to_fit();
         }
+    }
+
+    #[cfg(test)]
+    fn recomputed_content_bytes(&self) -> usize {
+        self.names
+            .iter()
+            .map(|(k, v)| k.capacity() + v.content_bytes())
+            .sum()
     }
 
     /// Remove statement from global cache.
     fn remove(&mut self, name: &str) {
         if let Some(stmt) = self.names.remove(name) {
+            self.content_bytes = self
+                .content_bytes
+                .saturating_sub(name.len() + stmt.content_bytes());
             self.statements.remove(stmt.cache_key());
         }
     }
@@ -304,7 +330,9 @@ impl GlobalCache {
                 used: 1,
             },
         );
-        self.names.insert(name.to_owned(), statement);
+        let key = name.to_owned();
+        self.content_bytes += key.capacity() + statement.content_bytes();
+        self.names.insert(key, statement);
     }
 }
 
@@ -714,5 +742,44 @@ mod test {
 
         assert_eq!(cache.len(), 10_000);
         assert!(cache.capacity() >= capacity / 2);
+    }
+
+    #[test]
+    fn test_content_bytes_tracks_all_mutations() {
+        use crate::net::messages::Field;
+
+        let mut cache = GlobalCache::default();
+        for i in 0..500 {
+            let parse = Parse::named("s", format!("SELECT {}", i));
+            cache.insert(&parse);
+            cache.insert(&parse);
+        }
+        for i in 0..50 {
+            cache.insert_prepare(
+                Bytes::from(format!("SELECT 'v{}'", i)),
+                &RewritePlan::default(),
+            );
+        }
+        let rewrite = Parse::named("__pgdog_1", "SELECT 1, 2, 3");
+        cache.rewrite(&rewrite);
+        cache.rewrite(&rewrite);
+        let row_description = RowDescription::new(&[Field::text("name"), Field::bigint("id")]);
+        cache.insert_row_description("__pgdog_2", row_description.clone());
+        cache.insert_row_description("__pgdog_2", row_description);
+        assert_eq!(cache.content_bytes, cache.recomputed_content_bytes());
+
+        for i in 1..=500 {
+            cache.close(&global_name(i));
+            cache.close(&global_name(i));
+        }
+        for i in 501..=550 {
+            cache.close(&global_name(i));
+        }
+        cache.close_unused(10);
+        assert_eq!(cache.len(), 10);
+        assert_eq!(cache.content_bytes, cache.recomputed_content_bytes());
+
+        cache.close_unused(0);
+        assert_eq!(cache.content_bytes, 0);
     }
 }

--- a/pgdog/src/frontend/prepared_statements/global_cache.rs
+++ b/pgdog/src/frontend/prepared_statements/global_cache.rs
@@ -657,7 +657,7 @@ mod test {
         let usage = cache.memory_usage();
         assert!(
             usage >= table_floor,
-            "memory_usage {usage} must include table capacity {table_floor}"
+            "memory_usage {usage} < table {table_floor}"
         );
     }
 
@@ -680,7 +680,7 @@ mod test {
         let shrunk_capacity = cache.capacity();
         assert!(
             shrunk_capacity < spike_capacity / 8,
-            "capacity {shrunk_capacity} must shrink well below spike {spike_capacity}"
+            "capacity {shrunk_capacity} not shrunk"
         );
         assert!(cache.memory_usage() < spike_memory / 8);
 

--- a/pgdog/src/frontend/prepared_statements/global_cache.rs
+++ b/pgdog/src/frontend/prepared_statements/global_cache.rs
@@ -651,11 +651,10 @@ mod test {
         // The table allocates capacity, not len; the accounting
         // must report that memory.
         let table_floor = spike_capacity * (std::mem::size_of::<(CacheKey, CachedStmt)>() + 1);
+        let usage = cache.memory_usage();
         assert!(
-            cache.memory_usage() >= table_floor,
-            "memory_usage {} must include table capacity {}",
-            cache.memory_usage(),
-            table_floor
+            usage >= table_floor,
+            "memory_usage {usage} must include table capacity {table_floor}"
         );
     }
 
@@ -675,11 +674,10 @@ mod test {
         cache.close_unused(100);
         assert_eq!(cache.len(), 100);
 
+        let shrunk_capacity = cache.capacity();
         assert!(
-            cache.capacity() < spike_capacity / 8,
-            "capacity {} must shrink well below spike {}",
-            cache.capacity(),
-            spike_capacity
+            shrunk_capacity < spike_capacity / 8,
+            "capacity {shrunk_capacity} must shrink well below spike {spike_capacity}"
         );
         assert!(cache.memory_usage() < spike_memory / 8);
 

--- a/pgdog/src/frontend/prepared_statements/global_cache.rs
+++ b/pgdog/src/frontend/prepared_statements/global_cache.rs
@@ -655,10 +655,7 @@ mod test {
         // must report that memory.
         let table_floor = spike_capacity * (std::mem::size_of::<(CacheKey, CachedStmt)>() + 1);
         let usage = cache.memory_usage();
-        assert!(
-            usage >= table_floor,
-            "memory_usage {usage} < table {table_floor}"
-        );
+        assert!(usage >= table_floor);
     }
 
     #[test]
@@ -678,10 +675,7 @@ mod test {
         assert_eq!(cache.len(), 100);
 
         let shrunk_capacity = cache.capacity();
-        assert!(
-            shrunk_capacity < spike_capacity / 8,
-            "capacity {shrunk_capacity} not shrunk"
-        );
+        assert!(shrunk_capacity < spike_capacity / 8);
         assert!(cache.memory_usage() < spike_memory / 8);
 
         // Statements that survived the sweep are still usable.

--- a/pgdog/src/frontend/prepared_statements/statement.rs
+++ b/pgdog/src/frontend/prepared_statements/statement.rs
@@ -45,13 +45,7 @@ impl MemoryUsage for StatementType {
 impl MemoryUsage for Statement {
     #[inline]
     fn memory_usage(&self) -> usize {
-        self.stmt.memory_usage()
-            + if let Some(row_description) = &self.row_description {
-                row_description.memory_usage()
-            } else {
-                0
-            }
-            + self.cache_key.memory_usage()
+        self.content_bytes() + self.cache_key.memory_usage()
     }
 }
 
@@ -90,6 +84,15 @@ impl Statement {
 
     pub(super) fn cache_key(&self) -> &CacheKey {
         &self.cache_key
+    }
+
+    pub(super) fn content_bytes(&self) -> usize {
+        self.stmt.memory_usage()
+            + self
+                .row_description
+                .as_ref()
+                .map(|row_description| row_description.memory_usage())
+                .unwrap_or_default()
     }
 
     pub(super) fn set_rewrite(&mut self, parse: &Parse) {

--- a/pgdog/src/stats/memory.rs
+++ b/pgdog/src/stats/memory.rs
@@ -84,7 +84,6 @@ impl<K: MemoryUsage, V: MemoryUsage> MemoryUsage for BTreeMap<K, V> {
 impl<V: MemoryUsage, S> MemoryUsage for HashSet<V, S> {
     #[inline(always)]
     fn memory_usage(&self) -> usize {
-        // Same as HashMap: count allocated slots, not just live entries.
         self.capacity() * (std::mem::size_of::<V>() + 1)
             + self.iter().map(|v| v.memory_usage()).sum::<usize>()
     }

--- a/pgdog/src/stats/memory.rs
+++ b/pgdog/src/stats/memory.rs
@@ -54,12 +54,17 @@ impl<V: MemoryUsage> MemoryUsage for Vec<V> {
     }
 }
 
-impl<K: MemoryUsage, V: MemoryUsage> MemoryUsage for HashMap<K, V> {
+impl<K: MemoryUsage, V: MemoryUsage, S> MemoryUsage for HashMap<K, V, S> {
     #[inline(always)]
     fn memory_usage(&self) -> usize {
-        self.iter()
-            .map(|(k, v)| k.memory_usage() + v.memory_usage())
-            .sum::<usize>()
+        // The table allocates capacity() slots (plus one control byte each),
+        // not len(): spare capacity left behind by removed entries still
+        // occupies memory and has to be counted.
+        self.capacity() * (std::mem::size_of::<(K, V)>() + 1)
+            + self
+                .iter()
+                .map(|(k, v)| k.memory_usage() + v.memory_usage())
+                .sum::<usize>()
     }
 }
 
@@ -72,10 +77,12 @@ impl<K: MemoryUsage, V: MemoryUsage> MemoryUsage for BTreeMap<K, V> {
     }
 }
 
-impl<V: MemoryUsage> MemoryUsage for HashSet<V> {
+impl<V: MemoryUsage, S> MemoryUsage for HashSet<V, S> {
     #[inline(always)]
     fn memory_usage(&self) -> usize {
-        self.iter().map(|v| v.memory_usage()).sum::<usize>()
+        // Same as HashMap: count allocated slots, not just live entries.
+        self.capacity() * (std::mem::size_of::<V>() + 1)
+            + self.iter().map(|v| v.memory_usage()).sum::<usize>()
     }
 }
 
@@ -99,5 +106,42 @@ impl MemoryUsage for Bytes {
     #[inline(always)]
     fn memory_usage(&self) -> usize {
         0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hash_map_counts_spare_capacity() {
+        let mut map: HashMap<usize, usize> = HashMap::new();
+        for i in 0..1000 {
+            map.insert(i, i);
+        }
+        let capacity = map.capacity();
+        for i in 0..1000 {
+            map.remove(&i);
+        }
+        assert!(map.is_empty());
+        // The allocation survives removals; capacity() may dip slightly
+        // due to tombstones but stays the same order of magnitude.
+        assert!(map.capacity() * 2 >= capacity);
+        assert!(
+            map.memory_usage() >= map.capacity() * (std::mem::size_of::<(usize, usize)>() + 1),
+            "spare capacity left by removed entries must be counted"
+        );
+    }
+
+    #[test]
+    fn hash_set_counts_spare_capacity() {
+        let mut set: HashSet<usize> = HashSet::new();
+        for i in 0..1000 {
+            set.insert(i);
+        }
+        let capacity = set.capacity();
+        set.clear();
+        assert_eq!(set.capacity(), capacity);
+        assert!(set.memory_usage() >= capacity * (std::mem::size_of::<usize>() + 1));
     }
 }

--- a/pgdog/src/stats/memory.rs
+++ b/pgdog/src/stats/memory.rs
@@ -131,9 +131,10 @@ mod tests {
         // The allocation survives removals; capacity() may dip slightly
         // due to tombstones but stays the same order of magnitude.
         assert!(map.capacity() * 2 >= capacity);
+        let floor = map.capacity() * (std::mem::size_of::<(usize, usize)>() + 1);
         assert!(
-            map.memory_usage() >= map.capacity() * (std::mem::size_of::<(usize, usize)>() + 1),
-            "spare capacity left by removed entries must be counted"
+            map.memory_usage() >= floor,
+            "spare capacity must be counted"
         );
     }
 

--- a/pgdog/src/stats/memory.rs
+++ b/pgdog/src/stats/memory.rs
@@ -3,13 +3,10 @@ use lru::LruCache;
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::hash::Hash;
 
-/// Approximate number of bytes attributable to a value, for observability.
+/// Approximate bytes attributable to a value, for metrics.
 ///
-/// Scalar impls report their inline size (so summing over a collection's
-/// elements works), container impls report allocated capacity plus the sum
-/// over live elements. As a result, the inline portion of live entries can
-/// be counted both in the container's capacity term and in the element sum:
-/// numbers are upper-bound approximations, not exact accounting.
+/// Scalars report their inline size, containers report allocated capacity
+/// plus the sum over elements: treat results as an upper bound.
 pub trait MemoryUsage {
     fn memory_usage(&self) -> usize;
 }

--- a/pgdog/src/stats/memory.rs
+++ b/pgdog/src/stats/memory.rs
@@ -3,6 +3,13 @@ use lru::LruCache;
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::hash::Hash;
 
+/// Approximate number of bytes attributable to a value, for observability.
+///
+/// Scalar impls report their inline size (so summing over a collection's
+/// elements works), container impls report allocated capacity plus the sum
+/// over live elements. As a result, the inline portion of live entries can
+/// be counted both in the container's capacity term and in the element sum:
+/// numbers are upper-bound approximations, not exact accounting.
 pub trait MemoryUsage {
     fn memory_usage(&self) -> usize;
 }

--- a/pgdog/src/stats/memory.rs
+++ b/pgdog/src/stats/memory.rs
@@ -132,10 +132,7 @@ mod tests {
         // due to tombstones but stays the same order of magnitude.
         assert!(map.capacity() * 2 >= capacity);
         let floor = map.capacity() * (std::mem::size_of::<(usize, usize)>() + 1);
-        assert!(
-            map.memory_usage() >= floor,
-            "spare capacity must be counted"
-        );
+        assert!(map.memory_usage() >= floor);
     }
 
     #[test]

--- a/pgdog/src/stats/query_cache.rs
+++ b/pgdog/src/stats/query_cache.rs
@@ -19,15 +19,16 @@ pub struct QueryCache {
     stats: Stats,
     len: usize,
     prepared_statements: usize,
+    prepared_statements_capacity: usize,
     prepared_statements_memory: usize,
 }
 
 impl QueryCache {
     pub(crate) fn load() -> Self {
-        let (prepared_statements, prepared_statements_memory) = {
+        let (prepared_statements, prepared_statements_capacity, prepared_statements_memory) = {
             let global = PreparedStatements::global();
             let guard = global.read();
-            (guard.len(), guard.memory_usage())
+            (guard.len(), guard.capacity(), guard.memory_usage())
         };
 
         let (stats, len) = Cache::stats();
@@ -36,6 +37,7 @@ impl QueryCache {
             stats,
             len,
             prepared_statements,
+            prepared_statements_capacity,
             prepared_statements_memory,
         }
     }
@@ -88,6 +90,12 @@ impl QueryCache {
                 name: "prepared_statements".into(),
                 help: "Number of prepared statements in the cache".into(),
                 value: self.prepared_statements,
+                gauge: true,
+            }),
+            Metric::new(QueryCacheMetric {
+                name: "prepared_statements_capacity".into(),
+                help: "Number of slots allocated by the prepared statements cache".into(),
+                value: self.prepared_statements_capacity,
                 gauge: true,
             }),
             Metric::new(QueryCacheMetric {
@@ -173,6 +181,7 @@ mod tests {
             },
             len: 5,
             prepared_statements: 6,
+            prepared_statements_capacity: 8,
             prepared_statements_memory: 7,
         };
 
@@ -189,6 +198,7 @@ mod tests {
                 "query_cache_parse_time".to_string(),
                 "query_cache_fingerprints".to_string(),
                 "prepared_statements".to_string(),
+                "prepared_statements_capacity".to_string(),
                 "prepared_statements_memory_used".to_string(),
             ]
         );

--- a/pgdog/src/stats/query_cache.rs
+++ b/pgdog/src/stats/query_cache.rs
@@ -94,7 +94,8 @@ impl QueryCache {
             }),
             Metric::new(QueryCacheMetric {
                 name: "prepared_statements_capacity".into(),
-                help: "Number of slots allocated by the prepared statements cache".into(),
+                help: "Number of slots allocated by the statements table of the prepared statements cache"
+                    .into(),
                 value: self.prepared_statements_capacity,
                 gauge: true,
             }),


### PR DESCRIPTION
## Problem

Long-lived clients that keep preparing unique SQL statements (report jobs, ORMs interpolating values into SQL) grow the global prepared statements cache to millions of entries. When they disconnect, the maintenance sweep correctly trims entries down to `prepared_statements_limit` — but the process keeps holding gigabytes of RSS indefinitely:

1. `HashMap`/`HashSet` never return capacity to the allocator. After a spike of 10M statements, the three tables in `GlobalCache` (`statements`, `names`, `unused`) keep ~13.5M slots (~5.9 GiB) at 100 live entries, forever.
2. `prepared_statements_memory_used` is blind to this: `MemoryUsage for HashMap` sums live entries via `iter()`, so it reports ~44 KiB while RSS holds ~10 GiB.

Reproduction (docker compose + load generator): https://gist.github.com/IgorOhrimenko/8ba71664c7cf27f005e9ef80a48cf97c

Measured on a synthetic load test (10M unique prepared statements at ~7k/s through one PgDog instance, then all clients disconnect; all values settled):

| build | peak RSS | `memory_used` after disconnect | `capacity` after disconnect | RSS after disconnect |
|---|---|---|---|---|
| v0.1.50 | 15.5 GiB | 44 KiB | — | 10.1 GiB, held |
| + accounting fix | 15.5 GiB | 5.91 GiB (real) | 13 478 814 | 9.9 GiB, held |
| + shrink fix | 15.5 GiB | 148 KiB (real — memory returned) | 224 | 2.5 GiB |

## Changes

**`fix(stats)`: count hash table capacity in memory accounting**
- `MemoryUsage for HashMap`/`HashSet` now counts allocated slots (plus control bytes) and is generic over the hasher, so `FnvHashSet` is covered.
- New `prepared_statements_capacity` gauge: `capacity` far above `prepared_statements` signals memory held from a past spike, which makes this failure mode visible on a dashboard.

**`fix(memory)`: shrink the tables in the maintenance sweep**
- `close_unused()` calls `shrink_to(len * 2)` on all three tables once they are mostly empty (`capacity > 8 * len`) and large enough to matter (`> 4096` slots). Hysteresis avoids rehashing on every sweep; with jemalloc's `background_thread` (default since #1260) the freed pages are returned to the OS within seconds.
- `reset()` also releases capacity.

Peak memory under load is unchanged — entries held by connected clients are legitimate cache content; this PR is about returning the memory after they are gone.

## Testing

- Unit tests for the capacity accounting, the shrink, and the hysteresis guards (no shrink for small or mostly-full tables).
- `cargo nextest run --test-threads=1` over the workspace packages against a local Postgres — green.
- Verified end-to-end with the load test above.


