### PR TITLE
Refactor how we (skip) loading schema in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3357,6 +3357,7 @@ dependencies = [
  "dashmap",
  "derive_builder",
  "derive_more",
+ "dyn-clone",
  "fnv",
  "futures",
  "hex",

--- a/pgdog/Cargo.toml
+++ b/pgdog/Cargo.toml
@@ -86,6 +86,7 @@ hex = "0.4"
 x509-parser = "0.18"
 pg_raw_parse = { workspace = true, optional = true }
 itertools = "0.15.0"
+dyn-clone = "1.0.20"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/pgdog/src/backend/pool/cluster.rs
+++ b/pgdog/src/backend/pool/cluster.rs
@@ -23,11 +23,14 @@ use crate::{
     net::{Query, messages::FrontendPid},
 };
 
-use super::{
-    Address, Config, Error, Guard, MirrorStats, Request, Shard, ShardConfig,
-    cluster_launch::Readiness,
-};
+use super::{Address, Config, Error, Guard, MirrorStats, Request, Shard, ShardConfig};
 use crate::config::LoadBalancingStrategy;
+use launch::Readiness;
+
+pub(crate) mod launch;
+pub(crate) mod schema_loader;
+
+pub(crate) use schema_loader::SchemaLoader;
 
 #[derive(Clone, Debug, Default)]
 /// Database configuration.
@@ -40,7 +43,8 @@ pub struct PoolConfig {
 
 /// A collection of sharded replicas and primaries
 /// belonging to the same database cluster.
-#[derive(Clone, Default, Debug)]
+#[derive(Clone, Debug)]
+#[cfg_attr(test, derive(Default))]
 pub struct Cluster {
     identifier: Arc<DatabaseUser>,
     shards: Vec<Shard>,
@@ -57,7 +61,7 @@ pub struct Cluster {
     cross_shard_disabled: bool,
     two_phase_commit: bool,
     two_phase_commit_auto: bool,
-    pub(super) readiness: Arc<Readiness>,
+    readiness: Arc<Readiness>,
     rewrite: Rewrite,
     prepared_statements: PreparedStatements,
     dry_run: bool,
@@ -79,6 +83,8 @@ pub struct Cluster {
     regex_parser: RegexParser,
     identity: Option<String>,
     tls_client_certificate_required: bool,
+    #[debug(skip)]
+    schema_loader: Box<dyn SchemaLoader>,
 }
 
 /// Sharding configuration from the cluster.
@@ -350,6 +356,7 @@ impl Cluster {
             regex_parser: RegexParser::new(regex_parser_limit, query_parser),
             identity: identity.clone(),
             tls_client_certificate_required,
+            schema_loader: Box::new(schema_loader::FromServer),
         }
     }
 
@@ -681,6 +688,7 @@ mod test {
         ConfigAndUsers, OmnishardedTable, PoolerMode, QueryParserLevel, ShardedSchema,
     };
 
+    use crate::backend::pool::cluster::SchemaLoader;
     use crate::frontend::router::sharding::ShardedTable;
     use crate::{
         backend::{
@@ -996,11 +1004,6 @@ mod test {
         let config = ConfigAndUsers::default();
         let cluster = Cluster::new_test(&config);
 
-        // Pre-populate per-shard schemas so launch doesn't touch a real database.
-        for shard in &cluster.shards {
-            shard.schema_not_needed();
-        }
-
         assert!(!cluster.ready());
         cluster.launch();
         cluster.wait_ready().await;
@@ -1037,13 +1040,6 @@ mod test {
 
         assert!(cluster.load_schema());
 
-        // Pre-populate per-shard schemas so launch's spawned loaders become
-        // no-ops (Shard::load_schema returns Ok(false) when already initialized).
-        // This avoids touching a real database in the test.
-        for shard in &cluster.shards {
-            shard.schema_not_needed();
-        }
-
         cluster.launch();
         cluster.wait_ready().await;
 
@@ -1055,28 +1051,40 @@ mod test {
 
     #[tokio::test]
     async fn test_wait_ready_waits_for_schema_notification() {
-        use tokio::time::{Duration, sleep, timeout};
+        use futures::poll;
+
+        #[derive(Clone)]
+        struct ManuallyLoad;
+
+        impl SchemaLoader for ManuallyLoad {
+            fn launch_schema_sync(&self, _: &Cluster) {}
+        }
 
         let config = ConfigAndUsers::default();
-        let cluster = Cluster::new_test(&config);
+        let cluster = Cluster {
+            schema_loader: Box::new(ManuallyLoad),
+            ..Cluster::new_test(&config)
+        };
 
         cluster.launch();
 
         // Schemas not loaded yet, readiness is pending.
         assert!(!cluster.ready());
 
-        // Simulate schema load finishing on each shard: the readiness
-        // monitor wakes up via the per-shard schema_waiter notification.
-        let shards: Vec<_> = cluster.shards.to_vec();
-        tokio::spawn(async move {
-            sleep(Duration::from_millis(10)).await;
-            for shard in &shards {
-                shard.schema_not_needed();
-            }
-        });
+        let mut result = std::pin::pin!(cluster.wait_ready());
 
-        let result = timeout(Duration::from_millis(500), cluster.wait_ready()).await;
-        assert!(result.is_ok());
+        // Finish loading on all but one shard
+        for shard in &cluster.shards[1..] {
+            shard.schema_not_needed();
+        }
+
+        tokio::task::yield_now().await;
+        assert!(poll!(result.as_mut()).is_pending());
+
+        cluster.shards[0].schema_not_needed();
+
+        tokio::task::yield_now().await;
+        assert!(poll!(result.as_mut()).is_ready());
         assert!(cluster.ready());
     }
 

--- a/pgdog/src/backend/pool/cluster.rs
+++ b/pgdog/src/backend/pool/cluster.rs
@@ -1071,7 +1071,7 @@ mod test {
         // Schemas not loaded yet, readiness is pending.
         assert!(!cluster.ready());
 
-        let mut result = std::pin::pin!(cluster.wait_ready());
+        let mut cluster_ready = std::pin::pin!(cluster.wait_ready());
 
         // Finish loading on all but one shard
         for shard in &cluster.shards[1..] {
@@ -1079,12 +1079,12 @@ mod test {
         }
 
         tokio::task::yield_now().await;
-        assert!(poll!(result.as_mut()).is_pending());
+        assert!(poll!(cluster_ready.as_mut()).is_pending());
 
         cluster.shards[0].schema_not_needed();
 
         tokio::task::yield_now().await;
-        assert!(poll!(result.as_mut()).is_ready());
+        assert!(poll!(cluster_ready.as_mut()).is_ready());
         assert!(cluster.ready());
     }
 

--- a/pgdog/src/backend/pool/cluster/launch.rs
+++ b/pgdog/src/backend/pool/cluster/launch.rs
@@ -4,13 +4,10 @@
 //! traffic until boot-time maintenance has completed.
 
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Duration;
 
-use tokio::{select, time::sleep};
+use tokio::select;
 use tokio_util::sync::CancellationToken;
-use tracing::error;
 
-use crate::backend::pool::ee::schema_changed_hook;
 use crate::tasks;
 
 use super::Cluster;
@@ -118,50 +115,6 @@ impl Cluster {
     /// Load database schema in the background, retrying
     /// until success or shutdown.
     fn launch_schema_sync(&self) {
-        if !self.load_schema() {
-            for shard in self.shards() {
-                shard.schema_not_needed();
-            }
-            return;
-        }
-
-        for shard in self.shards() {
-            let identifier = self.identifier();
-            let shard = shard.clone();
-            let shutdown = tasks::shutdown_signal();
-
-            tasks::spawn("shard schema sync", async move {
-                loop {
-                    let loader = shard.load_schema();
-                    let result = select! {
-                        _ = shutdown.cancelled() => break,
-                        result = loader => { result },
-                    };
-
-                    match result {
-                        Ok(true) => {
-                            schema_changed_hook(&shard.schema(), &identifier, &shard);
-                            return;
-                        }
-                        Ok(false) => return,
-                        Err(err) => {
-                            if shard.online() {
-                                error!(
-                                    "error loading schema for shard {}: {}",
-                                    shard.number(),
-                                    err
-                                );
-                                sleep(Duration::from_millis(100)).await;
-                            } else {
-                                // Cluster is shutting down: unblock any
-                                // wait_schema_loaded callers.
-                                shard.schema_not_needed();
-                                return;
-                            }
-                        }
-                    }
-                }
-            });
-        }
+        self.schema_loader.launch_schema_sync(self)
     }
 }

--- a/pgdog/src/backend/pool/cluster/schema_loader.rs
+++ b/pgdog/src/backend/pool/cluster/schema_loader.rs
@@ -1,0 +1,86 @@
+use super::Cluster;
+use crate::backend::pool::ee::schema_changed_hook;
+use crate::tasks;
+use dyn_clone::DynClone;
+use std::time::Duration;
+use tokio::{select, time::sleep};
+use tracing::error;
+
+pub(crate) trait SchemaLoader: Send + Sync + DynClone {
+    fn launch_schema_sync(&self, cluster: &Cluster);
+}
+
+dyn_clone::clone_trait_object!(SchemaLoader);
+
+#[derive(Clone, Copy)]
+pub(super) struct FromServer;
+
+impl SchemaLoader for FromServer {
+    fn launch_schema_sync(&self, cluster: &Cluster) {
+        if !cluster.load_schema() {
+            for shard in cluster.shards() {
+                shard.schema_not_needed();
+            }
+            return;
+        }
+
+        for shard in cluster.shards() {
+            let identifier = cluster.identifier();
+            let shard = shard.clone();
+            let shutdown = tasks::shutdown_signal();
+
+            tasks::spawn("shard schema sync", async move {
+                loop {
+                    let loader = shard.load_schema();
+                    let result = select! {
+                        _ = shutdown.cancelled() => break,
+                        result = loader => { result },
+                    };
+
+                    match result {
+                        Ok(true) => {
+                            schema_changed_hook(&shard.schema(), &identifier, &shard);
+                            return;
+                        }
+                        Ok(false) => return,
+                        Err(err) => {
+                            if shard.online() {
+                                error!(
+                                    "error loading schema for shard {}: {}",
+                                    shard.number(),
+                                    err
+                                );
+                                sleep(Duration::from_millis(100)).await;
+                            } else {
+                                // Cluster is shutting down: unblock any
+                                // wait_schema_loaded callers.
+                                shard.schema_not_needed();
+                                return;
+                            }
+                        }
+                    }
+                }
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy)]
+pub(crate) struct Dummy;
+
+#[cfg(test)]
+impl SchemaLoader for Dummy {
+    fn launch_schema_sync(&self, cluster: &Cluster) {
+        for shard in cluster.shards() {
+            shard.schema_not_needed();
+        }
+    }
+}
+
+#[cfg(test)]
+impl Default for Box<dyn SchemaLoader> {
+    fn default() -> Self {
+        Box::new(Dummy)
+    }
+}

--- a/pgdog/src/backend/pool/mod.rs
+++ b/pgdog/src/backend/pool/mod.rs
@@ -3,7 +3,6 @@
 pub mod address;
 pub mod cleanup;
 pub mod cluster;
-pub mod cluster_launch;
 pub mod comms;
 pub mod config;
 pub mod connection;


### PR DESCRIPTION
Any time we're constructing `Cluster` manually in tests, we can reasonably assume we do not want to be hitting the database. Avoiding that isn't as simple as just setting `load_schema: LoadSchema::Off`, as we still want to test other behavior around `cluster.load_schema()`.

Additionally, having that behavior only be configured by a single enum makes it much more difficult to *test* how schema loading works, and leads to funky assumptions with sleeps and timeouts.

Instead we can inject this behavior, defaulting to what we were doing before, but inserting a dummy implementation that is an immediate no-op in tests. Any tests that actually do want to hit a real server for schema loading information are either going through a different code path that creates the cluster from a config like real code, or they can inject `schema_loader::FromServer` themself.

I've taken advantage of the `Default` impl for `Cluster` to have the dummy impl be used by default there, as that's how the majority of our tests are constructing it. Constructing a cluster via `Cluster::default` outside of tests would almost certainly be a bug (and I've ensured it doesn't happen by only deriving it in tests)

For the vast majority of our tests, this will do nothing other than avoiding unnecessary network I/O. It's otherwise a no-op (but the tests that were manually trying to avoid hitting a real server no longer need to worry about it). For tests that actually care about the details of how schema loading works, it's now much easier for them to have complete control over when each shard does its business.

Long term it'd probably be worth a deeper refactor where this trait object actually gets passed all the way down into `Shard`, rather than just mocking out the task spawning.

I'd be great to get rid of `Cluster: Clone`, as it seems like something that smells like a bug if it's used. The only place that uses it is converting to logical replication, which can presumably take `Cluster` by value or as a mutable reference. But that would result in churn in a *ton* of our tests, so in the short term I've just added `DynClone` to handle it.