### PR TITLE
Track a client's parameter changes on the server connection

### DIFF
--- a/integration/pgdog.toml
+++ b/integration/pgdog.toml
@@ -56,6 +56,18 @@ role = "replica"
 read_only = true
 
 # ------------------------------------------------------------------------------
+# ----- Database :: pgdog_leak -------------------------------------------------
+# Exactly one server connection, kept around: tests for session state leaking
+# between clients need the next client to get the same connection back.
+
+[[databases]]
+name = "pgdog_leak"
+host = "127.0.0.1"
+database_name = "pgdog"
+pool_size = 1
+min_pool_size = 1
+
+# ------------------------------------------------------------------------------
 # ----- Database :: pgdog_sharded ----------------------------------------------
 
 [[databases]]

--- a/integration/pgdog.toml
+++ b/integration/pgdog.toml
@@ -57,8 +57,7 @@ read_only = true
 
 # ------------------------------------------------------------------------------
 # ----- Database :: pgdog_leak -------------------------------------------------
-# Exactly one server connection, kept around: tests for session state leaking
-# between clients need the next client to get the same connection back.
+# One server connection, never reaped: the next client has to get the same one.
 
 [[databases]]
 name = "pgdog_leak"

--- a/integration/python/test_session_params_leak.py
+++ b/integration/python/test_session_params_leak.py
@@ -1,0 +1,71 @@
+"""Session parameters must not survive the client that set them.
+
+Runs against a database with a single server connection, so the next client
+always gets the connection the previous one used. current_setting() is used
+instead of SHOW because SHOW can be answered by PgDog itself.
+"""
+
+import psycopg
+
+
+def connect():
+    conn = psycopg.connect(
+        user="pgdog",
+        password="pgdog",
+        dbname="pgdog_leak",
+        host="127.0.0.1",
+        port=6432,
+    )
+    # Without autocommit every statement runs in a transaction that is rolled
+    # back on close, which would undo the very state we're testing for.
+    conn.autocommit = True
+    return conn
+
+
+def read(setting):
+    conn = connect()
+    value = conn.execute(f"SELECT current_setting('{setting}')").fetchone()[0]
+    conn.close()
+
+    return value
+
+
+def test_reset_rolled_back():
+    """A ROLLBACK brings back the value the RESET cleared.
+
+    This is the sequence pg_dump -t <table> emits. SET search_path TO '' leaves
+    an empty quoted identifier, hence the two spellings of "empty".
+    """
+    conn = connect()
+    conn.execute("SET search_path TO ''")
+    with conn.transaction():
+        conn.execute("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY")
+        conn.execute("RESET search_path")
+        conn.execute("SELECT 1")
+        raise psycopg.Rollback()
+    conn.close()
+
+    assert read("search_path") not in ("", '""')
+
+
+def test_set_committed_after_connecting():
+    """A SET that lands once the connection is already ours."""
+    conn = connect()
+    with conn.transaction():
+        conn.execute("SELECT 1")
+        conn.execute("SET statement_timeout TO '5s'")
+    conn.close()
+
+    assert read("statement_timeout") == "0"
+
+
+def test_reset_committed():
+    """A committed RESET is permanent and needs no undoing."""
+    conn = connect()
+    conn.execute("SET search_path TO public")
+    with conn.transaction():
+        conn.execute("SELECT 1")
+        conn.execute("RESET search_path")
+    conn.close()
+
+    assert read("search_path") == '"$user", public'

--- a/integration/python/test_session_params_leak.py
+++ b/integration/python/test_session_params_leak.py
@@ -16,8 +16,8 @@ def connect():
         host="127.0.0.1",
         port=6432,
     )
-    # Without autocommit every statement runs in a transaction that is rolled
-    # back on close, which would undo the very state we're testing for.
+    # Otherwise psycopg wraps each statement in a transaction and rolls it
+    # back on close, undoing the state we're testing for.
     conn.autocommit = True
     return conn
 

--- a/integration/users.toml
+++ b/integration/users.toml
@@ -4,6 +4,11 @@ database = "pgdog"
 password = "pgdog"
 
 [[users]]
+name = "pgdog"
+database = "pgdog_leak"
+password = "pgdog"
+
+[[users]]
 name = "pgdog_migrator"
 database = "pgdog"
 password = "pgdog"

--- a/pgdog/src/backend/pool/connection/binding.rs
+++ b/pgdog/src/backend/pool/connection/binding.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     frontend::{
-        ClientRequest,
+        ClientRequest, SetParam,
         client::query_engine::{
             TwoPcPhase,
             two_pc::{TwoPcTransaction, statement::phase_control},
@@ -440,6 +440,28 @@ impl Binding {
             }
 
             _ => Ok(0),
+        }
+    }
+
+    /// Record a client parameter change on every server we hold.
+    pub fn record_params(&mut self, params: &[SetParam], in_transaction: bool) {
+        match self {
+            Binding::Direct(server, ..) => server.record_params(params, in_transaction),
+            Binding::MultiShard(servers, _) => servers
+                .iter_mut()
+                .for_each(|server| server.record_params(params, in_transaction)),
+            _ => (),
+        }
+    }
+
+    /// Record a client `RESET ALL` on every server we hold.
+    pub fn record_reset_all(&mut self, in_transaction: bool) {
+        match self {
+            Binding::Direct(server, ..) => server.record_reset_all(in_transaction),
+            Binding::MultiShard(servers, _) => servers
+                .iter_mut()
+                .for_each(|server| server.record_reset_all(in_transaction)),
+            _ => (),
         }
     }
 

--- a/pgdog/src/backend/pool/connection/binding.rs
+++ b/pgdog/src/backend/pool/connection/binding.rs
@@ -443,7 +443,6 @@ impl Binding {
         }
     }
 
-    /// Record a client parameter change on every server we hold.
     pub fn record_params(&mut self, params: &[SetParam], in_transaction: bool) {
         match self {
             Binding::Direct(server, ..) => server.record_params(params, in_transaction),
@@ -454,7 +453,6 @@ impl Binding {
         }
     }
 
-    /// Record a client `RESET ALL` on every server we hold.
     pub fn record_reset_all(&mut self, in_transaction: bool) {
         match self {
             Binding::Direct(server, ..) => server.record_reset_all(in_transaction),

--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -141,8 +141,8 @@ pub struct Server {
     streaming: bool,
     schema_changed: bool,
     sync_prepared: bool,
-    // The client's parameter change for the statement in flight is already
-    // recorded, so its CommandComplete tells us nothing we don't know.
+    // The change in flight is already recorded, so its CommandComplete
+    // tells us nothing new.
     params_recorded: bool,
     in_transaction: bool,
     re_synced: bool,
@@ -673,9 +673,8 @@ impl Server {
                         self.prepared_statements.clear();
                         self.client_params.clear();
                     }
-                    // Someone reset params. If we didn't see which ones (the query
-                    // parser is off, or the RESET came from somewhere we don't
-                    // track), the cache is worthless and we re-sync from scratch.
+                    // A RESET nobody told us the contents of: we can't tell
+                    // what it touched, so drop everything.
                     "RESET" if !self.params_recorded => self.client_params.clear(),
                     _ => (),
                 }
@@ -771,8 +770,8 @@ impl Server {
         Ok(executed)
     }
 
-    /// Record a parameter change the client is making on this connection, so
-    /// we know what to undo before handing it to somebody else.
+    /// Record a client's parameter change, so we know what to undo before
+    /// this connection goes to somebody else.
     pub fn record_params(&mut self, params: &[SetParam], in_transaction: bool) {
         for param in params {
             match (&param.value, in_transaction) {
@@ -791,7 +790,7 @@ impl Server {
         self.params_recorded = true;
     }
 
-    /// Record a `RESET ALL` the client is making on this connection.
+    /// Record a client's `RESET ALL`.
     pub fn record_reset_all(&mut self, in_transaction: bool) {
         if in_transaction {
             self.client_params.reset_all_transaction();
@@ -3265,8 +3264,6 @@ pub mod test {
         server.execute("ROLLBACK").await.unwrap();
         server.transaction_params_hook(true);
 
-        // The ROLLBACK brought search_path back, so we still owe the next
-        // client a RESET for it.
         let queries = server
             .client_params
             .reset_queries(&Parameters::default())
@@ -3299,7 +3296,6 @@ pub mod test {
         server.execute("COMMIT").await.unwrap();
         server.transaction_params_hook(false);
 
-        // Committed: the server really is back to its default, nothing to undo.
         assert!(
             server
                 .client_params
@@ -3316,7 +3312,6 @@ pub mod test {
             .await
             .unwrap();
 
-        // A SET that lands after the connection is already ours.
         server.record_params(
             &[SetParam {
                 name: "statement_timeout".into(),
@@ -3360,7 +3355,6 @@ pub mod test {
             .await
             .unwrap();
 
-        // Resetting one parameter says nothing about the others.
         server.record_params(
             &[SetParam {
                 name: "search_path".into(),
@@ -3390,8 +3384,7 @@ pub mod test {
             .await
             .unwrap();
 
-        // Nobody told us what this RESET touched (query parser off), so the
-        // cache is worthless and we start over.
+        // A RESET we never recorded, as when the query parser is off.
         server.execute("RESET search_path").await.unwrap();
 
         assert!(server.client_params.is_empty());

--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -790,7 +790,6 @@ impl Server {
         self.params_recorded = true;
     }
 
-    /// Record a client's `RESET ALL`.
     pub fn record_reset_all(&mut self, in_transaction: bool) {
         if in_transaction {
             self.client_params.reset_all_transaction();

--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -21,7 +21,7 @@ use crate::{
     auth::{md5, scram::Client},
     backend::pool::stats::MemoryStats,
     config::AuthType,
-    frontend::ClientRequest,
+    frontend::{ClientRequest, SetParam},
     net::{
         Close, Liveness, MessageBuffer, Parameter, ProtocolMessage, Sync,
         messages::{
@@ -141,6 +141,9 @@ pub struct Server {
     streaming: bool,
     schema_changed: bool,
     sync_prepared: bool,
+    // The client's parameter change for the statement in flight is already
+    // recorded, so its CommandComplete tells us nothing we don't know.
+    params_recorded: bool,
     in_transaction: bool,
     re_synced: bool,
     replication_mode: bool,
@@ -432,6 +435,7 @@ impl Server {
             streaming: false,
             schema_changed: false,
             sync_prepared: false,
+            params_recorded: false,
             in_transaction: false,
             statement_executed: false,
             re_synced: false,
@@ -610,6 +614,8 @@ impl Server {
 
         match message.code() {
             'Z' => {
+                self.params_recorded = false;
+
                 let now = Instant::now();
                 let rfq = ReadyForQuery::from_bytes(message.payload())?;
 
@@ -667,7 +673,10 @@ impl Server {
                         self.prepared_statements.clear();
                         self.client_params.clear();
                     }
-                    "RESET" => self.client_params.clear(), // Someone reset params, we're gonna need to re-sync.
+                    // Someone reset params. If we didn't see which ones (the query
+                    // parser is off, or the RESET came from somewhere we don't
+                    // track), the cache is worthless and we re-sync from scratch.
+                    "RESET" if !self.params_recorded => self.client_params.clear(),
                     _ => (),
                 }
                 self.stats.rows_affected(&cmd);
@@ -760,6 +769,37 @@ impl Server {
         }
 
         Ok(executed)
+    }
+
+    /// Record a parameter change the client is making on this connection, so
+    /// we know what to undo before handing it to somebody else.
+    pub fn record_params(&mut self, params: &[SetParam], in_transaction: bool) {
+        for param in params {
+            match (&param.value, in_transaction) {
+                (Some(value), true) => {
+                    self.client_params
+                        .insert_transaction(&param.name, value.clone(), param.local);
+                }
+                (Some(value), false) => {
+                    self.client_params.insert(&param.name, value.clone());
+                }
+                (None, true) => self.client_params.reset_transaction(&param.name),
+                (None, false) => self.client_params.reset(&param.name),
+            }
+        }
+
+        self.params_recorded = true;
+    }
+
+    /// Record a `RESET ALL` the client is making on this connection.
+    pub fn record_reset_all(&mut self, in_transaction: bool) {
+        if in_transaction {
+            self.client_params.reset_all_transaction();
+        } else {
+            self.client_params.reset_all();
+        }
+
+        self.params_recorded = true;
     }
 
     // Handle COMMIT/ROLLBACK for in-transaction params tracking.
@@ -1340,7 +1380,7 @@ pub mod test {
         backend::pool::token_cache::TokenCache,
         config::Memory,
         frontend::{PreparedStatements, RewritePlan},
-        net::{Prepare, *},
+        net::{Prepare, parameter::ParameterValue, *},
     };
 
     use super::{Error, *};
@@ -1384,6 +1424,7 @@ pub mod test {
                 streaming: false,
                 schema_changed: false,
                 sync_prepared: false,
+                params_recorded: false,
                 in_transaction: false,
                 re_synced: false,
                 replication_mode: false,
@@ -3199,6 +3240,161 @@ pub mod test {
             server.stats().get_state() == State::Error,
             "state should be Error after detecting desync"
         )
+    }
+
+    #[tokio::test]
+    async fn test_recorded_reset_survives_rollback() {
+        let mut server = test_server().await;
+        let mut params = Parameters::default();
+        params.insert("search_path", "");
+        server
+            .link_client(FrontendPid::new(), &params, None)
+            .await
+            .unwrap();
+
+        server.execute("BEGIN").await.unwrap();
+        server.record_params(
+            &[SetParam {
+                name: "search_path".into(),
+                value: None,
+                local: false,
+            }],
+            true,
+        );
+        server.execute("RESET search_path").await.unwrap();
+        server.execute("ROLLBACK").await.unwrap();
+        server.transaction_params_hook(true);
+
+        // The ROLLBACK brought search_path back, so we still owe the next
+        // client a RESET for it.
+        let queries = server
+            .client_params
+            .reset_queries(&Parameters::default())
+            .into_iter()
+            .map(|query| query.query().to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(queries, vec![r#"RESET "search_path""#]);
+    }
+
+    #[tokio::test]
+    async fn test_recorded_reset_committed_is_permanent() {
+        let mut server = test_server().await;
+        let mut params = Parameters::default();
+        params.insert("search_path", "");
+        server
+            .link_client(FrontendPid::new(), &params, None)
+            .await
+            .unwrap();
+
+        server.execute("BEGIN").await.unwrap();
+        server.record_params(
+            &[SetParam {
+                name: "search_path".into(),
+                value: None,
+                local: false,
+            }],
+            true,
+        );
+        server.execute("RESET search_path").await.unwrap();
+        server.execute("COMMIT").await.unwrap();
+        server.transaction_params_hook(false);
+
+        // Committed: the server really is back to its default, nothing to undo.
+        assert!(
+            server
+                .client_params
+                .reset_queries(&Parameters::default())
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_recorded_set_is_undone_for_the_next_client() {
+        let mut server = test_server().await;
+        server
+            .link_client(FrontendPid::new(), &Parameters::default(), None)
+            .await
+            .unwrap();
+
+        // A SET that lands after the connection is already ours.
+        server.record_params(
+            &[SetParam {
+                name: "statement_timeout".into(),
+                value: Some(ParameterValue::String("5s".into())),
+                local: false,
+            }],
+            false,
+        );
+        server
+            .execute("SET statement_timeout TO '5s'")
+            .await
+            .unwrap();
+
+        let queries = server
+            .client_params
+            .reset_queries(&Parameters::default())
+            .into_iter()
+            .map(|query| query.query().to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(queries, vec![r#"RESET "statement_timeout""#]);
+    }
+
+    #[tokio::test]
+    async fn test_reset_keeps_other_recorded_params() {
+        let mut server = test_server().await;
+        server
+            .link_client(FrontendPid::new(), &Parameters::default(), None)
+            .await
+            .unwrap();
+
+        server.record_params(
+            &[SetParam {
+                name: "statement_timeout".into(),
+                value: Some(ParameterValue::String("5s".into())),
+                local: false,
+            }],
+            false,
+        );
+        server
+            .execute("SET statement_timeout TO '5s'")
+            .await
+            .unwrap();
+
+        // Resetting one parameter says nothing about the others.
+        server.record_params(
+            &[SetParam {
+                name: "search_path".into(),
+                value: None,
+                local: false,
+            }],
+            false,
+        );
+        server.execute("RESET search_path").await.unwrap();
+
+        let queries = server
+            .client_params
+            .reset_queries(&Parameters::default())
+            .into_iter()
+            .map(|query| query.query().to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(queries, vec![r#"RESET "statement_timeout""#]);
+    }
+
+    #[tokio::test]
+    async fn test_untracked_reset_still_clears_client_params() {
+        let mut server = test_server().await;
+        let mut params = Parameters::default();
+        params.insert("search_path", "public");
+        server
+            .link_client(FrontendPid::new(), &params, None)
+            .await
+            .unwrap();
+
+        // Nobody told us what this RESET touched (query parser off), so the
+        // cache is worthless and we start over.
+        server.execute("RESET search_path").await.unwrap();
+
+        assert!(server.client_params.is_empty());
     }
 
     #[tokio::test]

--- a/pgdog/src/frontend/client/query_engine/set.rs
+++ b/pgdog/src/frontend/client/query_engine/set.rs
@@ -44,7 +44,11 @@ impl QueryEngine {
                 }
             } else {
                 fake_command = "RESET";
-                context.params.reset(&param.name);
+                if context.in_transaction() {
+                    context.params.reset_transaction(&param.name);
+                } else {
+                    context.params.reset(&param.name);
+                }
                 if is_pin {
                     self.manual_lock = false;
                 }
@@ -56,6 +60,10 @@ impl QueryEngine {
         }
 
         if self.backend.connected() {
+            // The server is ours right now, so its session changes with the
+            // client's. Record it, or we won't know to undo it for whoever
+            // gets this connection next.
+            self.backend.record_params(params, context.in_transaction());
             self.execute(context).await?;
         } else {
             let values_to_return =
@@ -96,9 +104,14 @@ impl QueryEngine {
         &mut self,
         context: &mut QueryEngineContext<'_>,
     ) -> Result<(), Error> {
-        context.params.reset_all();
+        if context.in_transaction() {
+            context.params.reset_all_transaction();
+        } else {
+            context.params.reset_all();
+        }
 
         if self.backend.connected() {
+            self.backend.record_reset_all(context.in_transaction());
             self.execute(context).await?;
         } else {
             self.fake_command_response(context, "RESET", None::<Option<_>>)

--- a/pgdog/src/frontend/client/query_engine/set.rs
+++ b/pgdog/src/frontend/client/query_engine/set.rs
@@ -60,9 +60,8 @@ impl QueryEngine {
         }
 
         if self.backend.connected() {
-            // The server is ours right now, so its session changes with the
-            // client's. Record it, or we won't know to undo it for whoever
-            // gets this connection next.
+            // The server is ours, so its session changes with the client's:
+            // record it or we won't know what to undo for the next client.
             self.backend.record_params(params, context.in_transaction());
             self.execute(context).await?;
         } else {

--- a/pgdog/src/net/parameter.rs
+++ b/pgdog/src/net/parameter.rs
@@ -301,7 +301,6 @@ impl Parameters {
         }
     }
 
-    /// Reset all tracked parameters until the transaction ends.
     pub fn reset_all_transaction(&mut self) {
         for key in self.resettable_keys() {
             self.reset_transaction(&key);

--- a/pgdog/src/net/parameter.rs
+++ b/pgdog/src/net/parameter.rs
@@ -267,8 +267,7 @@ impl Parameters {
         }
     }
 
-    /// Remove parameter from params temporarily. The transaction
-    /// is comitted, it will be removed permanently.
+    /// Remove a parameter permanently.
     pub fn reset(&mut self, name: impl AsRef<str>) {
         let name = name.as_ref().to_lowercase();
 
@@ -278,12 +277,11 @@ impl Parameters {
 
         self.transaction_params.remove(&name);
         self.transaction_local_params.remove(&name);
-        // Nothing left to restore: the value is gone for good.
+        // Nothing left to restore on a rollback.
         self.reset_params.remove(&name);
     }
 
-    /// Remove a parameter, but only for the duration of the transaction:
-    /// a ROLLBACK brings its value back.
+    /// Remove a parameter until the transaction ends: a ROLLBACK brings it back.
     pub fn reset_transaction(&mut self, name: impl AsRef<str>) {
         let name = name.as_ref().to_lowercase();
 
@@ -303,7 +301,7 @@ impl Parameters {
         }
     }
 
-    /// Reset all tracked parameters for the duration of the transaction.
+    /// Reset all tracked parameters until the transaction ends.
     pub fn reset_all_transaction(&mut self) {
         for key in self.resettable_keys() {
             self.reset_transaction(&key);
@@ -311,8 +309,7 @@ impl Parameters {
     }
 
     fn resettable_keys(&self) -> Vec<String> {
-        // The keys have to be lifted out before we can reset them: resetting
-        // borrows the maps we'd be iterating.
+        // Lifted out first: resetting borrows the maps we'd be iterating.
         let mut keys: Vec<String> = self
             .params
             .keys()
@@ -1035,7 +1032,7 @@ mod test {
 
         params.reset("search_path");
 
-        // A transaction that comes later has nothing to do with that RESET.
+        // A later transaction has nothing to do with that RESET.
         params.rollback();
 
         assert_eq!(params.get("search_path"), None);

--- a/pgdog/src/net/parameter.rs
+++ b/pgdog/src/net/parameter.rs
@@ -311,12 +311,18 @@ impl Parameters {
     }
 
     fn resettable_keys(&self) -> Vec<String> {
-        let mut keys: Vec<String> = self.params.keys().cloned().collect();
-        keys.extend(self.transaction_params.keys().cloned());
-        keys.extend(self.transaction_local_params.keys().cloned());
+        // The keys have to be lifted out before we can reset them: resetting
+        // borrows the maps we'd be iterating.
+        let mut keys: Vec<String> = self
+            .params
+            .keys()
+            .chain(self.transaction_params.keys())
+            .chain(self.transaction_local_params.keys())
+            .filter(|key| !UNTRACKED_PARAMS.contains(key))
+            .cloned()
+            .collect();
         keys.sort();
         keys.dedup();
-        keys.retain(|key| !UNTRACKED_PARAMS.contains(key));
 
         keys
     }

--- a/pgdog/src/net/parameter.rs
+++ b/pgdog/src/net/parameter.rs
@@ -272,6 +272,21 @@ impl Parameters {
     pub fn reset(&mut self, name: impl AsRef<str>) {
         let name = name.as_ref().to_lowercase();
 
+        if self.params.remove(&name).is_some() {
+            self.hash = Self::compute_hash(&self.params);
+        }
+
+        self.transaction_params.remove(&name);
+        self.transaction_local_params.remove(&name);
+        // Nothing left to restore: the value is gone for good.
+        self.reset_params.remove(&name);
+    }
+
+    /// Remove a parameter, but only for the duration of the transaction:
+    /// a ROLLBACK brings its value back.
+    pub fn reset_transaction(&mut self, name: impl AsRef<str>) {
+        let name = name.as_ref().to_lowercase();
+
         if let Some(value) = self.params.remove(&name) {
             self.reset_params.insert(name.clone(), value);
             self.hash = Self::compute_hash(&self.params);
@@ -283,17 +298,27 @@ impl Parameters {
 
     /// Reset all tracked parameters.
     pub fn reset_all(&mut self) {
+        for key in self.resettable_keys() {
+            self.reset(&key);
+        }
+    }
+
+    /// Reset all tracked parameters for the duration of the transaction.
+    pub fn reset_all_transaction(&mut self) {
+        for key in self.resettable_keys() {
+            self.reset_transaction(&key);
+        }
+    }
+
+    fn resettable_keys(&self) -> Vec<String> {
         let mut keys: Vec<String> = self.params.keys().cloned().collect();
         keys.extend(self.transaction_params.keys().cloned());
         keys.extend(self.transaction_local_params.keys().cloned());
         keys.sort();
         keys.dedup();
+        keys.retain(|key| !UNTRACKED_PARAMS.contains(key));
 
-        for key in keys {
-            if !UNTRACKED_PARAMS.contains(&key) {
-                self.reset(&key);
-            }
-        }
+        keys
     }
 
     /// Commit params we saved during the transaction.
@@ -998,11 +1023,37 @@ mod test {
     }
 
     #[test]
-    fn test_reset_rollback_restores_param() {
+    fn test_reset_outside_transaction_is_permanent() {
         let mut params = Parameters::default();
         params.insert("search_path", "public");
 
         params.reset("search_path");
+
+        // A transaction that comes later has nothing to do with that RESET.
+        params.rollback();
+
+        assert_eq!(params.get("search_path"), None);
+    }
+
+    #[test]
+    fn test_reset_all_outside_transaction_is_permanent() {
+        let mut params = Parameters::default();
+        params.insert("search_path", "public");
+        params.insert("timezone", "UTC");
+
+        params.reset_all();
+        params.rollback();
+
+        assert_eq!(params.get("search_path"), None);
+        assert_eq!(params.get("timezone"), None);
+    }
+
+    #[test]
+    fn test_reset_rollback_restores_param() {
+        let mut params = Parameters::default();
+        params.insert("search_path", "public");
+
+        params.reset_transaction("search_path");
         assert_eq!(params.get("search_path"), None);
 
         params.rollback();
@@ -1104,7 +1155,7 @@ mod test {
         params.insert("search_path", "public");
         params.insert("timezone", "UTC");
 
-        params.reset_all();
+        params.reset_all_transaction();
         assert_eq!(params.get("search_path"), None);
         assert_eq!(params.get("timezone"), None);
 


### PR DESCRIPTION
## Problem

A `SET` or `RESET` the client sends once a server is attached changes that server's session, but nothing wrote it down. What we did instead was clear the whole parameter cache whenever a `CommandComplete` said `RESET` — which trades one problem for another, because that cache is exactly what tells us to undo the change for the next client.

`pg_dump -t <table>` walks straight into it:

```sql
SET search_path TO '';
BEGIN;
SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY;
RESET search_path;
ROLLBACK;
```

The `ROLLBACK` undoes the `RESET`, so the empty `search_path` is back on the server, but the cache no longer mentions it. The next client gets that connection and every unqualified name fails with `42P01`.

A `SET` has the same hole in the other direction, and it needs no `pg_dump` at all:

```sql
BEGIN;
SELECT 1;                          -- a server is ours from here on
SET statement_timeout TO '5s';
COMMIT;
```

On `main` the next client sees `statement_timeout = 5s`. Nothing resets it, because the connection's parameter cache never learned about it — `link_client` only ever recorded what the client had at checkout time.

## Fix

Record the change where it happens, instead of reacting to a tag afterwards.

`RESET` gets the transaction handling `SET` always had — `reset` vs `reset_transaction`, next to `insert` and `insert_transaction` — so a rollback restores what it cleared and a commit makes it permanent. That also fixes a smaller thing on the way: an autocommit `RESET` used to leave its old value in `reset_params` forever, so an unrelated transaction rolling back later would resurrect it.

The server connection then keeps the same record its client does, and the existing parameter diff does the rest. The next client is handed a precise `RESET "search_path"` for what it doesn't want, rather than a connection nobody dares reuse.

The `CommandComplete` fallback stays for RESETs we don't see coming: with the query parser off, that is still all we have.

## Testing

- `Parameters`: rollback restores an in-transaction reset, a commit makes it permanent, and a reset outside a transaction is not resurrected by a later rollback.
- `Server`: a recorded reset survives `ROLLBACK` and still produces `RESET "search_path"` for the next client; a committed one produces nothing; a recorded `SET` is undone for the next client; resetting one parameter no longer forgets the others; an untracked `RESET` still clears the cache.
- `integration/python/test_session_params_leak.py`: the `pg_dump` sequence, a `SET` committed after connecting, and a committed `RESET`. Verified to fail on `main` (the first two) and pass here.
- On a live pool with one server connection, the wire shows exactly one `RESET "search_path"` when the connection is handed over — no `RESET ALL`, no churn.
