### PR TITLE
Stop testing implementation detail of exact transaction count

### DIFF
--- a/integration/go/go_pgx/pg_tests_test.go
+++ b/integration/go/go_pgx/pg_tests_test.go
@@ -19,9 +19,9 @@ func assertShowField(t *testing.T, query string, field string, value int64, user
 	assert.Equal(t, value, actualValue, fmt.Sprintf("\"%s\" in %s is not %d", field, query, value))
 }
 
-func assertShowFieldGt(t *testing.T, query string, field string, value int64, user string, database string, shard int64, role string) {
+func assertShowFieldGe(t *testing.T, query string, field string, value int64, user string, database string, shard int64, role string) {
 	actualValue := showField(t, query, field, user, database, shard, role)
-	assert.Greater(t, value, actualValue, fmt.Sprintf("\"%s\" in %s is not greater than %d", field, query, value))
+	assert.GreaterOrEqual(t, value, actualValue, fmt.Sprintf("\"%s\" in %s is not greater than %d", field, query, value))
 }
 
 func showField(t *testing.T, query string, field string, user string, database string, shard int64, role string) int64 {

--- a/integration/go/go_pgx/pg_tests_test.go
+++ b/integration/go/go_pgx/pg_tests_test.go
@@ -19,9 +19,9 @@ func assertShowField(t *testing.T, query string, field string, value int64, user
 	assert.Equal(t, value, actualValue, fmt.Sprintf("\"%s\" in %s is not %d", field, query, value))
 }
 
-func assertShowFieldOneOf(t *testing.T, query string, field string, values []int64, user string, database string, shard int64, role string) {
+func assertShowFieldGt(t *testing.T, query string, field string, value int64, user string, database string, shard int64, role string) {
 	actualValue := showField(t, query, field, user, database, shard, role)
-	assert.Contains(t, values, actualValue, fmt.Sprintf("\"%s\" in %s is not one of %v", field, query, values))
+	assert.Greater(t, value, actualValue, fmt.Sprintf("\"%s\" in %s is not greater than %d", field, query, value))
 }
 
 func showField(t *testing.T, query string, field string, user string, database string, shard int64, role string) int64 {

--- a/integration/go/go_pgx/pg_tests_test.go
+++ b/integration/go/go_pgx/pg_tests_test.go
@@ -19,9 +19,9 @@ func assertShowField(t *testing.T, query string, field string, value int64, user
 	assert.Equal(t, value, actualValue, fmt.Sprintf("\"%s\" in %s is not %d", field, query, value))
 }
 
-func assertShowFieldGe(t *testing.T, query string, field string, value int64, user string, database string, shard int64, role string) {
+func assertShowFieldGe(t *testing.T, query string, field string, min int64, user string, database string, shard int64, role string) {
 	actualValue := showField(t, query, field, user, database, shard, role)
-	assert.GreaterOrEqual(t, value, actualValue, fmt.Sprintf("\"%s\" in %s is not greater than %d", field, query, value))
+	assert.GreaterOrEqual(t, actualValue, min, fmt.Sprintf("\"%s\" in %s is not greater than %d", field, query, min))
 }
 
 func showField(t *testing.T, query string, field string, user string, database string, shard int64, role string) int64 {

--- a/integration/go/go_pgx/sharded_test.go
+++ b/integration/go/go_pgx/sharded_test.go
@@ -232,11 +232,8 @@ func TestShardedTwoPc(t *testing.T) {
 
 	assertShowField(t, "SHOW STATS", "total_xact_2pc_count", 200, "pgdog_2pc", "pgdog_sharded", 0, "primary")
 	assertShowField(t, "SHOW STATS", "total_xact_2pc_count", 200, "pgdog_2pc", "pgdog_sharded", 1, "primary")
-	// The schema cache is shared across users. If pgdog_2pc wins the cache-fill
-	// race after RELOAD, the five schema queries are counted in its pool stats.
-	expectedXactCounts := []int64{401, 406}
-	assertShowFieldOneOf(t, "SHOW STATS", "total_xact_count", expectedXactCounts, "pgdog_2pc", "pgdog_sharded", 0, "primary")
-	assertShowFieldOneOf(t, "SHOW STATS", "total_xact_count", expectedXactCounts, "pgdog_2pc", "pgdog_sharded", 1, "primary")
+	assertShowFieldGt(t, "SHOW STATS", "total_xact_count", 400, "pgdog_2pc", "pgdog_sharded", 0, "primary")
+	assertShowFieldGt(t, "SHOW STATS", "total_xact_count", 400, "pgdog_2pc", "pgdog_sharded", 1, "primary")
 
 	for i := range 200 {
 		rows, err := conn.Query(

--- a/integration/go/go_pgx/sharded_test.go
+++ b/integration/go/go_pgx/sharded_test.go
@@ -232,8 +232,8 @@ func TestShardedTwoPc(t *testing.T) {
 
 	assertShowField(t, "SHOW STATS", "total_xact_2pc_count", 200, "pgdog_2pc", "pgdog_sharded", 0, "primary")
 	assertShowField(t, "SHOW STATS", "total_xact_2pc_count", 200, "pgdog_2pc", "pgdog_sharded", 1, "primary")
-	assertShowFieldGt(t, "SHOW STATS", "total_xact_count", 400, "pgdog_2pc", "pgdog_sharded", 0, "primary")
-	assertShowFieldGt(t, "SHOW STATS", "total_xact_count", 400, "pgdog_2pc", "pgdog_sharded", 1, "primary")
+	assertShowFieldGe(t, "SHOW STATS", "total_xact_count", 400, "pgdog_2pc", "pgdog_sharded", 0, "primary")
+	assertShowFieldGe(t, "SHOW STATS", "total_xact_count", 400, "pgdog_2pc", "pgdog_sharded", 1, "primary")
 
 	for i := range 200 {
 		rows, err := conn.Query(


### PR DESCRIPTION
This test is purely trying to test that 2pc works. If the data was inserted correctly, appears where we expect it to be, and the 2pc stats are correct, we don't need to concern ourselves with exactly how many health checks and/or schema queries ran during that time.