### PR TITLE
Add ClientsLocked OTEL metric to track count of clients locked to a specific server

### DIFF
--- a/pgdog-stats/src/pool.rs
+++ b/pgdog-stats/src/pool.rs
@@ -254,6 +254,8 @@ pub struct State {
     pub out_of_sync: usize,
     /// Re-synced servers.
     pub re_synced: usize,
+    /// Locked
+    pub locked: usize,
     /// Statistics
     pub stats: Stats,
     /// Max wait.

--- a/pgdog/src/backend/pool/connection/binding.rs
+++ b/pgdog/src/backend/pool/connection/binding.rs
@@ -13,7 +13,6 @@ use crate::{
 };
 
 use futures::future::join_all;
-use tracing::warn;
 
 use super::*;
 

--- a/pgdog/src/backend/pool/connection/binding.rs
+++ b/pgdog/src/backend/pool/connection/binding.rs
@@ -13,6 +13,7 @@ use crate::{
 };
 
 use futures::future::join_all;
+use tracing::warn;
 
 use super::*;
 
@@ -486,6 +487,44 @@ impl Binding {
                 servers.iter_mut().for_each(|s| s.mark_dirty(true))
             }
             _ => (),
+        }
+    }
+
+    /// Propagate the client's lock state to every held Guard so each pool's
+    /// `sv_locked` reflects the pin.
+    pub(super) fn set_locked(&mut self, locked: bool) {
+        match self {
+            Binding::Direct(server, ..) => server.set_locked(locked),
+            Binding::MultiShard(servers, _) => {
+                for server in servers {
+                    server.set_locked(locked);
+                }
+            }
+            _ => (),
+        }
+    }
+
+    /// Aggregate lock state across the held Guard(s). All shards in a
+    /// multi-shard binding are set/cleared together via [`Self::set_locked`],
+    /// so they should always agree; if they don't, warn and err on the side
+    /// of "locked" so we don't recycle a pinned connection.
+    pub(super) fn is_locked(&self) -> bool {
+        match self {
+            Binding::Direct(server, ..) => server.is_locked(),
+            Binding::MultiShard(servers, _) => {
+                let mut any = false;
+                let mut all = true;
+                for server in servers {
+                    let l = server.is_locked();
+                    any |= l;
+                    all &= l;
+                }
+                if any && !all {
+                    warn!("inconsistent lock state across multi-shard binding; assuming locked");
+                }
+                any
+            }
+            _ => false,
         }
     }
 

--- a/pgdog/src/backend/pool/connection/binding.rs
+++ b/pgdog/src/backend/pool/connection/binding.rs
@@ -512,17 +512,12 @@ impl Binding {
         match self {
             Binding::Direct(server, ..) => server.is_locked(),
             Binding::MultiShard(servers, _) => {
-                let mut any = false;
-                let mut all = true;
-                for server in servers {
-                    let l = server.is_locked();
-                    any |= l;
-                    all &= l;
-                }
-                if any && !all {
-                    warn!("inconsistent lock state across multi-shard binding; assuming locked");
-                }
-                any
+                debug_assert!(
+                    servers.iter().all(|s| s.is_locked()) == servers.iter().any(|s| s.is_locked()),
+                    "Shards disagree on lock status {servers:?}"
+                );
+
+                servers.iter().any(|s| s.is_locked())
             }
             _ => false,
         }

--- a/pgdog/src/backend/pool/connection/mod.rs
+++ b/pgdog/src/backend/pool/connection/mod.rs
@@ -52,7 +52,6 @@ pub struct Connection {
     binding: Binding,
     cluster: Option<Cluster>,
     mirrors: Vec<MirrorHandler>,
-    locked: bool,
     pub_sub: PubSubClient,
 }
 
@@ -69,7 +68,6 @@ impl Connection {
             user: user.to_owned(),
             database: database.to_owned(),
             mirrors: vec![],
-            locked: false,
             pub_sub: PubSubClient::new(),
         };
 
@@ -425,22 +423,22 @@ impl Connection {
 
     /// We are done and can disconnect from this server.
     pub(crate) fn done(&self) -> bool {
-        self.binding.done() && !self.locked
+        self.binding.done() && !self.binding.is_locked()
     }
 
     /// Lock this connection to the client, preventing it's
     /// release back into the pool.
     pub(crate) fn lock(&mut self, lock: bool) {
-        self.locked = lock;
+        self.binding.set_locked(lock);
         if lock {
             self.binding.dirty();
         }
     }
 
-    /// Check if this connection is locked to a client.
+    /// Check if any held server connection is currently locked to a client.
     #[cfg(test)]
     pub(crate) fn locked(&self) -> bool {
-        self.locked
+        self.binding.is_locked()
     }
 
     /// Get connected servers addresses.

--- a/pgdog/src/backend/pool/guard.rs
+++ b/pgdog/src/backend/pool/guard.rs
@@ -17,6 +17,10 @@ pub struct Guard {
     server: Option<Box<Server>>,
     pub(super) pool: Pool,
     pub(super) reset: bool,
+
+    /// Frontend has pinned this guard to its client
+    // NOTE: We cache this value seperately to prevent lock contention to read locked state
+    locked: bool,
 }
 
 impl std::fmt::Debug for Guard {
@@ -43,7 +47,23 @@ impl Guard {
             server: Some(server),
             pool,
             reset: false,
+            locked: false,
         }
+    }
+
+    /// Mark or unmark this checkout as pinned to its client. Propagates to
+    /// the pool so `sv_locked` reflects reality per pool.
+    pub(crate) fn set_locked(&mut self, locked: bool) {
+        self.locked = locked;
+        if let Some(server) = self.server.as_deref() {
+            self.pool.set_locked(server.id(), locked);
+        }
+    }
+
+    /// Whether this guard is currently pinned to its client.
+    #[inline]
+    pub(crate) fn is_locked(&self) -> bool {
+        self.locked
     }
 
     /// Rollback any unfinished transactions and check the connection

--- a/pgdog/src/backend/pool/guard.rs
+++ b/pgdog/src/backend/pool/guard.rs
@@ -19,7 +19,7 @@ pub struct Guard {
     pub(super) reset: bool,
 
     /// Frontend has pinned this guard to its client
-    // NOTE: We cache this value seperately to prevent lock contention to read locked state
+    // NOTE: We cache this value seperately to minimize pool lock contention
     locked: bool,
 }
 
@@ -54,6 +54,11 @@ impl Guard {
     /// Mark or unmark this checkout as pinned to its client. Propagates to
     /// the pool so `sv_locked` reflects reality per pool.
     pub(crate) fn set_locked(&mut self, locked: bool) {
+        if self.locked == locked {
+            // No-op, don't bother aquiring a lock
+            return;
+        }
+
         self.locked = locked;
         if let Some(server) = self.server.as_deref() {
             self.pool.set_locked(server.id(), locked);

--- a/pgdog/src/backend/pool/inner.rs
+++ b/pgdog/src/backend/pool/inner.rs
@@ -6,7 +6,7 @@ use std::fmt::Display;
 
 use crate::backend::{ConnectReason, DisconnectReason};
 use crate::backend::{Server, stats::Counts as BackendCounts};
-use crate::net::messages::{BackendKeyData, FrontendPid};
+use crate::net::messages::{BackendKeyData, BackendPid, FrontendPid};
 
 use tokio::time::Instant;
 
@@ -113,6 +113,18 @@ impl Inner {
     #[inline]
     pub(super) fn checked_out(&self) -> usize {
         self.taken.len()
+    }
+
+    /// Number of checked-out connections currently pinned to their client.
+    #[inline]
+    pub(super) fn count_locked_connections(&self) -> usize {
+        self.taken.locked_count()
+    }
+
+    /// Mark a checked-out backend as pinned (or release the pin)
+    #[inline]
+    pub(super) fn set_locked(&mut self, backend: BackendPid, locked: bool) {
+        self.taken.set_locked(backend, locked);
     }
 
     /// Cancel key for the server currently assigned to this client.

--- a/pgdog/src/backend/pool/pool_impl.rs
+++ b/pgdog/src/backend/pool/pool_impl.rs
@@ -15,7 +15,7 @@ use tracing::{debug, error};
 use crate::backend::pool::LsnStats;
 use crate::backend::{ConnectReason, DisconnectReason, Server, ServerOptions};
 use crate::config::PoolerMode;
-use crate::net::messages::FrontendPid;
+use crate::net::messages::{BackendPid, FrontendPid};
 use crate::net::{Parameter, Parameters};
 
 use super::inner::CheckInResult;
@@ -392,6 +392,17 @@ impl Pool {
     #[inline]
     pub(super) fn lock(&self) -> MutexGuard<'_, RawMutex, Inner> {
         self.inner.inner.lock()
+    }
+
+    /// Mark or unmark a checked-out backend as pinned to its client.
+    ///
+    /// Called by [`Guard::set_locked`] when the frontend takes or releases an
+    /// advisory lock / manual pin, so `sv_locked` reflects reality per-pool.
+    /// On checkin the `Taken` entry is removed entirely, so no explicit
+    /// cleanup is needed on drop.
+    #[inline]
+    pub(crate) fn set_locked(&self, backend: BackendPid, locked: bool) {
+        self.lock().set_locked(backend, locked);
     }
 
     /// Internal notifications.

--- a/pgdog/src/backend/pool/state.rs
+++ b/pgdog/src/backend/pool/state.rs
@@ -46,6 +46,7 @@ impl State {
                 errors: guard.errors,
                 out_of_sync: guard.out_of_sync,
                 re_synced: guard.re_synced,
+                locked: guard.count_locked_connections(),
                 stats: *guard.stats,
                 maxwait: guard
                     .waiting

--- a/pgdog/src/backend/pool/taken.rs
+++ b/pgdog/src/backend/pool/taken.rs
@@ -11,6 +11,10 @@ use super::Error;
 struct Checkout {
     backend: BackendPid,
     key: BackendKeyData,
+    /// The client has pinned this checkout (e.g. holds an advisory lock),
+    /// so it must not be recycled back into transaction pooling until the
+    /// pin is released.
+    locked: bool,
 }
 
 /// Track the link between a frontend connection and the backend connection it
@@ -34,10 +38,21 @@ impl Taken {
     #[inline]
     pub(super) fn take(&mut self, frontend: FrontendPid, backend: BackendPid, key: BackendKeyData) {
         self.backend_to_frontend.insert(backend, frontend);
-        self.frontend_to_cancel
-            .insert(frontend, Checkout { backend, key });
+        self.frontend_to_cancel.insert(
+            frontend,
+            Checkout {
+                backend,
+                key,
+                locked: false,
+            },
+        );
     }
 
+    /// Clear the checkout tracking for a backend being returned to the pool.
+    ///
+    /// Returns [`Error::UntrackedConnCheckin`] if the backend was never
+    /// tracked — a double-checkin or a checkin for a backend that never went
+    /// through [`Self::take`].
     #[inline]
     pub(super) fn check_in(&mut self, backend: BackendPid) -> Result<(), Error> {
         let frontend = self
@@ -78,6 +93,27 @@ impl Taken {
     /// returned (matches prior behavior).
     pub(super) fn cancel_keys(&self) -> impl Iterator<Item = &BackendKeyData> {
         self.frontend_to_cancel.values().map(|c| &c.key)
+    }
+
+    /// Mark or unmark a checked-out backend as pinned to its client. Called by
+    /// the frontend when it takes/releases an advisory lock or manual pin.
+    #[inline]
+    pub(super) fn set_locked(&mut self, backend: BackendPid, locked: bool) {
+        if let Some(&frontend) = self.backend_to_frontend.get(&backend)
+            && let Some(entry) = self.frontend_to_cancel.get_mut(&frontend)
+            && entry.backend == backend
+        {
+            entry.locked = locked;
+        }
+    }
+
+    /// Count checked-out backends currently pinned to their client.
+    #[inline]
+    pub(super) fn locked_count(&self) -> usize {
+        self.frontend_to_cancel
+            .values()
+            .filter(|c| c.locked)
+            .count()
     }
 
     #[cfg(test)]
@@ -227,6 +263,70 @@ mod tests {
         );
         taken.check_in(backend_b).unwrap();
         assert!(taken.is_empty());
+    }
+
+    #[test]
+    fn set_locked_toggles_bit_and_counts() {
+        let mut taken = Taken::default();
+        let (fa, ba) = (FrontendPid::new(), BackendPid::for_test(10));
+        let (fb, bb) = (FrontendPid::new(), BackendPid::for_test(11));
+
+        taken.take(fa, ba, key(ba.pid()));
+        taken.take(fb, bb, key(bb.pid()));
+        assert_eq!(taken.locked_count(), 0);
+
+        taken.set_locked(ba, true);
+        assert_eq!(taken.locked_count(), 1);
+
+        taken.set_locked(bb, true);
+        assert_eq!(taken.locked_count(), 2);
+
+        taken.set_locked(ba, false);
+        assert_eq!(taken.locked_count(), 1);
+    }
+
+    #[test]
+    fn check_in_clears_locked_state() {
+        let mut taken = Taken::default();
+        let frontend = FrontendPid::new();
+        let backend = BackendPid::for_test(12);
+
+        taken.take(frontend, backend, key(backend.pid()));
+        taken.set_locked(backend, true);
+        assert_eq!(taken.locked_count(), 1);
+
+        taken.check_in(backend).unwrap();
+        assert_eq!(taken.locked_count(), 0);
+    }
+
+    #[test]
+    fn set_locked_unknown_backend_is_noop() {
+        let mut taken = Taken::default();
+        let unknown = BackendPid::for_test(13);
+
+        taken.set_locked(unknown, true);
+        assert_eq!(taken.locked_count(), 0);
+    }
+
+    /// After a retake race, a stale backend's `set_locked` call must NOT flip
+    /// the current live backend's bit (see `deferred_check_in_after_same_frontend_retake`).
+    #[test]
+    fn set_locked_after_retake_race_ignores_stale_backend() {
+        let mut taken = Taken::default();
+        let frontend = FrontendPid::new();
+        let backend_a = BackendPid::for_test(14);
+        let backend_b = BackendPid::for_test(15);
+
+        taken.take(frontend, backend_a, key(backend_a.pid()));
+        taken.take(frontend, backend_b, key(backend_b.pid()));
+
+        // Stale A tries to set locked. Must not affect B.
+        taken.set_locked(backend_a, true);
+        assert_eq!(taken.locked_count(), 0);
+
+        // Live B still works normally.
+        taken.set_locked(backend_b, true);
+        assert_eq!(taken.locked_count(), 1);
     }
 
     #[test]

--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -1100,8 +1100,8 @@ impl Server {
         self.stream.as_mut().unwrap()
     }
 
-    /// Server needs a cleanup because client changed a session variable
-    /// of parameter.
+    /// Server needs a cleanup because client changed a session variable,
+    /// parameter, or advisory lock state
     #[inline]
     pub fn dirty(&self) -> bool {
         self.dirty

--- a/pgdog/src/frontend/comms.rs
+++ b/pgdog/src/frontend/comms.rs
@@ -71,6 +71,15 @@ impl Comms {
             .collect()
     }
 
+    /// Get number of clients who are currently locked.
+    pub fn clients_locked_count(&self) -> usize {
+        self.global
+            .clients
+            .iter()
+            .filter(|client| client.stats.locked)
+            .count()
+    }
+
     /// Number of connected clients.
     pub fn clients_len(&self) -> usize {
         self.global.clients.len()

--- a/pgdog/src/stats/clients_locked.rs
+++ b/pgdog/src/stats/clients_locked.rs
@@ -1,0 +1,72 @@
+//! Clients metrics.
+
+use crate::frontend::comms::comms;
+
+use super::{Measurement, Metric, OpenMetric};
+
+pub struct ClientsLocked {
+    total_locked: usize,
+}
+
+impl ClientsLocked {
+    pub fn load() -> Metric {
+        let total_locked = comms().clients_locked_count();
+        Metric::new(Self { total_locked })
+    }
+}
+
+impl OpenMetric for ClientsLocked {
+    fn name(&self) -> String {
+        "clients_locked".into()
+    }
+
+    fn measurements(&self) -> Vec<Measurement> {
+        vec![Measurement {
+            labels: vec![],
+            measurement: self.total_locked.into(),
+        }]
+    }
+
+    fn help(&self) -> Option<String> {
+        Some("Total number of locked clients.".into())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        config::{self, ConfigAndUsers},
+        stats::Metric,
+    };
+
+    use super::*;
+
+    #[test]
+    fn test_clients_locked() {
+        let clients = ClientsLocked { total_locked: 25 };
+        let metric = Metric::new(clients);
+        let metric = metric.to_string();
+        let mut lines = metric.lines();
+        assert_eq!(lines.next().unwrap(), "# TYPE clients_locked gauge");
+        assert_eq!(
+            lines.next().unwrap(),
+            "# HELP clients_locked Total number of locked clients."
+        );
+        assert_eq!(lines.next().unwrap(), "clients_locked 25");
+    }
+
+    #[test]
+    fn clients_locked_load_uses_global_state() {
+        config::set(ConfigAndUsers::default()).unwrap();
+
+        let metric = ClientsLocked::load();
+        let rendered = metric.to_string();
+        let lines: Vec<&str> = rendered.lines().collect();
+        assert_eq!(lines[0], "# TYPE clients_locked gauge");
+        assert_eq!(
+            lines[1],
+            "# HELP clients_locked Total number of locked clients."
+        );
+        assert_eq!(lines.last().copied(), Some("clients_locked 0"));
+    }
+}

--- a/pgdog/src/stats/clients_locked.rs
+++ b/pgdog/src/stats/clients_locked.rs
@@ -1,4 +1,4 @@
-//! Clients metrics.
+//! Clients locked metrics.
 
 use crate::frontend::comms::comms;
 
@@ -28,7 +28,7 @@ impl OpenMetric for ClientsLocked {
     }
 
     fn help(&self) -> Option<String> {
-        Some("Total number of locked clients.".into())
+        Some("Number of currently locked (pinned) clients.".into())
     }
 }
 
@@ -50,7 +50,7 @@ mod test {
         assert_eq!(lines.next().unwrap(), "# TYPE clients_locked gauge");
         assert_eq!(
             lines.next().unwrap(),
-            "# HELP clients_locked Total number of locked clients."
+            "# HELP clients_locked Number of currently locked (pinned) clients."
         );
         assert_eq!(lines.next().unwrap(), "clients_locked 25");
     }
@@ -65,7 +65,7 @@ mod test {
         assert_eq!(lines[0], "# TYPE clients_locked gauge");
         assert_eq!(
             lines[1],
-            "# HELP clients_locked Total number of locked clients."
+            "# HELP clients_locked Number of currently locked (pinned) clients."
         );
         assert_eq!(lines.last().copied(), Some("clients_locked 0"));
     }

--- a/pgdog/src/stats/http_server.rs
+++ b/pgdog/src/stats/http_server.rs
@@ -11,11 +11,12 @@ use tokio::net::TcpListener;
 use tokio::select;
 use tracing::{info, warn};
 
-use super::{Clients, Listeners, MirrorStatsMetrics, Pools, QueryCache, TwoPc};
+use super::{Clients, ClientsLocked, Listeners, MirrorStatsMetrics, Pools, QueryCache, TwoPc};
 use crate::tasks;
 
 async fn metrics(_: Request<hyper::body::Incoming>) -> Result<Response<Full<Bytes>>, Infallible> {
     let clients = Clients::load();
+    let clients_locked = ClientsLocked::load();
     let pools = Pools::load();
     let mirror_stats: Vec<_> = MirrorStatsMetrics::load()
         .into_iter()
@@ -35,6 +36,8 @@ async fn metrics(_: Request<hyper::body::Incoming>) -> Result<Response<Full<Byte
     let query_cache = query_cache.join("\n");
     let two_pc = TwoPc::load();
     let metrics_data = clients.to_string()
+        + "\n"
+        + &clients_locked.to_string()
         + "\n"
         + &pools.to_string()
         + "\n"

--- a/pgdog/src/stats/mod.rs
+++ b/pgdog/src/stats/mod.rs
@@ -1,5 +1,6 @@
 //! Statistics.
 pub mod clients;
+pub mod clients_locked;
 pub mod http_server;
 pub mod mirror_stats;
 pub mod open_metric;

--- a/pgdog/src/stats/mod.rs
+++ b/pgdog/src/stats/mod.rs
@@ -15,6 +15,7 @@ pub mod query_cache;
 pub mod two_pc;
 
 pub use clients::Clients;
+pub use clients_locked::ClientsLocked;
 pub use listeners::Listeners;
 pub use logger::Logger as StatsLogger;
 pub use mirror_stats::MirrorStatsMetrics;

--- a/pgdog/src/stats/otel_exporter.rs
+++ b/pgdog/src/stats/otel_exporter.rs
@@ -9,7 +9,7 @@ use tokio::time::sleep;
 use tracing::{info, warn};
 
 use super::otel;
-use super::{Clients, Listeners, MirrorStatsMetrics, Pools, QueryCache, TwoPc};
+use super::{Clients, ClientsLocked, Listeners, MirrorStatsMetrics, Pools, QueryCache, TwoPc};
 use crate::{config::config, tasks};
 
 /// Maximum number of metrics per OTLP request to stay under endpoint payload limits.
@@ -41,13 +41,14 @@ pub async fn run() {
         }
 
         let clients = Clients::load();
+        let clients_locked = ClientsLocked::load();
         let pools = Pools::load().into_metrics();
         let mirror = MirrorStatsMetrics::load();
         let listeners = Listeners::load();
         let query_cache = QueryCache::load().metrics();
         let two_pc = TwoPc::load();
 
-        let mut all: Vec<&super::Metric> = vec![&clients, &two_pc];
+        let mut all: Vec<&super::Metric> = vec![&clients, &clients_locked, &two_pc];
         all.extend(pools.iter());
         all.extend(mirror.iter());
         all.extend(listeners.iter());

--- a/pgdog/src/stats/pools.rs
+++ b/pgdog/src/stats/pools.rs
@@ -48,6 +48,7 @@ impl Pools {
         let mut cl_waiting = vec![];
         let mut sv_active = vec![];
         let mut sv_idle = vec![];
+        let mut sv_locked = vec![];
         let mut maxwait = vec![];
         let mut errors = vec![];
         let mut out_of_sync = vec![];
@@ -120,6 +121,11 @@ impl Pools {
                     sv_idle.push(Measurement {
                         labels: labels.clone(),
                         measurement: state.idle.into(),
+                    });
+
+                    sv_locked.push(Measurement {
+                        labels: labels.clone(),
+                        measurement: state.locked.into(),
                     });
 
                     maxwait.push(Measurement {
@@ -369,6 +375,16 @@ impl Pools {
             name: "sv_idle".into(),
             measurements: sv_idle,
             help: "Servers available for clients to use.".into(),
+            unit: None,
+            metric_type: None,
+        }));
+
+        metrics.push(Metric::new(PoolMetric {
+            name: "sv_locked".into(),
+            measurements: sv_locked,
+            help: "Servers pinned to a client (advisory lock or manual pin), \
+                   ineligible for transaction pooling."
+                .into(),
             unit: None,
             metric_type: None,
         }));


### PR DESCRIPTION
Implements #1264

I used this issue to get familiar with the codebase. Happy to rework any of it to fit how you want the stats module structured.

# Summary

This PR adds an OTEL metric called ClientsLocked that records the current number of locked clients.

On naming: I kept “locked” to match the internal and SHOW CLIENTS verbiage, but I’d actually argue for using the word “pinned”. Pinning describes the pooler-side behavior: a server connection bound to a specific client, excluded from multiplexing. Meanwhile, “locked” names one client-side cause and could be misread as row-level locking. Happy to do that rename separately if you agree. I also wonder whether there will be other scenarios where pinning connections are useful beyond locking.

# Validation

My friend Claude and I wrote a script to query and validate that the metric updates. You can view it in [this commit.](https://github.com/KennanHunter/pgdog/commit/cfd5ce9559b38776d135e136fdd841a2b2158239)

Here’s the script output:

```sh
✔ Container pgdog-pgdog-1   Started                                                                                    0.1s
 ✔ Container pgdog-shard_0-1 Started                                                                                    0.2s
 ✔ Container pgdog-shard_1-1 Started                                                                                    0.1s
 ✔ Container pgdog-shard_2-1 Started                                                                                    0.1s
== waiting for pgdog on :6432 ==
== waiting for /metrics on :9090 ==
== baseline ==
  clients_locked = 0
== opening persistent psql session via FIFO ==
== acquiring advisory lock ==
== polling for clients_locked = 1 ==
  clients_locked = 1
== releasing advisory lock on same connection ==
== polling for clients_locked = 0 ==
  clients_locked = 0
== closing psql session ==
PASS
```