### PR TITLE
Wait for shutdown instead of assuming it took under a second

### DIFF
--- a/integration/complex/shutdown.sh
+++ b/integration/complex/shutdown.sh
@@ -3,6 +3,21 @@ set -e
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source ${SCRIPT_DIR}/../common.sh
 
+# Draining the pools takes as long as it takes, and a busy runner needs more
+# than the moment we'd like it to be. Poll instead of guessing.
+function wait_for_shutdown() {
+    local waited=0
+    while pgrep -x pgdog > /dev/null && [ ${waited} -lt 100 ]; do
+        sleep 0.1
+        waited=$((waited + 1))
+    done
+
+    if pgrep -x pgdog > /dev/null; then
+        echo "Shutdown failed"
+        exit 1
+    fi
+}
+
 run_pgdog
 wait_for_pgdog
 
@@ -12,12 +27,7 @@ pushd ${SCRIPT_DIR}
 python shutdown.py pgdog
 popd
 
-sleep 1
-
-if pgrep pgdog; then
-    echo "Shutdown failed"
-    exit 1
-fi
+wait_for_shutdown
 
 run_pgdog
 wait_for_pgdog
@@ -26,11 +36,6 @@ pushd ${SCRIPT_DIR}
 python shutdown.py pgdog_sharded
 popd
 
-sleep 1
-
-if pgrep pgdog; then
-    echo "Shutdown failed"
-    exit 1
-fi
+wait_for_shutdown
 
 stop_pgdog


### PR DESCRIPTION
## Problem

`integration/complex/shutdown.sh` sleeps for one second after asking PgDog to shut down, then fails the job if the process is still around. Draining the pools takes as long as it takes, and on a busy runner that is sometimes longer than a second, so the job fails with nothing actually wrong.

From a recent run — every server connection is closed, the check fires one second later, and the process exits right after:

```
07:29:18.48  closing server connection: state=idle, reason=pool offline  (last one)
07:29:19.49  6749
07:29:19.49  Shutdown failed
07:29:19.49  🐕 PgDog is shutting down immediately [SIGTERM]
```

It has failed this way on `main` as well (`e37160da`), and it flips between runs of the same commit.

## Fix

Poll for up to ten seconds instead of guessing. A pooler that genuinely doesn't shut down still fails the test — it just no longer depends on how loaded the runner is.

Verified against a process that exits immediately (returns at once), one that exits after 2.5s (previously a failure, now passes), and one that never exits (still fails, after ~10s).
