### PR TITLE
fix: schema sharding should bypass omnishard check

### DIFF
--- a/integration/pgdog.toml
+++ b/integration/pgdog.toml
@@ -437,6 +437,10 @@ tables = ["sharded_omni"]
 # ------------------------------------------------------------------------------
 # ----- Schema-based sharding --------------------------------------------------
 
+[[omnisharded_tables]]
+database = "pgdog_schema"
+tables = ["sharded_omni"]
+
 [[databases]]
 name = "pgdog_schema"
 host = "127.0.0.1"

--- a/integration/python/test_asyncpg.py
+++ b/integration/python/test_asyncpg.py
@@ -602,6 +602,38 @@ async def test_schema_sharding_default():
 
 
 @pytest.mark.asyncio
+async def test_schema_sharding_set_shard_allows_omnisharded_write():
+    conn = await schema_sharded_async()
+    row_id = random.randrange(1 << 32, 1 << 63)
+
+    try:
+        await conn.execute("SET pgdog.shard TO 1")
+        result = await conn.execute(
+            "INSERT INTO sharded_omni (id, value) VALUES ($1, $2)",
+            row_id,
+            "schema-sharded",
+        )
+        assert result == "INSERT 0 1"
+        assert (
+            await conn.fetchval("SELECT COUNT(*) FROM sharded_omni WHERE id = $1", row_id)
+            == 1
+        )
+
+        await conn.execute("SET pgdog.shard TO 0")
+        assert (
+            await conn.fetchval("SELECT COUNT(*) FROM sharded_omni WHERE id = $1", row_id)
+            == 0
+        )
+    finally:
+        await conn.close()
+        cleanup = await schema_sharded_async()
+        try:
+            await cleanup.execute("DELETE FROM sharded_omni WHERE id = $1", row_id)
+        finally:
+            await cleanup.close()
+
+
+@pytest.mark.asyncio
 async def test_schema_sharding_search_path():
     admin().cursor().execute("SET cross_shard_disabled TO true")
 

--- a/pgdog/src/frontend/client/query_engine/test/test_omnisharded.rs
+++ b/pgdog/src/frontend/client/query_engine/test/test_omnisharded.rs
@@ -18,14 +18,25 @@ use crate::{
 
 use super::prelude::*;
 
-/// Message returned by [`ErrorResponse::omni_write_with_directive`]. The
+/// Message returned by [`ErrorResponse::omni_in_direct_to_shard`]. The
 /// SQLSTATE (58000) is shared by several errors, so we match on the message
-/// instead. This parser-level check preempts the engine's
-/// omni-in-direct-to-shard guard for directive-pinned transactions; the
-/// engine guard remains as defense in depth for connections pinned some
-/// other way.
+/// instead.
+const OMNI_IN_DIRECT_TO_SHARD_MESSAGE: &str =
+    "cannot write to an omnisharded table in a direct-to-shard transaction";
+
+/// Message returned by [`ErrorResponse::omni_write_with_directive`].
 const OMNI_WRITE_WITH_DIRECTIVE_MESSAGE: &str =
     "cannot write to an omnisharded table with a shard directive";
+
+/// Assert that `err` came from the engine guard for a backend connection that
+/// is already pinned to fewer than all shards.
+fn assert_omni_in_direct_to_shard(err: &ErrorResponse) {
+    assert_eq!(
+        err.message, OMNI_IN_DIRECT_TO_SHARD_MESSAGE,
+        "unexpected error: {:?}",
+        err
+    );
+}
 
 /// Assert that `err` is the omni-write-with-directive error, returned when a
 /// shard directive (comment or SET) is present on a statement routed as a
@@ -125,7 +136,7 @@ async fn test_omni_write_blocked_in_direct_to_shard_transaction() {
         .await;
 
     let err = expect_message!(client.read().await, ErrorResponse);
-    assert_omni_write_with_directive(&err);
+    assert_omni_in_direct_to_shard(&err);
     // Transaction is now in the aborted state.
     let rfq = expect_message!(client.read().await, ReadyForQuery);
     assert_eq!(rfq.status, 'E');
@@ -200,7 +211,7 @@ async fn test_omni_read_blocked_in_direct_to_shard_transaction() {
         .send_simple(Query::new("SELECT * FROM sharded_omni"))
         .await;
     let err = expect_message!(client.read().await, ErrorResponse);
-    assert_omni_write_with_directive(&err);
+    assert_omni_in_direct_to_shard(&err);
     let rfq = expect_message!(client.read().await, ReadyForQuery);
     assert_eq!(rfq.status, 'E');
 

--- a/pgdog/src/frontend/router/parser/query/mod.rs
+++ b/pgdog/src/frontend/router/parser/query/mod.rs
@@ -109,24 +109,27 @@ impl QueryParser {
                     route.set_shard(context.shards_calculator.shard());
                 }
 
-                // Schema-based sharding.
+                // Search path routing used for schema sharding.
+                // FIXME(lev): It's duplicative, since we explicitely
+                // check for presence of schema sharding below.
                 let is_search_path = context.shards_calculator.is_search_path();
                 route.set_search_path_driven(is_search_path);
 
-                // A non-schema-routed write that only touches omnisharded tables
-                // must reach every shard. A shard directive (a comment or SET)
-                // routing it to one shard would silently diverge the table, so
-                // it's an error. A pending lookup for a bare key is deferred when
-                // search_path currently controls the route; after the lookup is
-                // resolved, the second routing pass performs this check again.
-                if route.requires_full_shard_coverage()
-                    && (matches!(
-                        route.shard_with_priority().source(),
-                        ShardSource::Comment | ShardSource::Set
-                    ) || !context.bare_key_lookups.is_empty())
-                {
+                let full_shard_coverage = route.requires_full_shard_coverage();
+                let schema_sharding = !context.sharding_schema.schemas.is_empty();
+                let manual_routing = matches!(
+                    route.shard_with_priority().source(),
+                    ShardSource::Comment | ShardSource::Set
+                );
+
+                // This means we are serving the request, not just extracting
+                // which keys we need to lookup in the routing table.
+                let have_lookups = !context.bare_key_lookups.is_empty();
+
+                if full_shard_coverage && (manual_routing || have_lookups) && !schema_sharding {
                     return Err(Error::OmniWriteWithDirective);
                 }
+
                 context
                     .pending_lookups
                     .extend(std::mem::take(&mut context.bare_key_lookups));

--- a/pgdog/src/frontend/router/parser/query/test/test_sharding.rs
+++ b/pgdog/src/frontend/router/parser/query/test/test_sharding.rs
@@ -375,16 +375,18 @@ fn test_set_sharding_key_goes_through_lookup() {
     );
 }
 
-/// A write that only touches omnisharded tables must reach every
-/// shard: a shard directive on it is an error, with a cold cache
-/// (the key's lookup doesn't run) and with a warm one.
+/// Without schema sharding, a write that only touches omnisharded tables must
+/// reach every shard. A shard directive is an error with both a cold cache (the
+/// key's lookup doesn't run) and a warm one.
 #[test]
-fn test_comment_key_errors_on_omnisharded_write() {
+fn test_comment_key_errors_on_omnisharded_write_without_schema_sharding() {
     use crate::frontend::router::parser::Error;
 
     // Cold cache.
     let tables = lookup_rule_tables();
-    let mut test = QueryParserTest::new().with_sharded_tables(tables.clone());
+    let mut test = QueryParserTest::new()
+        .with_sharded_tables(tables.clone())
+        .without_sharded_schemas();
     let result = test.try_execute(vec![
         Query::new(
             "/* pgdog_sharding_key: 'org_child' */ INSERT INTO organizations (id, name) VALUES ('org_child', 'child')",
@@ -454,12 +456,10 @@ fn test_search_path_defers_omnisharded_write_with_pending_comment_key() {
     );
 }
 
-/// Once the deferred comment lookup resolves, routing checks the omnisharded
-/// write again. The higher-priority comment now selects one shard, so the write
-/// must be rejected instead of partially updating the table.
+/// With schema sharding configured, an omnisharded write may target the shard
+/// selected by a resolved comment key.
 #[test]
-fn test_resolved_comment_key_errors_on_search_path_omnisharded_write() {
-    use crate::frontend::router::parser::Error;
+fn test_resolved_comment_key_allowed_on_schema_sharded_omnisharded_write() {
     use crate::frontend::router::sharding::{LookupTable, ResolvedLookups};
 
     let key = LookupTable {
@@ -473,6 +473,43 @@ fn test_resolved_comment_key_errors_on_search_path_omnisharded_write() {
     let mut test = QueryParserTest::new()
         .with_sharded_tables(lookup_rule_tables())
         .with_param("search_path", ParameterValue::String("shard_0".into()))
+        .with_resolved_lookups(resolved);
+
+    let command = test.execute(vec![
+        Query::new(
+            "/* pgdog_sharding_key: 'org_child' */ INSERT INTO organizations (id, name) VALUES ('org_child', 'child')",
+        )
+        .into(),
+    ]);
+
+    assert!(command.route().is_omnisharded());
+    assert!(!command.route().is_search_path_driven());
+    assert!(command.route().pending_lookups().is_empty());
+    assert!(command.route().shard().is_direct());
+    assert_eq!(
+        command.route().shard_with_priority().source(),
+        &ShardSource::Comment
+    );
+}
+
+/// Without schema sharding, resolving a comment key must not allow an
+/// omnisharded write to target only the resolved shard.
+#[test]
+fn test_resolved_comment_key_errors_on_omnisharded_write_without_schema_sharding() {
+    use crate::frontend::router::parser::Error;
+    use crate::frontend::router::sharding::{LookupTable, ResolvedLookups};
+
+    let key = LookupTable {
+        schema: None,
+        name: None,
+        column: "organization_id".into(),
+    };
+    let mut resolved = ResolvedLookups::default();
+    resolved.insert(key, "org_child".into(), "org_root".into());
+
+    let mut test = QueryParserTest::new()
+        .with_sharded_tables(lookup_rule_tables())
+        .without_sharded_schemas()
         .with_resolved_lookups(resolved);
 
     let result = test.try_execute(vec![


### PR DESCRIPTION
Bypass the omni partial write check if using schema sharding. Schema-sharding implies all tables are sharded, and our parser really needs to detect this instead of this spaghetti. Next week is spring (summer I guess) cleaning.