### PR TITLE
fix: don't hand clients a connection Postgres already closed

### DIFF
--- a/pgdog/src/backend/disconnect_reason.rs
+++ b/pgdog/src/backend/disconnect_reason.rs
@@ -14,6 +14,7 @@ pub enum DisconnectReason {
     Healthcheck,
     PubSub,
     CredentialsRefresh,
+    ServerClosed,
     #[default]
     Other,
 }
@@ -34,6 +35,7 @@ impl Display for DisconnectReason {
             Self::Healthcheck => "standalone healthcheck",
             Self::PubSub => "pub/sub",
             Self::CredentialsRefresh => "credentials refresh",
+            Self::ServerClosed => "server closed",
         };
 
         write!(f, "{}", reason)

--- a/pgdog/src/backend/pool/error.rs
+++ b/pgdog/src/backend/pool/error.rs
@@ -35,6 +35,9 @@ pub enum Error {
     #[error("healthcheck error")]
     HealthcheckError,
 
+    #[error("server closed")]
+    ServerClosed,
+
     #[error("primary lsn query failed")]
     PrimaryLsnQueryFailed,
 
@@ -118,6 +121,7 @@ mod tests {
         assert!(Error::ServerError.is_retryable());
         assert!(Error::HealthcheckTimeout.is_retryable());
         assert!(Error::HealthcheckError.is_retryable());
+        assert!(Error::ServerClosed.is_retryable());
         assert!(Error::PrimaryLsnQueryFailed.is_retryable());
         assert!(Error::ReplicaLsnQueryFailed.is_retryable());
         assert!(Error::Offline.is_retryable());

--- a/pgdog/src/backend/pool/pool_impl.rs
+++ b/pgdog/src/backend/pool/pool_impl.rs
@@ -17,7 +17,7 @@ use crate::backend::pool::LsnStats;
 use crate::backend::{ConnectReason, DisconnectReason, Server, ServerOptions};
 use crate::config::PoolerMode;
 use crate::net::messages::{BackendPid, FrontendPid};
-use crate::net::{Parameter, Parameters};
+use crate::net::{Liveness, Parameter, Parameters};
 
 use super::inner::CheckInResult;
 use super::{
@@ -193,6 +193,7 @@ impl Pool {
                 Ok(conn) => return Ok(conn),
                 // Try another connection.
                 Err(Error::HealthcheckError) => continue,
+                Err(Error::ServerClosed) => continue,
                 Err(err) => return Err(err),
             }
         }
@@ -217,6 +218,13 @@ impl Pool {
         healthcheck_interval: Duration,
         now: Instant,
     ) -> Result<Guard, Error> {
+        if conn.liveness() != Liveness::Clean {
+            conn.stats_mut().state(crate::state::State::ForceClose);
+            conn.disconnect_reason(DisconnectReason::ServerClosed);
+            drop(conn);
+            return Err(Error::ServerClosed);
+        }
+
         let mut healthcheck = Healtcheck::conditional(
             &mut conn,
             self,

--- a/pgdog/src/backend/pool/pool_impl.rs
+++ b/pgdog/src/backend/pool/pool_impl.rs
@@ -221,7 +221,6 @@ impl Pool {
         if conn.liveness() != Liveness::Clean {
             conn.stats_mut().state(crate::state::State::ForceClose);
             conn.disconnect_reason(DisconnectReason::ServerClosed);
-            drop(conn);
             return Err(Error::ServerClosed);
         }
 

--- a/pgdog/src/backend/pool/test/mod.rs
+++ b/pgdog/src/backend/pool/test/mod.rs
@@ -68,6 +68,48 @@ pub fn pool_with_prepared_capacity(capacity: usize) -> Pool {
     pool
 }
 
+async fn terminate_backend(pid: i32) {
+    let mut killer = crate::backend::server::test::test_server().await;
+    killer
+        .execute(&format!("SELECT pg_terminate_backend({})", pid))
+        .await
+        .unwrap();
+    sleep(Duration::from_millis(100)).await;
+}
+
+#[tokio::test]
+async fn test_checkout_replaces_connection_closed_by_server() {
+    crate::logger();
+
+    let pool = pool();
+    let conn = pool.get(&Request::default()).await.unwrap();
+    let killed = conn.id();
+    drop(conn);
+
+    terminate_backend(killed.pid()).await;
+
+    let conn = pool.get(&Request::default()).await.unwrap();
+
+    assert_ne!(conn.id(), killed);
+}
+
+#[tokio::test]
+async fn test_server_closed_does_not_mark_pool_unhealthy() {
+    crate::logger();
+
+    let pool = pool();
+    let conn = pool.get(&Request::default()).await.unwrap();
+    let killed = conn.id();
+    drop(conn);
+
+    terminate_backend(killed.pid()).await;
+
+    let conn = pool.get(&Request::default()).await.unwrap();
+    drop(conn);
+
+    assert!(pool.healthy());
+}
+
 #[tokio::test(flavor = "current_thread")]
 async fn test_pool_checkout() {
     crate::logger();

--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -22,7 +22,7 @@ use crate::{
     config::AuthType,
     frontend::ClientRequest,
     net::{
-        Close, MessageBuffer, Parameter, ProtocolMessage, Sync,
+        Close, Liveness, MessageBuffer, Parameter, ProtocolMessage, Sync,
         messages::{
             Authentication, BackendKeyData, BackendPid, Bind, ErrorResponse, Execute, Format,
             FromBytes, FrontendPid, Message, ParameterStatus, Password, Protocol, Query,
@@ -778,6 +778,13 @@ impl Server {
             .unwrap_or(false)
     }
 
+    pub fn liveness(&mut self) -> Liveness {
+        self.stream
+            .as_mut()
+            .map(|stream| stream.liveness())
+            .unwrap_or(Liveness::Closed)
+    }
+
     /// Server can execute a query.
     pub fn in_sync(&self) -> bool {
         matches!(
@@ -1418,6 +1425,48 @@ pub mod test {
         )
         .await
         .unwrap()
+    }
+
+    async fn server_with_peer() -> (Server, tokio::net::TcpStream) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let peer = tokio::spawn(async move { tokio::net::TcpStream::connect(addr).await.unwrap() });
+        let (ours, _) = listener.accept().await.unwrap();
+
+        let mut server = Server::default();
+        server.stream = Some(Stream::plain(ours, 4096));
+
+        (server, peer.await.unwrap())
+    }
+
+    #[test]
+    fn test_liveness_without_stream_is_closed() {
+        let mut server = Server::default();
+
+        assert_eq!(server.liveness(), Liveness::Closed);
+    }
+
+    #[tokio::test]
+    async fn test_liveness_tracks_the_underlying_socket() {
+        let (mut server, peer) = server_with_peer().await;
+
+        assert_eq!(server.liveness(), Liveness::Clean);
+
+        drop(peer);
+        tokio::task::yield_now().await;
+
+        assert_eq!(server.liveness(), Liveness::Closed);
+    }
+
+    #[tokio::test]
+    async fn test_liveness_reports_unsolicited_server_data() {
+        let (mut server, mut peer) = server_with_peer().await;
+
+        peer.write_all(b"E").await.unwrap();
+        peer.flush().await.unwrap();
+        tokio::task::yield_now().await;
+
+        assert_eq!(server.liveness(), Liveness::DataPending);
     }
 
     #[tokio::test]

--- a/pgdog/src/net/mod.rs
+++ b/pgdog/src/net/mod.rs
@@ -14,7 +14,7 @@ pub use error::Error;
 pub use messages::*;
 pub use parameter::{Parameter, Parameters};
 pub use protocol_message::ProtocolMessage;
-pub use stream::Stream;
+pub use stream::{Liveness, Stream};
 pub use tweaks::tweak;
 
 use std::{io::Cursor, marker::Unpin};

--- a/pgdog/src/net/stream.rs
+++ b/pgdog/src/net/stream.rs
@@ -182,22 +182,17 @@ impl Stream {
 
     pub fn liveness(&mut self) -> Liveness {
         let mut buf = [0u8; 1];
-        match &mut self.inner {
-            StreamInner::Plain(plain) => match plain.get_mut().peek(&mut buf).now_or_never() {
-                None => Liveness::Clean,
-                Some(Ok(0)) => Liveness::Closed,
-                Some(Ok(_)) => Liveness::DataPending,
-                Some(Err(_)) => Liveness::Closed,
-            },
-            StreamInner::Tls(tls) => {
-                match tls.get_mut().get_mut().0.peek(&mut buf).now_or_never() {
-                    None => Liveness::Clean,
-                    Some(Ok(0)) => Liveness::Closed,
-                    Some(Ok(_)) => Liveness::DataPending,
-                    Some(Err(_)) => Liveness::Closed,
-                }
-            }
-            StreamInner::DevNull => Liveness::Clean,
+        let peeked = match &mut self.inner {
+            StreamInner::Plain(plain) => plain.get_mut().peek(&mut buf).now_or_never(),
+            StreamInner::Tls(tls) => tls.get_mut().get_mut().0.peek(&mut buf).now_or_never(),
+            StreamInner::DevNull => return Liveness::Clean,
+        };
+
+        match peeked {
+            None => Liveness::Clean,
+            Some(Ok(0)) => Liveness::Closed,
+            Some(Ok(_)) => Liveness::DataPending,
+            Some(Err(_)) => Liveness::Closed,
         }
     }
 

--- a/pgdog/src/net/stream.rs
+++ b/pgdog/src/net/stream.rs
@@ -1,6 +1,7 @@
 //! Network socket wrapper allowing us to treat secure, plain and UNIX
 //! connections the same across the code.
 use bytes::{BufMut, BytesMut};
+use futures::FutureExt;
 use pin_project::pin_project;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufStream, ReadBuf};
 use tokio::net::TcpStream;
@@ -22,6 +23,13 @@ enum StreamInner {
     Plain(#[pin] BufStream<TcpStream>),
     Tls(#[pin] BufStream<tokio_rustls::TlsStream<TcpStream>>),
     DevNull,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Liveness {
+    Clean,
+    DataPending,
+    Closed,
 }
 
 /// A network socket.
@@ -170,6 +178,27 @@ impl Stream {
         };
 
         Ok(())
+    }
+
+    pub fn liveness(&mut self) -> Liveness {
+        let mut buf = [0u8; 1];
+        match &mut self.inner {
+            StreamInner::Plain(plain) => match plain.get_mut().peek(&mut buf).now_or_never() {
+                None => Liveness::Clean,
+                Some(Ok(0)) => Liveness::Closed,
+                Some(Ok(_)) => Liveness::DataPending,
+                Some(Err(_)) => Liveness::Closed,
+            },
+            StreamInner::Tls(tls) => {
+                match tls.get_mut().get_mut().0.peek(&mut buf).now_or_never() {
+                    None => Liveness::Clean,
+                    Some(Ok(0)) => Liveness::Closed,
+                    Some(Ok(_)) => Liveness::DataPending,
+                    Some(Err(_)) => Liveness::Closed,
+                }
+            }
+            StreamInner::DevNull => Liveness::Clean,
+        }
     }
 
     /// Get the current io_in_progress state.
@@ -371,6 +400,8 @@ impl std::fmt::Debug for PeerAddr {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
     use tokio::net::TcpListener;
 
@@ -416,5 +447,78 @@ mod tests {
 
         assert!(!stream.tls_client_certificate());
         assert_eq!(stream.tls_identity(), None);
+    }
+
+    async fn connected_pair() -> (Stream, TcpStream) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let peer = tokio::spawn(async move { TcpStream::connect(addr).await.unwrap() });
+        let (ours, _) = listener.accept().await.unwrap();
+
+        (Stream::plain(ours, 4096), peer.await.unwrap())
+    }
+
+    #[tokio::test]
+    async fn test_liveness_clean_when_peer_idle() {
+        let (mut stream, _peer) = connected_pair().await;
+
+        assert_eq!(stream.liveness(), Liveness::Clean);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_liveness_does_not_block_on_idle_socket() {
+        let (mut stream, _peer) = connected_pair().await;
+
+        let checked =
+            tokio::time::timeout(Duration::from_secs(5), async { stream.liveness() }).await;
+
+        assert_eq!(
+            checked.expect("liveness() blocked on an idle socket"),
+            Liveness::Clean
+        );
+    }
+
+    #[tokio::test]
+    async fn test_liveness_reports_unsolicited_data() {
+        let (mut stream, mut peer) = connected_pair().await;
+
+        peer.write_all(b"E").await.unwrap();
+        peer.flush().await.unwrap();
+        tokio::task::yield_now().await;
+
+        assert_eq!(stream.liveness(), Liveness::DataPending);
+    }
+
+    #[tokio::test]
+    async fn test_liveness_reports_closed_peer() {
+        let (mut stream, peer) = connected_pair().await;
+
+        drop(peer);
+        tokio::task::yield_now().await;
+
+        assert_eq!(stream.liveness(), Liveness::Closed);
+    }
+
+    #[tokio::test]
+    async fn test_liveness_does_not_consume_pending_bytes() {
+        let (mut stream, mut peer) = connected_pair().await;
+
+        peer.write_all(b"hello").await.unwrap();
+        peer.flush().await.unwrap();
+        tokio::task::yield_now().await;
+
+        assert_eq!(stream.liveness(), Liveness::DataPending);
+        assert_eq!(stream.liveness(), Liveness::DataPending);
+
+        let mut buf = [0u8; 5];
+        stream.read_exact(&mut buf).await.unwrap();
+        assert_eq!(&buf, b"hello");
+    }
+
+    #[test]
+    fn test_liveness_dev_null_is_clean() {
+        let mut stream = Stream::dev_null();
+
+        assert_eq!(stream.liveness(), Liveness::Clean);
     }
 }


### PR DESCRIPTION
Healthchecks only run every `healthcheck_interval` (30s by default), so a backend terminated by `pg_terminate_backend` or an `admin` restart stayed in the pool and was handed to clients unchecked until the interval elapsed.

Adds a non-blocking liveness peek on every checkout. An idle pooled connection should have nothing waiting to be read, so pending bytes or a closed socket disqualify it: the connection is force-closed and the existing retry loop fetches another.

Pending data is treated as fatal without parsing it. That also discards connections that merely received an asynchronous `NoticeResponse`, which costs a reconnect but never correctness, and keeps the check cheap enough to run on every checkout.

Uses a distinct `Error::ServerClosed` rather than HealthcheckError so a dead connection does not toggle pool health. The check runs far more often than a healthcheck, and one terminated backend must not ban the pool or trigger failover.

Closes #614 