### PR TITLE
perf(prepared_statements): lower number of allocations

### DIFF
--- a/pgdog/src/backend/prepared_statements.rs
+++ b/pgdog/src/backend/prepared_statements.rs
@@ -458,6 +458,7 @@ impl PreparedStatements {
     /// Make sure to actually execute the close messages you receive
     /// from this method, or the statements will be out of sync with
     /// what's actually inside Postgres.
+    #[must_use]
     pub fn ensure_capacity(&mut self) -> Vec<Close> {
         let mut close = vec![];
         while self.local_cache.len() > self.capacity {

--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -1786,7 +1786,7 @@ pub mod test {
             let parse = Parse::named(&name, format!("SELECT $1, 'test_{}'", name));
             let (new, new_name) = PreparedStatements::global().write().insert(&parse);
             let name = new_name;
-            let parse = parse.rename(&name);
+            let parse = parse.renamed(&name);
             assert!(new);
 
             let describe = Describe::new_statement(&name);
@@ -1860,7 +1860,7 @@ pub mod test {
         let parse = Parse::named("random_name", "SELECT $1");
         let (new, name) = global.write().insert(&parse);
         assert!(new);
-        let parse = parse.rename(&name);
+        let parse = parse.renamed(&name);
         assert_eq!(parse.name(), "__pgdog_1");
 
         let mut server = test_server().await;

--- a/pgdog/src/frontend/prepared_statements/global_cache.rs
+++ b/pgdog/src/frontend/prepared_statements/global_cache.rs
@@ -22,7 +22,6 @@ pub struct Statement {
     #[allow(dead_code)]
     version: usize,
     cache_key: CacheKey,
-    evict_on_close: bool,
 }
 
 impl MemoryUsage for Statement {
@@ -35,7 +34,6 @@ impl MemoryUsage for Statement {
                 0
             }
             + self.cache_key.memory_usage()
-            + self.evict_on_close.memory_usage()
     }
 }
 
@@ -44,8 +42,8 @@ impl Statement {
         self.parse.query()
     }
 
-    fn cache_key(&self) -> CacheKey {
-        self.cache_key.clone()
+    fn cache_key(&self) -> &CacheKey {
+        &self.cache_key
     }
 }
 
@@ -66,8 +64,8 @@ pub struct CacheKey {
 impl MemoryUsage for CacheKey {
     #[inline]
     fn memory_usage(&self) -> usize {
-        // Bytes refer to memory allocated by someone else.
-        std::mem::size_of::<Bytes>() * 2 + self.version.memory_usage()
+        // The Bytes alias the Parse in Statement, which counts them via Parse::len.
+        std::mem::size_of::<Self>()
     }
 }
 
@@ -124,7 +122,7 @@ impl MemoryUsage for GlobalCache {
             + self.names.memory_usage()
             + self.counter.memory_usage()
             + self.versions.memory_usage()
-            + self.unused.len() * std::mem::size_of::<usize>()
+            + self.unused.capacity() * 1usize.memory_usage()
     }
 }
 
@@ -150,7 +148,15 @@ impl GlobalCache {
         } else {
             self.counter += 1;
             let name = global_name(self.counter);
-            let parse = parse.rename(&name);
+            // PERF: we explicitly create the new parse with renamed
+            // to reallocate the data and not to hold original buffer
+            // from pgdog/src/frontend/client/mod.rs
+            // smaller memory footprints and smaller allocations, since
+            // the client buffer is generally bigger than the query.
+            // Holding onto it would also fragment that buffer: the client
+            // keeps appending messages to it and can't free the middle,
+            // so the buffer grows monotonically.
+            let parse = parse.renamed(&name);
 
             let cache_key = CacheKey {
                 query: parse.query_ref(),
@@ -186,7 +192,7 @@ impl GlobalCache {
         self.versions += 1;
 
         let name = global_name(self.counter);
-        let parse = parse.rename(&name);
+        let parse = parse.renamed(&name);
 
         let key = CacheKey {
             query: parse.query_ref(),
@@ -301,11 +307,9 @@ impl GlobalCache {
         if let Some(statement) = self.names.get(name) {
             let key = statement.cache_key();
 
-            if let Some(entry) = self.statements.get_mut(&key) {
+            if let Some(entry) = self.statements.get_mut(key) {
                 entry.used = entry.used.saturating_sub(1);
-                if entry.used == 0 && statement.evict_on_close {
-                    self.remove(name);
-                } else if entry.used == 0 {
+                if entry.used == 0 {
                     self.unused.insert(entry.counter);
                 }
             }
@@ -317,27 +321,42 @@ impl GlobalCache {
     /// names are never reused.
     pub fn close_unused(&mut self, capacity: usize) -> usize {
         let over = self.len().saturating_sub(capacity);
-        let remove = self.unused.iter().take(over).copied().collect::<Vec<_>>();
 
-        for counter in &remove {
-            self.unused.remove(counter);
-            self.remove(&global_name(*counter));
-        }
+        // move out of unused to mutate it without borrowing the self to be able to call self.remove later
+        // this helps avoid allocations to remove only part of keys from unused
+        // PERF: the remove though removes once at a time in the loop, that could
+        // defeat this optimization actually
+        let mut unused = std::mem::take(&mut self.unused);
 
-        remove.len()
+        let removed = unused
+            .extract_if(|counter| {
+                // PERF: the global_name always allocates
+                // do we need to actually store this by String or
+                // can we use buffer
+                self.remove(&global_name(*counter));
+
+                true
+            })
+            .take(over)
+            .count();
+
+        // unused will hold the remaining elements that was not extracted above
+        self.unused = unused;
+
+        removed
     }
 
     /// Remove statement from global cache.
     fn remove(&mut self, name: &str) {
         if let Some(stmt) = self.names.remove(name) {
-            self.statements.remove(&stmt.cache_key());
+            self.statements.remove(stmt.cache_key());
         }
     }
 
     /// Decrement usage of prepared statement without removing it.
     pub fn decrement(&mut self, name: &str) {
         if let Some(stmt) = self.names.get(name)
-            && let Some(stmt) = self.statements.get_mut(&stmt.cache_key())
+            && let Some(stmt) = self.statements.get_mut(stmt.cache_key())
         {
             stmt.used = stmt.used.saturating_sub(1);
             if stmt.used == 0 {
@@ -378,6 +397,21 @@ mod test {
     }
 
     #[test]
+    fn test_cache_key_aliases_the_stored_parse() {
+        let mut cache = GlobalCache::default();
+        let source = Parse::named("client_name", "SELECT $1");
+        let (_, name) = cache.insert(&source);
+
+        let stored = cache.names.get(&name).unwrap();
+        let map_key = cache.statements.keys().next().unwrap();
+        let owned = stored.parse.query_ref();
+
+        assert_eq!(owned.as_ptr(), stored.cache_key.query.as_ptr());
+        assert_eq!(owned.as_ptr(), map_key.query.as_ptr());
+        assert_ne!(owned.as_ptr(), source.query_ref().as_ptr());
+    }
+
+    #[test]
     fn test_prep_stmt_cache_close() {
         let mut cache = GlobalCache::default();
         let parse = Parse::named("test", "SELECT $1");
@@ -391,7 +425,7 @@ mod test {
             assert_eq!(name, "__pgdog_1");
         }
         let stmt = cache.names.get("__pgdog_1").unwrap().clone();
-        let entry = cache.statements.get(&stmt.cache_key()).unwrap();
+        let entry = cache.statements.get(stmt.cache_key()).unwrap();
 
         assert_eq!(entry.used, 26);
 
@@ -399,12 +433,12 @@ mod test {
             cache.close("__pgdog_1");
         }
 
-        let entry = cache.statements.get(&stmt.cache_key()).unwrap();
+        let entry = cache.statements.get(stmt.cache_key()).unwrap();
         assert_eq!(entry.used, 1);
         assert!(cache.unused.is_empty());
 
         cache.close("__pgdog_1");
-        let entry = cache.statements.get(&stmt.cache_key()).unwrap();
+        let entry = cache.statements.get(stmt.cache_key()).unwrap();
         assert_eq!(entry.used, 0);
         assert!(cache.unused.contains(&1)); // __pgdog_1
 
@@ -447,7 +481,7 @@ mod test {
 
         cache.close(&name);
         let stmt = cache.names.get(&name).unwrap().clone();
-        let entry = cache.statements.get(&stmt.cache_key()).unwrap();
+        let entry = cache.statements.get(stmt.cache_key()).unwrap();
         assert_eq!(entry.used, 0);
         assert!(cache.unused.contains(&1));
 
@@ -456,7 +490,7 @@ mod test {
         assert_eq!(name, name_again);
         assert!(!cache.unused.contains(&1));
 
-        let entry = cache.statements.get(&stmt.cache_key()).unwrap();
+        let entry = cache.statements.get(stmt.cache_key()).unwrap();
         assert_eq!(entry.used, 1);
     }
 
@@ -519,22 +553,22 @@ mod test {
         cache.insert(&parse);
 
         let stmt = cache.names.get(&name).unwrap().clone();
-        let entry = cache.statements.get(&stmt.cache_key()).unwrap();
+        let entry = cache.statements.get(stmt.cache_key()).unwrap();
         assert_eq!(entry.used, 3);
 
         cache.decrement(&name);
-        let entry = cache.statements.get(&stmt.cache_key()).unwrap();
+        let entry = cache.statements.get(stmt.cache_key()).unwrap();
         assert_eq!(entry.used, 2);
         assert!(cache.unused.is_empty());
 
         cache.decrement(&name);
         cache.decrement(&name);
-        let entry = cache.statements.get(&stmt.cache_key()).unwrap();
+        let entry = cache.statements.get(stmt.cache_key()).unwrap();
         assert_eq!(entry.used, 0);
         assert!(cache.unused.contains(&1));
 
         cache.decrement(&name);
-        let entry = cache.statements.get(&stmt.cache_key()).unwrap();
+        let entry = cache.statements.get(stmt.cache_key()).unwrap();
         assert_eq!(entry.used, 0);
     }
 

--- a/pgdog/src/frontend/prepared_statements/mod.rs
+++ b/pgdog/src/frontend/prepared_statements/mod.rs
@@ -31,6 +31,7 @@ fn str_mem(s: &str) -> usize {
 #[derive(Clone, Debug)]
 pub struct PreparedStatements {
     pub(super) global: Arc<RwLock<GlobalCache>>,
+    // mapping the client statement name -> __pgdog__ name from global cache
     pub(super) local: HashMap<String, String>,
     pub(super) level: PreparedStatementsLevel,
     pub(super) memory_used: usize,
@@ -84,7 +85,7 @@ impl PreparedStatements {
             self.memory_used += str_mem(key) + str_mem(&name);
         }
 
-        parse.rename_fast(&name)
+        parse.rename(&name)
     }
 
     /// Insert statement into the cache bypassing duplicate checks.
@@ -102,7 +103,7 @@ impl PreparedStatements {
             self.memory_used += str_mem(key) + str_mem(&name);
         }
 
-        parse.rename_fast(&name)
+        parse.rename(&name)
     }
 
     /// Get global statement counter.

--- a/pgdog/src/frontend/prepared_statements/rewrite.rs
+++ b/pgdog/src/frontend/prepared_statements/rewrite.rs
@@ -24,7 +24,7 @@ impl<'a> Rewrite<'a> {
             ProtocolMessage::Bind(bind) => Ok(self.bind(bind)?),
             ProtocolMessage::Describe(describe) => Ok(self.describe(describe)?),
             ProtocolMessage::Parse(parse) => Ok(self.parse(parse)?),
-            &mut ProtocolMessage::Close(ref close) => Ok(self.close(close)?),
+            ProtocolMessage::Close(close) => Ok(self.close(close)?),
             _ => Ok(()),
         }
     }

--- a/pgdog/src/frontend/router/parser/rewrite/statement/insert.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/insert.rs
@@ -56,7 +56,7 @@ impl InsertSplit {
                     new_parse.set_query(&self.stmt);
 
                     if let Some(name) = self.statement_name() {
-                        new_parse.rename_fast(name);
+                        new_parse.rename(name);
                     }
 
                     ProtocolMessage::Parse(new_parse)
@@ -87,7 +87,7 @@ impl InsertSplit {
             let mut split_parse = parse.clone();
             split_parse.set_query(&self.stmt);
             if let Some(name) = self.statement_name() {
-                split_parse.rename_fast(name);
+                split_parse.rename(name);
             }
             new_request.last_parse = Some(split_parse);
         }

--- a/pgdog/src/net/messages/parse.rs
+++ b/pgdog/src/net/messages/parse.rs
@@ -11,6 +11,10 @@ use std::str::from_utf8_unchecked;
 use super::code;
 use super::prelude::*;
 
+fn c_string(value: &str) -> Bytes {
+    Bytes::from([value.as_bytes(), b"\0"].concat())
+}
+
 /// Parse (F) message.
 #[derive(Clone, Hash, Eq, PartialEq, Default)]
 pub struct Parse {
@@ -44,7 +48,7 @@ impl Parse {
     pub fn new_anonymous(query: &str) -> Self {
         Self {
             name: Bytes::from("\0"),
-            query: Bytes::from(query.to_owned() + "\0"),
+            query: c_string(query),
             data_types: Bytes::copy_from_slice(&0i16.to_be_bytes()),
             original: None,
         }
@@ -53,8 +57,8 @@ impl Parse {
     /// New prepared statement.
     pub fn named(name: impl ToString, query: impl ToString) -> Self {
         Self {
-            name: Bytes::from(name.to_string() + "\0"),
-            query: Bytes::from(query.to_string() + "\0"),
+            name: c_string(&name.to_string()),
+            query: c_string(&query.to_string()),
             data_types: Bytes::copy_from_slice(&0i16.to_be_bytes()),
             original: None,
         }
@@ -81,25 +85,28 @@ impl Parse {
     }
 
     /// Rename prepared statement, re-allocating it into its own memory space.
-    pub fn rename(&self, name: &str) -> Parse {
+    pub fn renamed(&self, name: &str) -> Parse {
+        // PERF: the allocation will create new allocation for inner data, that
+        // won't pin any original buffers (allowing to modify them without new allocation)
+        // and the new allocation memory size will be just limited by the actual data, not buffers
         Parse {
-            name: Bytes::from(name.to_string() + "\0"),
-            query: Bytes::from(self.query().to_owned() + "\0"),
-            data_types: Bytes::copy_from_slice(&self.data_types[..]),
+            name: c_string(name),
+            query: Bytes::copy_from_slice(&self.query),
+            data_types: Bytes::copy_from_slice(&self.data_types),
             original: None,
         }
     }
 
     /// Rename the prepared statement with minimal allocations.
-    pub fn rename_fast(&mut self, name: &str) {
-        self.name = Bytes::from(name.to_string() + "\0");
+    pub fn rename(&mut self, name: &str) {
+        self.name = c_string(name);
         self.original = None;
     }
 
     /// Make this an anonymous Parse.
     pub fn anonymize(&mut self) {
         if !self.anonymous() {
-            self.rename_fast("");
+            self.rename("");
         }
     }
 
@@ -109,7 +116,7 @@ impl Parse {
 
     /// Update the SQL for this prepared statement.
     pub fn set_query(&mut self, query: &str) {
-        self.query = Bytes::from(query.to_string() + "\0");
+        self.query = c_string(query);
         self.original = None;
     }
 
@@ -272,5 +279,29 @@ mod test {
         let mapping = [(10_001, 10_002)].into_iter().collect();
         assert!(parse.rewrite_data_types(&mapping));
         assert!(!parse.to_bytes().is_empty());
+    }
+
+    #[test]
+    fn test_renamed_owns_exact_memory() {
+        let source = Parse::named("client_name", "SELECT $1").with_data_types(&[20, 25]);
+        let renamed = source.renamed("__pgdog_7");
+
+        assert_eq!(renamed.name(), "__pgdog_7");
+        assert_eq!(renamed.query(), "SELECT $1");
+        assert_eq!(renamed.data_types_ref(), source.data_types_ref());
+        assert_ne!(renamed.query_ref().as_ptr(), source.query_ref().as_ptr());
+        assert_ne!(
+            renamed.data_types_ref().as_ptr(),
+            source.data_types_ref().as_ptr()
+        );
+
+        let fresh = Parse::named("__pgdog_7", "SELECT $1").with_data_types(&[20, 25]);
+        assert_eq!(renamed.to_bytes(), fresh.to_bytes());
+        assert_eq!(renamed.to_bytes().len(), renamed.len());
+
+        let round_trip = Parse::from_bytes(renamed.to_bytes()).unwrap();
+        assert_eq!(round_trip.name(), renamed.name());
+        assert_eq!(round_trip.query(), renamed.query());
+        assert_eq!(round_trip.data_types_ref(), renamed.data_types_ref());
     }
 }


### PR DESCRIPTION
Little performance improvements, performance comments and more explicit names for prepared statements.

- avoid allocations on cleaning
- avoid cloning for cache_key (yes, there are Bytes clone that is arc::clone, but still)
- when creating new CacheKey to put into cache make sure we consume only necessary amount of memory and now the memory occupied by String::capacity
- more realistic memory_usage calculation.

The perf improvements are pure vibes - I don't have numbers.