### PR TITLE
ci: bump macOS release runner to macos-26 (deprecation in macos-14)

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -27,7 +27,7 @@ jobs:
             runner: blacksmith-4vcpu-ubuntu-2404-arm
             deb: true
           - target: aarch64-apple-darwin      # Apple Silicon
-            runner: macos-14
+            runner: macos-26
     steps:
       - uses: actions/checkout@v6
 
@@ -39,15 +39,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             build-essential cmake clang pkg-config libssl-dev mold
-
-      # openssl-sys needs Homebrew OpenSSL; bindgen/clang-sys need libclang from
-      # the (keg-only) llvm formula, found via LIBCLANG_PATH.
-      - name: Install build dependencies (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          brew install llvm pkg-config openssl@3
-          echo "OPENSSL_DIR=$(brew --prefix openssl@3)" >> "$GITHUB_ENV"
-          echo "LIBCLANG_PATH=$(brew --prefix llvm)/lib" >> "$GITHUB_ENV"
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
macOS 14 runners, which we use in our CI release workflow, [will be fully unsupported in a few months](https://github.com/actions/runner-images/issues/13518). Bumped to use macOS 26 runners.

I also got rid of an unnecessary macOS install dependency step: we don't build openssl-sys, runner images come with pkgconf, and the build uses Xcode's libclang (not llvm).

Verified macOS 26 build success in the release workflow in my fork (running on top of https://github.com/pgdogdev/pgdog/pull/1336 fix): https://github.com/jkaczman/pgdog/actions/runs/31486516587/job/93763057440