### PR TITLE
 feat(tls): allow password users to connect over TLS without a  client certificate

### DIFF
--- a/.schema/users.schema.json
+++ b/.schema/users.schema.json
@@ -291,6 +291,13 @@
           "format": "uint64",
           "minimum": 0
         },
+        "tls_client_certificate_required": {
+          "description": "Require this user to present a client TLS certificate.\n\nOnly enforced when [`tls_client_ca_certificate`](https://docs.pgdog.dev/configuration/pgdog.toml/general/)\nis configured and the client connected over TLS: without a client CA no\ncertificate is ever requested, and plaintext connections are governed by\n`tls_client_required` instead.\n\nDefaults to `true`, which preserves mandatory mTLS. Set to `false` to let\na user authenticate with a password over TLS without presenting a client\ncertificate, which allows password and mTLS users to share a listener.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "two_phase_commit": {
           "description": "Overrides [`two_phase_commit`](https://docs.pgdog.dev/configuration/pgdog.toml/general/#two_phase_commit) for this user.\n\n<https://docs.pgdog.dev/configuration/users.toml/users/#two_phase_commit>",
           "type": [

--- a/.schema/users.schema.json
+++ b/.schema/users.schema.json
@@ -292,7 +292,7 @@
           "minimum": 0
         },
         "tls_client_certificate_required": {
-          "description": "Require this user to present a client TLS certificate.\n\nOnly enforced when [`tls_client_ca_certificate`](https://docs.pgdog.dev/configuration/pgdog.toml/general/)\nis configured and the client connected over TLS: without a client CA no\ncertificate is ever requested, and plaintext connections are governed by\n`tls_client_required` instead.\n\nDefaults to `true`, which preserves mandatory mTLS. Set to `false` to let\na user authenticate with a password over TLS without presenting a client\ncertificate, which allows password and mTLS users to share a listener.",
+          "description": "Require this user to present a client TLS certificate. Defaults to `true`.\n\nOnly enforced when `tls_client_ca_certificate` is configured and the client\nconnected over TLS. Set to `false` to let password and mTLS users share a listener.",
           "type": [
             "boolean",
             "null"

--- a/example.users.toml
+++ b/example.users.toml
@@ -43,3 +43,11 @@ password = "pgdog"
 # server_user = "pgdog_service"
 # server_auth = "vault_static"
 # server_vault_path = "database/static-creds/pgdog-service"
+
+# Example: let this user authenticate with a password over TLS without
+# presenting a client certificate, while other users on the same listener still
+# authenticate with mTLS. Only meaningful when `tls_client_ca_certificate` is
+# configured in pgdog.toml; defaults to true, which requires a certificate from
+# every user connecting over TLS. Plaintext connections are governed by
+# `tls_client_required` instead.
+# tls_client_certificate_required = false

--- a/example.users.toml
+++ b/example.users.toml
@@ -44,10 +44,7 @@ password = "pgdog"
 # server_auth = "vault_static"
 # server_vault_path = "database/static-creds/pgdog-service"
 
-# Example: let this user authenticate with a password over TLS without
-# presenting a client certificate, while other users on the same listener still
-# authenticate with mTLS. Only meaningful when `tls_client_ca_certificate` is
-# configured in pgdog.toml; defaults to true, which requires a certificate from
-# every user connecting over TLS. Plaintext connections are governed by
-# `tls_client_required` instead.
+# Example: let this user authenticate with a password over TLS without presenting
+# a client certificate, while mTLS users share the same listener. Defaults to true.
+# Only applies when `tls_client_ca_certificate` is set in pgdog.toml.
 # tls_client_certificate_required = false

--- a/integration/tls/dev.sh
+++ b/integration/tls/dev.sh
@@ -7,9 +7,16 @@ PORT=6432
 DB=pgdog
 USER_A=tls_user_a
 USER_B=tls_user_b
+USER_C=tls_user_c
+USER_D=tls_user_d
 
 run_psql() {
     psql "host=$HOST port=$PORT dbname=$DB user=$1 sslmode=require sslcert=$DIR/$2.crt sslkey=$DIR/$2.key" -c "SELECT 1" > /dev/null 2>&1
+}
+
+# TLS without offering a client certificate.
+run_psql_no_cert() {
+    PGPASSWORD=pgdog psql "host=$HOST port=$PORT dbname=$DB user=$1 sslmode=require" -c "SELECT 1" > /dev/null 2>&1
 }
 
 if [ "${1:-}" = "--source-only" ]; then
@@ -64,6 +71,26 @@ fi
 # Test 5: no TLS at all (should fail)
 echo -n "no TLS: "
 if psql "host=$HOST port=$PORT dbname=$DB user=$USER_A sslmode=disable" -c "SELECT 1" > /dev/null 2>&1; then
+    echo "FAIL (expected rejection)"
+    FAIL=$((FAIL + 1))
+else
+    echo "OK (rejected)"
+    PASS=$((PASS + 1))
+fi
+
+# Test 6: password user opted out of client certs, TLS but no cert (should succeed)
+echo -n "$USER_C opted out + no cert: "
+if run_psql_no_cert "$USER_C"; then
+    echo "OK"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL (expected success)"
+    FAIL=$((FAIL + 1))
+fi
+
+# Test 7: password user that did not opt out, TLS but no cert (should fail)
+echo -n "$USER_D not opted out + no cert: "
+if run_psql_no_cert "$USER_D"; then
     echo "FAIL (expected rejection)"
     FAIL=$((FAIL + 1))
 else

--- a/integration/tls/users.toml
+++ b/integration/tls/users.toml
@@ -11,3 +11,21 @@ database = "pgdog"
 identity = "pgdog2"
 server_user = "pgdog"
 server_password = "pgdog"
+
+# Password user that opts out of client certificates, sharing the listener
+# with the mTLS users above.
+[[users]]
+name = "tls_user_c"
+database = "pgdog"
+password = "pgdog"
+tls_client_certificate_required = false
+server_user = "pgdog"
+server_password = "pgdog"
+
+# Password user that does not opt out, so a certificate is still required.
+[[users]]
+name = "tls_user_d"
+database = "pgdog"
+password = "pgdog"
+server_user = "pgdog"
+server_password = "pgdog"

--- a/pgdog-config/src/users.rs
+++ b/pgdog-config/src/users.rs
@@ -264,16 +264,10 @@ impl Display for PasswordKind {
 pub struct User {
     /// User identity used for mTLS.
     pub identity: Option<String>,
-    /// Require this user to present a client TLS certificate.
+    /// Require this user to present a client TLS certificate. Defaults to `true`.
     ///
-    /// Only enforced when [`tls_client_ca_certificate`](https://docs.pgdog.dev/configuration/pgdog.toml/general/)
-    /// is configured and the client connected over TLS: without a client CA no
-    /// certificate is ever requested, and plaintext connections are governed by
-    /// `tls_client_required` instead.
-    ///
-    /// Defaults to `true`, which preserves mandatory mTLS. Set to `false` to let
-    /// a user authenticate with a password over TLS without presenting a client
-    /// certificate, which allows password and mTLS users to share a listener.
+    /// Only enforced when `tls_client_ca_certificate` is configured and the client
+    /// connected over TLS. Set to `false` to let password and mTLS users share a listener.
     pub tls_client_certificate_required: Option<bool>,
     /// Name of the user. Clients that connect to PgDog will need to use this username.
     ///
@@ -740,8 +734,7 @@ password = "secret"
 
         let users: Users = toml::from_str(source).unwrap();
         let user = users.users.first().unwrap();
-        // Unset is resolved to `true` when the cluster is built, so configuring
-        // a client CA keeps mandatory mTLS for users that don't opt out.
+        // Unset resolves to `true` when the cluster is built.
         assert_eq!(user.tls_client_certificate_required, None);
     }
 

--- a/pgdog-config/src/users.rs
+++ b/pgdog-config/src/users.rs
@@ -264,6 +264,17 @@ impl Display for PasswordKind {
 pub struct User {
     /// User identity used for mTLS.
     pub identity: Option<String>,
+    /// Require this user to present a client TLS certificate.
+    ///
+    /// Only enforced when [`tls_client_ca_certificate`](https://docs.pgdog.dev/configuration/pgdog.toml/general/)
+    /// is configured and the client connected over TLS: without a client CA no
+    /// certificate is ever requested, and plaintext connections are governed by
+    /// `tls_client_required` instead.
+    ///
+    /// Defaults to `true`, which preserves mandatory mTLS. Set to `false` to let
+    /// a user authenticate with a password over TLS without presenting a client
+    /// certificate, which allows password and mTLS users to share a listener.
+    pub tls_client_certificate_required: Option<bool>,
     /// Name of the user. Clients that connect to PgDog will need to use this username.
     ///
     /// <https://docs.pgdog.dev/configuration/users.toml/users/#name>
@@ -716,6 +727,37 @@ server_auth = "azure_workload_identity"
         let users: Users = toml::from_str(source).unwrap();
         let user = users.users.first().unwrap();
         assert_eq!(user.server_auth, ServerAuth::AzureWorkloadIdentity);
+    }
+
+    #[test]
+    fn test_tls_client_certificate_required_unset() {
+        let source = r#"
+[[users]]
+name = "alice"
+database = "db"
+password = "secret"
+"#;
+
+        let users: Users = toml::from_str(source).unwrap();
+        let user = users.users.first().unwrap();
+        // Unset is resolved to `true` when the cluster is built, so configuring
+        // a client CA keeps mandatory mTLS for users that don't opt out.
+        assert_eq!(user.tls_client_certificate_required, None);
+    }
+
+    #[test]
+    fn test_tls_client_certificate_required_opt_out() {
+        let source = r#"
+[[users]]
+name = "alice"
+database = "db"
+password = "secret"
+tls_client_certificate_required = false
+"#;
+
+        let users: Users = toml::from_str(source).unwrap();
+        let user = users.users.first().unwrap();
+        assert_eq!(user.tls_client_certificate_required, Some(false));
     }
 
     #[test]

--- a/pgdog/src/auth/auth_result.rs
+++ b/pgdog/src/auth/auth_result.rs
@@ -11,6 +11,8 @@ pub enum AuthResult {
     NoPasswordConfig,
     /// User identity (TLS cert) doesn't match configured identity.
     NoIdentity,
+    /// User requires a client TLS certificate but didn't provide one.
+    NoClientCertificate,
     /// Passthrough auth says user doesn't exist.
     NoPassthroughNoUser,
     /// Passthrough auth doesn't allow password changes.
@@ -40,6 +42,12 @@ impl Display for AuthResult {
             Self::NoPasswordMatch => write!(f, "wrong password"),
             Self::NoPasswordConfig => write!(f, "user has no passwords in config"),
             Self::NoIdentity => write!(f, "user identity does not match certificate"),
+            Self::NoClientCertificate => {
+                write!(
+                    f,
+                    "user requires a client certificate but none was provided"
+                )
+            }
             Self::NoPassthroughNoUser => write!(f, "no user in config (passthrough auth)"),
             Self::NoPassthroughPasswordChange => {
                 write!(f, "passthrough auth does not allow password change")

--- a/pgdog/src/auth/auth_result.rs
+++ b/pgdog/src/auth/auth_result.rs
@@ -57,3 +57,19 @@ impl Display for AuthResult {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::AuthResult;
+
+    #[test]
+    fn no_client_certificate_is_an_error_and_explains_itself() {
+        let result = AuthResult::NoClientCertificate;
+
+        assert!(!result.is_ok());
+        assert_eq!(
+            result.to_string(),
+            "user requires a client certificate but none was provided"
+        );
+    }
+}

--- a/pgdog/src/backend/pool/cluster.rs
+++ b/pgdog/src/backend/pool/cluster.rs
@@ -78,6 +78,7 @@ pub struct Cluster {
     resharding_replication_retry_min_delay: Duration,
     regex_parser: RegexParser,
     identity: Option<String>,
+    tls_client_certificate_required: bool,
 }
 
 /// Sharding configuration from the cluster.
@@ -165,6 +166,7 @@ pub struct ClusterConfig<'a> {
     regex_parser_limit: usize,
     pub_sub_enabled: bool,
     identity: &'a Option<String>,
+    tls_client_certificate_required: bool,
     schema_cache: SchemaCache,
 }
 
@@ -235,6 +237,7 @@ impl<'a> ClusterConfig<'a> {
             regex_parser_limit: general.regex_parser_limit,
             pub_sub_enabled: general.pub_sub_enabled(),
             identity: &user.identity,
+            tls_client_certificate_required: user.tls_client_certificate_required.unwrap_or(true),
             schema_cache,
         }
     }
@@ -282,6 +285,7 @@ impl Cluster {
             regex_parser_limit,
             pub_sub_enabled,
             identity,
+            tls_client_certificate_required,
             schema_cache,
         } = config;
 
@@ -345,6 +349,7 @@ impl Cluster {
             ),
             regex_parser: RegexParser::new(regex_parser_limit, query_parser),
             identity: identity.clone(),
+            tls_client_certificate_required,
         }
     }
 
@@ -411,6 +416,11 @@ impl Cluster {
     /// when connecting.
     pub fn identity(&self) -> Option<&str> {
         self.identity.as_deref()
+    }
+
+    /// This user must present a client TLS certificate when connecting over TLS.
+    pub fn tls_client_certificate_required(&self) -> bool {
+        self.tls_client_certificate_required
     }
 
     /// User name.

--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -200,7 +200,7 @@ impl Server {
                     Ok(tls_stream) => {
                         debug!("TLS handshake successful with {}", addr.host);
                         let cipher = tokio_rustls::TlsStream::Client(tls_stream);
-                        stream = Stream::tls(cipher, config.config.memory.net_buffer, None);
+                        stream = Stream::tls(cipher, config.config.memory.net_buffer, None, false);
                     }
                     Err(e) => {
                         error!("TLS handshake failed with {:?} [{}]", e, addr);

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -95,18 +95,27 @@ pub struct Client {
     query_size_limit: Option<usize>,
 }
 
-/// Reject a client that owed us a certificate and didn't send one.
-///
-/// Only meaningful when a client CA is configured, since otherwise no certificate
-/// is ever requested, and only over TLS, since plaintext is governed by
-/// `tls_client_required`.
-fn missing_required_client_certificate(
+/// Inputs to the per-user client certificate check.
+struct ClientCertificateCheck {
+    /// A client CA is configured, so certificates are requested at all.
     client_ca_configured: bool,
+    /// The client connected over TLS.
     is_tls: bool,
+    /// This user's `tls_client_certificate_required`.
     required: bool,
+    /// The client presented a certificate during the handshake.
     presented: bool,
-) -> bool {
-    client_ca_configured && is_tls && required && !presented
+}
+
+impl ClientCertificateCheck {
+    /// The client owed us a certificate and didn't send one.
+    ///
+    /// Only meaningful when a client CA is configured, since otherwise no
+    /// certificate is ever requested, and only over TLS, since plaintext is
+    /// governed by `tls_client_required`.
+    fn rejected(&self) -> bool {
+        self.client_ca_configured && self.is_tls && self.required && !self.presented
+    }
 }
 
 impl Client {
@@ -296,12 +305,14 @@ impl Client {
                         } else {
                             AuthResult::NoIdentity
                         }
-                    } else if missing_required_client_certificate(
+                    } else if (ClientCertificateCheck {
                         client_ca_configured,
-                        stream.is_tls(),
-                        cluster.tls_client_certificate_required(),
-                        stream.tls_client_certificate(),
-                    ) {
+                        is_tls: stream.is_tls(),
+                        required: cluster.tls_client_certificate_required(),
+                        presented: stream.tls_client_certificate(),
+                    })
+                    .rejected()
+                    {
                         // Asked for a certificate and declined. Users that opt out
                         // fall through to password authentication instead.
                         AuthResult::NoClientCertificate
@@ -736,27 +747,54 @@ pub mod test;
 
 #[cfg(test)]
 mod client_certificate_tests {
-    use super::missing_required_client_certificate;
+    use super::ClientCertificateCheck;
+
+    /// A user that owes a certificate over TLS and didn't send one.
+    fn rejected() -> ClientCertificateCheck {
+        ClientCertificateCheck {
+            client_ca_configured: true,
+            is_tls: true,
+            required: true,
+            presented: false,
+        }
+    }
 
     #[test]
     fn rejects_only_when_a_certificate_was_owed_and_withheld() {
-        //    client CA, is_tls, required, presented
-        assert!(missing_required_client_certificate(true, true, true, false));
+        assert!(rejected().rejected());
 
         // Opted out with `tls_client_certificate_required = false`.
-        assert!(!missing_required_client_certificate(
-            true, true, false, false
-        ));
+        assert!(
+            !ClientCertificateCheck {
+                required: false,
+                ..rejected()
+            }
+            .rejected()
+        );
         // Presented a certificate.
-        assert!(!missing_required_client_certificate(true, true, true, true));
+        assert!(
+            !ClientCertificateCheck {
+                presented: true,
+                ..rejected()
+            }
+            .rejected()
+        );
         // Plaintext: governed by `tls_client_required` instead.
-        assert!(!missing_required_client_certificate(
-            true, false, true, false
-        ));
+        assert!(
+            !ClientCertificateCheck {
+                is_tls: false,
+                ..rejected()
+            }
+            .rejected()
+        );
         // No client CA: a certificate is never requested, so none can be owed.
-        assert!(!missing_required_client_certificate(
-            false, true, true, false
-        ));
+        assert!(
+            !ClientCertificateCheck {
+                client_ca_configured: false,
+                ..rejected()
+            }
+            .rejected()
+        );
     }
 }
 

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -95,6 +95,20 @@ pub struct Client {
     query_size_limit: Option<usize>,
 }
 
+/// Reject a client that owed us a certificate and didn't send one.
+///
+/// Only meaningful when a client CA is configured, since otherwise no certificate
+/// is ever requested, and only over TLS, since plaintext is governed by
+/// `tls_client_required`.
+fn missing_required_client_certificate(
+    client_ca_configured: bool,
+    is_tls: bool,
+    required: bool,
+    presented: bool,
+) -> bool {
+    client_ca_configured && is_tls && required && !presented
+}
+
 impl Client {
     /// Create new frontend client from the a TCP socket.
     ///
@@ -239,8 +253,8 @@ impl Client {
         let key = BackendKeyData::new_frontend(protocol_version, id);
         let comms = ClientComms::new(id);
         let log_connections = config.config.general.log_connections;
-        // Without a client CA no certificate is ever requested during the
-        // handshake, so requiring one could never be satisfied.
+        // Without a client CA, no certificate is ever requested, so requiring one
+        // could never be satisfied.
         let client_ca_configured = config.config.general.tls_client_ca_certificate.is_some();
 
         // Check if we need to ask the client for its password in plaintext
@@ -282,16 +296,14 @@ impl Client {
                         } else {
                             AuthResult::NoIdentity
                         }
-                    } else if client_ca_configured
-                        && stream.is_tls()
-                        && cluster.tls_client_certificate_required()
-                        && !stream.tls_client_certificate()
-                    {
-                        // The client negotiated TLS while a client CA is
-                        // configured, so it was asked for a certificate and
-                        // declined. Users that opt out with
-                        // `tls_client_certificate_required = false` fall
-                        // through to password authentication instead.
+                    } else if missing_required_client_certificate(
+                        client_ca_configured,
+                        stream.is_tls(),
+                        cluster.tls_client_certificate_required(),
+                        stream.tls_client_certificate(),
+                    ) {
+                        // Asked for a certificate and declined. Users that opt out
+                        // fall through to password authentication instead.
                         AuthResult::NoClientCertificate
                     } else {
                         // Resolve Vault static role
@@ -721,6 +733,32 @@ impl MemoryUsage for Client {
 
 #[cfg(test)]
 pub mod test;
+
+#[cfg(test)]
+mod client_certificate_tests {
+    use super::missing_required_client_certificate;
+
+    #[test]
+    fn rejects_only_when_a_certificate_was_owed_and_withheld() {
+        //    client CA, is_tls, required, presented
+        assert!(missing_required_client_certificate(true, true, true, false));
+
+        // Opted out with `tls_client_certificate_required = false`.
+        assert!(!missing_required_client_certificate(
+            true, true, false, false
+        ));
+        // Presented a certificate.
+        assert!(!missing_required_client_certificate(true, true, true, true));
+        // Plaintext: governed by `tls_client_required` instead.
+        assert!(!missing_required_client_certificate(
+            true, false, true, false
+        ));
+        // No client CA: a certificate is never requested, so none can be owed.
+        assert!(!missing_required_client_certificate(
+            false, true, true, false
+        ));
+    }
+}
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 enum BufferEvent {

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -239,6 +239,9 @@ impl Client {
         let key = BackendKeyData::new_frontend(protocol_version, id);
         let comms = ClientComms::new(id);
         let log_connections = config.config.general.log_connections;
+        // Without a client CA no certificate is ever requested during the
+        // handshake, so requiring one could never be satisfied.
+        let client_ca_configured = config.config.general.tls_client_ca_certificate.is_some();
 
         // Check if we need to ask the client for its password in plaintext
         // because we don't actually have it configured.
@@ -279,6 +282,17 @@ impl Client {
                         } else {
                             AuthResult::NoIdentity
                         }
+                    } else if client_ca_configured
+                        && stream.is_tls()
+                        && cluster.tls_client_certificate_required()
+                        && !stream.tls_client_certificate()
+                    {
+                        // The client negotiated TLS while a client CA is
+                        // configured, so it was asked for a certificate and
+                        // declined. Users that opt out with
+                        // `tls_client_certificate_required = false` fall
+                        // through to password authentication instead.
+                        AuthResult::NoClientCertificate
                     } else {
                         // Resolve Vault static role
                         // entries to plaintext before the auth exchange

--- a/pgdog/src/frontend/listener.rs
+++ b/pgdog/src/frontend/listener.rs
@@ -8,7 +8,7 @@ use crate::backend::databases::{databases, reload, shutdown};
 use crate::config::config;
 use crate::frontend::client::query_engine::two_pc::Manager;
 use crate::net::messages::{FrontendPid, NegotiateProtocolVersion, Startup, hello::SslReply};
-use crate::net::tls::{acceptor, peer_identity};
+use crate::net::tls::{acceptor, peer_certificate_present, peer_identity};
 use crate::net::{self, Stream, tweak};
 use crate::sighup::Sighup;
 use tokio::net::{TcpListener, TcpStream};
@@ -198,10 +198,12 @@ impl Listener {
                             }
                         };
                         let tls_identity = peer_identity(cipher.get_ref().1);
+                        let tls_client_certificate = peer_certificate_present(cipher.get_ref().1);
                         stream = Stream::tls(
                             tokio_rustls::TlsStream::Server(cipher),
                             config.config.memory.net_buffer,
                             tls_identity,
+                            tls_client_certificate,
                         );
                     } else {
                         stream.send_flush(&SslReply::No).await?;

--- a/pgdog/src/net/stream.rs
+++ b/pgdog/src/net/stream.rs
@@ -140,10 +140,7 @@ impl Stream {
         self.tls_identity.as_deref()
     }
 
-    /// The client presented a TLS certificate during the handshake.
-    ///
-    /// Unlike [`Stream::tls_identity`], this is true even when the certificate
-    /// carries no name we can derive an identity from.
+    /// The client presented a TLS certificate, even one we can't name.
     pub fn tls_client_certificate(&self) -> bool {
         self.tls_client_certificate
     }
@@ -393,5 +390,31 @@ mod tests {
         );
 
         client.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_plain_stream_has_no_client_certificate() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let client = tokio::spawn(async move { TcpStream::connect(addr).await.unwrap() });
+
+        let (server_stream, _) = listener.accept().await.unwrap();
+        let stream = Stream::plain(server_stream, 4096);
+
+        // No TLS handshake happened, so there is nothing to have presented.
+        assert!(!stream.is_tls());
+        assert!(!stream.tls_client_certificate());
+        assert_eq!(stream.tls_identity(), None);
+
+        client.await.unwrap();
+    }
+
+    #[test]
+    fn test_dev_null_has_no_client_certificate() {
+        let stream = Stream::dev_null();
+
+        assert!(!stream.tls_client_certificate());
+        assert_eq!(stream.tls_identity(), None);
     }
 }

--- a/pgdog/src/net/stream.rs
+++ b/pgdog/src/net/stream.rs
@@ -33,6 +33,7 @@ pub struct Stream {
     io_in_progress: bool,
     capacity: usize,
     tls_identity: Option<String>,
+    tls_client_certificate: bool,
 }
 
 impl AsyncRead for Stream {
@@ -102,6 +103,7 @@ impl Stream {
             io_in_progress: false,
             capacity,
             tls_identity: None,
+            tls_client_certificate: false,
         }
     }
 
@@ -110,12 +112,14 @@ impl Stream {
         stream: tokio_rustls::TlsStream<TcpStream>,
         capacity: usize,
         tls_identity: Option<String>,
+        tls_client_certificate: bool,
     ) -> Self {
         Self {
             inner: StreamInner::Tls(BufStream::with_capacity(capacity, capacity, stream)),
             io_in_progress: false,
             capacity,
             tls_identity,
+            tls_client_certificate,
         }
     }
 
@@ -126,6 +130,7 @@ impl Stream {
             io_in_progress: false,
             capacity: 0,
             tls_identity: None,
+            tls_client_certificate: false,
         }
     }
 
@@ -133,6 +138,14 @@ impl Stream {
     /// from the client's TLS certificate, if any.
     pub fn tls_identity(&self) -> Option<&str> {
         self.tls_identity.as_deref()
+    }
+
+    /// The client presented a TLS certificate during the handshake.
+    ///
+    /// Unlike [`Stream::tls_identity`], this is true even when the certificate
+    /// carries no name we can derive an identity from.
+    pub fn tls_client_certificate(&self) -> bool {
+        self.tls_client_certificate
     }
 
     /// This is a TLS stream.

--- a/pgdog/src/net/tls.rs
+++ b/pgdog/src/net/tls.rs
@@ -90,11 +90,8 @@ pub fn peer_identity(conn: &ServerConnection) -> Option<String> {
     identity_from_certs(conn.peer_certificates()?)
 }
 
-/// The peer presented a client certificate during the handshake.
-///
-/// Distinct from [`peer_identity`], which returns `None` both when no
-/// certificate was presented and when one was presented but carries no
-/// `dNSName` SAN or Subject CN to derive an identity from.
+/// The peer presented a client certificate. Unlike [`peer_identity`], this is
+/// true even when the certificate has no name to derive an identity from.
 pub fn peer_certificate_present(conn: &ServerConnection) -> bool {
     conn.peer_certificates()
         .is_some_and(|certs| !certs.is_empty())
@@ -217,15 +214,10 @@ fn build_acceptor(cert: &Path, key: &Path, client_ca: Option<&Path>) -> Result<T
     Ok(TlsAcceptor::from(Arc::new(config)))
 }
 
-/// Build a client certificate verifier that accepts anonymous clients.
-///
-/// A certificate presented by the client is still verified against the CA
-/// bundle, and an untrusted one still fails the handshake. Clients that present
-/// no certificate are allowed through so that the per-user
-/// `tls_client_certificate_required` setting can be applied during
-/// authentication, once the startup packet has told us which user is
-/// connecting. The TLS handshake completes before that packet arrives, so it is
-/// not a layer that can make a per-user decision.
+/// Build a client certificate verifier. Presented certificates are verified
+/// against the CA bundle; clients that present none are allowed through so the
+/// per-user `tls_client_certificate_required` check can run during auth, once
+/// the startup packet says who is connecting.
 fn build_client_cert_verifier(ca_path: &Path) -> Result<Arc<dyn ClientCertVerifier>, Error> {
     let roots = load_ca_bundle(ca_path, "client CA")?;
 
@@ -661,13 +653,9 @@ mod tests {
         let verifier =
             super::build_client_cert_verifier(&client_ca).expect("verifier builds from CA bundle");
 
-        // A certificate is still requested, so clients that have one send it
-        // and it gets verified against the bundle.
+        // Still requested, so mTLS clients send one and it gets verified.
         assert!(verifier.offer_client_auth());
-        // Clients that present none still complete the handshake. The per-user
-        // `tls_client_certificate_required` check rejects them during
-        // authentication instead, once the startup packet says who is
-        // connecting.
+        // But its absence no longer fails the handshake.
         assert!(!verifier.client_auth_mandatory());
     }
 

--- a/pgdog/src/net/tls.rs
+++ b/pgdog/src/net/tls.rs
@@ -90,6 +90,16 @@ pub fn peer_identity(conn: &ServerConnection) -> Option<String> {
     identity_from_certs(conn.peer_certificates()?)
 }
 
+/// The peer presented a client certificate during the handshake.
+///
+/// Distinct from [`peer_identity`], which returns `None` both when no
+/// certificate was presented and when one was presented but carries no
+/// `dNSName` SAN or Subject CN to derive an identity from.
+pub fn peer_certificate_present(conn: &ServerConnection) -> bool {
+    conn.peer_certificates()
+        .is_some_and(|certs| !certs.is_empty())
+}
+
 /// Extract a hostname identity from the first certificate in the chain.
 ///
 /// Prefers the first `dNSName` in the Subject Alternative Name extension and
@@ -207,10 +217,20 @@ fn build_acceptor(cert: &Path, key: &Path, client_ca: Option<&Path>) -> Result<T
     Ok(TlsAcceptor::from(Arc::new(config)))
 }
 
+/// Build a client certificate verifier that accepts anonymous clients.
+///
+/// A certificate presented by the client is still verified against the CA
+/// bundle, and an untrusted one still fails the handshake. Clients that present
+/// no certificate are allowed through so that the per-user
+/// `tls_client_certificate_required` setting can be applied during
+/// authentication, once the startup packet has told us which user is
+/// connecting. The TLS handshake completes before that packet arrives, so it is
+/// not a layer that can make a per-user decision.
 fn build_client_cert_verifier(ca_path: &Path) -> Result<Arc<dyn ClientCertVerifier>, Error> {
     let roots = load_ca_bundle(ca_path, "client CA")?;
 
     WebPkiClientVerifier::builder(Arc::new(roots))
+        .allow_unauthenticated()
         .build()
         .map_err(|e| invalid_data(format!("failed to build client certificate verifier: {e}")))
 }
@@ -632,6 +652,23 @@ mod tests {
 
         super::test_reset_acceptor();
         crate::config::set(crate::config::ConfigAndUsers::default()).unwrap();
+    }
+
+    #[test]
+    fn client_cert_verifier_allows_anonymous_clients() {
+        let client_ca = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/tls/cert.pem");
+
+        let verifier =
+            super::build_client_cert_verifier(&client_ca).expect("verifier builds from CA bundle");
+
+        // A certificate is still requested, so clients that have one send it
+        // and it gets verified against the bundle.
+        assert!(verifier.offer_client_auth());
+        // Clients that present none still complete the handshake. The per-user
+        // `tls_client_certificate_required` check rejects them during
+        // authentication instead, once the startup packet says who is
+        // connecting.
+        assert!(!verifier.client_auth_mandatory());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

Setting `tls_client_ca_certificate` makes client certificates mandatory for every TLS connection, because rustls' default client verifier denies anonymous clients. On a listener serving both mTLS users (`identity`) and password users (`password`/`password_hash`), that leaves the password users unable to negotiate TLS at all — they get a `certificate_required` alert, so their only working option is a plaintext connection:

```
$ psql "host=... user=some_password_user sslmode=require"
psql: error: connection to server at "..." failed:
      SSL error: tlsv13 alert certificate required

$ psql "host=... user=some_password_user sslmode=disable"
psql (17.7)          # works, unencrypted
```

PgDog can't resolve this during the handshake, which completes before the startup packet carrying `user=` arrives — at that point it has no idea who is connecting. So the choice is currently all-or-nothing for every connection on the listener.

Worth noting the current requirement doesn't actually protect those users: they're already reachable unauthenticated over plaintext. It only forces the legitimate ones onto the unencrypted path.

## Change

Build the verifier with `allow_unauthenticated()` so a certificate is verified when presented but its absence no longer fails the handshake, and move the requirement to authentication, where the user is known.

A new per-user `tls_client_certificate_required` defaults to `true` and is enforced only when a client CA is configured **and** the client connected over TLS:

- without a client CA, no certificate is ever requested (`with_no_client_auth`), so requiring one could never be satisfied — enforcing it unconditionally would reject every user in every deployment that doesn't configure client CAs;
- plaintext connections stay governed by `tls_client_required`.

```toml
[[users]]
name = "app"
database = "db"
password_hash = "SCRAM-SHA-256$4096:..."
tls_client_certificate_required = false   # TLS, no client cert
```

## Backwards compatibility

Behavior is unchanged at the default:

| Client | Before | After |
|---|---|---|
| TLS, no cert, client CA set | rejected (TLS alert) | rejected (`NoClientCertificate`) |
| TLS, no cert, **opted out** | rejected | **authenticates over TLS** |
| TLS, valid cert | verified | verified, unchanged |
| TLS, untrusted cert | rejected at handshake | rejected at handshake |
| Plaintext | governed by `tls_client_required` | unchanged |
| No client CA configured | cert never requested | unchanged |

The one visible difference at default is that a certless client is now rejected after the handshake rather than during it, so the error is a Postgres auth failure instead of a TLS alert. That also means slightly more work per rejected connection — happy to gate the verifier change behind a config flag instead if you'd prefer to keep the early rejection.

## mTLS is unaffected

Identity enforcement never lived in the handshake — `client/mod.rs` already requires `stream.tls_identity() == Some(identity)` for any user with a configured identity, and a certless client gets `None`, so it still fails with `NoIdentity`. An entry with neither identity nor password still fails closed via the existing `NoPasswordConfig` guard. Certificates that *are* presented are verified against the CA bundle exactly as before; only the empty-certificate case changes.

 
## Testing

- `cargo fmt --all -- --check` and `cargo clippy --all-targets -- -D warnings` clean
- `cargo test -p pgdog-config` — 83 passed
- New: `client_cert_verifier_allows_anonymous_clients` asserts `offer_client_auth()` stays true while `client_auth_mandatory()` becomes false; two config tests cover the unset and opted-out cases

