### PR TITLE
fix: bump pg_raw_parse for macOS link error, add macOS to CI

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,16 @@
+name: macos
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  macos:
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v6
+      - uses: Swatinem/rust-cache@v2
+      - name: Build
+        run: cargo build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3271,7 +3271,7 @@ dependencies = [
 [[package]]
 name = "pg_raw_parse"
 version = "0.1.0"
-source = "git+https://github.com/pgdogdev/pg_raw_parse.git?rev=b24ff5d#b24ff5d077f629f116334a9c9c706bc5cd18b005"
+source = "git+https://github.com/pgdogdev/pg_raw_parse.git?rev=8758803#8758803494e9f6eb4c4fbb47168aecc13614aa8f"
 dependencies = [
  "bindgen 0.72.1",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ edition = "2024"
 pgdog-plugin = { path = "./pgdog-plugin", version = "0.4.0", default-features = false }
 pgdog-config = { path = "./pgdog-config", version = "0.1.0" }
 pgdog-postgres-types = { path = "./pgdog-postgres-types"}
-pg_raw_parse = { git = "https://github.com/pgdogdev/pg_raw_parse.git", rev = "b24ff5d" }
+pg_raw_parse = { git = "https://github.com/pgdogdev/pg_raw_parse.git", rev = "8758803" }
 bon = "3.9"
 schemars = { version = "1.2.1", features = ["uuid1"] }
 serde_json = "1.0"


### PR DESCRIPTION
Following up on https://github.com/pgdogdev/pg_raw_parse/pull/49, bumping the pg_raw_parse rev here to fix the macOS link error.

Also added a simple CI job that runs cargo build to prevent regressions. It uses macos-26 instead of macos-14 (used by release CI) [since that image will be fully unsupported soon](https://github.com/actions/runner-images/issues/13518).  Follow up PR: https://github.com/pgdogdev/pgdog/pull/1337