### PR TITLE
fix: migrate to safe_sleep/safe_interval/safe_timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5383,9 +5383,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",

--- a/pgdog/src/admin/probe.rs
+++ b/pgdog/src/admin/probe.rs
@@ -1,4 +1,4 @@
-use tokio::time::{Duration, Instant, timeout};
+use tokio::time::{Duration, Instant};
 use url::Url;
 
 use crate::{
@@ -7,6 +7,7 @@ use crate::{
 };
 
 use super::prelude::*;
+use crate::util::safe_timeout;
 
 #[derive(Debug, Clone)]
 pub struct Probe {
@@ -25,7 +26,7 @@ impl Command for Probe {
     }
 
     async fn execute(&self) -> Result<Vec<Message>, Error> {
-        let mut conn = timeout(
+        let mut conn = safe_timeout(
             Duration::from_millis(config().config.general.connect_timeout),
             Server::connect(
                 &Address::try_from(self.url.clone()).map_err(|_| Error::InvalidAddress)?,

--- a/pgdog/src/admin/server.rs
+++ b/pgdog/src/admin/server.rs
@@ -3,7 +3,6 @@
 use std::collections::VecDeque;
 use std::time::Duration;
 
-use tokio::time::sleep;
 use tracing::debug;
 
 use crate::frontend::ClientRequest;
@@ -15,6 +14,7 @@ use crate::net::messages::{ErrorResponse, FromBytes, Protocol, Query, ReadyForQu
 use super::Error;
 use super::parser::Parser;
 use super::prelude::Message;
+use crate::util::safe_sleep;
 
 /// Admin backend.
 #[derive(Debug)]
@@ -71,7 +71,7 @@ impl AdminServer {
         match self.messages.pop_front() {
             Some(message) => Ok(message),
             _ => loop {
-                sleep(Duration::MAX).await;
+                safe_sleep(Duration::MAX).await;
             },
         }
     }

--- a/pgdog/src/api/async_task.rs
+++ b/pgdog/src/api/async_task.rs
@@ -12,11 +12,11 @@ use parking_lot::RwLock;
 use pgdog_postgres_types::ToDataRowColumn;
 use tokio::select;
 use tokio::sync::oneshot::{self, Receiver};
-use tokio::time::timeout;
 use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, Span, error, info, info_span, warn};
 
 use crate::tasks;
+use crate::util::safe_timeout;
 
 /// Represent the ID of the async task.
 #[derive(Copy, Clone, Debug, Display, FromStr, Hash, PartialEq, Eq, PartialOrd, Ord)]
@@ -391,7 +391,7 @@ fn run_task<P: Task, T: Task>(
             _ = cancellation_token.cancelled() => {
                 ctx.transition(TaskStatus::Cancelling);
                 if ctx.task.cooperative.load(Ordering::Relaxed) {
-                    match timeout(T::cancel_timeout(), &mut handle).await {
+                    match safe_timeout(T::cancel_timeout(), &mut handle).await {
                         Ok(res) => res,
                         Err(_) => {
                             // The timeout fired: abort the task
@@ -584,6 +584,7 @@ impl AsyncTasksStorage {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::util::safe_sleep;
     use parking_lot::Mutex;
     use std::convert::Infallible;
     use std::fmt::Debug;
@@ -591,7 +592,6 @@ mod tests {
     use tokio::sync::Notify;
     use tokio::task::yield_now;
     use tokio::test;
-    use tokio::time::sleep;
 
     type State = Arc<Mutex<&'static str>>;
 
@@ -767,7 +767,7 @@ mod tests {
             tokio::select! {
                 _ = self.notify.notified() => {}
                 _ = token.cancelled() => {
-                    sleep(self.wind_down).await;
+                    safe_sleep(self.wind_down).await;
                     *self.state.lock() = "cancelled";
                     return Ok(true);
                 }

--- a/pgdog/src/backend/pool/cluster/schema_loader.rs
+++ b/pgdog/src/backend/pool/cluster/schema_loader.rs
@@ -1,9 +1,10 @@
 use super::Cluster;
 use crate::backend::pool::ee::schema_changed_hook;
 use crate::tasks;
+use crate::util::safe_sleep;
 use dyn_clone::DynClone;
 use std::time::Duration;
-use tokio::{select, time::sleep};
+use tokio::select;
 use tracing::error;
 
 pub(crate) trait SchemaLoader: Send + Sync + DynClone {
@@ -50,7 +51,7 @@ impl SchemaLoader for FromServer {
                                     shard.number(),
                                     err
                                 );
-                                sleep(Duration::from_millis(100)).await;
+                                safe_sleep(Duration::from_millis(100)).await;
                             } else {
                                 // Cluster is shutting down: unblock any
                                 // wait_schema_loaded callers.

--- a/pgdog/src/backend/pool/connection/binding.rs
+++ b/pgdog/src/backend/pool/connection/binding.rs
@@ -15,6 +15,7 @@ use crate::{
 use futures::future::join_all;
 
 use super::*;
+use crate::util::safe_sleep;
 
 /// The server(s) the client is connected to.
 #[derive(Debug, Default)]
@@ -90,7 +91,7 @@ impl Binding {
 
             Binding::NotConnected => loop {
                 debug!("binding suspended");
-                sleep(Duration::MAX).await
+                safe_sleep(Duration::MAX).await
             },
 
             Binding::Admin(backend) => Ok(backend.read().await?),
@@ -98,7 +99,7 @@ impl Binding {
                 if shards.is_empty() {
                     loop {
                         debug!("multi-shard binding suspended");
-                        sleep(Duration::MAX).await;
+                        safe_sleep(Duration::MAX).await;
                     }
                 } else {
                     // Loop until we read a message from a shard
@@ -130,7 +131,7 @@ impl Binding {
                     loop {
                         state.reset();
                         debug!("multi-shard binding done");
-                        sleep(Duration::MAX).await;
+                        safe_sleep(Duration::MAX).await;
                     }
                 }
             }

--- a/pgdog/src/backend/pool/connection/mirror/mod.rs
+++ b/pgdog/src/backend/pool/connection/mirror/mod.rs
@@ -6,7 +6,7 @@ use pgdog_config::MirroringLevel;
 use rand::{Rng, rng};
 use tokio::select;
 use tokio::sync::mpsc::*;
-use tokio::time::{Instant, sleep};
+use tokio::time::Instant;
 use tracing::{debug, error, warn};
 
 use crate::backend::Cluster;
@@ -19,6 +19,7 @@ use crate::net::{FrontendPid, Parameter, Parameters, Stream};
 use crate::tasks;
 
 use super::Error;
+use crate::util::safe_sleep;
 
 pub mod buffer_with_delay;
 pub mod handler;
@@ -154,7 +155,7 @@ impl Mirror {
 
         for req in &mut request.buffer {
             if req.delay > Duration::ZERO {
-                sleep(req.delay).await;
+                safe_sleep(req.delay).await;
             }
 
             let mut context = QueryEngineContext::new_mirror(self, &mut req.buffer);
@@ -268,14 +269,14 @@ mod test {
                 3,
                 "mirror buffer should have 3 requests"
             );
-            sleep(Duration::from_millis(50)).await;
+            safe_sleep(Duration::from_millis(50)).await;
             // Nothing happens until we flush.
             assert!(
                 conn.execute("DROP TABLE pgdog.test_mirror").await.is_err(),
                 "table pgdog.test_mirror shouldn't exist yet"
             );
             assert!(mirror.flush(), "mirror didn't flush");
-            sleep(Duration::from_millis(50)).await;
+            safe_sleep(Duration::from_millis(50)).await;
             assert!(
                 conn.execute("DROP TABLE pgdog.test_mirror").await.is_ok(),
                 "pgdog.test_mirror should exist"
@@ -310,7 +311,7 @@ mod test {
         assert!(mirror.flush());
 
         // Wait for async processing
-        sleep(Duration::from_millis(100)).await;
+        safe_sleep(Duration::from_millis(100)).await;
 
         // Verify stats were incremented
         let final_stats = {

--- a/pgdog/src/backend/pool/connection/mod.rs
+++ b/pgdog/src/backend/pool/connection/mod.rs
@@ -2,7 +2,7 @@
 
 use mirror::MirrorHandler;
 use pgdog_config::users::PasswordKind;
-use tokio::{select, time::sleep};
+use tokio::select;
 use tracing::debug;
 
 use crate::{

--- a/pgdog/src/backend/pool/guard.rs
+++ b/pgdog/src/backend/pool/guard.rs
@@ -3,7 +3,6 @@
 use std::ops::{Deref, DerefMut};
 
 use pgdog_config::pooling::ConnectionRecovery;
-use tokio::time::timeout;
 use tokio::{spawn, time::Instant};
 use tracing::{debug, error};
 
@@ -11,6 +10,7 @@ use crate::backend::{Error, Server};
 use crate::state::State;
 
 use super::{Pool, cleanup::Cleanup};
+use crate::util::safe_timeout;
 
 /// Connection guard.
 pub struct Guard {
@@ -95,7 +95,7 @@ impl Guard {
                 let addr = self.pool.addr().clone();
 
                 spawn(async move {
-                    match timeout(
+                    match safe_timeout(
                         rollback_timeout,
                         Self::cleanup_internal(&mut server, cleanup, conn_recovery),
                     )
@@ -240,8 +240,9 @@ mod test {
     use std::time::Duration;
 
     use pgdog_config::pooling::ConnectionRecovery;
-    use tokio::time::{Instant, sleep, timeout};
+    use tokio::time::Instant;
 
+    use crate::util::{safe_sleep, safe_timeout};
     use crate::{
         backend::{
             pool::{
@@ -365,7 +366,7 @@ mod test {
                 .unwrap();
         }
 
-        sleep(Duration::from_millis(500)).await;
+        safe_sleep(Duration::from_millis(500)).await;
 
         {
             let state = pool.lock();
@@ -435,7 +436,7 @@ mod test {
         let mut server = test_server().await;
         let select = (0..50_000_000).map(|_| 'b').collect::<String>();
         let select = Query::new(format!("SELECT '{}'", select));
-        let res = timeout(
+        let res = safe_timeout(
             Duration::from_millis(1),
             server.send(&vec![select.into()].into()),
         )
@@ -845,7 +846,7 @@ mod test {
         let pool = pool();
 
         {
-            let mut guard = timeout(Duration::from_secs(5), pool.get(&Request::default()))
+            let mut guard = safe_timeout(Duration::from_secs(5), pool.get(&Request::default()))
                 .await
                 .expect("timed out getting connection")
                 .unwrap();
@@ -854,7 +855,7 @@ mod test {
             let large_query = (0..50_000_000).map(|_| 'b').collect::<String>();
             let large_query = Query::new(format!("SELECT '{}'", large_query));
 
-            let res = timeout(
+            let res = safe_timeout(
                 Duration::from_millis(1),
                 guard.send(&vec![large_query.into()].into()),
             )
@@ -867,7 +868,7 @@ mod test {
             );
         }
 
-        sleep(Duration::from_millis(100)).await;
+        safe_sleep(Duration::from_millis(100)).await;
 
         let state = pool.state();
         assert_eq!(

--- a/pgdog/src/backend/pool/healthcheck.rs
+++ b/pgdog/src/backend/pool/healthcheck.rs
@@ -3,11 +3,11 @@
 use std::time::Duration;
 
 use tokio::time::Instant;
-use tokio::time::timeout;
 use tracing::error;
 
 use super::{Error, Pool};
 use crate::backend::Server;
+use crate::util::safe_timeout;
 
 /// Perform a healtcheck on a connection.
 pub struct Healtcheck<'a> {
@@ -55,7 +55,7 @@ impl<'a> Healtcheck<'a> {
             return Ok(());
         }
 
-        match timeout(self.healthcheck_timeout, self.conn.healthcheck(";")).await {
+        match safe_timeout(self.healthcheck_timeout, self.conn.healthcheck(";")).await {
             Ok(Ok(())) => Ok(()),
             Ok(Err(err)) => {
                 // Check if this is an administrator command termination

--- a/pgdog/src/backend/pool/lb/mod.rs
+++ b/pgdog/src/backend/pool/lb/mod.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use rand::seq::SliceRandom;
-use tokio::{sync::Notify, time::timeout};
+use tokio::sync::Notify;
 use tracing::warn;
 
 use crate::{config::config, net::messages::FrontendPid};
@@ -19,6 +19,7 @@ use crate::{
 };
 
 use super::{Error, Guard, Pool, PoolConfig, Request};
+use crate::util::safe_timeout;
 
 pub mod ban;
 pub mod monitor;
@@ -310,7 +311,7 @@ impl LoadBalancer {
     /// callers will block until their `checkout_timeout` fires.
     async fn wait_roles_detected(&self) -> Result<(), Error> {
         if !self.roles_detected() {
-            if timeout(self.checkout_timeout, self.role_detection.notified())
+            if safe_timeout(self.checkout_timeout, self.role_detection.notified())
                 .await
                 .is_err()
             {

--- a/pgdog/src/backend/pool/lb/monitor.rs
+++ b/pgdog/src/backend/pool/lb/monitor.rs
@@ -4,8 +4,9 @@ use crate::{config::config, tasks};
 
 use super::*;
 
+use crate::util::safe_interval;
 use pgdog_stats::ReplicaLag;
-use tokio::{select, task::JoinHandle, time::interval};
+use tokio::{select, task::JoinHandle};
 use tracing::debug;
 
 static MAINTENANCE: Duration = Duration::from_millis(333);
@@ -36,7 +37,7 @@ impl Monitor {
     }
 
     async fn run(&self) {
-        let mut interval = interval(MAINTENANCE);
+        let mut interval = safe_interval(MAINTENANCE);
 
         debug!("replicas monitor running");
         let config = config();

--- a/pgdog/src/backend/pool/lsn_monitor.rs
+++ b/pgdog/src/backend/pool/lsn_monitor.rs
@@ -3,10 +3,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use tokio::{
-    select,
-    time::{interval, sleep, timeout},
-};
+use tokio::select;
 use tracing::{debug, error, trace};
 
 use crate::{
@@ -18,6 +15,7 @@ use crate::{
 use super::*;
 use pgdog_postgres_types::Format;
 
+use crate::util::{safe_interval, safe_sleep, safe_timeout};
 use pgdog_stats::LsnStats as StatsLsnStats;
 pub use pgdog_stats::replication::ReplicaLag;
 
@@ -141,7 +139,7 @@ impl LsnMonitor {
     }
 
     async fn run_query(&self, conn: &mut Server, query: &str) -> Option<DataRow> {
-        match timeout(self.pool.config().lsn_check_timeout, conn.fetch_all(query)).await {
+        match safe_timeout(self.pool.config().lsn_check_timeout, conn.fetch_all(query)).await {
             Ok(Ok(rows)) => rows.into_iter().next(),
             Ok(Err(err)) => {
                 error!("lsn monitor query error: {} [{}]", err, self.pool.addr());
@@ -155,7 +153,7 @@ impl LsnMonitor {
     }
 
     async fn detect_aurora(&self, conn: &mut Server) -> Option<bool> {
-        match timeout(
+        match safe_timeout(
             self.pool.config().lsn_check_timeout,
             conn.fetch_all::<DataRow>(AURORA_DETECTION_QUERY),
         )
@@ -186,14 +184,14 @@ impl LsnMonitor {
 
     async fn spawn(&self) {
         select! {
-            _ = sleep(self.pool.config().lsn_check_delay) => {},
+            _ = safe_sleep(self.pool.config().lsn_check_delay) => {},
             _ = self.pool.comms().shutdown.cancelled() => { return; }
         }
 
         debug!("lsn monitor loop is running [{}]", self.pool.addr());
 
         let mut aurora_detected: Option<bool> = None;
-        let mut interval = interval(self.pool.config().lsn_check_interval);
+        let mut interval = safe_interval(self.pool.config().lsn_check_interval);
 
         loop {
             select! {
@@ -413,7 +411,7 @@ mod test {
         // so this first check flips to primary and fires one notification —
         // drain that stored permit before testing the steady state.
         assert_eq!(monitor.run_check(Some(false)).await, Ok(Some(false)));
-        let _ = timeout(
+        let _ = safe_timeout(
             Duration::from_millis(50),
             monitor.pool.inner().lsn_role_change.notified(),
         )

--- a/pgdog/src/backend/pool/monitor.rs
+++ b/pgdog/src/backend/pool/monitor.rs
@@ -53,8 +53,9 @@ use crate::backend::{ConnectReason, DisconnectReason, Server};
 use crate::config::ServerAuth;
 use crate::tasks;
 
+use crate::util::{safe_interval, safe_sleep, safe_timeout};
 use tokio::select;
-use tokio::time::{Instant, interval, sleep, timeout};
+use tokio::time::Instant;
 use tracing::{debug, error, info, warn};
 
 static MAINTENANCE: Duration = Duration::from_millis(333);
@@ -108,7 +109,7 @@ impl Monitor {
         if !replication_mode && interval > Duration::ZERO {
             tasks::spawn("pool healthchecks", async move {
                 select! {
-                    _ = sleep(delay) => {}
+                    _ = safe_sleep(delay) => {}
                     _ = pool.comms().shutdown.cancelled() => return,
                 }
                 Self::healthchecks(pool).await
@@ -199,7 +200,7 @@ impl Monitor {
             let sleep_duration = TokenCache::global().refresh_in(&addr);
 
             select! {
-                _ = sleep(sleep_duration) => {
+                _ = safe_sleep(sleep_duration) => {
                     let result = match addr.server_auth {
                         ServerAuth::RdsIam => rds_iam::token(addr.clone()).await.map(
                             |(token, expires_at)| {
@@ -255,7 +256,7 @@ impl Monitor {
     ///
     /// Runs regularly and ensures the pool triggers health checks on idle connections.
     async fn healthchecks(pool: Pool) {
-        let mut tick = interval(pool.lock().config().idle_healthcheck_interval());
+        let mut tick = safe_interval(pool.lock().config().idle_healthcheck_interval());
         let comms = pool.comms();
 
         debug!("health checks running [{}]", pool.addr());
@@ -290,7 +291,7 @@ impl Monitor {
 
     /// Perform maintenance on the pool periodically.
     async fn maintenance(pool: Pool) {
-        let mut tick = interval(MAINTENANCE);
+        let mut tick = safe_interval(MAINTENANCE);
         let comms = pool.comms();
 
         debug!("maintenance started [{}]", pool.addr());
@@ -407,7 +408,7 @@ impl Monitor {
             return;
         }
 
-        let mut interval = interval(pool.config().stats_period);
+        let mut interval = safe_interval(pool.config().stats_period);
 
         loop {
             select! {
@@ -441,7 +442,7 @@ impl Monitor {
         let max_age_jitter = pool.config().max_age_jitter;
 
         for attempt in 0..connect_attempts {
-            match timeout(
+            match safe_timeout(
                 connect_timeout,
                 Server::connect(pool.addr(), options.clone(), reason),
             )
@@ -492,7 +493,7 @@ impl Monitor {
                 }
             }
 
-            sleep(connect_attempt_delay).await;
+            safe_sleep(connect_attempt_delay).await;
         }
 
         Err(error)

--- a/pgdog/src/backend/pool/pool_impl.rs
+++ b/pgdog/src/backend/pool/pool_impl.rs
@@ -9,7 +9,7 @@ use once_cell::sync::{Lazy, OnceCell};
 use parking_lot::RwLock;
 use parking_lot::{Mutex, RawMutex, lock_api::MutexGuard};
 use tokio::sync::Notify;
-use tokio::time::{Instant, timeout};
+use tokio::time::Instant;
 use tracing::{debug, error};
 
 use crate::backend::pool::LsnStats;
@@ -25,6 +25,7 @@ use super::{
     lb::TargetHealth,
     lsn_monitor::{LsnMonitor, ReplicaLag},
 };
+use crate::util::safe_timeout;
 
 static ID_COUNTER: Lazy<Arc<AtomicU64>> = Lazy::new(|| Arc::new(AtomicU64::new(0)));
 fn next_pool_id() -> u64 {
@@ -106,7 +107,7 @@ impl Pool {
     }
 
     pub async fn get(&self, request: &Request) -> Result<Guard, Error> {
-        match timeout(self.config().checkout_timeout, self.get_internal(request)).await {
+        match safe_timeout(self.config().checkout_timeout, self.get_internal(request)).await {
             Ok(Ok(conn)) => Ok(conn),
             Err(_) => {
                 self.inner.health.toggle(false);

--- a/pgdog/src/backend/pool/shard/monitor.rs
+++ b/pgdog/src/backend/pool/shard/monitor.rs
@@ -5,8 +5,8 @@ use crate::{
 
 use super::*;
 
+use crate::util::safe_interval;
 use futures::stream::{FuturesUnordered, StreamExt};
-use tokio::time::interval;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
@@ -49,7 +49,7 @@ impl ShardMonitor {
     async fn spawn(&self) {
         let maintenance = (self.shard.comms().lsn_check_interval / 2)
             .clamp(Duration::from_millis(333), Duration::MAX);
-        let mut maintenance = interval(maintenance);
+        let mut maintenance = safe_interval(maintenance);
 
         debug!(
             "shard {} monitor running [{}]",
@@ -164,9 +164,9 @@ mod test {
     use crate::backend::pool::{Address, Config, PoolConfig};
     use crate::backend::replication::publisher::Lsn;
     use crate::config::{ReadWriteSplit, Role};
+    use crate::util::safe_sleep;
     use pgdog_postgres_types::{Format, FromDataType, TimestampTz};
     use pgdog_stats::LsnStats as StatsLsnStats;
-    use tokio::time::sleep;
 
     use super::super::ShardConfig;
     use super::*;
@@ -328,7 +328,7 @@ mod test {
         // Wait for the monitor to re-detect roles.
         let mut promoted = false;
         for _ in 0..40 {
-            sleep(Duration::from_millis(50)).await;
+            safe_sleep(Duration::from_millis(50)).await;
             let roles = shard.pools_with_roles();
             if roles[0].0 == Role::Primary {
                 assert_eq!(roles[1].0, Role::Replica, "old primary demoted");

--- a/pgdog/src/backend/pub_sub/listener.rs
+++ b/pgdog/src/backend/pub_sub/listener.rs
@@ -15,12 +15,12 @@ use parking_lot::Mutex;
 use tokio::{
     select,
     sync::{Notify, broadcast, mpsc},
-    time::sleep,
 };
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info};
 
 use super::{Stats, StatsSnapshot, channel_size};
+use crate::util::safe_sleep;
 use crate::{
     backend::{self, ConnectReason, DisconnectReason, Pool, pool::Error},
     config::config,
@@ -212,7 +212,7 @@ impl PubSubListener {
                             // Don't reconnect for another connect attempt delay
                             // to avoid connection storms during incidents.
                             select! {
-                                _ = sleep(Duration::from_millis(config().config.general.connect_attempt_delay)) => {}
+                                _ = safe_sleep(Duration::from_millis(config().config.general.connect_attempt_delay)) => {}
                                 _ = comms.shutdown.cancelled() => rx.close(),
                             }
                         }

--- a/pgdog/src/backend/replication/logical/orchestrator.rs
+++ b/pgdog/src/backend/replication/logical/orchestrator.rs
@@ -9,15 +9,12 @@ use crate::{
 };
 use pgdog_config::{ConfigAndUsers, CutoverTimeoutAction, RewriteMode};
 use std::{fmt::Display, sync::Arc, time::Duration};
-use tokio::{
-    select,
-    sync::Mutex,
-    time::{Instant, interval},
-};
+use tokio::{select, sync::Mutex, time::Instant};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
 use super::*;
+use crate::util::safe_interval;
 
 #[derive(Debug, Clone)]
 pub(crate) struct Orchestrator {
@@ -296,7 +293,7 @@ impl ReplicationWaiter {
         );
 
         // Check once a second how far we got.
-        let mut check = interval(Duration::from_secs(1));
+        let mut check = safe_interval(Duration::from_secs(1));
 
         loop {
             select! {
@@ -379,8 +376,8 @@ impl ReplicationWaiter {
         );
 
         // Check more frequently.
-        let mut check = interval(Duration::from_millis(50));
-        let mut log = interval(Duration::from_secs(1));
+        let mut check = safe_interval(Duration::from_millis(50));
+        let mut log = safe_interval(Duration::from_secs(1));
         // Abort clock starts now.
         let start = Instant::now();
 
@@ -545,6 +542,7 @@ use ok_or_abort;
 mod tests {
     use super::*;
     use crate::backend::pool::Cluster;
+    use crate::util::{safe_sleep, safe_timeout};
     use pgdog_config::ConfigAndUsers;
     use std::assert_matches;
     use std::sync::Arc;
@@ -831,7 +829,6 @@ mod tests {
     #[tokio::test]
     async fn wait_for_replication_finishes_with_unrelated_writes() {
         use crate::backend::server::test::test_server;
-        use tokio::time::{sleep, timeout};
 
         crate::logger();
         maintenance_mode::stop(None);
@@ -906,11 +903,11 @@ mod tests {
 
         // Let one check_lag tick (1s) refresh the lag cache with the post-write
         // value before sampling the gate.
-        sleep(Duration::from_secs(1)).await;
+        safe_sleep(Duration::from_secs(1)).await;
 
         // 30s margin: keepalive cadence (wal_sender_timeout) is not bounded by
         // the 1s sleep, so give confirmed_flush_lsn room to advance.
-        let result = timeout(Duration::from_secs(20), waiter.wait_for_replication()).await;
+        let result = safe_timeout(Duration::from_secs(20), waiter.wait_for_replication()).await;
         let maintenance_on = maintenance_mode::is_on("");
 
         // Clean up before asserting so a failure can't leak slots or maintenance mode.

--- a/pgdog/src/backend/replication/logical/publisher/parallel_sync.rs
+++ b/pgdog/src/backend/replication/logical/publisher/parallel_sync.rs
@@ -5,7 +5,7 @@
 //!
 use std::sync::Arc;
 
-use tokio::{sync::Semaphore, task::JoinHandle, time::sleep};
+use tokio::{sync::Semaphore, task::JoinHandle};
 use tracing::{info, warn};
 
 use super::super::Error;
@@ -18,6 +18,7 @@ use crate::frontend::client::query_engine::two_pc::Manager;
 use crate::net::messages::Protocol;
 use crate::tasks;
 use crate::util::escape_identifier;
+use crate::util::safe_sleep;
 use futures::{StreamExt, stream::FuturesUnordered};
 use tokio_util::sync::CancellationToken;
 
@@ -89,7 +90,7 @@ impl ParallelSync {
                     // Reset counters so the next attempt's progress is reported accurately.
                     tracker.reset();
 
-                    sleep(backoff).await;
+                    safe_sleep(backoff).await;
 
                     if self.dest.two_pc_enabled()
                         && let Some(txn) = err.two_pc_cleanup_transaction()

--- a/pgdog/src/backend/replication/logical/publisher/progress.rs
+++ b/pgdog/src/backend/replication/logical/publisher/progress.rs
@@ -4,11 +4,11 @@ use std::time::Duration;
 
 use tokio::select;
 use tokio::sync::Notify;
-use tokio::time::sleep;
 use tracing::info;
 
 use crate::backend::replication::publisher::{Lsn, PublicationTable};
 use crate::tasks;
+use crate::util::safe_sleep;
 
 #[derive(Debug)]
 struct Inner {
@@ -63,7 +63,7 @@ impl Progress {
             };
             loop {
                 select! {
-                    _ = sleep(Duration::from_secs(5)) => {
+                    _ = safe_sleep(Duration::from_secs(5)) => {
                         let written = notify.bytes_sharded.load(Ordering::Relaxed);
                         let lsn = notify.lsn.load(Ordering::Relaxed);
 

--- a/pgdog/src/backend/replication/logical/publisher/publisher_impl.rs
+++ b/pgdog/src/backend/replication/logical/publisher/publisher_impl.rs
@@ -5,10 +5,10 @@ use std::time::Duration;
 use futures::stream::{FuturesUnordered, StreamExt};
 use parking_lot::Mutex;
 use pgdog_config::QueryParserEngine;
+use tokio::select;
 use tokio::task::JoinHandle;
-use tokio::time::{Instant, sleep};
+use tokio::time::Instant;
 use tokio::try_join;
-use tokio::{select, time::interval};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
@@ -26,6 +26,7 @@ use crate::backend::{Cluster, pool::Request};
 use crate::config::Role;
 use crate::net::replication::ReplicationMeta;
 use crate::tasks;
+use crate::util::{safe_interval, safe_sleep};
 
 fn merge_table_lsns(
     tables: Vec<Table>,
@@ -231,7 +232,7 @@ impl Publisher {
                 .ok_or(Error::NoReplicationSlot(number))?;
             stream.set_current_lsn(slot.lsn().lsn);
 
-            let mut check_lag = interval(Duration::from_secs(1));
+            let mut check_lag = safe_interval(Duration::from_secs(1));
             let replication_lag = self.replication_lag.clone();
             let stop = stop.clone();
             let last_transaction = self.last_transaction.clone();
@@ -321,7 +322,7 @@ impl Publisher {
                                         "[replication] error ({attempt}/{max_attempts}): {err}, reconnecting in {}ms",
                                         delay.as_millis()
                                     );
-                                    sleep(delay).await;
+                                    safe_sleep(delay).await;
                                     if let Err(reconnect_err) =
                                         try_join!(slot.reconnect(), stream.reconnect())
                                     {

--- a/pgdog/src/backend/replication/logical/publisher/slot.rs
+++ b/pgdog/src/backend/replication/logical/publisher/slot.rs
@@ -11,9 +11,9 @@ use crate::{
     util::random_string,
 };
 
+use crate::util::safe_timeout;
 use pgdog_config::CopyFormat;
 use std::{fmt::Display, str::FromStr, time::Duration};
-use tokio::time::timeout;
 use tracing::{debug, info, trace, warn};
 
 pub use pgdog_stats::Lsn;
@@ -333,7 +333,7 @@ impl ReplicationSlot {
         max_wait: Duration,
     ) -> Result<Option<ReplicationData>, Error> {
         loop {
-            let message = match timeout(max_wait, self.server()?.read()).await {
+            let message = match safe_timeout(max_wait, self.server()?.read()).await {
                 Err(_err) => return Err(Error::ReplicationTimeout),
                 Ok(message) => message?,
             };

--- a/pgdog/src/frontend/client/query_engine/two_pc/manager.rs
+++ b/pgdog/src/frontend/client/query_engine/two_pc/manager.rs
@@ -13,11 +13,7 @@ use std::{
     },
     time::Duration,
 };
-use tokio::{
-    select,
-    sync::Notify,
-    time::{Instant, interval, sleep},
-};
+use tokio::{select, sync::Notify, time::Instant};
 use tracing::{debug, error, info, warn};
 
 use crate::{
@@ -30,6 +26,7 @@ use crate::{
         parser::{Shard, ShardWithPriority},
     },
     tasks,
+    util::{safe_interval, safe_sleep},
 };
 
 use super::{
@@ -153,7 +150,7 @@ impl Manager {
             }
             select! {
                 _ = self.notify.notify.notified() => {}
-                _ = sleep(remaining) => {}
+                _ = safe_sleep(remaining) => {}
             }
         }
     }
@@ -276,7 +273,7 @@ impl Manager {
     }
 
     async fn monitor(manager: Self) {
-        let mut interval = interval(MAINTENANCE);
+        let mut interval = safe_interval(MAINTENANCE);
         let notify = manager.notify.clone();
 
         debug!("[2pc] monitor started");

--- a/pgdog/src/frontend/client/query_engine/two_pc/wal/checkpoint.rs
+++ b/pgdog/src/frontend/client/query_engine/two_pc/wal/checkpoint.rs
@@ -2,6 +2,7 @@
 
 use crate::net::Error;
 use crate::tasks;
+use crate::util::safe_sleep;
 use std::time::Duration;
 use std::{
     io::ErrorKind,
@@ -9,7 +10,7 @@ use std::{
 };
 use tokio::fs::remove_file;
 use tokio::select;
-use tokio::time::{Instant, sleep};
+use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info};
 
@@ -70,7 +71,7 @@ impl Checkpointer {
                 }
 
                 select! {
-                    _ = sleep(checkpointer.checkpoint_interval) => {},
+                    _ = safe_sleep(checkpointer.checkpoint_interval) => {},
                     _ = checkpointer.shutdown.cancelled() => { break; },
                 }
             }

--- a/pgdog/src/frontend/client/query_engine/two_pc/wal/live_segment.rs
+++ b/pgdog/src/frontend/client/query_engine/two_pc/wal/live_segment.rs
@@ -11,6 +11,7 @@ use super::{Record, Segment, SegmentRegistry, SegmentStatus};
 use crate::{
     net::{Error, ToBytes},
     tasks,
+    util::safe_interval,
 };
 use parking_lot::Mutex;
 use tokio::{
@@ -18,7 +19,7 @@ use tokio::{
     io::{AsyncWriteExt, BufWriter},
     select,
     sync::{Notify, oneshot},
-    time::{MissedTickBehavior, interval},
+    time::MissedTickBehavior,
 };
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error};
@@ -168,7 +169,7 @@ impl LiveSegment {
         let mut fsync = if self.fsync_interval.is_zero() {
             None
         } else {
-            let mut fsync = interval(self.fsync_interval);
+            let mut fsync = safe_interval(self.fsync_interval);
             fsync.set_missed_tick_behavior(MissedTickBehavior::Delay);
             fsync.tick().await; // The first tick completes immediately.
             Some(fsync)

--- a/pgdog/src/frontend/listener.rs
+++ b/pgdog/src/frontend/listener.rs
@@ -14,12 +14,12 @@ use crate::sighup::Sighup;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::signal::ctrl_c;
 use tokio::sync::Notify;
-use tokio::time::timeout;
 use tokio::{select, spawn};
 
 use tracing::{error, info, warn};
 
 use super::{Client, Error, comms::comms};
+use crate::util::safe_timeout;
 
 /// Client connections listener and handler.
 #[derive(Debug, Clone)]
@@ -117,7 +117,7 @@ impl Listener {
 
         let comms = comms();
 
-        if timeout(shutdown_timeout, comms.tracker().wait())
+        if safe_timeout(shutdown_timeout, comms.tracker().wait())
             .await
             .is_err()
         {
@@ -139,7 +139,7 @@ impl Listener {
                 });
                 let cancel_all = futures::future::join_all(cancel_futures);
 
-                if timeout(termination_timeout, cancel_all).await.is_err() {
+                if safe_timeout(termination_timeout, cancel_all).await.is_err() {
                     error!(
                         "forced shutdown: abandoning {} outstanding cancel requests after waiting {:.3}s",
                         comms.clients().len(),

--- a/pgdog/src/frontend/prepared_statements/mod.rs
+++ b/pgdog/src/frontend/prepared_statements/mod.rs
@@ -4,9 +4,9 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use once_cell::sync::Lazy;
 use parking_lot::RwLock;
-use tokio::time::sleep;
 use tracing::debug;
 
+use crate::util::safe_sleep;
 use crate::{
     config::{PreparedStatements as PreparedStatementsLevel, config},
     net::{Parse, ProtocolMessage},
@@ -176,7 +176,7 @@ pub fn start_maintenance() {
         let shutdown = crate::tasks::shutdown_signal();
         loop {
             tokio::select! {
-                _ = sleep(Duration::from_secs(1)) => {}
+                _ = safe_sleep(Duration::from_secs(1)) => {}
                 _ = shutdown.cancelled() => break,
             }
             run_maintenance();

--- a/pgdog/src/net/discovery/listener.rs
+++ b/pgdog/src/net/discovery/listener.rs
@@ -12,10 +12,11 @@ use std::time::SystemTime;
 
 use tokio::net::UdpSocket;
 use tokio::select;
-use tokio::time::{Duration, interval};
+use tokio::time::Duration;
 
 use super::{Error, Message, Payload};
 use crate::tasks;
+use crate::util::safe_interval;
 
 /// Service discovery listener.
 #[derive(Clone, Debug)]
@@ -78,7 +79,7 @@ impl Listener {
         socket.multicast_loop_v4()?; // Won't work on IPv6, but nice for debugging.
 
         let mut buf = vec![0u8; 1024];
-        let mut interval = interval(Duration::from_secs(1));
+        let mut interval = safe_interval(Duration::from_secs(1));
         let shutdown = tasks::shutdown_signal();
 
         loop {

--- a/pgdog/src/sighup.rs
+++ b/pgdog/src/sighup.rs
@@ -27,7 +27,7 @@ impl Sighup {
             use std::time::Duration;
             use tokio::time::sleep;
 
-            sleep(Duration::MAX).await;
+            safe_sleep(Duration::MAX).await;
         }
     }
 }

--- a/pgdog/src/stats/logger.rs
+++ b/pgdog/src/stats/logger.rs
@@ -1,10 +1,11 @@
 use std::{sync::Arc, time::Duration};
 
-use tokio::{select, sync::Notify, time::sleep};
+use tokio::{select, sync::Notify};
 use tracing::info;
 
 use crate::frontend::router::parser::Cache;
 use crate::tasks;
+use crate::util::safe_sleep;
 
 #[derive(Debug, Clone)]
 pub struct Logger {
@@ -37,7 +38,7 @@ impl Logger {
             let shutdown = tasks::shutdown_signal();
             loop {
                 select! {
-                    _ = sleep(me.interval) => {
+                    _ = safe_sleep(me.interval) => {
                         let (stats, len) = Cache::stats();
 
                         info!(

--- a/pgdog/src/stats/otel_exporter.rs
+++ b/pgdog/src/stats/otel_exporter.rs
@@ -5,11 +5,11 @@
 
 use std::time::Duration;
 
-use tokio::time::sleep;
 use tracing::{info, warn};
 
 use super::otel;
 use super::{Clients, ClientsLocked, Listeners, MirrorStatsMetrics, Pools, QueryCache, TwoPc};
+use crate::util::safe_sleep;
 use crate::{config::config, tasks};
 
 /// Maximum number of metrics per OTLP request to stay under endpoint payload limits.
@@ -36,7 +36,7 @@ pub async fn run() {
 
     loop {
         tokio::select! {
-            _ = sleep(interval) => {}
+            _ = safe_sleep(interval) => {}
             _ = shutdown.cancelled() => break,
         }
 

--- a/pgdog/src/tasks.rs
+++ b/pgdog/src/tasks.rs
@@ -7,12 +7,13 @@ use std::{
 
 use dashmap::DashMap;
 use once_cell::sync::Lazy;
-use tokio::{task::JoinHandle, time::timeout};
+use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
 use tracing::{error, info};
 
 use crate::config::config;
+use crate::util::safe_timeout;
 
 static TASKS: Lazy<BackgroundTasks> = Lazy::new(BackgroundTasks::default);
 
@@ -68,7 +69,7 @@ pub async fn shutdown() {
 
     info!("waiting on {} background tasks", TASKS.tracker.len());
 
-    let wait = timeout(
+    let wait = safe_timeout(
         config().config.general.shutdown_timeout(),
         TASKS.tracker.wait(),
     );

--- a/pgdog/src/util.rs
+++ b/pgdog/src/util.rs
@@ -2,11 +2,13 @@
 
 use chrono::{DateTime, Local, Utc};
 use once_cell::sync::Lazy;
-use pgdog_config::MAX_DURATION;
 use rand::{Rng, distr::Alphanumeric};
 #[cfg(feature = "new_parser")]
 use std::ops::ControlFlow;
-use std::{env, future::Future, num::ParseIntError, time::Duration};
+use std::panic::Location;
+use std::{env, future::Future, future::pending, num::ParseIntError, time::Duration};
+use tokio::time::Interval;
+use tracing::warn;
 
 use crate::net::Parameters; // 0.8
 
@@ -298,14 +300,20 @@ pub fn sanitize_log_sample(s: &str, limit: usize) -> String {
     truncate_utf8(s, limit).replace(|c: char| c.is_control(), " ")
 }
 
-/// Avoid calling [`tokio::time::timeout`] on [`Duration`] that lasts effectively forever.
+/// Longest deadline Tokio's timer wheel can address (`64^6` ms, a bit over
+/// two years). A longer timer eventually stops every other timer in the
+/// runtime from firing.
 ///
-/// The Tokio timers can run hot and, if we can, we should avoid that mutex.
-///
-/// We did switch to the experimental timer that uses thread-locals, so
-/// this shouldn't be a problem anymore, but I still would like to avoid
-/// calling into time runtime if we don't have to.
-///
+/// See <https://github.com/pgdogdev/pgdog/issues/1017> and
+/// <https://github.com/tokio-rs/tokio/pull/8334>.
+const MAX_TIMER_DURATION: Duration = Duration::from_millis(1 << 36);
+
+fn armable(duration: Option<Duration>) -> Option<Duration> {
+    duration.filter(|duration| *duration < MAX_TIMER_DURATION)
+}
+
+/// [`tokio::time::timeout`] that waits forever instead of arming a timer
+/// outside [`MAX_TIMER_DURATION`].
 pub(crate) async fn safe_timeout<F>(
     duration: Duration,
     future: F,
@@ -313,10 +321,58 @@ pub(crate) async fn safe_timeout<F>(
 where
     F: Future,
 {
-    if duration == Duration::MAX || duration == MAX_DURATION {
-        Ok(future.await)
-    } else {
-        tokio::time::timeout(duration, future).await
+    match armable(Some(duration)) {
+        Some(duration) => tokio::time::timeout(duration, future).await,
+        None => Ok(future.await),
+    }
+}
+
+/// [`tokio::time::sleep`] that waits forever instead of arming a timer
+/// outside [`MAX_TIMER_DURATION`].
+pub(crate) async fn safe_sleep(duration: Duration) {
+    match armable(Some(duration)) {
+        Some(duration) => tokio::time::sleep(duration).await,
+        None => pending().await,
+    }
+}
+
+/// [`tokio::time::interval`] that is disabled instead of arming a timer
+/// outside [`MAX_TIMER_DURATION`], or panicking on a zero period.
+#[track_caller]
+pub(crate) fn safe_interval(period: Duration) -> SafeInterval {
+    match armable(Some(period)).filter(|period| !period.is_zero()) {
+        Some(period) => SafeInterval(Some(tokio::time::interval(period))),
+        None => {
+            warn!(
+                "{} is not a usable tick interval, timer disabled [{}]",
+                human_duration(period),
+                Location::caller()
+            );
+            SafeInterval(None)
+        }
+    }
+}
+
+/// An [`Interval`] that may not be running at all.
+pub(crate) struct SafeInterval(Option<Interval>);
+
+impl SafeInterval {
+    /// Wait for the next tick, or forever when the interval is disabled.
+    ///
+    /// Cancel safe: both branches are.
+    pub(crate) async fn tick(&mut self) {
+        match self.0.as_mut() {
+            Some(interval) => {
+                interval.tick().await;
+            }
+            None => pending().await,
+        }
+    }
+
+    pub(crate) fn set_missed_tick_behavior(&mut self, behavior: tokio::time::MissedTickBehavior) {
+        if let Some(interval) = self.0.as_mut() {
+            interval.set_missed_tick_behavior(behavior);
+        }
     }
 }
 
@@ -349,15 +405,79 @@ mod test {
         assert_eq!(human_duration(Duration::from_millis(1000 * 3600)), "1h");
     }
 
+    #[test]
+    fn test_armable_boundary() {
+        assert_eq!(MAX_TIMER_DURATION.as_millis(), 1 << 36);
+
+        let just_under = MAX_TIMER_DURATION - Duration::from_millis(1);
+
+        assert_eq!(armable(None), None);
+        assert_eq!(armable(Some(Duration::ZERO)), Some(Duration::ZERO));
+        assert_eq!(armable(Some(just_under)), Some(just_under));
+        assert_eq!(armable(Some(MAX_TIMER_DURATION)), None);
+        assert_eq!(armable(Some(Duration::MAX)), None);
+    }
+
     #[tokio::test]
-    async fn test_safe_timeout_allows_duration_max() {
+    async fn test_safe_timeout_never_arms_forever() {
         assert_eq!(safe_timeout(Duration::MAX, async { 42 }).await.unwrap(), 42);
+        assert_eq!(
+            safe_timeout(MAX_TIMER_DURATION, async { 42 })
+                .await
+                .unwrap(),
+            42
+        );
     }
 
     #[tokio::test(start_paused = true)]
     async fn test_safe_timeout_times_out() {
         let result = safe_timeout(Duration::from_millis(1), std::future::pending::<()>()).await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_safe_sleep() {
+        safe_sleep(Duration::from_millis(10)).await;
+
+        for forever in [MAX_TIMER_DURATION, Duration::MAX] {
+            assert!(
+                tokio::time::timeout(Duration::from_secs(60), safe_sleep(forever))
+                    .await
+                    .is_err(),
+                "{:?} must never wake up",
+                forever
+            );
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_safe_interval_ticks() {
+        let mut interval = safe_interval(Duration::from_millis(10));
+
+        // The first tick of a live interval resolves immediately.
+        interval.tick().await;
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), interval.tick())
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_safe_interval_disabled_never_ticks() {
+        // Zero panics `tokio::time::interval`; the rest would run the wheel hot.
+        for period in [Duration::ZERO, MAX_TIMER_DURATION, Duration::MAX] {
+            let mut interval = safe_interval(period);
+
+            assert!(
+                tokio::time::timeout(Duration::from_secs(60), interval.tick())
+                    .await
+                    .is_err(),
+                "{:?} must never tick",
+                period
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Kind of fix for the https://github.com/pgdogdev/pgdog/issues/1017 and a hope that proper fix will land on tokio with https://github.com/tokio-rs/tokio/pull/8334

## Issue

The details are explained in the https://github.com/tokio-rs/tokio/pull/8334 but in short: the tokio internally uses a special wheel to represent different segments of time. The last segment (level) is wraps the timers higher than 2^30 ms (12 days). When we get close to this mark the new sleep/interval timers go to the top level that later processed when reaching the 2^30 deadline.

The bug resides in the top level implementation - into the top level all the timers that are higher than 2^30 goes to this level. And surprisingly we have such timers that are delayed in the long future https://github.com/pgdogdev/pgdog/blob/b86c26540423db1103a0a45fa84b2b1de4d6b7f3/pgdog-config/src/lib.rs#L49

this timer goes to the top level initially and new timers go to the top level after 12 days and boom - the MAX_DURATION is identified by tokio wheel as the next one, instead of our 333ms next interval. That's exactly because only the top level have special meaning and accepts all the delays more than the level itself (> 2^36).

That's a rare case I believe - without MAX_DURATION timer everything works because the next occupied slot will be any actual near timer. Also, this

https://github.com/pgdogdev/pgdog/blob/9b27309d37c690f9e280768575fc16c8ce05f258/pgdog/src/backend/pool/connection/binding.rs#L93

was not the issue, since the sleep checks for overflows and basically ignores this timer.

The issue were reproducing for me locally because the default `lsn_check_timeout` is using MAX_DURATION and without it was working fine.

## Reproduction

Two tokio fork branches that could be used to verify the bug:
- https://github.com/meskill/tokio/pull/1
- https://github.com/meskill/tokio/pull/2

1. Clone, go to branch, 
2. on pgdog update cargo.toml to read from local package for tokio
3. enable logs for maintenance tasks
4. read the description of the pr for setup
5. make sure any MAX_DURATION triggered
6. the maintenance should stuck after some seconds

If alt timers enabled it's better to use 1 worker to reproduce since the alt timers have distribute wheel that could not lead to hang reliably.

## Fix

If fixed by https://github.com/tokio-rs/tokio/pull/8334 if it'll be merged.

And the current one is to replace all the calls to sleep/interval/timeout to "safe" versions that ignore the triggers longer than 2^36 ms (2 years btw), so until we reach the 2 years of uptime, boys!