### PR TITLE
Fix examples/demo Docker volume directory for PG 18

### DIFF
--- a/examples/demo/docker-compose.yml
+++ b/examples/demo/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - 6000:5432
     volumes:
-      - shard_0:/var/lib/postgresql/data
+      - shard_0:/var/lib/postgresql
   db_1:
     image: postgres:18
     environment:
@@ -14,7 +14,7 @@ services:
     ports:
       - 6001:5432
     volumes:
-      - shard_1:/var/lib/postgresql/data
+      - shard_1:/var/lib/postgresql
   db_2:
     image: postgres:18
     environment:
@@ -22,7 +22,7 @@ services:
     ports:
       - 6002:5432
     volumes:
-      - shard_2:/var/lib/postgresql/data
+      - shard_2:/var/lib/postgresql
 
 volumes:
   shard_0:


### PR DESCRIPTION
Docker changed how the PGDATA directory works in Postgres 18. This changed directory structure allows "docker compose up" to run as expected from this directory, and should be a durable change across future Postgres versions (by not including a specific Postgres version in the path)

Fixes https://github.com/pgdogdev/pgdog/issues/1253