### PR TITLE
Deallocate client prepared statements at checkin

### DIFF
--- a/integration/pgdog.toml
+++ b/integration/pgdog.toml
@@ -56,6 +56,17 @@ role = "replica"
 read_only = true
 
 # ------------------------------------------------------------------------------
+# ----- Database :: pgdog_leak -------------------------------------------------
+# One server connection only, so tests for session state leaking between
+# clients are deterministic.
+
+[[databases]]
+name = "pgdog_leak"
+host = "127.0.0.1"
+database_name = "pgdog"
+pool_size = 1
+
+# ------------------------------------------------------------------------------
 # ----- Database :: pgdog_sharded ----------------------------------------------
 
 [[databases]]

--- a/integration/pgdog.toml
+++ b/integration/pgdog.toml
@@ -55,14 +55,15 @@ read_only = true
 
 # ------------------------------------------------------------------------------
 # ----- Database :: pgdog_leak -------------------------------------------------
-# One server connection only, so tests for session state leaking between
-# clients are deterministic.
+# Exactly one server connection, kept around: tests for session state leaking
+# between clients need the next client to get the same connection back.
 
 [[databases]]
 name = "pgdog_leak"
 host = "127.0.0.1"
 database_name = "pgdog"
 pool_size = 1
+min_pool_size = 1
 
 # ------------------------------------------------------------------------------
 # ----- Database :: pgdog_sharded ----------------------------------------------

--- a/integration/pgdog.toml
+++ b/integration/pgdog.toml
@@ -54,6 +54,17 @@ role = "replica"
 read_only = true
 
 # ------------------------------------------------------------------------------
+# ----- Database :: pgdog_leak -------------------------------------------------
+# One server connection only, so tests for session state leaking between
+# clients are deterministic.
+
+[[databases]]
+name = "pgdog_leak"
+host = "127.0.0.1"
+database_name = "pgdog"
+pool_size = 1
+
+# ------------------------------------------------------------------------------
 # ----- Database :: pgdog_sharded ----------------------------------------------
 
 [[databases]]

--- a/integration/pgdog.toml
+++ b/integration/pgdog.toml
@@ -57,14 +57,15 @@ read_only = true
 
 # ------------------------------------------------------------------------------
 # ----- Database :: pgdog_leak -------------------------------------------------
-# One server connection only, so tests for session state leaking between
-# clients are deterministic.
+# Exactly one server connection, kept around: tests for session state leaking
+# between clients need the next client to get the same connection back.
 
 [[databases]]
 name = "pgdog_leak"
 host = "127.0.0.1"
 database_name = "pgdog"
 pool_size = 1
+min_pool_size = 1
 
 # ------------------------------------------------------------------------------
 # ----- Database :: pgdog_sharded ----------------------------------------------

--- a/integration/python/test_pg_dump.py
+++ b/integration/python/test_pg_dump.py
@@ -12,7 +12,21 @@ on the one another dump just used.
 import os
 import subprocess
 
+import psycopg
+
 DUMPS = 3
+
+
+def connect():
+    conn = psycopg.connect(
+        user="pgdog",
+        password="pgdog",
+        dbname="pgdog_leak",
+        host="127.0.0.1",
+        port=6432,
+    )
+    conn.autocommit = True
+    return conn
 
 
 def pg_dump():
@@ -26,8 +40,31 @@ def pg_dump():
 
 
 def test_repeated_dumps():
+    # pg_dump only prepares its statement when there are functions to dump,
+    # so don't rely on whatever else happens to live in the database.
+    conn = connect()
+    conn.execute("CREATE OR REPLACE FUNCTION public.pg_dump_probe() RETURNS int AS $$ SELECT 1 $$ LANGUAGE SQL")
+    conn.close()
+
     for attempt in range(DUMPS):
         result = pg_dump()
         assert result.returncode == 0, (
             f"dump {attempt + 1} of {DUMPS} failed: {result.stderr.strip()}"
         )
+
+
+def test_prepared_statement_with_dirty_connection():
+    """A connection can need both a parameter reset and a deallocate."""
+    conn = connect()
+    conn.execute("SET pgdog.pin TO true")
+    conn.execute("PREPARE pg_dump_probe_stmt AS SELECT 1")
+    conn.close()
+
+    conn = connect()
+    left = conn.execute(
+        "SELECT count(*) FROM pg_catalog.pg_prepared_statements "
+        "WHERE name = 'pg_dump_probe_stmt'"
+    ).fetchone()[0]
+    conn.close()
+
+    assert left == 0, "prepared statement outlived its client's checkin"

--- a/integration/python/test_pg_dump.py
+++ b/integration/python/test_pg_dump.py
@@ -1,0 +1,33 @@
+"""pg_dump must work against a pooled connection that already served one.
+
+pg_dump creates a SQL-level prepared statement ("dumpfunc"). In transaction
+pooling the server connection goes back into the pool at the end of the
+transaction, so the next dump that lands on it fails with "prepared statement
+already exists" unless the pooler cleans that state up.
+
+Runs against a database with a single server connection, so every dump lands
+on the one another dump just used.
+"""
+
+import os
+import subprocess
+
+DUMPS = 3
+
+
+def pg_dump():
+    return subprocess.run(
+        ["pg_dump", "-h", "127.0.0.1", "-p", "6432", "-U", "pgdog", "-d", "pgdog_leak"],
+        env=dict(os.environ, PGPASSWORD="pgdog"),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def test_repeated_dumps():
+    for attempt in range(DUMPS):
+        result = pg_dump()
+        assert result.returncode == 0, (
+            f"dump {attempt + 1} of {DUMPS} failed: {result.stderr.strip()}"
+        )

--- a/integration/users.toml
+++ b/integration/users.toml
@@ -4,6 +4,11 @@ database = "pgdog"
 password = "pgdog"
 
 [[users]]
+name = "pgdog"
+database = "pgdog_leak"
+password = "pgdog"
+
+[[users]]
 name = "pgdog_migrator"
 database = "pgdog"
 password = "pgdog"

--- a/pgdog/src/backend/pool/cleanup.rs
+++ b/pgdog/src/backend/pool/cleanup.rs
@@ -84,7 +84,6 @@ impl Cleanup {
         clean
     }
 
-    /// Append more queries to run during the same cleanup.
     fn add(&mut self, queries: &'static [Query]) {
         self.queries.to_mut().extend_from_slice(queries);
     }

--- a/pgdog/src/backend/pool/cleanup.rs
+++ b/pgdog/src/backend/pool/cleanup.rs
@@ -1,4 +1,6 @@
 //! Cleanup queries for servers altered by client behavior.
+use std::borrow::Cow;
+
 use once_cell::sync::Lazy;
 
 use crate::net::{Close, Query};
@@ -27,20 +29,18 @@ static NONE: Lazy<Vec<Query>> = Lazy::new(Vec::new);
 /// client modifications.
 #[allow(dead_code)]
 pub struct Cleanup {
-    queries: &'static Vec<Query>,
+    queries: Cow<'static, [Query]>,
     reset: bool,
     dirty: bool,
-    deallocate: bool,
     close: Vec<Close>,
 }
 
 impl Default for Cleanup {
     fn default() -> Self {
         Self {
-            queries: &*NONE,
+            queries: Cow::Borrowed(&NONE),
             reset: false,
             dirty: false,
-            deallocate: false,
             close: vec![],
         }
     }
@@ -63,11 +63,20 @@ impl std::fmt::Display for Cleanup {
 impl Cleanup {
     /// New cleanup operation.
     pub fn new(guard: &Guard, server: &mut Server) -> Self {
+        // A client that prepared statements with SQL leaves them on the
+        // connection. They belong to its session, so drop them before another
+        // client gets the connection and collides with their names.
+        let deallocate = server.schema_changed() || server.sync_prepared();
+
         let mut clean = if guard.reset {
             Self::all()
         } else if server.dirty() {
-            Self::parameters()
-        } else if server.schema_changed() {
+            let mut clean = Self::parameters();
+            if deallocate {
+                clean.add(&PREPARED);
+            }
+            clean
+        } else if deallocate {
             Self::prepared_statements()
         } else {
             Self::none()
@@ -78,6 +87,11 @@ impl Cleanup {
         clean
     }
 
+    /// Append more queries to run during the same cleanup.
+    fn add(&mut self, queries: &'static [Query]) {
+        self.queries.to_mut().extend_from_slice(queries);
+    }
+
     /// Number of queries to run for cleanup.
     pub fn len(&self) -> usize {
         self.queries.len()
@@ -86,8 +100,7 @@ impl Cleanup {
     /// Cleanup prepared statements.
     pub fn prepared_statements() -> Self {
         Self {
-            queries: &*PREPARED,
-            deallocate: true,
+            queries: Cow::Borrowed(&PREPARED),
             ..Default::default()
         }
     }
@@ -95,7 +108,7 @@ impl Cleanup {
     /// Cleanup parameters.
     pub fn parameters() -> Self {
         Self {
-            queries: &*DIRTY,
+            queries: Cow::Borrowed(&DIRTY),
             dirty: true,
             ..Default::default()
         }
@@ -106,8 +119,7 @@ impl Cleanup {
         Self {
             reset: true,
             dirty: true,
-            deallocate: true,
-            queries: &*ALL,
+            queries: Cow::Borrowed(&ALL),
             close: vec![],
         }
     }
@@ -124,7 +136,7 @@ impl Cleanup {
 
     /// Get queries to execute on the server to perform cleanup.
     pub fn queries(&self) -> &[Query] {
-        self.queries
+        &self.queries
     }
 
     /// Prepared statemens to close.
@@ -134,9 +146,5 @@ impl Cleanup {
 
     pub fn is_reset_params(&self) -> bool {
         self.dirty
-    }
-
-    pub fn is_deallocate(&self) -> bool {
-        self.deallocate
     }
 }

--- a/pgdog/src/backend/pool/cleanup.rs
+++ b/pgdog/src/backend/pool/cleanup.rs
@@ -1,4 +1,6 @@
 //! Cleanup queries for servers altered by client behavior.
+use std::borrow::Cow;
+
 use once_cell::sync::Lazy;
 
 use crate::net::{Close, Query};
@@ -26,18 +28,18 @@ static NONE: Lazy<Vec<Query>> = Lazy::new(Vec::new);
 /// Queries used to clean up server connections after
 /// client modifications.
 pub struct Cleanup {
-    queries: &'static Vec<Query>,
+    queries: Cow<'static, [Query]>,
+    reset: bool,
     dirty: bool,
-    deallocate: bool,
     close: Vec<Close>,
 }
 
 impl Default for Cleanup {
     fn default() -> Self {
         Self {
-            queries: &*NONE,
+            queries: Cow::Borrowed(&NONE),
+            reset: false,
             dirty: false,
-            deallocate: false,
             close: vec![],
         }
     }
@@ -60,11 +62,20 @@ impl std::fmt::Display for Cleanup {
 impl Cleanup {
     /// New cleanup operation.
     pub fn new(guard: &Guard, server: &mut Server) -> Self {
+        // A client that prepared statements with SQL leaves them on the
+        // connection. They belong to its session, so drop them before another
+        // client gets the connection and collides with their names.
+        let deallocate = server.schema_changed() || server.sync_prepared();
+
         let mut clean = if guard.reset {
             Self::all()
         } else if server.dirty() {
-            Self::parameters()
-        } else if server.schema_changed() {
+            let mut clean = Self::parameters();
+            if deallocate {
+                clean.add(&PREPARED);
+            }
+            clean
+        } else if deallocate {
             Self::prepared_statements()
         } else {
             Self::none()
@@ -75,6 +86,11 @@ impl Cleanup {
         clean
     }
 
+    /// Append more queries to run during the same cleanup.
+    fn add(&mut self, queries: &'static [Query]) {
+        self.queries.to_mut().extend_from_slice(queries);
+    }
+
     /// Number of queries to run for cleanup.
     pub fn len(&self) -> usize {
         self.queries.len()
@@ -83,8 +99,7 @@ impl Cleanup {
     /// Cleanup prepared statements.
     pub fn prepared_statements() -> Self {
         Self {
-            queries: &*PREPARED,
-            deallocate: true,
+            queries: Cow::Borrowed(&PREPARED),
             ..Default::default()
         }
     }
@@ -92,7 +107,7 @@ impl Cleanup {
     /// Cleanup parameters.
     pub fn parameters() -> Self {
         Self {
-            queries: &*DIRTY,
+            queries: Cow::Borrowed(&DIRTY),
             dirty: true,
             ..Default::default()
         }
@@ -102,8 +117,7 @@ impl Cleanup {
     pub fn all() -> Self {
         Self {
             dirty: true,
-            deallocate: true,
-            queries: &*ALL,
+            queries: Cow::Borrowed(&ALL),
             close: vec![],
         }
     }
@@ -120,7 +134,7 @@ impl Cleanup {
 
     /// Get queries to execute on the server to perform cleanup.
     pub fn queries(&self) -> &[Query] {
-        self.queries
+        &self.queries
     }
 
     /// Prepared statemens to close.
@@ -130,9 +144,5 @@ impl Cleanup {
 
     pub fn is_reset_params(&self) -> bool {
         self.dirty
-    }
-
-    pub fn is_deallocate(&self) -> bool {
-        self.deallocate
     }
 }

--- a/pgdog/src/backend/pool/cleanup.rs
+++ b/pgdog/src/backend/pool/cleanup.rs
@@ -29,7 +29,6 @@ static NONE: Lazy<Vec<Query>> = Lazy::new(Vec::new);
 /// client modifications.
 pub struct Cleanup {
     queries: Cow<'static, [Query]>,
-    reset: bool,
     dirty: bool,
     close: Vec<Close>,
 }
@@ -38,7 +37,6 @@ impl Default for Cleanup {
     fn default() -> Self {
         Self {
             queries: Cow::Borrowed(&NONE),
-            reset: false,
             dirty: false,
             close: vec![],
         }

--- a/pgdog/src/backend/pool/guard.rs
+++ b/pgdog/src/backend/pool/guard.rs
@@ -137,7 +137,6 @@ impl Guard {
         conn_recovery: ConnectionRecovery,
     ) -> Result<(), Error> {
         let schema_changed = server.schema_changed();
-        let sync_prepared = server.sync_prepared();
         let needs_drain = server.needs_drain();
 
         if needs_drain {
@@ -180,11 +179,9 @@ impl Guard {
                 server.stats().get_state(),
                 server.addr()
             );
+            // The cache is dropped by the DEALLOCATE ALL / DISCARD ALL
+            // response, so there is nothing to clear here.
             server.execute_batch(cleanup.queries()).await?;
-
-            if cleanup.is_deallocate() {
-                server.prepared_statements_mut().clear();
-            }
             server.cleaned();
 
             debug!(
@@ -200,15 +197,6 @@ impl Guard {
 
         if cleanup.is_reset_params() {
             server.reset_params();
-        }
-
-        if sync_prepared {
-            debug!(
-                "[cleanup] syncing prepared statements, server in \"{}\" state [{}]",
-                server.stats().get_state(),
-                server.addr()
-            );
-            server.sync_prepared_statements().await?;
         }
 
         Ok(())
@@ -762,7 +750,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_cleanup_syncs_prepared_statements() {
+    async fn test_cleanup_deallocates_client_prepared_statements() {
         crate::logger();
 
         let mut server = Guard::new(
@@ -802,9 +790,15 @@ mod test {
         );
 
         assert!(
-            server.prepared_statements_mut().contains("test_stmt"),
-            "Statement should be in local cache after sync"
+            !server.prepared_statements_mut().contains("test_stmt"),
+            "statement prepared by a client must not outlive its checkin"
         );
+
+        // The next client can use the same name, which is what pg_dump does.
+        server
+            .execute("PREPARE test_stmt AS SELECT $1::bigint")
+            .await
+            .unwrap();
 
         let one: Vec<i32> = server.fetch_all("SELECT 1").await.unwrap();
         assert_eq!(one[0], 1);

--- a/pgdog/src/backend/pool/guard.rs
+++ b/pgdog/src/backend/pool/guard.rs
@@ -137,7 +137,6 @@ impl Guard {
         conn_recovery: ConnectionRecovery,
     ) -> Result<(), Error> {
         let schema_changed = server.schema_changed();
-        let sync_prepared = server.sync_prepared();
         let needs_drain = server.needs_drain();
 
         if needs_drain {
@@ -180,11 +179,9 @@ impl Guard {
                 server.stats().get_state(),
                 server.addr()
             );
+            // The cache is dropped by the DEALLOCATE ALL / DISCARD ALL
+            // response, so there is nothing to clear here.
             server.execute_batch(cleanup.queries()).await?;
-
-            if cleanup.is_deallocate() {
-                server.prepared_statements_mut().clear();
-            }
             server.cleaned();
 
             debug!(
@@ -200,15 +197,6 @@ impl Guard {
 
         if cleanup.is_reset_params() {
             server.reset_params();
-        }
-
-        if sync_prepared {
-            debug!(
-                "[cleanup] syncing prepared statements, server in \"{}\" state [{}]",
-                server.stats().get_state(),
-                server.addr()
-            );
-            server.sync_prepared_statements().await?;
         }
 
         Ok(())
@@ -788,7 +776,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_cleanup_syncs_prepared_statements() {
+    async fn test_cleanup_deallocates_client_prepared_statements() {
         crate::logger();
 
         let mut server = Guard::new(
@@ -828,9 +816,15 @@ mod test {
         );
 
         assert!(
-            server.prepared_statements_mut().contains("test_stmt"),
-            "Statement should be in local cache after sync"
+            !server.prepared_statements_mut().contains("test_stmt"),
+            "statement prepared by a client must not outlive its checkin"
         );
+
+        // The next client can use the same name, which is what pg_dump does.
+        server
+            .execute("PREPARE test_stmt AS SELECT $1::bigint")
+            .await
+            .unwrap();
 
         let one: Vec<i32> = server.fetch_all("SELECT 1").await.unwrap();
         assert_eq!(one[0], 1);

--- a/pgdog/src/backend/pool/test/mod.rs
+++ b/pgdog/src/backend/pool/test/mod.rs
@@ -437,14 +437,14 @@ async fn test_prepared_statements_limit() {
     assert_eq!(guard.prepared_statements_mut().len(), 2);
 
     // Let's make sure Postgres agreees.
-    guard.sync_prepared_statements().await.unwrap();
+    let named: Vec<String> = guard
+        .fetch_all("SELECT name FROM pg_prepared_statements")
+        .await
+        .unwrap();
 
     // It's random!
-    assert!(
-        guard.prepared_statements_mut().contains("__pgdog_99")
-            || guard.prepared_statements_mut().contains("__pgdog_98")
-    );
-    assert_eq!(guard.prepared_statements_mut().len(), 2);
+    assert!(named.contains(&"__pgdog_99".to_string()) || named.contains(&"__pgdog_98".to_string()));
+    assert_eq!(named.len(), 2);
     assert_eq!(guard.stats().total().prepared_statements, 2); // stats are accurate.
 
     let pool = pool_with_prepared_capacity(100);
@@ -476,10 +476,13 @@ async fn test_prepared_statements_limit() {
     assert_eq!(guard.stats().total().prepared_statements, 100); // stats are accurate.
 
     // Let's make sure Postgres agreees.
-    guard.sync_prepared_statements().await.unwrap();
+    let named: Vec<String> = guard
+        .fetch_all("SELECT name FROM pg_prepared_statements")
+        .await
+        .unwrap();
 
-    assert!(guard.prepared_statements_mut().contains("__pgdog_99"));
-    assert_eq!(guard.prepared_statements_mut().len(), 100);
+    assert!(named.contains(&"__pgdog_99".to_string()));
+    assert_eq!(named.len(), 100);
     assert_eq!(guard.stats().total().prepared_statements, 100); // stats are accurate.
 }
 

--- a/pgdog/src/backend/pool/test/mod.rs
+++ b/pgdog/src/backend/pool/test/mod.rs
@@ -482,14 +482,14 @@ async fn test_prepared_statements_limit() {
     assert_eq!(guard.prepared_statements_mut().len(), 2);
 
     // Let's make sure Postgres agreees.
-    guard.sync_prepared_statements().await.unwrap();
+    let named: Vec<String> = guard
+        .fetch_all("SELECT name FROM pg_prepared_statements")
+        .await
+        .unwrap();
 
     // It's random!
-    assert!(
-        guard.prepared_statements_mut().contains("__pgdog_99")
-            || guard.prepared_statements_mut().contains("__pgdog_98")
-    );
-    assert_eq!(guard.prepared_statements_mut().len(), 2);
+    assert!(named.contains(&"__pgdog_99".to_string()) || named.contains(&"__pgdog_98".to_string()));
+    assert_eq!(named.len(), 2);
     assert_eq!(guard.stats().total().prepared_statements, 2); // stats are accurate.
 
     let pool = pool_with_prepared_capacity(100);
@@ -521,10 +521,13 @@ async fn test_prepared_statements_limit() {
     assert_eq!(guard.stats().total().prepared_statements, 100); // stats are accurate.
 
     // Let's make sure Postgres agreees.
-    guard.sync_prepared_statements().await.unwrap();
+    let named: Vec<String> = guard
+        .fetch_all("SELECT name FROM pg_prepared_statements")
+        .await
+        .unwrap();
 
-    assert!(guard.prepared_statements_mut().contains("__pgdog_99"));
-    assert_eq!(guard.prepared_statements_mut().len(), 100);
+    assert!(named.contains(&"__pgdog_99".to_string()));
+    assert_eq!(named.len(), 100);
     assert_eq!(guard.stats().total().prepared_statements, 100); // stats are accurate.
 }
 

--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -1085,7 +1085,6 @@ impl Server {
         self.clear_prepared_statements();
     }
 
-    /// Drop the prepared statements cache, and the stat that counts them.
     #[inline]
     fn clear_prepared_statements(&mut self) {
         self.prepared_statements.clear();

--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -564,9 +564,9 @@ impl Server {
                 let cmd = CommandComplete::from_bytes(message.to_bytes())?;
                 match cmd.command() {
                     "PREPARE" | "DEALLOCATE" => self.sync_prepared = true,
-                    "DEALLOCATE ALL" => self.prepared_statements.clear(),
+                    "DEALLOCATE ALL" => self.clear_prepared_statements(),
                     "DISCARD ALL" => {
-                        self.prepared_statements.clear();
+                        self.clear_prepared_statements();
                         self.client_params.clear();
                     }
                     "RESET" => self.client_params.clear(), // Someone reset params, we're gonna need to re-sync.
@@ -902,25 +902,6 @@ impl Server {
         Ok(())
     }
 
-    /// Synchronize prepared statements from Postgres.
-    pub(super) async fn sync_prepared_statements(&mut self) -> Result<(), Error> {
-        let names = self
-            .fetch_all::<String>("SELECT name FROM pg_prepared_statements")
-            .await?;
-
-        for name in names {
-            self.prepared_statements.prepared(&name);
-        }
-
-        debug!("prepared statements synchronized [{}]", self.addr());
-
-        let count = self.prepared_statements.len();
-        self.stats.set_prepared_statements(count);
-        self.sync_prepared = false;
-
-        Ok(())
-    }
-
     /// Close any prepared statements that exceed cache capacity.
     pub(super) fn ensure_prepared_capacity(&mut self) -> Vec<Close> {
         let close = self.prepared_statements.ensure_capacity();
@@ -977,7 +958,14 @@ impl Server {
     #[inline]
     pub fn reset_schema_changed(&mut self) {
         self.schema_changed = false;
+        self.clear_prepared_statements();
+    }
+
+    /// Drop the prepared statements cache, and the stat that counts them.
+    #[inline]
+    fn clear_prepared_statements(&mut self) {
         self.prepared_statements.clear();
+        self.stats.clear_prepared_statements();
     }
 
     #[inline]
@@ -1116,6 +1104,7 @@ impl Server {
     #[inline]
     pub(super) fn cleaned(&mut self) {
         self.dirty = false;
+        self.sync_prepared = false;
         self.stats.cleaned();
     }
 
@@ -2115,7 +2104,7 @@ pub mod test {
             assert_eq!(msg.code(), c);
         }
         assert!(server.sync_prepared());
-        server.sync_prepared_statements().await.unwrap();
+        server.prepared_statements.prepared("__pgdog_1");
         assert!(server.prepared_statements.contains("__pgdog_1"));
 
         let describe = Describe::new_statement("__pgdog_1");
@@ -2635,6 +2624,34 @@ pub mod test {
     }
 
     #[tokio::test]
+    async fn test_reset_schema_changed_clears_cache() {
+        let mut server = test_server().await;
+
+        server
+            .send(
+                &vec![
+                    Query::new("PREPARE schema_stmt AS SELECT 1").into(),
+                    Sync.into(),
+                ]
+                .into(),
+            )
+            .await
+            .unwrap();
+        for c in ['C', 'Z'] {
+            let msg = server.read().await.unwrap();
+            assert_eq!(msg.code(), c);
+        }
+        server.prepared_statements.prepared("schema_stmt");
+        assert!(!server.prepared_statements.is_empty());
+
+        // A schema change invalidates everything we cached for this connection.
+        server.reset_schema_changed();
+
+        assert!(server.prepared_statements.is_empty());
+        assert_eq!(server.stats().total().prepared_statements, 0);
+    }
+
+    #[tokio::test]
     async fn test_discard_all_clears_cache() {
         let mut server = test_server().await;
 
@@ -2841,11 +2858,11 @@ pub mod test {
             "sync_prepared flag should be set after PREPARE command"
         );
 
-        server.sync_prepared_statements().await.unwrap();
+        server.cleaned();
 
         assert!(
             !server.sync_prepared(),
-            "sync_prepared flag should be cleared after sync_prepared_statements()"
+            "sync_prepared flag should be cleared once the connection is cleaned"
         );
 
         server.execute("SELECT 1").await.unwrap();
@@ -3779,10 +3796,12 @@ pub mod test {
                 "cache should be cleared after RFQ in extended_anonymous mode"
             );
             // Verify Postgres has no named prepared statements stored.
-            server.sync_prepared_statements().await.unwrap();
-            assert_eq!(
-                server.prepared_statements.len(),
-                0,
+            let named: Vec<String> = server
+                .fetch_all("SELECT name FROM pg_prepared_statements")
+                .await
+                .unwrap();
+            assert!(
+                named.is_empty(),
                 "Postgres should have no prepared statements in extended_anonymous mode"
             );
         }
@@ -3820,8 +3839,11 @@ pub mod test {
         assert!(server.done());
         assert_eq!(server.prepared_statements.len(), 0);
         // Verify Postgres has no named prepared statements stored.
-        server.sync_prepared_statements().await.unwrap();
-        assert_eq!(server.prepared_statements.len(), 0);
+        let named: Vec<String> = server
+            .fetch_all("SELECT name FROM pg_prepared_statements")
+            .await
+            .unwrap();
+        assert!(named.is_empty());
     }
 
     #[tokio::test]
@@ -3871,10 +3893,12 @@ pub mod test {
             assert!(server.done());
         }
         // Verify Postgres has no named prepared statements stored.
-        server.sync_prepared_statements().await.unwrap();
-        assert_eq!(
-            server.prepared_statements.len(),
-            0,
+        let named: Vec<String> = server
+            .fetch_all("SELECT name FROM pg_prepared_statements")
+            .await
+            .unwrap();
+        assert!(
+            named.is_empty(),
             "Postgres should have no prepared statements after repeated anonymous usage"
         );
     }
@@ -3908,8 +3932,11 @@ pub mod test {
 
         assert!(server.done());
         // Verify Postgres has no named prepared statements stored.
-        server.sync_prepared_statements().await.unwrap();
-        assert_eq!(server.prepared_statements.len(), 0);
+        let named: Vec<String> = server
+            .fetch_all("SELECT name FROM pg_prepared_statements")
+            .await
+            .unwrap();
+        assert!(named.is_empty());
     }
 
     #[tokio::test]
@@ -3942,8 +3969,11 @@ pub mod test {
         // Server should still be usable.
         verify_server_usable(&mut server).await;
         // Verify Postgres has no named prepared statements stored.
-        server.sync_prepared_statements().await.unwrap();
-        assert_eq!(server.prepared_statements.len(), 0);
+        let named: Vec<String> = server
+            .fetch_all("SELECT name FROM pg_prepared_statements")
+            .await
+            .unwrap();
+        assert!(named.is_empty());
     }
 
     #[tokio::test]
@@ -3993,8 +4023,11 @@ pub mod test {
 
         assert!(server.done());
         // Verify Postgres has no named prepared statements stored.
-        server.sync_prepared_statements().await.unwrap();
-        assert_eq!(server.prepared_statements.len(), 0);
+        let named: Vec<String> = server
+            .fetch_all("SELECT name FROM pg_prepared_statements")
+            .await
+            .unwrap();
+        assert!(named.is_empty());
     }
 
     #[tokio::test]
@@ -4041,10 +4074,12 @@ pub mod test {
             assert!(server.prepared_statements.ensure_capacity().is_empty());
         }
         // Verify Postgres has no named prepared statements stored.
-        server.sync_prepared_statements().await.unwrap();
-        assert_eq!(
-            server.prepared_statements.len(),
-            0,
+        let named: Vec<String> = server
+            .fetch_all("SELECT name FROM pg_prepared_statements")
+            .await
+            .unwrap();
+        assert!(
+            named.is_empty(),
             "Postgres should have no prepared statements despite many named parses"
         );
     }

--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -662,9 +662,9 @@ impl Server {
                 let cmd = CommandComplete::from_bytes(message.to_bytes())?;
                 match cmd.command() {
                     "PREPARE" | "DEALLOCATE" => self.sync_prepared = true,
-                    "DEALLOCATE ALL" => self.prepared_statements.clear(),
+                    "DEALLOCATE ALL" => self.clear_prepared_statements(),
                     "DISCARD ALL" => {
-                        self.prepared_statements.clear();
+                        self.clear_prepared_statements();
                         self.client_params.clear();
                     }
                     "RESET" => self.client_params.clear(), // Someone reset params, we're gonna need to re-sync.
@@ -1026,25 +1026,6 @@ impl Server {
         Ok(())
     }
 
-    /// Synchronize prepared statements from Postgres.
-    pub(super) async fn sync_prepared_statements(&mut self) -> Result<(), Error> {
-        let names = self
-            .fetch_all::<String>("SELECT name FROM pg_prepared_statements")
-            .await?;
-
-        for name in names {
-            self.prepared_statements.prepared(&name);
-        }
-
-        debug!("prepared statements synchronized [{}]", self.addr());
-
-        let count = self.prepared_statements.len();
-        self.stats.set_prepared_statements(count);
-        self.sync_prepared = false;
-
-        Ok(())
-    }
-
     /// Close any prepared statements that exceed cache capacity.
     pub(super) fn ensure_prepared_capacity(&mut self) -> Vec<Close> {
         let close = self.prepared_statements.ensure_capacity();
@@ -1101,7 +1082,14 @@ impl Server {
     #[inline]
     pub fn reset_schema_changed(&mut self) {
         self.schema_changed = false;
+        self.clear_prepared_statements();
+    }
+
+    /// Drop the prepared statements cache, and the stat that counts them.
+    #[inline]
+    fn clear_prepared_statements(&mut self) {
         self.prepared_statements.clear();
+        self.stats.clear_prepared_statements();
     }
 
     #[inline]
@@ -1240,6 +1228,7 @@ impl Server {
     #[inline]
     pub(super) fn cleaned(&mut self) {
         self.dirty = false;
+        self.sync_prepared = false;
         self.stats.cleaned();
     }
 
@@ -2342,7 +2331,7 @@ pub mod test {
             assert_eq!(msg.code(), c);
         }
         assert!(server.sync_prepared());
-        server.sync_prepared_statements().await.unwrap();
+        server.prepared_statements.prepared("__pgdog_1");
         assert!(server.prepared_statements.contains("__pgdog_1"));
 
         let describe = Describe::new_statement("__pgdog_1");
@@ -2948,6 +2937,34 @@ pub mod test {
     }
 
     #[tokio::test]
+    async fn test_reset_schema_changed_clears_cache() {
+        let mut server = test_server().await;
+
+        server
+            .send(
+                &vec![
+                    Query::new("PREPARE schema_stmt AS SELECT 1").into(),
+                    Sync.into(),
+                ]
+                .into(),
+            )
+            .await
+            .unwrap();
+        for c in ['C', 'Z'] {
+            let msg = server.read().await.unwrap();
+            assert_eq!(msg.code(), c);
+        }
+        server.prepared_statements.prepared("schema_stmt");
+        assert!(!server.prepared_statements.is_empty());
+
+        // A schema change invalidates everything we cached for this connection.
+        server.reset_schema_changed();
+
+        assert!(server.prepared_statements.is_empty());
+        assert_eq!(server.stats().total().prepared_statements, 0);
+    }
+
+    #[tokio::test]
     async fn test_discard_all_clears_cache() {
         let mut server = test_server().await;
 
@@ -3154,11 +3171,11 @@ pub mod test {
             "sync_prepared flag should be set after PREPARE command"
         );
 
-        server.sync_prepared_statements().await.unwrap();
+        server.cleaned();
 
         assert!(
             !server.sync_prepared(),
-            "sync_prepared flag should be cleared after sync_prepared_statements()"
+            "sync_prepared flag should be cleared once the connection is cleaned"
         );
 
         server.execute("SELECT 1").await.unwrap();
@@ -4095,10 +4112,12 @@ pub mod test {
                 "cache should be cleared after RFQ in extended_anonymous mode"
             );
             // Verify Postgres has no named prepared statements stored.
-            server.sync_prepared_statements().await.unwrap();
-            assert_eq!(
-                server.prepared_statements.len(),
-                0,
+            let named: Vec<String> = server
+                .fetch_all("SELECT name FROM pg_prepared_statements")
+                .await
+                .unwrap();
+            assert!(
+                named.is_empty(),
                 "Postgres should have no prepared statements in extended_anonymous mode"
             );
         }
@@ -4136,8 +4155,11 @@ pub mod test {
         assert!(server.done());
         assert_eq!(server.prepared_statements.len(), 0);
         // Verify Postgres has no named prepared statements stored.
-        server.sync_prepared_statements().await.unwrap();
-        assert_eq!(server.prepared_statements.len(), 0);
+        let named: Vec<String> = server
+            .fetch_all("SELECT name FROM pg_prepared_statements")
+            .await
+            .unwrap();
+        assert!(named.is_empty());
     }
 
     #[tokio::test]
@@ -4187,10 +4209,12 @@ pub mod test {
             assert!(server.done());
         }
         // Verify Postgres has no named prepared statements stored.
-        server.sync_prepared_statements().await.unwrap();
-        assert_eq!(
-            server.prepared_statements.len(),
-            0,
+        let named: Vec<String> = server
+            .fetch_all("SELECT name FROM pg_prepared_statements")
+            .await
+            .unwrap();
+        assert!(
+            named.is_empty(),
             "Postgres should have no prepared statements after repeated anonymous usage"
         );
     }
@@ -4224,8 +4248,11 @@ pub mod test {
 
         assert!(server.done());
         // Verify Postgres has no named prepared statements stored.
-        server.sync_prepared_statements().await.unwrap();
-        assert_eq!(server.prepared_statements.len(), 0);
+        let named: Vec<String> = server
+            .fetch_all("SELECT name FROM pg_prepared_statements")
+            .await
+            .unwrap();
+        assert!(named.is_empty());
     }
 
     #[tokio::test]
@@ -4258,8 +4285,11 @@ pub mod test {
         // Server should still be usable.
         verify_server_usable(&mut server).await;
         // Verify Postgres has no named prepared statements stored.
-        server.sync_prepared_statements().await.unwrap();
-        assert_eq!(server.prepared_statements.len(), 0);
+        let named: Vec<String> = server
+            .fetch_all("SELECT name FROM pg_prepared_statements")
+            .await
+            .unwrap();
+        assert!(named.is_empty());
     }
 
     #[tokio::test]
@@ -4309,8 +4339,11 @@ pub mod test {
 
         assert!(server.done());
         // Verify Postgres has no named prepared statements stored.
-        server.sync_prepared_statements().await.unwrap();
-        assert_eq!(server.prepared_statements.len(), 0);
+        let named: Vec<String> = server
+            .fetch_all("SELECT name FROM pg_prepared_statements")
+            .await
+            .unwrap();
+        assert!(named.is_empty());
     }
 
     #[tokio::test]
@@ -4359,10 +4392,12 @@ pub mod test {
             assert!(server.prepared_statements.ensure_capacity().is_empty());
         }
         // Verify Postgres has no named prepared statements stored.
-        server.sync_prepared_statements().await.unwrap();
-        assert_eq!(
-            server.prepared_statements.len(),
-            0,
+        let named: Vec<String> = server
+            .fetch_all("SELECT name FROM pg_prepared_statements")
+            .await
+            .unwrap();
+        assert!(
+            named.is_empty(),
             "Postgres should have no prepared statements despite many named parses"
         );
     }

--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -2941,20 +2941,11 @@ pub mod test {
         let mut server = test_server().await;
 
         server
-            .send(
-                &vec![
-                    Query::new("PREPARE schema_stmt AS SELECT 1").into(),
-                    Sync.into(),
-                ]
-                .into(),
-            )
+            .send(&vec![Parse::named("__pgdog_1", "SELECT 1").into(), Flush.into()].into())
             .await
             .unwrap();
-        for c in ['C', 'Z'] {
-            let msg = server.read().await.unwrap();
-            assert_eq!(msg.code(), c);
-        }
-        server.prepared_statements.prepared("schema_stmt");
+        let msg = server.read().await.unwrap();
+        assert_eq!(msg.code(), '1');
         assert!(!server.prepared_statements.is_empty());
 
         // A schema change invalidates everything we cached for this connection.

--- a/pgdog/src/backend/stats.rs
+++ b/pgdog/src/backend/stats.rs
@@ -170,7 +170,6 @@ impl Stats {
         self.local.last_checkout.prepared_statements += 1;
     }
 
-    /// Prepared statements are gone from the server, so the cache is empty.
     pub fn clear_prepared_statements(&mut self) {
         self.local.total.prepared_statements = 0;
         self.sync_to_shared();

--- a/pgdog/src/backend/stats.rs
+++ b/pgdog/src/backend/stats.rs
@@ -170,11 +170,9 @@ impl Stats {
         self.local.last_checkout.prepared_statements += 1;
     }
 
-    /// Overwrite how many prepared statements we have in the cache for stats.
-    pub fn set_prepared_statements(&mut self, size: usize) {
-        self.local.total.prepared_statements = size;
-        self.local.total.prepared_sync += 1;
-        self.local.last_checkout.prepared_sync += 1;
+    /// Prepared statements are gone from the server, so the cache is empty.
+    pub fn clear_prepared_statements(&mut self) {
+        self.local.total.prepared_statements = 0;
         self.sync_to_shared();
     }
 


### PR DESCRIPTION
## Problem

`pg_dump` prepares a statement with SQL (`PREPARE dumpFunc(pg_catalog.oid) AS ...`). In transaction pooling the server connection goes back into the pool at the end of the transaction and takes that statement with it, so the next dump that lands on the same connection fails:

```
pg_dump: error: query failed: ERROR:  prepared statement "dumpfunc" already exists
```

The first dump usually works — it gets a connection nobody has dumped on yet — which is what makes this look intermittent. With a single-connection pool it fails on the second dump, every time.

Reproduction:

```bash
pg_dump -h <pgdog> -p 6432 -U pgdog -d pgdog > /dev/null   # ok
pg_dump -h <pgdog> -p 6432 -U pgdog -d pgdog > /dev/null   # ERROR: prepared statement "dumpfunc" already exists
```

## Fix

Run `DEALLOCATE ALL` at checkin when the client prepared statements with SQL — the connection already tracks that in `sync_prepared`. Session-mode clients are unaffected: they keep the connection and already get `DISCARD ALL` when they leave.

Cleanup queries are now composed rather than picked from mutually exclusive branches: a connection can need both a parameter reset and a deallocate (`RESET x; PREPARE y ...` in one checkout), and the old `else if` chain silently dropped the second one.

Two follow-ons from that:

- With the statements dropped, re-reading `pg_prepared_statements` at checkin only ever returned an empty set, so that round trip and the method behind it are gone; the flag it cleared is cleared by the cleanup itself.
- Clearing the cache now also zeroes the prepared-statement stat, which previously only happened on that removed sync path.

Not touched here: `prepared_sync` in `pgdog-stats` is no longer incremented by anything. Removing it reaches into public structs of that crate, so it seemed better left to a separate change.

## Testing

- `integration/python/test_pg_dump.py`: three dumps in a row must all succeed, and a statement prepared on a connection that also needs a parameter reset must not outlive its client's checkin. Runs against a database with a single server connection, so the reuse is deterministic. Verified to fail on `main` (8 runs out of 8) and pass with this branch.
- Unit test updated to the new contract: a client's SQL-prepared statement is deallocated at checkin, and the next client can reuse the same name — which is exactly what `pg_dump` does.
- Verified on a live cluster: repeated full dumps and `pg_dump -t <table>` both clean, no `prepared statement already exists` in application logs afterwards.

Related: #1298 and #1299 fix the other two ways session state survived checkin (an untracked `set_config`, and a `RESET` revived by rollback). Same class of bug, independent code paths.
