### PR TITLE
Don't require RELOAD to keep exactly the same connection count

### DIFF
--- a/integration/rust/tests/integration/reload.rs
+++ b/integration/rust/tests/integration/reload.rs
@@ -60,9 +60,9 @@ async fn test_reload_connection_count_stable() {
         .unwrap()
         .get(0);
 
-    assert_eq!(
-        before, after,
-        "connection count changed after RELOAD: before={before}, after={after}"
+    assert!(
+        after as f64 / before as f64 <= 1.1,
+        "connection count changed by more than 10% after RELOAD: before={before}, after={after}"
     );
 
     direct.close().await;


### PR DESCRIPTION
The goal of this test to ensure that the existing connections are reused when `RELOAD` is issued. However, the exact number of connections needed to perform schema loading might differ slightly each time depending on the exact timing of when the queries complete. It's fine if the connection count increases slightly, we mostly want to make sure it doesn't double. 10% should give us enough wiggle room for this test to test what it's trying to test without breaking as implementation details change