### PR TITLE
Resolve set_config() arguments from the Bind message and let Postgres answer it

### DIFF
--- a/integration/pgdog.toml
+++ b/integration/pgdog.toml
@@ -512,3 +512,10 @@ password = "pgdog"
 database = "pgdog"
 level = "auto"
 engine = "pg_query_raw"
+
+# Session state leaks are what these tests are about, so don't let the parser
+# opt out of looking at the statements that cause them.
+[[query_parsers]]
+database = "pgdog_leak"
+level = "on"
+engine = "pg_query_raw"

--- a/integration/pgdog.toml
+++ b/integration/pgdog.toml
@@ -513,8 +513,7 @@ database = "pgdog"
 level = "auto"
 engine = "pg_query_raw"
 
-# Session state leaks are what these tests are about, so don't let the parser
-# opt out of looking at the statements that cause them.
+# These tests are about statements the parser would otherwise opt out of.
 [[query_parsers]]
 database = "pgdog_leak"
 level = "on"

--- a/integration/pgdog.toml
+++ b/integration/pgdog.toml
@@ -58,9 +58,18 @@ read_only = true
 # ------------------------------------------------------------------------------
 # ----- Database :: pgdog_leak -------------------------------------------------
 # One server connection, never reaped: the next client has to get the same one.
+# Two copies of the same single-primary database, differing only in parser level,
+# so the leak tests cover both ways a statement reaches the parser.
 
 [[databases]]
 name = "pgdog_leak"
+host = "127.0.0.1"
+database_name = "pgdog"
+pool_size = 1
+min_pool_size = 1
+
+[[databases]]
+name = "pgdog_leak_auto"
 host = "127.0.0.1"
 database_name = "pgdog"
 pool_size = 1
@@ -517,4 +526,12 @@ engine = "pg_query_raw"
 [[query_parsers]]
 database = "pgdog_leak"
 level = "on"
+engine = "pg_query_raw"
+
+# The same tests at the default level. A single primary with no replicas is the
+# topology where "auto" doesn't force the parser on, so the statement has to get
+# past the regex gate on its own -- the path "on" skips.
+[[query_parsers]]
+database = "pgdog_leak_auto"
+level = "auto"
 engine = "pg_query_raw"

--- a/integration/pgdog.toml
+++ b/integration/pgdog.toml
@@ -56,6 +56,18 @@ role = "replica"
 read_only = true
 
 # ------------------------------------------------------------------------------
+# ----- Database :: pgdog_leak -------------------------------------------------
+# Exactly one server connection, kept around: tests for session state leaking
+# between clients need the next client to get the same connection back.
+
+[[databases]]
+name = "pgdog_leak"
+host = "127.0.0.1"
+database_name = "pgdog"
+pool_size = 1
+min_pool_size = 1
+
+# ------------------------------------------------------------------------------
 # ----- Database :: pgdog_sharded ----------------------------------------------
 
 [[databases]]

--- a/integration/pgdog.toml
+++ b/integration/pgdog.toml
@@ -57,8 +57,7 @@ read_only = true
 
 # ------------------------------------------------------------------------------
 # ----- Database :: pgdog_leak -------------------------------------------------
-# Exactly one server connection, kept around: tests for session state leaking
-# between clients need the next client to get the same connection back.
+# One server connection, never reaped: the next client has to get the same one.
 
 [[databases]]
 name = "pgdog_leak"

--- a/integration/python/test_session_params_leak.py
+++ b/integration/python/test_session_params_leak.py
@@ -1,0 +1,71 @@
+"""Session parameters must not survive the client that set them.
+
+Runs against a database with a single server connection, so the next client
+always gets the connection the previous one used. current_setting() is used
+instead of SHOW because SHOW can be answered by PgDog itself.
+"""
+
+import psycopg
+
+
+def connect():
+    conn = psycopg.connect(
+        user="pgdog",
+        password="pgdog",
+        dbname="pgdog_leak",
+        host="127.0.0.1",
+        port=6432,
+    )
+    # Without autocommit every statement runs in a transaction that is rolled
+    # back on close, which would undo the very state we're testing for.
+    conn.autocommit = True
+    return conn
+
+
+def read(setting):
+    conn = connect()
+    value = conn.execute(f"SELECT current_setting('{setting}')").fetchone()[0]
+    conn.close()
+
+    return value
+
+
+def test_reset_rolled_back():
+    """A ROLLBACK brings back the value the RESET cleared.
+
+    This is the sequence pg_dump -t <table> emits. SET search_path TO '' leaves
+    an empty quoted identifier, hence the two spellings of "empty".
+    """
+    conn = connect()
+    conn.execute("SET search_path TO ''")
+    with conn.transaction():
+        conn.execute("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY")
+        conn.execute("RESET search_path")
+        conn.execute("SELECT 1")
+        raise psycopg.Rollback()
+    conn.close()
+
+    assert read("search_path") not in ("", '""')
+
+
+def test_set_committed_after_connecting():
+    """A SET that lands once the connection is already ours."""
+    conn = connect()
+    with conn.transaction():
+        conn.execute("SELECT 1")
+        conn.execute("SET statement_timeout TO '5s'")
+    conn.close()
+
+    assert read("statement_timeout") == "0"
+
+
+def test_reset_committed():
+    """A committed RESET is permanent and needs no undoing."""
+    conn = connect()
+    conn.execute("SET search_path TO public")
+    with conn.transaction():
+        conn.execute("SELECT 1")
+        conn.execute("RESET search_path")
+    conn.close()
+
+    assert read("search_path") == '"$user", public'

--- a/integration/python/test_session_params_leak.py
+++ b/integration/python/test_session_params_leak.py
@@ -59,6 +59,15 @@ def test_set_committed_after_connecting():
     assert read("statement_timeout") == "0"
 
 
+def test_set_config_bound_params():
+    """set_config() arguments arrive in the Bind message, not as constants."""
+    conn = connect()
+    conn.execute("SELECT pg_catalog.set_config(%s, %s, false)", ("search_path", ""))
+    conn.close()
+
+    assert read("search_path") not in ("", '""')
+
+
 def test_reset_committed():
     """A committed RESET is permanent and needs no undoing."""
     conn = connect()

--- a/integration/python/test_session_params_leak.py
+++ b/integration/python/test_session_params_leak.py
@@ -150,6 +150,7 @@ def test_tenant_guc_does_not_outlive_its_client(dbname, tenants):
         "SELECT pg_catalog.set_config('app.current_org_id', %s, false)", (TENANT_A,)
     )
     mine = first.execute(f"SELECT note FROM public.{tenants}").fetchall()
+    served_by = first.execute("SELECT pg_backend_pid()").fetchone()[0]
     first.close()
 
     assert mine == [("a",)], "the tenant that set the GUC sees its own row"
@@ -160,6 +161,11 @@ def test_tenant_guc_does_not_outlive_its_client(dbname, tenants):
     leaked = second.execute(
         "SELECT current_setting('app.current_org_id', true)"
     ).fetchone()[0]
+    same_server = second.execute("SELECT pg_backend_pid()").fetchone()[0]
     second.close()
 
-    assert theirs == [], f"next client read as tenant {leaked!r}"
+    # Without this the test passes whenever the pool happens to hand out a
+    # different connection, which proves nothing about what the first one left.
+    assert same_server == served_by, "clients did not share a server connection"
+    assert leaked in (None, ""), f"the tenant GUC outlived its client: {leaked!r}"
+    assert theirs == [], "next client read the previous tenant's rows"

--- a/integration/python/test_session_params_leak.py
+++ b/integration/python/test_session_params_leak.py
@@ -3,16 +3,27 @@
 Runs against a database with a single server connection, so the next client
 always gets the connection the previous one used. current_setting() is used
 instead of SHOW because SHOW can be answered by PgDog itself.
+
+Every test runs against two copies of that database that differ only in parser
+level: "on" always parses, "auto" leaves a single-primary cluster to the regex
+gate. A statement that only the gate can let through -- set_config(), a function
+call inside a SELECT rather than a statement-start keyword -- reaches the parser
+on one and has to earn it on the other.
 """
 
+import uuid
+
 import psycopg
+import pytest
+
+DATABASES = ["pgdog_leak", "pgdog_leak_auto"]
 
 
-def connect():
+def connect(dbname):
     conn = psycopg.connect(
         user="pgdog",
         password="pgdog",
-        dbname="pgdog_leak",
+        dbname=dbname,
         host="127.0.0.1",
         port=6432,
     )
@@ -22,21 +33,26 @@ def connect():
     return conn
 
 
-def read(setting):
-    conn = connect()
+def read(dbname, setting):
+    conn = connect(dbname)
     value = conn.execute(f"SELECT current_setting('{setting}')").fetchone()[0]
     conn.close()
 
     return value
 
 
-def test_reset_rolled_back():
+@pytest.fixture(params=DATABASES)
+def dbname(request):
+    return request.param
+
+
+def test_reset_rolled_back(dbname):
     """A ROLLBACK brings back the value the RESET cleared.
 
     This is the sequence pg_dump -t <table> emits. SET search_path TO '' leaves
     an empty quoted identifier, hence the two spellings of "empty".
     """
-    conn = connect()
+    conn = connect(dbname)
     conn.execute("SET search_path TO ''")
     with conn.transaction():
         conn.execute("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY")
@@ -45,36 +61,105 @@ def test_reset_rolled_back():
         raise psycopg.Rollback()
     conn.close()
 
-    assert read("search_path") not in ("", '""')
+    assert read(dbname, "search_path") not in ("", '""')
 
 
-def test_set_committed_after_connecting():
+def test_set_committed_after_connecting(dbname):
     """A SET that lands once the connection is already ours."""
-    conn = connect()
+    conn = connect(dbname)
     with conn.transaction():
         conn.execute("SELECT 1")
         conn.execute("SET statement_timeout TO '5s'")
     conn.close()
 
-    assert read("statement_timeout") == "0"
+    assert read(dbname, "statement_timeout") == "0"
 
 
-def test_set_config_bound_params():
+def test_set_config_bound_params(dbname):
     """set_config() arguments arrive in the Bind message, not as constants."""
-    conn = connect()
+    conn = connect(dbname)
     conn.execute("SELECT pg_catalog.set_config(%s, %s, false)", ("search_path", ""))
     conn.close()
 
-    assert read("search_path") not in ("", '""')
+    assert read(dbname, "search_path") not in ("", '""')
 
 
-def test_reset_committed():
+def test_reset_committed(dbname):
     """A committed RESET is permanent and needs no undoing."""
-    conn = connect()
+    conn = connect(dbname)
     conn.execute("SET search_path TO public")
     with conn.transaction():
         conn.execute("SELECT 1")
         conn.execute("RESET search_path")
     conn.close()
 
-    assert read("search_path") == '"$user", public'
+    assert read(dbname, "search_path") == '"$user", public'
+
+
+TENANT_A = "11111111-1111-1111-1111-111111111111"
+TENANT_B = "22222222-2222-2222-2222-222222222222"
+
+
+@pytest.fixture
+def tenants(dbname):
+    """A table whose rows are visible only to the tenant named in a GUC.
+
+    Reads go through a plain role: the pooler's own user is a superuser, and
+    superusers ignore row-level security however the table is configured.
+
+    NULLIF() is deliberate: a targeted RESET leaves the placeholder GUC as an
+    empty string rather than unset, and '' would fail the ::uuid cast.
+    """
+    table = "rls_probe_" + uuid.uuid4().hex[:8]
+    conn = connect(dbname)
+    conn.execute(
+        "DO $$ BEGIN CREATE ROLE rls_tenant NOLOGIN; "
+        "EXCEPTION WHEN duplicate_object THEN NULL; END $$"
+    )
+    conn.execute(f"CREATE TABLE public.{table} (org_id uuid, note text)")
+    conn.execute(
+        f"INSERT INTO public.{table} VALUES ('{TENANT_A}', 'a'), ('{TENANT_B}', 'b')"
+    )
+    conn.execute(f"GRANT SELECT ON public.{table} TO rls_tenant")
+    conn.execute(f"ALTER TABLE public.{table} ENABLE ROW LEVEL SECURITY")
+    conn.execute(
+        f"CREATE POLICY tenant_isolation ON public.{table} USING "
+        "(org_id = NULLIF(current_setting('app.current_org_id', true), '')::uuid)"
+    )
+    conn.close()
+
+    yield table
+
+    conn = connect(dbname)
+    conn.execute("RESET ROLE")
+    conn.execute(f"DROP TABLE public.{table}")
+    conn.close()
+
+
+def test_tenant_guc_does_not_outlive_its_client(dbname, tenants):
+    """The silent half of the leak: no error, just another tenant's rows.
+
+    Row-level security keyed on a custom GUC is how multi-tenant applications
+    isolate tenants, and set_config() with a bound parameter is how that GUC
+    gets set. A value that survives checkin makes the next client read as the
+    previous tenant.
+    """
+    first = connect(dbname)
+    first.execute("SET ROLE rls_tenant")
+    first.execute(
+        "SELECT pg_catalog.set_config('app.current_org_id', %s, false)", (TENANT_A,)
+    )
+    mine = first.execute(f"SELECT note FROM public.{tenants}").fetchall()
+    first.close()
+
+    assert mine == [("a",)], "the tenant that set the GUC sees its own row"
+
+    second = connect(dbname)
+    second.execute("SET ROLE rls_tenant")
+    theirs = second.execute(f"SELECT note FROM public.{tenants}").fetchall()
+    leaked = second.execute(
+        "SELECT current_setting('app.current_org_id', true)"
+    ).fetchone()[0]
+    second.close()
+
+    assert theirs == [], f"next client read as tenant {leaked!r}"

--- a/integration/python/test_session_params_leak.py
+++ b/integration/python/test_session_params_leak.py
@@ -16,8 +16,8 @@ def connect():
         host="127.0.0.1",
         port=6432,
     )
-    # Without autocommit every statement runs in a transaction that is rolled
-    # back on close, which would undo the very state we're testing for.
+    # Otherwise psycopg wraps each statement in a transaction and rolls it
+    # back on close, undoing the state we're testing for.
     conn.autocommit = True
     return conn
 

--- a/integration/rust/tests/integration/set_config.rs
+++ b/integration/rust/tests/integration/set_config.rs
@@ -28,12 +28,13 @@ async fn test_set_config_behaves_like_set() {
         .unwrap();
     assert_eq!(lock_timeout, "500s");
 
-    let set_config: Option<String> =
-        query_scalar("SELECT set_config('lock_timeout', NULL, false);")
-            .fetch_one(&mut *conn)
-            .await
-            .unwrap();
-    assert_eq!(set_config, None);
+    // A NULL resets the setting, and set_config answers with the value the
+    // setting landed on, not with the NULL it was handed.
+    let set_config: String = query_scalar("SELECT set_config('lock_timeout', NULL, false);")
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+    assert_eq!(set_config, "0");
 
     let lock_timeout: String = query_scalar("SHOW lock_timeout")
         .fetch_one(&mut *conn)

--- a/integration/rust/tests/integration/set_config.rs
+++ b/integration/rust/tests/integration/set_config.rs
@@ -28,8 +28,6 @@ async fn test_set_config_behaves_like_set() {
         .unwrap();
     assert_eq!(lock_timeout, "500s");
 
-    // A NULL resets the setting, and set_config answers with the value the
-    // setting landed on, not with the NULL it was handed.
     let set_config: String = query_scalar("SELECT set_config('lock_timeout', NULL, false);")
         .fetch_one(&mut *conn)
         .await

--- a/integration/users.toml
+++ b/integration/users.toml
@@ -4,6 +4,11 @@ database = "pgdog"
 password = "pgdog"
 
 [[users]]
+name = "pgdog"
+database = "pgdog_leak"
+password = "pgdog"
+
+[[users]]
 name = "pgdog_migrator"
 database = "pgdog"
 password = "pgdog"

--- a/integration/users.toml
+++ b/integration/users.toml
@@ -9,6 +9,11 @@ database = "pgdog_leak"
 password = "pgdog"
 
 [[users]]
+name = "pgdog"
+database = "pgdog_leak_auto"
+password = "pgdog"
+
+[[users]]
 name = "pgdog_migrator"
 database = "pgdog"
 password = "pgdog"

--- a/pgdog/src/backend/pool/connection/binding.rs
+++ b/pgdog/src/backend/pool/connection/binding.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     frontend::{
-        ClientRequest,
+        ClientRequest, SetParam,
         client::query_engine::{
             TwoPcPhase,
             two_pc::{TwoPcTransaction, statement::phase_control},
@@ -440,6 +440,28 @@ impl Binding {
             }
 
             _ => Ok(0),
+        }
+    }
+
+    /// Record a client parameter change on every server we hold.
+    pub fn record_params(&mut self, params: &[SetParam], in_transaction: bool) {
+        match self {
+            Binding::Direct(server, ..) => server.record_params(params, in_transaction),
+            Binding::MultiShard(servers, _) => servers
+                .iter_mut()
+                .for_each(|server| server.record_params(params, in_transaction)),
+            _ => (),
+        }
+    }
+
+    /// Record a client `RESET ALL` on every server we hold.
+    pub fn record_reset_all(&mut self, in_transaction: bool) {
+        match self {
+            Binding::Direct(server, ..) => server.record_reset_all(in_transaction),
+            Binding::MultiShard(servers, _) => servers
+                .iter_mut()
+                .for_each(|server| server.record_reset_all(in_transaction)),
+            _ => (),
         }
     }
 

--- a/pgdog/src/backend/pool/connection/binding.rs
+++ b/pgdog/src/backend/pool/connection/binding.rs
@@ -443,7 +443,6 @@ impl Binding {
         }
     }
 
-    /// Record a client parameter change on every server we hold.
     pub fn record_params(&mut self, params: &[SetParam], in_transaction: bool) {
         match self {
             Binding::Direct(server, ..) => server.record_params(params, in_transaction),
@@ -454,7 +453,6 @@ impl Binding {
         }
     }
 
-    /// Record a client `RESET ALL` on every server we hold.
     pub fn record_reset_all(&mut self, in_transaction: bool) {
         match self {
             Binding::Direct(server, ..) => server.record_reset_all(in_transaction),

--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -141,8 +141,8 @@ pub struct Server {
     streaming: bool,
     schema_changed: bool,
     sync_prepared: bool,
-    // The client's parameter change for the statement in flight is already
-    // recorded, so its CommandComplete tells us nothing we don't know.
+    // The change in flight is already recorded, so its CommandComplete
+    // tells us nothing new.
     params_recorded: bool,
     in_transaction: bool,
     re_synced: bool,
@@ -673,9 +673,8 @@ impl Server {
                         self.prepared_statements.clear();
                         self.client_params.clear();
                     }
-                    // Someone reset params. If we didn't see which ones (the query
-                    // parser is off, or the RESET came from somewhere we don't
-                    // track), the cache is worthless and we re-sync from scratch.
+                    // A RESET nobody told us the contents of: we can't tell
+                    // what it touched, so drop everything.
                     "RESET" if !self.params_recorded => self.client_params.clear(),
                     _ => (),
                 }
@@ -771,8 +770,8 @@ impl Server {
         Ok(executed)
     }
 
-    /// Record a parameter change the client is making on this connection, so
-    /// we know what to undo before handing it to somebody else.
+    /// Record a client's parameter change, so we know what to undo before
+    /// this connection goes to somebody else.
     pub fn record_params(&mut self, params: &[SetParam], in_transaction: bool) {
         for param in params {
             match (&param.value, in_transaction) {
@@ -791,7 +790,7 @@ impl Server {
         self.params_recorded = true;
     }
 
-    /// Record a `RESET ALL` the client is making on this connection.
+    /// Record a client's `RESET ALL`.
     pub fn record_reset_all(&mut self, in_transaction: bool) {
         if in_transaction {
             self.client_params.reset_all_transaction();
@@ -3265,8 +3264,6 @@ pub mod test {
         server.execute("ROLLBACK").await.unwrap();
         server.transaction_params_hook(true);
 
-        // The ROLLBACK brought search_path back, so we still owe the next
-        // client a RESET for it.
         let queries = server
             .client_params
             .reset_queries(&Parameters::default())
@@ -3299,7 +3296,6 @@ pub mod test {
         server.execute("COMMIT").await.unwrap();
         server.transaction_params_hook(false);
 
-        // Committed: the server really is back to its default, nothing to undo.
         assert!(
             server
                 .client_params
@@ -3316,7 +3312,6 @@ pub mod test {
             .await
             .unwrap();
 
-        // A SET that lands after the connection is already ours.
         server.record_params(
             &[SetParam {
                 name: "statement_timeout".into(),
@@ -3360,7 +3355,6 @@ pub mod test {
             .await
             .unwrap();
 
-        // Resetting one parameter says nothing about the others.
         server.record_params(
             &[SetParam {
                 name: "search_path".into(),
@@ -3390,8 +3384,7 @@ pub mod test {
             .await
             .unwrap();
 
-        // Nobody told us what this RESET touched (query parser off), so the
-        // cache is worthless and we start over.
+        // A RESET we never recorded, as when the query parser is off.
         server.execute("RESET search_path").await.unwrap();
 
         assert!(server.client_params.is_empty());

--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -790,7 +790,6 @@ impl Server {
         self.params_recorded = true;
     }
 
-    /// Record a client's `RESET ALL`.
     pub fn record_reset_all(&mut self, in_transaction: bool) {
         if in_transaction {
             self.client_params.reset_all_transaction();

--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -21,7 +21,7 @@ use crate::{
     auth::{md5, scram::Client},
     backend::pool::stats::MemoryStats,
     config::AuthType,
-    frontend::ClientRequest,
+    frontend::{ClientRequest, SetParam},
     net::{
         Close, Liveness, MessageBuffer, Parameter, ProtocolMessage, Sync,
         messages::{
@@ -141,6 +141,9 @@ pub struct Server {
     streaming: bool,
     schema_changed: bool,
     sync_prepared: bool,
+    // The client's parameter change for the statement in flight is already
+    // recorded, so its CommandComplete tells us nothing we don't know.
+    params_recorded: bool,
     in_transaction: bool,
     re_synced: bool,
     replication_mode: bool,
@@ -432,6 +435,7 @@ impl Server {
             streaming: false,
             schema_changed: false,
             sync_prepared: false,
+            params_recorded: false,
             in_transaction: false,
             statement_executed: false,
             re_synced: false,
@@ -610,6 +614,8 @@ impl Server {
 
         match message.code() {
             'Z' => {
+                self.params_recorded = false;
+
                 let now = Instant::now();
                 let rfq = ReadyForQuery::from_bytes(message.payload())?;
 
@@ -667,7 +673,10 @@ impl Server {
                         self.prepared_statements.clear();
                         self.client_params.clear();
                     }
-                    "RESET" => self.client_params.clear(), // Someone reset params, we're gonna need to re-sync.
+                    // Someone reset params. If we didn't see which ones (the query
+                    // parser is off, or the RESET came from somewhere we don't
+                    // track), the cache is worthless and we re-sync from scratch.
+                    "RESET" if !self.params_recorded => self.client_params.clear(),
                     _ => (),
                 }
                 self.stats.rows_affected(&cmd);
@@ -760,6 +769,37 @@ impl Server {
         }
 
         Ok(executed)
+    }
+
+    /// Record a parameter change the client is making on this connection, so
+    /// we know what to undo before handing it to somebody else.
+    pub fn record_params(&mut self, params: &[SetParam], in_transaction: bool) {
+        for param in params {
+            match (&param.value, in_transaction) {
+                (Some(value), true) => {
+                    self.client_params
+                        .insert_transaction(&param.name, value.clone(), param.local);
+                }
+                (Some(value), false) => {
+                    self.client_params.insert(&param.name, value.clone());
+                }
+                (None, true) => self.client_params.reset_transaction(&param.name),
+                (None, false) => self.client_params.reset(&param.name),
+            }
+        }
+
+        self.params_recorded = true;
+    }
+
+    /// Record a `RESET ALL` the client is making on this connection.
+    pub fn record_reset_all(&mut self, in_transaction: bool) {
+        if in_transaction {
+            self.client_params.reset_all_transaction();
+        } else {
+            self.client_params.reset_all();
+        }
+
+        self.params_recorded = true;
     }
 
     // Handle COMMIT/ROLLBACK for in-transaction params tracking.
@@ -1340,7 +1380,7 @@ pub mod test {
         backend::pool::token_cache::TokenCache,
         config::Memory,
         frontend::{PreparedStatements, RewritePlan},
-        net::{Prepare, *},
+        net::{Prepare, parameter::ParameterValue, *},
     };
 
     use super::{Error, *};
@@ -1384,6 +1424,7 @@ pub mod test {
                 streaming: false,
                 schema_changed: false,
                 sync_prepared: false,
+                params_recorded: false,
                 in_transaction: false,
                 re_synced: false,
                 replication_mode: false,
@@ -3199,6 +3240,161 @@ pub mod test {
             server.stats().get_state() == State::Error,
             "state should be Error after detecting desync"
         )
+    }
+
+    #[tokio::test]
+    async fn test_recorded_reset_survives_rollback() {
+        let mut server = test_server().await;
+        let mut params = Parameters::default();
+        params.insert("search_path", "");
+        server
+            .link_client(FrontendPid::new(), &params, None)
+            .await
+            .unwrap();
+
+        server.execute("BEGIN").await.unwrap();
+        server.record_params(
+            &[SetParam {
+                name: "search_path".into(),
+                value: None,
+                local: false,
+            }],
+            true,
+        );
+        server.execute("RESET search_path").await.unwrap();
+        server.execute("ROLLBACK").await.unwrap();
+        server.transaction_params_hook(true);
+
+        // The ROLLBACK brought search_path back, so we still owe the next
+        // client a RESET for it.
+        let queries = server
+            .client_params
+            .reset_queries(&Parameters::default())
+            .into_iter()
+            .map(|query| query.query().to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(queries, vec![r#"RESET "search_path""#]);
+    }
+
+    #[tokio::test]
+    async fn test_recorded_reset_committed_is_permanent() {
+        let mut server = test_server().await;
+        let mut params = Parameters::default();
+        params.insert("search_path", "");
+        server
+            .link_client(FrontendPid::new(), &params, None)
+            .await
+            .unwrap();
+
+        server.execute("BEGIN").await.unwrap();
+        server.record_params(
+            &[SetParam {
+                name: "search_path".into(),
+                value: None,
+                local: false,
+            }],
+            true,
+        );
+        server.execute("RESET search_path").await.unwrap();
+        server.execute("COMMIT").await.unwrap();
+        server.transaction_params_hook(false);
+
+        // Committed: the server really is back to its default, nothing to undo.
+        assert!(
+            server
+                .client_params
+                .reset_queries(&Parameters::default())
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_recorded_set_is_undone_for_the_next_client() {
+        let mut server = test_server().await;
+        server
+            .link_client(FrontendPid::new(), &Parameters::default(), None)
+            .await
+            .unwrap();
+
+        // A SET that lands after the connection is already ours.
+        server.record_params(
+            &[SetParam {
+                name: "statement_timeout".into(),
+                value: Some(ParameterValue::String("5s".into())),
+                local: false,
+            }],
+            false,
+        );
+        server
+            .execute("SET statement_timeout TO '5s'")
+            .await
+            .unwrap();
+
+        let queries = server
+            .client_params
+            .reset_queries(&Parameters::default())
+            .into_iter()
+            .map(|query| query.query().to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(queries, vec![r#"RESET "statement_timeout""#]);
+    }
+
+    #[tokio::test]
+    async fn test_reset_keeps_other_recorded_params() {
+        let mut server = test_server().await;
+        server
+            .link_client(FrontendPid::new(), &Parameters::default(), None)
+            .await
+            .unwrap();
+
+        server.record_params(
+            &[SetParam {
+                name: "statement_timeout".into(),
+                value: Some(ParameterValue::String("5s".into())),
+                local: false,
+            }],
+            false,
+        );
+        server
+            .execute("SET statement_timeout TO '5s'")
+            .await
+            .unwrap();
+
+        // Resetting one parameter says nothing about the others.
+        server.record_params(
+            &[SetParam {
+                name: "search_path".into(),
+                value: None,
+                local: false,
+            }],
+            false,
+        );
+        server.execute("RESET search_path").await.unwrap();
+
+        let queries = server
+            .client_params
+            .reset_queries(&Parameters::default())
+            .into_iter()
+            .map(|query| query.query().to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(queries, vec![r#"RESET "statement_timeout""#]);
+    }
+
+    #[tokio::test]
+    async fn test_untracked_reset_still_clears_client_params() {
+        let mut server = test_server().await;
+        let mut params = Parameters::default();
+        params.insert("search_path", "public");
+        server
+            .link_client(FrontendPid::new(), &params, None)
+            .await
+            .unwrap();
+
+        // Nobody told us what this RESET touched (query parser off), so the
+        // cache is worthless and we start over.
+        server.execute("RESET search_path").await.unwrap();
+
+        assert!(server.client_params.is_empty());
     }
 
     #[tokio::test]

--- a/pgdog/src/frontend/client/query_engine/mod.rs
+++ b/pgdog/src/frontend/client/query_engine/mod.rs
@@ -241,12 +241,10 @@ impl QueryEngine {
             }
             Command::Unlisten(channel) => self.unlisten(context, &channel.clone()).await?,
             Command::Set {
-                params,
-                behave_like_select,
-                ..
+                params, is_select, ..
             } => {
                 let params = params.clone();
-                self.set(context, &params, *behave_like_select).await?;
+                self.set(context, &params, *is_select).await?;
             }
             Command::ResetAll => {
                 self.reset_all(context).await?;

--- a/pgdog/src/frontend/client/query_engine/set.rs
+++ b/pgdog/src/frontend/client/query_engine/set.rs
@@ -44,7 +44,11 @@ impl QueryEngine {
                 }
             } else {
                 fake_command = "RESET";
-                context.params.reset(&param.name);
+                if context.in_transaction() {
+                    context.params.reset_transaction(&param.name);
+                } else {
+                    context.params.reset(&param.name);
+                }
                 if is_pin {
                     self.manual_lock = false;
                 }
@@ -56,6 +60,10 @@ impl QueryEngine {
         }
 
         if self.backend.connected() {
+            // The server is ours right now, so its session changes with the
+            // client's. Record it, or we won't know to undo it for whoever
+            // gets this connection next.
+            self.backend.record_params(params, context.in_transaction());
             self.execute(context).await?;
         } else {
             let values_to_return =
@@ -96,9 +104,14 @@ impl QueryEngine {
         &mut self,
         context: &mut QueryEngineContext<'_>,
     ) -> Result<(), Error> {
-        context.params.reset_all();
+        if context.in_transaction() {
+            context.params.reset_all_transaction();
+        } else {
+            context.params.reset_all();
+        }
 
         if self.backend.connected() {
+            self.backend.record_reset_all(context.in_transaction());
             self.execute(context).await?;
         } else {
             self.fake_command_response(context, "RESET", None::<Option<_>>)

--- a/pgdog/src/frontend/client/query_engine/set.rs
+++ b/pgdog/src/frontend/client/query_engine/set.rs
@@ -15,11 +15,26 @@ impl QueryEngine {
         &mut self,
         context: &mut QueryEngineContext<'_>,
         params: &[SetParam],
-        behave_like_select: bool,
+        is_select: bool,
     ) -> Result<(), Error> {
         // Make sure client isn't changing route mid-transaction.
         if self.route_change_check(context, params).await? {
             return Ok(());
+        }
+
+        // `SELECT set_config(...)` is a query and Postgres answers it, so take a
+        // server before touching the parameters: syncing a change the statement
+        // is about to make itself would just send it twice.
+        if is_select && !self.backend.connected() {
+            let connected = if context.in_transaction() {
+                self.connect_transaction(context).await?
+            } else {
+                self.connect(context, None).await?
+            };
+
+            if !connected {
+                return Ok(());
+            }
         }
 
         let mut fake_command = "SET";
@@ -65,9 +80,7 @@ impl QueryEngine {
             self.backend.record_params(params, context.in_transaction());
             self.execute(context).await?;
         } else {
-            let values_to_return =
-                behave_like_select.then(|| params.iter().map(|p| p.value.as_ref()));
-            self.fake_command_response(context, fake_command, values_to_return)
+            self.fake_command_response(context, fake_command, None::<Option<_>>)
                 .await?;
         }
 

--- a/pgdog/src/frontend/client/query_engine/set.rs
+++ b/pgdog/src/frontend/client/query_engine/set.rs
@@ -60,9 +60,8 @@ impl QueryEngine {
         }
 
         if self.backend.connected() {
-            // The server is ours right now, so its session changes with the
-            // client's. Record it, or we won't know to undo it for whoever
-            // gets this connection next.
+            // The server is ours, so its session changes with the client's:
+            // record it or we won't know what to undo for the next client.
             self.backend.record_params(params, context.in_transaction());
             self.execute(context).await?;
         } else {

--- a/pgdog/src/frontend/client/query_engine/set.rs
+++ b/pgdog/src/frontend/client/query_engine/set.rs
@@ -22,9 +22,8 @@ impl QueryEngine {
             return Ok(());
         }
 
-        // `SELECT set_config(...)` is a query and Postgres answers it, so take a
-        // server before touching the parameters: syncing a change the statement
-        // is about to make itself would just send it twice.
+        // Take a server before touching the parameters: syncing a change the
+        // statement is about to make itself would send it twice.
         if is_select && !self.backend.connected() {
             let connected = if context.in_transaction() {
                 self.connect_transaction(context).await?

--- a/pgdog/src/frontend/router/parser/command.rs
+++ b/pgdog/src/frontend/router/parser/command.rs
@@ -31,8 +31,7 @@ pub enum Command {
     Set {
         params: Vec<SetParam>,
         route: Route,
-        /// The statement is `SELECT set_config(...)`, not `SET`: Postgres has
-        /// to answer it, we only note what it changes.
+        /// `SELECT set_config(...)`, not `SET`: Postgres has to answer it.
         is_select: bool,
     },
     ResetAll,

--- a/pgdog/src/frontend/router/parser/command.rs
+++ b/pgdog/src/frontend/router/parser/command.rs
@@ -31,7 +31,9 @@ pub enum Command {
     Set {
         params: Vec<SetParam>,
         route: Route,
-        behave_like_select: bool,
+        /// The statement is `SELECT set_config(...)`, not `SET`: Postgres has
+        /// to answer it, we only note what it changes.
+        is_select: bool,
     },
     ResetAll,
     InternalField {

--- a/pgdog/src/frontend/router/parser/query/set.rs
+++ b/pgdog/src/frontend/router/parser/query/set.rs
@@ -130,5 +130,4 @@ impl QueryParser {
 
         Ok(value)
     }
-
 }

--- a/pgdog/src/frontend/router/parser/query/set.rs
+++ b/pgdog/src/frontend/router/parser/query/set.rs
@@ -27,7 +27,7 @@ impl QueryParser {
             Ok(Command::Set {
                 params: vec![param],
                 route: Route::write(context.shards_calculator.shard()),
-                behave_like_select: false,
+                is_select: false,
             })
         }
     }
@@ -99,7 +99,7 @@ impl QueryParser {
             Ok(Some(Command::Set {
                 params,
                 route: Route::write(context.shards_calculator.shard()),
-                behave_like_select: false,
+                is_select: false,
             }))
         }
     }
@@ -130,4 +130,5 @@ impl QueryParser {
 
         Ok(value)
     }
+
 }

--- a/pgdog/src/frontend/router/parser/query/set_config.rs
+++ b/pgdog/src/frontend/router/parser/query/set_config.rs
@@ -23,7 +23,6 @@ impl QueryParser {
             )
         }
     }
-
 }
 
 /// Returns None if the arguments could not be parsed
@@ -32,18 +31,6 @@ fn parse_args(fcall: &nodes::FuncCall, bind: Option<&Bind>) -> Option<SetParam> 
     let value = parse_config_value(fcall.args().get(1)?, bind)?;
     let local = parse_is_local(fcall.args().get(2)?, bind)?;
     Some(SetParam { name, value, local })
-}
-
-cfg_select! {
-    not(feature = "new_parser") => {
-        fn parse_args(fcall: &FuncCall, bind: Option<&Bind>) -> Option<SetParam> {
-            let name = parse_config_name(fcall.args.first()?, bind)?;
-            let value = parse_config_value(fcall.args.get(1)?, bind)?;
-            let local = parse_is_local(fcall.args.get(2)?, bind)?;
-            Some(SetParam { name, value, local })
-        }
-    }
-    _ => {}
 }
 
 /// Value bound to `$number`; the inner Option is the SQL NULL.
@@ -89,8 +76,6 @@ fn parse_config_name(arg: Node<'_>, bind: Option<&Bind>) -> Option<String> {
     }
 }
 
-/// Returns None if the name could not be parsed
-
 /// Returns None if the value could not be parsed, Some(None) if the value
 /// is NULL, and Some if the value was successfully parsed
 fn parse_config_value(arg: Node<'_>, bind: Option<&Bind>) -> Option<Option<ParameterValue>> {
@@ -116,4 +101,3 @@ fn parse_is_local(arg: Node<'_>, bind: Option<&Bind>) -> Option<bool> {
         _ => None,
     }
 }
-

--- a/pgdog/src/frontend/router/parser/query/set_config.rs
+++ b/pgdog/src/frontend/router/parser/query/set_config.rs
@@ -4,8 +4,8 @@ use crate::net::messages::{Bind, Format};
 impl QueryParser {
     /// Handle SELECT set_config('key', 'value', is_local)
     ///
-    /// Arguments we can't resolve leave the statement an ordinary query: it
-    /// runs, but we don't know what it changed.
+    /// Arguments we can't resolve leave it an ordinary query: it runs, but
+    /// we don't learn what it changed.
     pub(super) fn set_config(
         &mut self,
         fcall: &nodes::FuncCall,
@@ -34,7 +34,19 @@ fn parse_args(fcall: &nodes::FuncCall, bind: Option<&Bind>) -> Option<SetParam> 
     Some(SetParam { name, value, local })
 }
 
-/// Get the value bound to `$number`. The inner Option is the SQL NULL.
+cfg_select! {
+    not(feature = "new_parser") => {
+        fn parse_args(fcall: &FuncCall, bind: Option<&Bind>) -> Option<SetParam> {
+            let name = parse_config_name(fcall.args.first()?, bind)?;
+            let value = parse_config_value(fcall.args.get(1)?, bind)?;
+            let local = parse_is_local(fcall.args.get(2)?, bind)?;
+            Some(SetParam { name, value, local })
+        }
+    }
+    _ => {}
+}
+
+/// Value bound to `$number`; the inner Option is the SQL NULL.
 fn bound_text(bind: Option<&Bind>, number: i32) -> Option<Option<String>> {
     let index = usize::try_from(number).ok()?.checked_sub(1)?;
     let param = bind?.parameter(index).ok()??;

--- a/pgdog/src/frontend/router/parser/query/set_config.rs
+++ b/pgdog/src/frontend/router/parser/query/set_config.rs
@@ -1,20 +1,21 @@
 use super::*;
+use crate::net::messages::{Bind, Format};
 
 impl QueryParser {
     /// Handle SELECT set_config('key', 'value', is_local)
     ///
-    /// If the function arguments are a form we cannot handle, we warn and
-    /// pass through
+    /// Arguments we can't resolve leave the statement an ordinary query: it
+    /// runs, but we don't know what it changed.
     pub(super) fn set_config(
         &mut self,
         fcall: &nodes::FuncCall,
         context: &QueryParserContext,
     ) -> Command {
-        if let Some(param) = parse_args(fcall) {
+        if let Some(param) = parse_args(fcall, context.router_context.bind) {
             Command::Set {
                 params: vec![param],
                 route: Route::write(context.shards_calculator.shard()),
-                behave_like_select: true,
+                is_select: true,
             }
         } else {
             Command::Query(
@@ -22,28 +23,65 @@ impl QueryParser {
             )
         }
     }
+
 }
 
 /// Returns None if the arguments could not be parsed
-fn parse_args(fcall: &nodes::FuncCall) -> Option<SetParam> {
-    let name = parse_config_name(fcall.args().first()?)?;
-    let value = parse_config_value(fcall.args().get(1)?)?;
-    let local = parse_is_local(fcall.args().get(2)?)?;
+fn parse_args(fcall: &nodes::FuncCall, bind: Option<&Bind>) -> Option<SetParam> {
+    let name = parse_config_name(fcall.args().first()?, bind)?;
+    let value = parse_config_value(fcall.args().get(1)?, bind)?;
+    let local = parse_is_local(fcall.args().get(2)?, bind)?;
     Some(SetParam { name, value, local })
 }
 
+/// Get the value bound to `$number`. The inner Option is the SQL NULL.
+fn bound_text(bind: Option<&Bind>, number: i32) -> Option<Option<String>> {
+    let index = usize::try_from(number).ok()?.checked_sub(1)?;
+    let param = bind?.parameter(index).ok()??;
+
+    if param.is_null() {
+        Some(None)
+    } else {
+        Some(Some(param.text()?.to_owned()))
+    }
+}
+
+fn bound_bool(bind: Option<&Bind>, number: i32) -> Option<bool> {
+    let index = usize::try_from(number).ok()?.checked_sub(1)?;
+    let param = bind?.parameter(index).ok()??;
+
+    if param.is_null() {
+        return None;
+    }
+
+    match param.format() {
+        Format::Binary => match param.data() {
+            [0] => Some(false),
+            [1] => Some(true),
+            _ => None,
+        },
+        Format::Text => match param.text()?.trim().to_lowercase().as_str() {
+            "t" | "true" | "y" | "yes" | "on" | "1" => Some(true),
+            "f" | "false" | "n" | "no" | "off" | "0" => Some(false),
+            _ => None,
+        },
+    }
+}
+
 /// Returns None if the name could not be parsed
-fn parse_config_name(arg: Node<'_>) -> Option<String> {
+fn parse_config_name(arg: Node<'_>, bind: Option<&Bind>) -> Option<String> {
     match arg {
         Node::A_Const(c) => c.val()?.string_value().map(ToOwned::to_owned),
-        // Only constant strings can be handled for now
+        Node::ParamRef(nodes::ParamRef { number, .. }) => bound_text(bind, *number)?,
         _ => None,
     }
 }
 
+/// Returns None if the name could not be parsed
+
 /// Returns None if the value could not be parsed, Some(None) if the value
 /// is NULL, and Some if the value was successfully parsed
-fn parse_config_value(arg: Node<'_>) -> Option<Option<ParameterValue>> {
+fn parse_config_value(arg: Node<'_>, bind: Option<&Bind>) -> Option<Option<ParameterValue>> {
     match arg {
         Node::A_Const(c) => match c.val() {
             Some(value) => Some(Some(ParameterValue::String(
@@ -51,14 +89,19 @@ fn parse_config_value(arg: Node<'_>) -> Option<Option<ParameterValue>> {
             ))),
             None => Some(None),
         },
+        Node::ParamRef(nodes::ParamRef { number, .. }) => {
+            Some(bound_text(bind, *number)?.map(ParameterValue::String))
+        }
         _ => None,
     }
 }
 
 /// Returns None if the node was not a constant boolean
-fn parse_is_local(arg: Node<'_>) -> Option<bool> {
+fn parse_is_local(arg: Node<'_>, bind: Option<&Bind>) -> Option<bool> {
     match arg {
         Node::A_Const(c) => c.val()?.bool_value(),
+        Node::ParamRef(nodes::ParamRef { number, .. }) => bound_bool(bind, *number),
         _ => None,
     }
 }
+

--- a/pgdog/src/frontend/router/parser/query/set_config.rs
+++ b/pgdog/src/frontend/router/parser/query/set_config.rs
@@ -25,7 +25,6 @@ impl QueryParser {
     }
 }
 
-/// Returns None if the arguments could not be parsed
 fn parse_args(
     fcall: &nodes::FuncCall,
     params: Option<StatementParameters<'_>>,

--- a/pgdog/src/frontend/router/parser/query/set_config.rs
+++ b/pgdog/src/frontend/router/parser/query/set_config.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::net::messages::{Bind, Format};
+use crate::net::messages::Format;
 
 impl QueryParser {
     /// Handle SELECT set_config('key', 'value', is_local)
@@ -26,17 +26,20 @@ impl QueryParser {
 }
 
 /// Returns None if the arguments could not be parsed
-fn parse_args(fcall: &nodes::FuncCall, bind: Option<&Bind>) -> Option<SetParam> {
-    let name = parse_config_name(fcall.args().first()?, bind)?;
-    let value = parse_config_value(fcall.args().get(1)?, bind)?;
-    let local = parse_is_local(fcall.args().get(2)?, bind)?;
+fn parse_args(
+    fcall: &nodes::FuncCall,
+    params: Option<StatementParameters<'_>>,
+) -> Option<SetParam> {
+    let name = parse_config_name(fcall.args().first()?, params)?;
+    let value = parse_config_value(fcall.args().get(1)?, params)?;
+    let local = parse_is_local(fcall.args().get(2)?, params)?;
     Some(SetParam { name, value, local })
 }
 
 /// Value bound to `$number`; the inner Option is the SQL NULL.
-fn bound_text(bind: Option<&Bind>, number: i32) -> Option<Option<String>> {
+fn bound_text(params: Option<StatementParameters<'_>>, number: i32) -> Option<Option<String>> {
     let index = usize::try_from(number).ok()?.checked_sub(1)?;
-    let param = bind?.parameter(index).ok()??;
+    let param = params?.parameter(index).ok()??;
 
     if param.is_null() {
         Some(None)
@@ -45,9 +48,9 @@ fn bound_text(bind: Option<&Bind>, number: i32) -> Option<Option<String>> {
     }
 }
 
-fn bound_bool(bind: Option<&Bind>, number: i32) -> Option<bool> {
+fn bound_bool(params: Option<StatementParameters<'_>>, number: i32) -> Option<bool> {
     let index = usize::try_from(number).ok()?.checked_sub(1)?;
-    let param = bind?.parameter(index).ok()??;
+    let param = params?.parameter(index).ok()??;
 
     if param.is_null() {
         return None;
@@ -68,17 +71,20 @@ fn bound_bool(bind: Option<&Bind>, number: i32) -> Option<bool> {
 }
 
 /// Returns None if the name could not be parsed
-fn parse_config_name(arg: Node<'_>, bind: Option<&Bind>) -> Option<String> {
+fn parse_config_name(arg: Node<'_>, params: Option<StatementParameters<'_>>) -> Option<String> {
     match arg {
         Node::A_Const(c) => c.val()?.string_value().map(ToOwned::to_owned),
-        Node::ParamRef(nodes::ParamRef { number, .. }) => bound_text(bind, *number)?,
+        Node::ParamRef(nodes::ParamRef { number, .. }) => bound_text(params, *number)?,
         _ => None,
     }
 }
 
 /// Returns None if the value could not be parsed, Some(None) if the value
 /// is NULL, and Some if the value was successfully parsed
-fn parse_config_value(arg: Node<'_>, bind: Option<&Bind>) -> Option<Option<ParameterValue>> {
+fn parse_config_value(
+    arg: Node<'_>,
+    params: Option<StatementParameters<'_>>,
+) -> Option<Option<ParameterValue>> {
     match arg {
         Node::A_Const(c) => match c.val() {
             Some(value) => Some(Some(ParameterValue::String(
@@ -87,17 +93,17 @@ fn parse_config_value(arg: Node<'_>, bind: Option<&Bind>) -> Option<Option<Param
             None => Some(None),
         },
         Node::ParamRef(nodes::ParamRef { number, .. }) => {
-            Some(bound_text(bind, *number)?.map(ParameterValue::String))
+            Some(bound_text(params, *number)?.map(ParameterValue::String))
         }
         _ => None,
     }
 }
 
 /// Returns None if the node was not a constant boolean
-fn parse_is_local(arg: Node<'_>, bind: Option<&Bind>) -> Option<bool> {
+fn parse_is_local(arg: Node<'_>, params: Option<StatementParameters<'_>>) -> Option<bool> {
     match arg {
         Node::A_Const(c) => c.val()?.bool_value(),
-        Node::ParamRef(nodes::ParamRef { number, .. }) => bound_bool(bind, *number),
+        Node::ParamRef(nodes::ParamRef { number, .. }) => bound_bool(params, *number),
         _ => None,
     }
 }

--- a/pgdog/src/frontend/router/parser/query/test/test_set.rs
+++ b/pgdog/src/frontend/router/parser/query/test/test_set.rs
@@ -7,7 +7,7 @@ use crate::{
             route::{OverrideReason, ShardSource},
         },
     },
-    net::parameter::ParameterValue,
+    net::{Format, messages::Parameter, parameter::ParameterValue},
 };
 
 use super::setup::*;
@@ -66,15 +66,13 @@ fn test_set_config_null_value() {
 
     match command {
         Command::Set {
-            params,
-            behave_like_select,
-            ..
+            params, is_select, ..
         } => {
             assert_eq!(params.len(), 1);
             assert_eq!(params[0].name, "lock_timeout");
             assert_eq!(params[0].value, None);
             assert!(!params[0].local);
-            assert!(behave_like_select);
+            assert!(is_select);
         }
         _ => panic!("expected Command::Set, got {command:#?}"),
     }
@@ -251,4 +249,160 @@ fn test_single_shard_set() {
         Command::Set { route, .. } => assert!(!route.is_cross_shard()),
         _ => panic!("not a set"),
     }
+}
+
+#[test]
+fn test_set_config_bound_params() {
+    let mut test = QueryParserTest::new();
+
+    let command = test.execute(vec![
+        Parse::named(
+            "__test_set_config",
+            "SELECT pg_catalog.set_config($1, $2, $3)",
+        )
+        .into(),
+        Bind::new_params(
+            "__test_set_config",
+            &[
+                Parameter::new(b"search_path"),
+                Parameter::new(b""),
+                Parameter::new(b"f"),
+            ],
+        )
+        .into(),
+        Execute::new().into(),
+        Sync.into(),
+    ]);
+
+    match command {
+        Command::Set {
+            ref params,
+            is_select,
+            ..
+        } => {
+            assert_eq!(params.len(), 1);
+            assert_eq!(params[0].name, "search_path");
+            assert_eq!(params[0].value, Some(ParameterValue::String("".into())));
+            assert!(!params[0].local);
+            assert!(is_select);
+        }
+        _ => panic!("expected Command::Set, got {command:#?}"),
+    }
+}
+
+#[test]
+fn test_set_config_bound_null_value() {
+    let mut test = QueryParserTest::new();
+
+    let command = test.execute(vec![
+        Parse::named("__test_set_config_null", "SELECT set_config($1, $2, false)").into(),
+        Bind::new_params(
+            "__test_set_config_null",
+            &[Parameter::new(b"lock_timeout"), Parameter::new_null()],
+        )
+        .into(),
+        Execute::new().into(),
+        Sync.into(),
+    ]);
+
+    match command {
+        Command::Set { ref params, .. } => {
+            assert_eq!(params[0].name, "lock_timeout");
+            assert_eq!(params[0].value, None);
+        }
+        _ => panic!("expected Command::Set, got {command:#?}"),
+    }
+}
+
+#[test]
+fn test_set_config_unresolvable_args_stay_a_query() {
+    let mut test = QueryParserTest::new();
+
+    // No Bind message, so the parameters can't be resolved.
+    let command = test.execute(vec![
+        Query::new("SELECT pg_catalog.set_config($1, $2, false)").into(),
+    ]);
+
+    assert!(
+        matches!(command, Command::Query(_)),
+        "expected Command::Query, got {command:#?}",
+    );
+    assert!(command.route().is_write());
+}
+
+#[test]
+fn test_set_config_expression_stays_a_query() {
+    let mut test = QueryParserTest::new();
+
+    let command = test.execute(vec![
+        Query::new("SELECT set_config('search_path', current_setting('search_path'), false)")
+            .into(),
+    ]);
+
+    assert!(
+        matches!(command, Command::Query(_)),
+        "expected Command::Query, got {command:#?}",
+    );
+    assert!(command.route().is_write());
+}
+
+#[test]
+fn test_set_config_bound_binary_is_local() {
+    let mut test = QueryParserTest::new();
+
+    let command = test.execute(vec![
+        Parse::named("__test_set_config_bin", "SELECT set_config($1, $2, $3)").into(),
+        Bind::new_params_codes(
+            "__test_set_config_bin",
+            &[
+                Parameter::new(b"statement_timeout"),
+                Parameter::new(b"1000"),
+                Parameter::new(&[1]),
+            ],
+            &[Format::Text, Format::Text, Format::Binary],
+        )
+        .into(),
+        Execute::new().into(),
+        Sync.into(),
+    ]);
+
+    match command {
+        Command::Set { ref params, .. } => {
+            assert_eq!(params[0].name, "statement_timeout");
+            assert_eq!(params[0].value, Some(ParameterValue::String("1000".into())));
+            assert!(params[0].local, "binary true must be read as SET LOCAL");
+        }
+        _ => panic!("expected Command::Set, got {command:#?}"),
+    }
+}
+
+#[test]
+fn test_set_config_bound_non_utf8_stays_a_query() {
+    let mut test = QueryParserTest::new();
+
+    // set_config() only takes text; a value we can't read as text is one we
+    // can't track.
+    let command = test.execute(vec![
+        Parse::named(
+            "__test_set_config_bytes",
+            "SELECT set_config($1, $2, false)",
+        )
+        .into(),
+        Bind::new_params(
+            "__test_set_config_bytes",
+            &[
+                Parameter::new(b"search_path"),
+                Parameter::new(&[0xff, 0xfe]),
+            ],
+        )
+        .into(),
+        Execute::new().into(),
+        Sync.into(),
+    ]);
+
+    assert!(
+        matches!(command, Command::Query(_)),
+        "expected Command::Query, got {command:#?}",
+    );
+    assert!(command.route().is_write());
 }

--- a/pgdog/src/frontend/router/parser/query/test/test_set.rs
+++ b/pgdog/src/frontend/router/parser/query/test/test_set.rs
@@ -318,7 +318,6 @@ fn test_set_config_bound_null_value() {
 fn test_set_config_unresolvable_args_stay_a_query() {
     let mut test = QueryParserTest::new();
 
-    // No Bind message, so the parameters can't be resolved.
     let command = test.execute(vec![
         Query::new("SELECT pg_catalog.set_config($1, $2, false)").into(),
     ]);
@@ -380,8 +379,7 @@ fn test_set_config_bound_binary_is_local() {
 fn test_set_config_bound_non_utf8_stays_a_query() {
     let mut test = QueryParserTest::new();
 
-    // set_config() only takes text; a value we can't read as text is one we
-    // can't track.
+    // set_config() takes text; what we can't read as text we can't track.
     let command = test.execute(vec![
         Parse::named(
             "__test_set_config_bytes",

--- a/pgdog/src/net/parameter.rs
+++ b/pgdog/src/net/parameter.rs
@@ -301,7 +301,6 @@ impl Parameters {
         }
     }
 
-    /// Reset all tracked parameters until the transaction ends.
     pub fn reset_all_transaction(&mut self) {
         for key in self.resettable_keys() {
             self.reset_transaction(&key);

--- a/pgdog/src/net/parameter.rs
+++ b/pgdog/src/net/parameter.rs
@@ -267,8 +267,7 @@ impl Parameters {
         }
     }
 
-    /// Remove parameter from params temporarily. The transaction
-    /// is comitted, it will be removed permanently.
+    /// Remove a parameter permanently.
     pub fn reset(&mut self, name: impl AsRef<str>) {
         let name = name.as_ref().to_lowercase();
 
@@ -278,12 +277,11 @@ impl Parameters {
 
         self.transaction_params.remove(&name);
         self.transaction_local_params.remove(&name);
-        // Nothing left to restore: the value is gone for good.
+        // Nothing left to restore on a rollback.
         self.reset_params.remove(&name);
     }
 
-    /// Remove a parameter, but only for the duration of the transaction:
-    /// a ROLLBACK brings its value back.
+    /// Remove a parameter until the transaction ends: a ROLLBACK brings it back.
     pub fn reset_transaction(&mut self, name: impl AsRef<str>) {
         let name = name.as_ref().to_lowercase();
 
@@ -303,7 +301,7 @@ impl Parameters {
         }
     }
 
-    /// Reset all tracked parameters for the duration of the transaction.
+    /// Reset all tracked parameters until the transaction ends.
     pub fn reset_all_transaction(&mut self) {
         for key in self.resettable_keys() {
             self.reset_transaction(&key);
@@ -311,8 +309,7 @@ impl Parameters {
     }
 
     fn resettable_keys(&self) -> Vec<String> {
-        // The keys have to be lifted out before we can reset them: resetting
-        // borrows the maps we'd be iterating.
+        // Lifted out first: resetting borrows the maps we'd be iterating.
         let mut keys: Vec<String> = self
             .params
             .keys()
@@ -1035,7 +1032,7 @@ mod test {
 
         params.reset("search_path");
 
-        // A transaction that comes later has nothing to do with that RESET.
+        // A later transaction has nothing to do with that RESET.
         params.rollback();
 
         assert_eq!(params.get("search_path"), None);

--- a/pgdog/src/net/parameter.rs
+++ b/pgdog/src/net/parameter.rs
@@ -311,12 +311,18 @@ impl Parameters {
     }
 
     fn resettable_keys(&self) -> Vec<String> {
-        let mut keys: Vec<String> = self.params.keys().cloned().collect();
-        keys.extend(self.transaction_params.keys().cloned());
-        keys.extend(self.transaction_local_params.keys().cloned());
+        // The keys have to be lifted out before we can reset them: resetting
+        // borrows the maps we'd be iterating.
+        let mut keys: Vec<String> = self
+            .params
+            .keys()
+            .chain(self.transaction_params.keys())
+            .chain(self.transaction_local_params.keys())
+            .filter(|key| !UNTRACKED_PARAMS.contains(key))
+            .cloned()
+            .collect();
         keys.sort();
         keys.dedup();
-        keys.retain(|key| !UNTRACKED_PARAMS.contains(key));
 
         keys
     }

--- a/pgdog/src/net/parameter.rs
+++ b/pgdog/src/net/parameter.rs
@@ -272,6 +272,21 @@ impl Parameters {
     pub fn reset(&mut self, name: impl AsRef<str>) {
         let name = name.as_ref().to_lowercase();
 
+        if self.params.remove(&name).is_some() {
+            self.hash = Self::compute_hash(&self.params);
+        }
+
+        self.transaction_params.remove(&name);
+        self.transaction_local_params.remove(&name);
+        // Nothing left to restore: the value is gone for good.
+        self.reset_params.remove(&name);
+    }
+
+    /// Remove a parameter, but only for the duration of the transaction:
+    /// a ROLLBACK brings its value back.
+    pub fn reset_transaction(&mut self, name: impl AsRef<str>) {
+        let name = name.as_ref().to_lowercase();
+
         if let Some(value) = self.params.remove(&name) {
             self.reset_params.insert(name.clone(), value);
             self.hash = Self::compute_hash(&self.params);
@@ -283,17 +298,27 @@ impl Parameters {
 
     /// Reset all tracked parameters.
     pub fn reset_all(&mut self) {
+        for key in self.resettable_keys() {
+            self.reset(&key);
+        }
+    }
+
+    /// Reset all tracked parameters for the duration of the transaction.
+    pub fn reset_all_transaction(&mut self) {
+        for key in self.resettable_keys() {
+            self.reset_transaction(&key);
+        }
+    }
+
+    fn resettable_keys(&self) -> Vec<String> {
         let mut keys: Vec<String> = self.params.keys().cloned().collect();
         keys.extend(self.transaction_params.keys().cloned());
         keys.extend(self.transaction_local_params.keys().cloned());
         keys.sort();
         keys.dedup();
+        keys.retain(|key| !UNTRACKED_PARAMS.contains(key));
 
-        for key in keys {
-            if !UNTRACKED_PARAMS.contains(&key) {
-                self.reset(&key);
-            }
-        }
+        keys
     }
 
     /// Commit params we saved during the transaction.
@@ -998,11 +1023,37 @@ mod test {
     }
 
     #[test]
-    fn test_reset_rollback_restores_param() {
+    fn test_reset_outside_transaction_is_permanent() {
         let mut params = Parameters::default();
         params.insert("search_path", "public");
 
         params.reset("search_path");
+
+        // A transaction that comes later has nothing to do with that RESET.
+        params.rollback();
+
+        assert_eq!(params.get("search_path"), None);
+    }
+
+    #[test]
+    fn test_reset_all_outside_transaction_is_permanent() {
+        let mut params = Parameters::default();
+        params.insert("search_path", "public");
+        params.insert("timezone", "UTC");
+
+        params.reset_all();
+        params.rollback();
+
+        assert_eq!(params.get("search_path"), None);
+        assert_eq!(params.get("timezone"), None);
+    }
+
+    #[test]
+    fn test_reset_rollback_restores_param() {
+        let mut params = Parameters::default();
+        params.insert("search_path", "public");
+
+        params.reset_transaction("search_path");
         assert_eq!(params.get("search_path"), None);
 
         params.rollback();
@@ -1104,7 +1155,7 @@ mod test {
         params.insert("search_path", "public");
         params.insert("timezone", "UTC");
 
-        params.reset_all();
+        params.reset_all_transaction();
         assert_eq!(params.get("search_path"), None);
         assert_eq!(params.get("timezone"), None);
 


### PR DESCRIPTION
> Based on #1299 — its two commits are included here and the diff shows both. The two commits that belong to this PR are the last ones.

## Problem

`set_config()` interception only understood constant arguments, so a parameterized call went through untouched:

```sql
SELECT pg_catalog.set_config($1, $2, false)
-- Bind: $1 = 'search_path', $2 = ''
```

Whatever it changed stayed on the connection, and the next client inherited it — `42P01` on unqualified names until the connection was recycled.

The interception itself had a second problem. `SELECT set_config(...)` was answered locally, which meant inventing a response for a query the client asked Postgres to run: the tag was `SET` where Postgres sends `SELECT 1`, and describing the portal claimed no rows and then sent one, which libpq rejects with `D message without prior T`.

## Fix

Read `$n` from the Bind message, so a parameterized `set_config()` resolves like a constant one. The `is_local` argument is decoded from either wire format.

Then stop faking the answer. It is a query, so treat it as one: take a server, record what the statement changes on that connection (#1299's mechanism), and forward it. The client gets Postgres' own reply, and the next client gets the connection with that parameter reset — the invented response and its protocol bug are gone rather than fixed.

Arguments that still don't resolve — no Bind message, a parameter that isn't text, an expression such as `set_config('search_path', current_setting('x'), false)` — leave the statement an ordinary query. That is unchanged from today: it runs, and we don't know what it changed. Covering it would need a way to say "this parameter is now something we can't name", which I left out of this PR.

The flag marking these statements is renamed: it no longer describes how we imitate a `SELECT`, it says the statement is one.

## Testing

- Parser: `$1,$2,$3` resolve to the bound values; a NULL parameter becomes a reset; a binary `is_local` is decoded; arguments with no Bind, a non-UTF-8 value, or an expression stay an ordinary query.
- `integration/python/test_session_params_leak.py::test_set_config_bound_params`: a client poisons the pool through bound parameters, a later client must see a clean `search_path`. Fails on #1299 alone, passes here.
- On a live pool with one server connection, the wire now shows the statement itself going to Postgres and a single `RESET "search_path"` when the connection is handed over — no synthesized rows, no `RESET ALL`.


## Tests now cover both parser levels

@Bougerous reproduced this independently and pointed out that the test config
here pinned `pgdog_leak` to `level = "on"` — the one level that skips the regex
gate, so nothing exercised the path a statement takes at the default level.
That was a fair hit: `set_config()` is a function call inside a `SELECT`, it
matches no statement-start pattern, and on a single-primary cluster `auto`
leaves it to the gate, which drops it.

So the fixture is now two copies of the same single-primary database differing
only in parser level — `pgdog_leak` at `on`, `pgdog_leak_auto` at `auto` — and
every test runs against both.

A second test covers the half of this that reports nothing. Row-level security
keyed on a custom GUC is how multi-tenant applications isolate tenants, and
`set_config()` with a bound parameter is how that GUC gets set; a value that
outlives its client makes the next one read as the previous tenant, with no
error at all. Reads go through a plain role, since the pooler's own user is a
superuser and superusers ignore RLS.

**This leaves a test failing at `auto`** — `test_set_config_bound_params` — and
it stays that way until the gate learns about `set_config()`. That fix is
#1327, opened by @Bougerous, who found the gap and measured it; it is one
pattern in `regex_parser.rs`, a file this PR does not touch. **Merge #1327
first and this PR goes green with nothing else to do here.**

