### PR TITLE
Enforce prepared statements cache limits at runtime, add memory limit

### DIFF
--- a/.schema/pgdog.schema.json
+++ b/.schema/pgdog.schema.json
@@ -83,6 +83,7 @@
         "port": 6432,
         "prepared_statements": "extended",
         "prepared_statements_limit": 9223372036854775807,
+        "prepared_statements_memory_limit": 0,
         "pub_sub_channel_size": 0,
         "query_cache_limit": 1000,
         "query_log": null,
@@ -972,6 +973,13 @@
           "type": "integer",
           "format": "uint",
           "default": 9223372036854775807,
+          "minimum": 0
+        },
+        "prepared_statements_memory_limit": {
+          "description": "Approximate memory limit (bytes) for the global prepared statements cache. Statements no client is holding are evicted once the cache grows past it. `0` disables the limit.\n\n_Default:_ `0`\n\n<https://docs.pgdog.dev/configuration/pgdog.toml/general/#prepared_statements_memory_limit>",
+          "type": "integer",
+          "format": "uint",
+          "default": 0,
           "minimum": 0
         },
         "pub_sub_channel_size": {

--- a/.schema/pgdog.schema.json
+++ b/.schema/pgdog.schema.json
@@ -976,7 +976,7 @@
           "minimum": 0
         },
         "prepared_statements_memory_limit": {
-          "description": "Approximate memory limit (bytes) for the global prepared statements cache. Statements no client is holding are evicted once the cache grows past it. `0` disables the limit.\n\n_Default:_ `0`\n\n<https://docs.pgdog.dev/configuration/pgdog.toml/general/#prepared_statements_memory_limit>",
+          "description": "Approximate memory limit (bytes) for the global prepared statements cache. Statements no client is holding are evicted once the cache grows past it. `0` disables the limit.\n\n**Note:** A limit smaller than the working set causes constant eviction and re-preparation of statements; size it well above what the active workload keeps in flight.\n\n_Default:_ `0`\n\n<https://docs.pgdog.dev/configuration/pgdog.toml/general/#prepared_statements_memory_limit>",
           "type": "integer",
           "format": "uint",
           "default": 0,

--- a/pgdog-config/src/general.rs
+++ b/pgdog-config/src/general.rs
@@ -384,6 +384,8 @@ pub struct General {
 
     /// Approximate memory limit (bytes) for the global prepared statements cache. Statements no client is holding are evicted once the cache grows past it. `0` disables the limit.
     ///
+    /// **Note:** A limit smaller than the working set causes constant eviction and re-preparation of statements; size it well above what the active workload keeps in flight.
+    ///
     /// _Default:_ `0`
     ///
     /// <https://docs.pgdog.dev/configuration/pgdog.toml/general/#prepared_statements_memory_limit>

--- a/pgdog-config/src/general.rs
+++ b/pgdog-config/src/general.rs
@@ -382,6 +382,14 @@ pub struct General {
     #[serde(default = "General::prepared_statements_limit")]
     pub prepared_statements_limit: usize,
 
+    /// Approximate memory limit (bytes) for the global prepared statements cache. Statements no client is holding are evicted once the cache grows past it. `0` disables the limit.
+    ///
+    /// _Default:_ `0`
+    ///
+    /// <https://docs.pgdog.dev/configuration/pgdog.toml/general/#prepared_statements_memory_limit>
+    #[serde(default = "General::prepared_statements_memory_limit")]
+    pub prepared_statements_memory_limit: usize,
+
     /// Limit on the number of statements saved in the statement cache used to accelerate query parsing.
     ///
     /// _Default:_ `50000`
@@ -887,6 +895,7 @@ impl Default for General {
             regex_parser_limit: Self::regex_parser_limit(),
             query_parser_engine: QueryParserEngine::default(),
             prepared_statements_limit: Self::prepared_statements_limit(),
+            prepared_statements_memory_limit: Self::prepared_statements_memory_limit(),
             query_cache_limit: Self::query_cache_limit(),
             passthrough_auth: Self::default_passthrough_auth(),
             connect_timeout: Self::default_connect_timeout(),
@@ -1381,6 +1390,10 @@ impl General {
         Self::env_or_default("PGDOG_PREPARED_STATEMENTS_LIMIT", i64::MAX as usize)
     }
 
+    pub fn prepared_statements_memory_limit() -> usize {
+        Self::env_or_default("PGDOG_PREPARED_STATEMENTS_MEMORY_LIMIT", 0)
+    }
+
     pub fn query_cache_limit() -> usize {
         Self::env_or_default("PGDOG_QUERY_CACHE_LIMIT", 1_000)
     }
@@ -1826,12 +1839,14 @@ mod tests {
         let _guard = set_env_var("PGDOG_MIRROR_EXPOSURE", "0.5");
         let _guard = set_env_var("PGDOG_DNS_TTL", "60000");
         let _guard = set_env_var("PGDOG_PUB_SUB_CHANNEL_SIZE", "100");
+        let _guard = set_env_var("PGDOG_PREPARED_STATEMENTS_MEMORY_LIMIT", "4294967296");
         let _guard = set_env_var("PGDOG_LOG_MIN_DURATION_PARSE", "5");
         let _guard = set_env_var("PGDOG_LOG_QUERY_SAMPLE_LENGTH", "200");
 
         assert_eq!(General::broadcast_port(), 7432);
         assert_eq!(General::openmetrics_port(), Some(9090));
         assert_eq!(General::prepared_statements_limit(), 1000);
+        assert_eq!(General::prepared_statements_memory_limit(), 4294967296);
         assert_eq!(General::query_cache_limit(), 500);
         assert_eq!(General::connect_attempts(), 3);
         assert_eq!(General::mirror_queue(), 256);
@@ -1844,6 +1859,7 @@ mod tests {
         let _guard = remove_env_var("PGDOG_BROADCAST_PORT");
         let _guard = remove_env_var("PGDOG_OPENMETRICS_PORT");
         let _guard = remove_env_var("PGDOG_PREPARED_STATEMENTS_LIMIT");
+        let _guard = remove_env_var("PGDOG_PREPARED_STATEMENTS_MEMORY_LIMIT");
         let _guard = remove_env_var("PGDOG_QUERY_CACHE_LIMIT");
         let _guard = remove_env_var("PGDOG_CONNECT_ATTEMPTS");
         let _guard = remove_env_var("PGDOG_MIRROR_QUEUE");
@@ -1856,6 +1872,7 @@ mod tests {
         assert_eq!(General::broadcast_port(), General::port() + 1);
         assert_eq!(General::openmetrics_port(), None);
         assert_eq!(General::prepared_statements_limit(), i64::MAX as usize);
+        assert_eq!(General::prepared_statements_memory_limit(), 0);
         assert_eq!(General::query_cache_limit(), 1_000);
         assert_eq!(General::connect_attempts(), 1);
         assert_eq!(General::mirror_queue(), 128);

--- a/pgdog/src/admin/parser.rs
+++ b/pgdog/src/admin/parser.rs
@@ -256,6 +256,14 @@ mod tests {
     }
 
     #[test]
+    fn parses_reset_prepared_command() {
+        // The exact string the prepared_statements_limit=0 warning advises:
+        // if this stops parsing, the advice is broken.
+        let result = Parser::parse(super::super::reset_prepared::RESET_PREPARED);
+        assert!(matches!(result, Ok(ParseResult::ResetPrepared(_))));
+    }
+
+    #[test]
     fn rejects_unknown_admin_command() {
         let result = Parser::parse("FOO BAR");
         assert!(matches!(result, Err(Error::Syntax)));

--- a/pgdog/src/admin/reset_prepared.rs
+++ b/pgdog/src/admin/reset_prepared.rs
@@ -1,5 +1,4 @@
 //! RESET PREPARED.
-use crate::config::config;
 use crate::frontend::prepared_statements::PreparedStatements;
 
 use super::prelude::*;
@@ -17,10 +16,10 @@ impl Command for ResetPrepared {
     }
 
     async fn execute(&self) -> Result<Vec<Message>, Error> {
-        let config = config();
-        PreparedStatements::global()
-            .write()
-            .close_unused(config.config.general.prepared_statements_limit);
+        // Explicit 0: drop everything not in use, whatever the configured
+        // limit is. With the default (unlimited) limit this would otherwise
+        // be a no-op.
+        PreparedStatements::global().write().close_unused(0);
         Ok(vec![])
     }
 }

--- a/pgdog/src/admin/reset_prepared.rs
+++ b/pgdog/src/admin/reset_prepared.rs
@@ -3,12 +3,16 @@ use crate::frontend::prepared_statements::PreparedStatements;
 
 use super::prelude::*;
 
+/// The admin console spelling of this command. The limit-0 warning quotes
+/// it, and a parser test keeps the advice parseable.
+pub(super) const RESET_PREPARED: &str = "RESET PREPARED";
+
 pub struct ResetPrepared;
 
 #[async_trait]
 impl Command for ResetPrepared {
     fn name(&self) -> String {
-        "RESET PREPARED".into()
+        RESET_PREPARED.into()
     }
 
     fn parse(_: &str) -> Result<Self, Error> {

--- a/pgdog/src/admin/set.rs
+++ b/pgdog/src/admin/set.rs
@@ -120,7 +120,7 @@ impl Command for Set {
                 if config.config.general.prepared_statements_limit == 0 {
                     tracing::warn!(
                         "prepared_statements_limit set to 0, which now means unlimited; \
-                        to clear the cache, use RESET prepared_statements"
+                        to clear the cache, use RESET PREPARED"
                     );
                 }
                 PreparedStatements::global().write().configure(

--- a/pgdog/src/admin/set.rs
+++ b/pgdog/src/admin/set.rs
@@ -120,7 +120,8 @@ impl Command for Set {
                 if config.config.general.prepared_statements_limit == 0 {
                     tracing::warn!(
                         "prepared_statements_limit set to 0, which now means unlimited; \
-                        to clear the cache, use RESET PREPARED"
+                        to clear the cache, use {}",
+                        super::reset_prepared::RESET_PREPARED,
                     );
                 }
                 PreparedStatements::global().write().configure(

--- a/pgdog/src/admin/set.rs
+++ b/pgdog/src/admin/set.rs
@@ -117,9 +117,18 @@ impl Command for Set {
 
             "prepared_statements_limit" => {
                 config.config.general.prepared_statements_limit = self.value.parse()?;
-                PreparedStatements::global()
-                    .write()
-                    .close_unused(config.config.general.prepared_statements_limit);
+                PreparedStatements::global().write().configure(
+                    config.config.general.prepared_statements_limit,
+                    config.config.general.prepared_statements_memory_limit,
+                );
+            }
+
+            "prepared_statements_memory_limit" => {
+                config.config.general.prepared_statements_memory_limit = self.value.parse()?;
+                PreparedStatements::global().write().configure(
+                    config.config.general.prepared_statements_limit,
+                    config.config.general.prepared_statements_memory_limit,
+                );
             }
 
             "prepared_statements" => {

--- a/pgdog/src/admin/set.rs
+++ b/pgdog/src/admin/set.rs
@@ -117,6 +117,12 @@ impl Command for Set {
 
             "prepared_statements_limit" => {
                 config.config.general.prepared_statements_limit = self.value.parse()?;
+                if config.config.general.prepared_statements_limit == 0 {
+                    tracing::warn!(
+                        "prepared_statements_limit set to 0, which now means unlimited; \
+                        to clear the cache, use RESET prepared_statements"
+                    );
+                }
                 PreparedStatements::global().write().configure(
                     config.config.general.prepared_statements_limit,
                     config.config.general.prepared_statements_memory_limit,

--- a/pgdog/src/backend/databases.rs
+++ b/pgdog/src/backend/databases.rs
@@ -107,6 +107,12 @@ pub fn init() -> Result<(), Error> {
     // Resize query cache
     Cache::resize(config.config.general.query_cache_limit);
 
+    // Apply prepared statements cache limits.
+    PreparedStatements::global().write().configure(
+        config.config.general.prepared_statements_limit,
+        config.config.general.prepared_statements_memory_limit,
+    );
+
     // Start two-pc manager.
     let _monitor = Manager::get();
 
@@ -147,10 +153,12 @@ pub fn reload() -> Result<(), Error> {
     // Reload TLS connectors.
     tls::reload()?;
 
-    // Remove any unused prepared statements.
-    PreparedStatements::global()
-        .write()
-        .close_unused(new_config.config.general.prepared_statements_limit);
+    // Apply prepared statements cache limits, dropping anything
+    // unused over the new caps.
+    PreparedStatements::global().write().configure(
+        new_config.config.general.prepared_statements_limit,
+        new_config.config.general.prepared_statements_memory_limit,
+    );
 
     // Resize query cache.
     Cache::resize(new_config.config.general.query_cache_limit);

--- a/pgdog/src/frontend/prepared_statements/global_cache.rs
+++ b/pgdog/src/frontend/prepared_statements/global_cache.rs
@@ -32,6 +32,7 @@ impl MemoryUsage for Statement {
     #[inline]
     fn memory_usage(&self) -> usize {
         self.parse.len()
+            + self.rewrite.as_ref().map(|parse| parse.len()).unwrap_or(0)
             + if let Some(ref row_description) = self.row_description {
                 row_description.memory_usage()
             } else {
@@ -133,10 +134,11 @@ pub struct GlobalCache {
 }
 
 impl MemoryUsage for GlobalCache {
+    /// The same number the memory limit is enforced against, so the metric
+    /// and the budget can't drift apart, plus the bookkeeping fields.
     #[inline]
     fn memory_usage(&self) -> usize {
-        self.statements.memory_usage()
-            + self.names.memory_usage()
+        self.bytes
             + self.counter.memory_usage()
             + self.versions.memory_usage()
             + self.unused.len() * std::mem::size_of::<usize>()
@@ -185,10 +187,9 @@ impl GlobalCache {
     /// break the client using it.
     fn enforce(&mut self) {
         while self.over_budget() {
-            let Some(&counter) = self.unused.iter().next() else {
+            let Some(counter) = self.unused.pop_first() else {
                 break;
             };
-            self.unused.remove(&counter);
             self.remove(&global_name(counter));
         }
     }
@@ -278,7 +279,12 @@ impl GlobalCache {
     /// Rewrite prepared statement in the global cache.
     pub fn rewrite(&mut self, parse: &Parse) {
         if let Some(stmt) = self.names.get_mut(parse.name()) {
+            if let Some(old) = stmt.rewrite.take() {
+                self.bytes = self.bytes.saturating_sub(old.len());
+            }
+            self.bytes += parse.len();
             stmt.rewrite = Some(parse.clone());
+            self.enforce();
         }
     }
 
@@ -290,6 +296,7 @@ impl GlobalCache {
         {
             self.bytes += row_description.memory_usage();
             entry.row_description = Some(row_description);
+            self.enforce();
         }
     }
 
@@ -375,14 +382,11 @@ impl GlobalCache {
         }
     }
 
-    /// Close all unused statements exceeding capacity.
+    /// Close unused statements until the cache is down to `capacity` entries,
+    /// or nothing unused is left. `0` removes every statement not in use;
+    /// statements clients hold, and the name counter, are never touched, so
+    /// global names are not reused.
     pub fn close_unused(&mut self, capacity: usize) -> usize {
-        if capacity == 0 {
-            let removed = self.len();
-            self.reset();
-            return removed;
-        }
-
         let over = self.len().saturating_sub(capacity);
         let remove = self.unused.iter().take(over).copied().collect::<Vec<_>>();
 
@@ -396,10 +400,13 @@ impl GlobalCache {
 
     /// Remove statement from global cache.
     fn remove(&mut self, name: &str) {
-        if let Some(stmt) = self.names.remove(name)
-            && let Some(cached) = self.statements.remove(&stmt.cache_key())
-        {
-            self.entry_removed(name, &stmt, &cached);
+        if let Some(stmt) = self.names.remove(name) {
+            let cached = self.statements.remove(&stmt.cache_key());
+            debug_assert!(cached.is_some(), "names and statements maps out of sync");
+            if let Some(cached) = cached {
+                self.unused.remove(&cached.counter);
+                self.entry_removed(name, &stmt, &cached);
+            }
         }
     }
 
@@ -585,6 +592,24 @@ mod test {
     }
 
     #[test]
+    fn test_close_unused_zero_keeps_in_use_and_counter() {
+        let mut cache = GlobalCache::default();
+
+        let (_, held) = cache.insert(&Parse::named("s", "SELECT 'held'"));
+        let (_, released) = cache.insert(&Parse::named("s", "SELECT 'released'"));
+        cache.close(&released);
+
+        assert_eq!(cache.close_unused(0), 1);
+        assert!(cache.parse(&held).is_some(), "statements in use survive");
+        assert!(cache.parse(&released).is_none());
+
+        // The counter moves on: global names are never reused, so server
+        // connections holding old names can't be handed a different query.
+        let (_, next) = cache.insert(&Parse::named("s", "SELECT 'next'"));
+        assert_eq!(next, "__pgdog_3");
+    }
+
+    #[test]
     fn test_memory_accounting_survives_mixed_operations() {
         let mut cache = GlobalCache::default();
         cache.configure(0, 0);
@@ -597,6 +622,9 @@ mod test {
 
         // A RowDescription recorded later grows the entry.
         cache.insert_row_description(&names[0], RowDescription::new(&[Field::text("x")]));
+        // So does a rewritten Parse, twice to cover the replacement path.
+        cache.rewrite(&Parse::named(&names[1], "SELECT 1, 2"));
+        cache.rewrite(&Parse::named(&names[1], "SELECT 1, 2, 3"));
         // Duplicate insert of an existing statement adds nothing.
         cache.insert(&Parse::named("s", "SELECT 00"));
         // insert_anyway always creates a fresh entry.

--- a/pgdog/src/frontend/prepared_statements/global_cache.rs
+++ b/pgdog/src/frontend/prepared_statements/global_cache.rs
@@ -554,6 +554,28 @@ mod test {
     }
 
     #[test]
+    fn test_decrement_releases_for_eviction() {
+        let mut cache = GlobalCache::default();
+        cache.configure(1, 0);
+
+        let (_, first) = cache.insert(&Parse::named("s", "SELECT 1"));
+        let (_, second) = cache.insert(&Parse::named("s", "SELECT 2"));
+        assert_eq!(
+            cache.len(),
+            2,
+            "both in use: over capacity, nothing to evict"
+        );
+
+        // decrement() is the other way a statement gets released.
+        cache.decrement(&first);
+        assert_eq!(cache.len(), 1);
+        assert!(
+            cache.parse(&second).is_some(),
+            "the statement still in use survives"
+        );
+    }
+
+    #[test]
     fn test_memory_accounting_survives_mixed_operations() {
         let mut cache = GlobalCache::default();
         cache.configure(0, 0);

--- a/pgdog/src/frontend/prepared_statements/global_cache.rs
+++ b/pgdog/src/frontend/prepared_statements/global_cache.rs
@@ -8,6 +8,8 @@ use std::{collections::hash_map::HashMap, str::from_utf8};
 
 use fnv::FnvHashSet as HashSet;
 
+use super::str_mem;
+
 // Format the globally unique prepared statement
 // name based on the counter.
 fn global_name(counter: usize) -> String {
@@ -115,6 +117,16 @@ pub struct GlobalCache {
     unused: HashSet<usize>,
     counter: usize,
     versions: usize,
+    /// Maximum number of cached statements (0 = unlimited). Only statements
+    /// no client holds can be evicted, so the cache can exceed this while
+    /// they are all in use.
+    capacity: usize,
+    /// Approximate memory budget in bytes (0 = unlimited), enforced the same
+    /// way as `capacity`.
+    memory_limit: usize,
+    /// Incremental sum of what the live entries cost; kept in step with every
+    /// insert and remove so enforcement doesn't rescan the maps.
+    bytes: usize,
 }
 
 impl MemoryUsage for GlobalCache {
@@ -129,6 +141,55 @@ impl MemoryUsage for GlobalCache {
 }
 
 impl GlobalCache {
+    /// Apply cache limits from configuration, evicting anything over the new
+    /// caps. A `capacity` or `memory_limit` of 0 disables that limit.
+    pub fn configure(&mut self, capacity: usize, memory_limit: usize) {
+        self.capacity = capacity;
+        self.memory_limit = memory_limit;
+        self.enforce();
+    }
+
+    /// Approximate memory used by the cached statements.
+    pub fn memory_bytes(&self) -> usize {
+        self.bytes
+    }
+
+    /// What an entry adds to the byte total: both map entries, keyed by the
+    /// global name and the cache key. Kept symmetrical with `entry_removed`.
+    fn entry_inserted(&mut self, name: &str, statement: &Statement, cached: &CachedStmt) {
+        self.bytes += str_mem(name)
+            + statement.memory_usage()
+            + statement.cache_key.memory_usage()
+            + cached.memory_usage();
+    }
+
+    fn entry_removed(&mut self, name: &str, statement: &Statement, cached: &CachedStmt) {
+        self.bytes = self.bytes.saturating_sub(
+            str_mem(name)
+                + statement.memory_usage()
+                + statement.cache_key.memory_usage()
+                + cached.memory_usage(),
+        );
+    }
+
+    fn over_budget(&self) -> bool {
+        (self.capacity > 0 && self.statements.len() > self.capacity)
+            || (self.memory_limit > 0 && self.bytes > self.memory_limit)
+    }
+
+    /// Evict statements nobody holds until the cache fits its limits. If every
+    /// statement is in use the cache stays over budget: evicting one would
+    /// break the client using it.
+    fn enforce(&mut self) {
+        while self.over_budget() {
+            let Some(&counter) = self.unused.iter().next() else {
+                break;
+            };
+            self.unused.remove(&counter);
+            self.remove(&global_name(counter));
+        }
+    }
+
     /// Record a Parse message with the global cache and return a globally unique
     /// name PgDog is using for that statement.
     ///
@@ -158,22 +219,20 @@ impl GlobalCache {
                 version: 0,
             };
 
-            self.statements.insert(
-                cache_key.clone(),
-                CachedStmt {
-                    counter: self.counter,
-                    used: 1,
-                },
-            );
+            let cached = CachedStmt {
+                counter: self.counter,
+                used: 1,
+            };
+            let statement = Statement {
+                parse,
+                cache_key: cache_key.clone(),
+                ..Default::default()
+            };
 
-            self.names.insert(
-                name.clone(),
-                Statement {
-                    parse,
-                    cache_key,
-                    ..Default::default()
-                },
-            );
+            self.entry_inserted(&name, &statement, &cached);
+            self.statements.insert(cache_key, cached);
+            self.names.insert(name.clone(), statement);
+            self.enforce();
 
             (true, name)
         }
@@ -194,23 +253,21 @@ impl GlobalCache {
             version: self.versions,
         };
 
-        self.statements.insert(
-            key.clone(),
-            CachedStmt {
-                counter: self.counter,
-                used: 1,
-            },
-        );
+        let cached = CachedStmt {
+            counter: self.counter,
+            used: 1,
+        };
+        let statement = Statement {
+            parse,
+            version: self.versions,
+            cache_key: key.clone(),
+            ..Default::default()
+        };
 
-        self.names.insert(
-            name.clone(),
-            Statement {
-                parse,
-                version: self.versions,
-                cache_key: key,
-                ..Default::default()
-            },
-        );
+        self.entry_inserted(&name, &statement, &cached);
+        self.statements.insert(key, cached);
+        self.names.insert(name.clone(), statement);
+        self.enforce();
 
         name
     }
@@ -228,6 +285,7 @@ impl GlobalCache {
         if let Some(ref mut entry) = self.names.get_mut(name)
             && entry.row_description.is_none()
         {
+            self.bytes += row_description.memory_usage();
             entry.row_description = Some(row_description);
         }
     }
@@ -239,6 +297,7 @@ impl GlobalCache {
         self.unused.clear();
         self.counter = 0;
         self.versions = 0;
+        self.bytes = 0;
     }
 
     /// Get the query string stored in the global cache
@@ -305,6 +364,9 @@ impl GlobalCache {
                     self.remove(name);
                 } else if entry.used == 0 {
                     self.unused.insert(entry.counter);
+                    // The statement just became evictable; if the cache is
+                    // over budget, this is the moment it can shrink.
+                    self.enforce();
                 }
             }
         }
@@ -331,8 +393,10 @@ impl GlobalCache {
 
     /// Remove statement from global cache.
     fn remove(&mut self, name: &str) {
-        if let Some(stmt) = self.names.remove(name) {
-            self.statements.remove(&stmt.cache_key());
+        if let Some(stmt) = self.names.remove(name)
+            && let Some(cached) = self.statements.remove(&stmt.cache_key())
+        {
+            self.entry_removed(name, &stmt, &cached);
         }
     }
 
@@ -344,6 +408,7 @@ impl GlobalCache {
             stmt.used = stmt.used.saturating_sub(1);
             if stmt.used == 0 {
                 self.unused.insert(stmt.counter);
+                self.enforce();
             }
         }
     }
@@ -361,6 +426,166 @@ impl GlobalCache {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    use super::super::str_mem;
+    use crate::net::messages::Field;
+
+    /// The incremental byte counter must equal a from-scratch recount over the
+    /// live entries, no matter what sequence of operations got us here.
+    fn recount(cache: &GlobalCache) -> usize {
+        cache
+            .names()
+            .iter()
+            .map(|(name, stmt)| str_mem(name) + stmt.memory_usage())
+            .sum::<usize>()
+            + cache
+                .statements()
+                .iter()
+                .map(|(key, stmt)| key.memory_usage() + stmt.memory_usage())
+                .sum::<usize>()
+    }
+
+    #[test]
+    fn test_capacity_evicts_unused_on_insert() {
+        let mut cache = GlobalCache::default();
+        cache.configure(10, 0);
+
+        // Ten statements nobody uses anymore.
+        for i in 0..10 {
+            let (_, name) = cache.insert(&Parse::named("s", format!("SELECT {i:02}")));
+            cache.close(&name);
+        }
+        assert_eq!(cache.len(), 10);
+
+        // The next insert pushes an unused one out instead of growing the cache.
+        let (new, name) = cache.insert(&Parse::named("s", "SELECT 'over'"));
+        assert!(new);
+        assert_eq!(cache.len(), 10);
+        assert!(cache.parse(&name).is_some(), "the new statement is cached");
+    }
+
+    #[test]
+    fn test_capacity_never_evicts_statements_in_use() {
+        let mut cache = GlobalCache::default();
+        cache.configure(5, 0);
+
+        let mut names = vec![];
+        for i in 0..10 {
+            let (_, name) = cache.insert(&Parse::named("s", format!("SELECT {i:02}")));
+            names.push(name);
+        }
+
+        // All ten are still held by clients: over capacity, but evicting any
+        // of them would break the client using it.
+        assert_eq!(cache.len(), 10);
+
+        // As clients let go, the cache falls back to its capacity.
+        for name in &names {
+            cache.close(name);
+        }
+        assert_eq!(cache.len(), 5);
+    }
+
+    #[test]
+    fn test_memory_limit_evicts_unused() {
+        // Measure what one entry costs, then budget for about three.
+        let mut probe = GlobalCache::default();
+        let (_, name) = probe.insert(&Parse::named("s", "SELECT 00"));
+        probe.close(&name);
+        let per_entry = probe.memory_bytes();
+        assert!(per_entry > 0);
+
+        let budget = per_entry * 3 + per_entry / 2;
+        let mut cache = GlobalCache::default();
+        cache.configure(0, budget);
+
+        for i in 0..10 {
+            let (_, name) = cache.insert(&Parse::named("s", format!("SELECT {i:02}")));
+            cache.close(&name);
+        }
+
+        assert!(
+            cache.memory_bytes() <= budget,
+            "cache stays within its memory budget: {} <= {}",
+            cache.memory_bytes(),
+            budget
+        );
+        assert_eq!(cache.len(), 3);
+    }
+
+    #[test]
+    fn test_memory_limit_never_evicts_statements_in_use() {
+        let mut cache = GlobalCache::default();
+        cache.configure(0, 1); // Nothing fits.
+
+        let (_, name) = cache.insert(&Parse::named("s", "SELECT 1"));
+        assert_eq!(cache.len(), 1, "a statement in use stays regardless");
+
+        cache.close(&name);
+        assert_eq!(cache.len(), 0, "and goes as soon as nobody holds it");
+    }
+
+    #[test]
+    fn test_zero_limits_mean_unlimited() {
+        let mut cache = GlobalCache::default();
+        cache.configure(0, 0);
+
+        for i in 0..1000 {
+            let (_, name) = cache.insert(&Parse::named("s", format!("SELECT {i:04}")));
+            cache.close(&name);
+        }
+
+        assert_eq!(cache.len(), 1000);
+    }
+
+    #[test]
+    fn test_configure_enforces_immediately() {
+        let mut cache = GlobalCache::default();
+
+        for i in 0..100 {
+            let (_, name) = cache.insert(&Parse::named("s", format!("SELECT {i:03}")));
+            cache.close(&name);
+        }
+        assert_eq!(cache.len(), 100);
+
+        // A reload with a smaller limit shrinks the cache on the spot.
+        cache.configure(10, 0);
+        assert_eq!(cache.len(), 10);
+    }
+
+    #[test]
+    fn test_memory_accounting_survives_mixed_operations() {
+        let mut cache = GlobalCache::default();
+        cache.configure(0, 0);
+
+        let mut names = vec![];
+        for i in 0..20 {
+            let (_, name) = cache.insert(&Parse::named("s", format!("SELECT {i:02}")));
+            names.push(name);
+        }
+
+        // A RowDescription recorded later grows the entry.
+        cache.insert_row_description(&names[0], RowDescription::new(&[Field::text("x")]));
+        // Duplicate insert of an existing statement adds nothing.
+        cache.insert(&Parse::named("s", "SELECT 00"));
+        // insert_anyway always creates a fresh entry.
+        let extra = cache.insert_anyway(&Parse::named("s", "SELECT 00"));
+
+        for name in names.iter().chain([&extra]) {
+            cache.close(name);
+        }
+        cache.close(&names[0]); // The duplicate insert above took a second hold.
+
+        assert_eq!(cache.memory_bytes(), recount(&cache));
+
+        // Evictions subtract what the entries actually cost.
+        cache.configure(5, 0);
+        assert_eq!(cache.len(), 5);
+        assert_eq!(cache.memory_bytes(), recount(&cache));
+
+        cache.reset();
+        assert_eq!(cache.memory_bytes(), 0);
+    }
 
     #[test]
     fn test_prep_stmt_cache_close() {

--- a/pgdog/src/frontend/prepared_statements/global_cache.rs
+++ b/pgdog/src/frontend/prepared_statements/global_cache.rs
@@ -300,7 +300,10 @@ impl GlobalCache {
         }
     }
 
-    /// Clear the global cache.
+    /// Clear the global cache. Test-only: rolling the name counter back
+    /// would let a server connection holding an old `__pgdog_N` name be
+    /// handed a different query under it.
+    #[cfg(test)]
     pub fn reset(&mut self) {
         self.statements.clear();
         self.names.clear();

--- a/pgdog/src/frontend/prepared_statements/global_cache.rs
+++ b/pgdog/src/frontend/prepared_statements/global_cache.rs
@@ -4,9 +4,10 @@ use crate::{
     net::messages::{Parse, RowDescription},
     stats::memory::MemoryUsage,
 };
-use std::{collections::hash_map::HashMap, str::from_utf8};
-
-use fnv::FnvHashSet as HashSet;
+use std::{
+    collections::{BTreeSet, hash_map::HashMap},
+    str::from_utf8,
+};
 
 use super::str_mem;
 
@@ -114,7 +115,9 @@ impl CachedStmt {
 pub struct GlobalCache {
     statements: HashMap<CacheKey, CachedStmt>,
     names: HashMap<String, Statement>,
-    unused: HashSet<usize>,
+    /// Statements no client is holding, ordered by creation: eviction takes
+    /// the oldest first, deterministically.
+    unused: BTreeSet<usize>,
     counter: usize,
     versions: usize,
     /// Maximum number of cached statements (0 = unlimited). Only statements
@@ -457,11 +460,17 @@ mod test {
         }
         assert_eq!(cache.len(), 10);
 
-        // The next insert pushes an unused one out instead of growing the cache.
+        // The next insert pushes the oldest unused one out instead of growing
+        // the cache.
         let (new, name) = cache.insert(&Parse::named("s", "SELECT 'over'"));
         assert!(new);
         assert_eq!(cache.len(), 10);
         assert!(cache.parse(&name).is_some(), "the new statement is cached");
+        assert!(
+            cache.parse("__pgdog_1").is_none(),
+            "eviction is deterministic: oldest unused goes first"
+        );
+        assert!(cache.parse("__pgdog_2").is_some());
     }
 
     #[test]

--- a/pgdog/src/frontend/prepared_statements/mod.rs
+++ b/pgdog/src/frontend/prepared_statements/mod.rs
@@ -184,11 +184,16 @@ pub fn start_maintenance() {
     });
 }
 
-/// Check prepared statements cache for overflows
-/// and remove any unused statements exceeding the limit.
+/// Re-apply the configured cache limits, evicting anything unused over
+/// them. A safety net behind the enforcement that already runs when the
+/// cache grows or a statement is released; `0` means unlimited here the
+/// same as everywhere else.
 pub fn run_maintenance() {
-    let capacity = config().config.general.prepared_statements_limit;
-    PreparedStatements::global().write().close_unused(capacity);
+    let general = &config().config.general;
+    PreparedStatements::global().write().configure(
+        general.prepared_statements_limit,
+        general.prepared_statements_memory_limit,
+    );
 }
 
 #[cfg(test)]

--- a/pgdog/src/stats/pools.rs
+++ b/pgdog/src/stats/pools.rs
@@ -345,6 +345,17 @@ impl Pools {
         }));
 
         metrics.push(Metric::new(PoolMetric {
+            name: "prepared_statements_memory_limit".into(),
+            measurements: vec![Measurement {
+                labels: vec![],
+                measurement: general.prepared_statements_memory_limit.into(),
+            }],
+            help: "Memory limit (bytes) for the prepared statements cache, 0 = unlimited".into(),
+            unit: None,
+            metric_type: None,
+        }));
+
+        metrics.push(Metric::new(PoolMetric {
             name: "query_cache_limit".into(),
             measurements: vec![Measurement {
                 labels: vec![],


### PR DESCRIPTION
## Problem

The global prepared statements cache is enforced by a 1 Hz maintenance task that calls `close_unused(prepared_statements_limit)`, but three things undermine it:

- The default `prepared_statements_limit` is `i64::MAX`, so out of the box every statement a client ever released is kept forever.
- There is no memory-based limit at all: the count says nothing about entry size, and entries carry the full `Parse` (plus a rewritten copy and a `RowDescription` when present).
- Enforcement only happens once a second, so a burst of prepare/close cycles can overshoot between ticks.

**What this PR does not fix, explicitly:** statements a client is still holding can never be evicted — dropping one would break the client using it. A workload that keeps millions of unique statements *open* (we watched ~6M held statements take a pooler to ~7 GiB RSS until the clients disconnected) is out of reach for any unused-only eviction, including this one and the existing maintenance task. Protecting against that needs a per-client cap or similar — happy to discuss as a follow-up; this PR bounds what *released* statements can accumulate, immediately rather than at the next tick.

## Change

Same shape as the query cache limits in #1266:

- `prepared_statements_limit` and the new `prepared_statements_memory_limit` (bytes, `0` = unlimited, env `PGDOG_PREPARED_STATEMENTS_MEMORY_LIMIT`, settable from the admin console) are enforced at the moment the cache grows or a statement is released, not just at the next maintenance tick.
- Eviction is deterministic — oldest released statement first (`unused` is a `BTreeSet` now) — and only ever touches statements nobody holds.
- The byte total is maintained incrementally on insert/remove/rewrite/describe, so enforcement doesn't rescan the maps, and `GlobalCache::memory_usage()` returns that same number — the `prepared_statements_memory_used` metric and the budget can't drift apart. A `prepared_statements_memory_limit` gauge is exported next to it.

## Behavior changes

- Admin console `SET prepared_statements_limit TO 0` used to wipe the cache; it now means "unlimited" (matching the config semantics) and logs a warning pointing at `RESET PREPARED`.
- `RESET PREPARED` now passes `0` explicitly and clears everything not in use regardless of the configured limit — with the default (unlimited) limit it used to be a no-op.
- `close_unused(0)` no longer resets the name counter: global `__pgdog_N` names are never reused, so a server connection holding an old name can't be handed a different query under it.

## Testing

Unit tests for enforcement (capacity and memory eviction, in-use statements never evicted, `0` = unlimited, immediate enforcement on configure, deterministic oldest-first order, release via both `close()` and `decrement()`, counter preserved across `RESET PREPARED`) and a byte-accounting invariant test that recounts the total from live entries after a mix of inserts, duplicate inserts, `insert_anyway`, late `RowDescription`, `rewrite()` (including replacement), closes and evictions. Config env/default tests; JSON schema regenerated.

## Cost note

Eviction runs under the global cache write lock. The maintenance task now goes through `configure()` once a second too, but when the cache is within its limits that's a couple of integer comparisons — there is nothing to evict, because insert/release enforcement already kept it in budget. The one expensive case is *lowering* a limit (admin `SET`, `RELOAD`) over a cache holding millions of released statements: they are all evicted in one pass and cache users wait for the duration. That's a one-off administrative action; chunked eviction can be added if it matters in practice.

Docs PR to follow once the shape is agreed on.



