### PR TITLE
feat(openmetrics): make host configurable

### DIFF
--- a/.schema/pgdog.schema.json
+++ b/.schema/pgdog.schema.json
@@ -76,6 +76,7 @@
         "mirror_exposure": 1.0,
         "mirror_queue": 128,
         "omnisharded_sticky": false,
+        "openmetrics_host": "0.0.0.0",
         "openmetrics_namespace": null,
         "openmetrics_port": null,
         "passthrough_auth": "disabled",
@@ -982,6 +983,11 @@
           "description": "If turned on, queries touching omnisharded tables are always sent to the same shard for any given client connection. The shard is determined at random on connection creation.\n\n_Default:_ `false`\n\n<https://docs.pgdog.dev/configuration/pgdog.toml/general/#omnisharded_sticky>",
           "type": "boolean",
           "default": false
+        },
+        "openmetrics_host": {
+          "description": "The IP address of the local network interface the OpenMetrics HTTP endpoint will bind to.\n\n**Note:** This setting cannot be changed at runtime.\n\n_Default:_ `0.0.0.0`\n\n<https://docs.pgdog.dev/configuration/pgdog.toml/general/#openmetrics_host>",
+          "type": "string",
+          "default": "0.0.0.0"
         },
         "openmetrics_namespace": {
           "description": "Prefix added to all metric names exposed via the OpenMetrics endpoint.\n\n<https://docs.pgdog.dev/configuration/pgdog.toml/general/#openmetrics_namespace>",

--- a/example.pgdog.toml
+++ b/example.pgdog.toml
@@ -146,6 +146,10 @@ shutdown_termination_timeout = 60_000
 #
 # Default: not set
 openmetrics_port = 9090
+# The IP address the OpenMetrics HTTP endpoint will bind to.
+#
+# Default: 0.0.0.0
+openmetrics_host = "0.0.0.0"
 # Namespace to use for Prometheus metrics.
 #
 # Disambiguates metric names from metrics scraped from other apps.

--- a/pgdog-config/src/general.rs
+++ b/pgdog-config/src/general.rs
@@ -334,6 +334,16 @@ pub struct General {
     #[serde(default = "General::query_size_limit_action")]
     pub query_size_limit_action: QuerySizeLimitAction,
 
+    /// The IP address of the local network interface the OpenMetrics HTTP endpoint will bind to.
+    ///
+    /// **Note:** This setting cannot be changed at runtime.
+    ///
+    /// _Default:_ `0.0.0.0`
+    ///
+    /// <https://docs.pgdog.dev/configuration/pgdog.toml/general/#openmetrics_host>
+    #[serde(default = "General::openmetrics_host")]
+    pub openmetrics_host: String,
+
     /// The port used for the OpenMetrics HTTP endpoint.
     ///
     /// <https://docs.pgdog.dev/configuration/pgdog.toml/general/#openmetrics_port>
@@ -903,6 +913,7 @@ impl Default for General {
             log_query_sample_length: Self::log_query_sample_length(),
             query_size_limit: Self::default_query_size_limit(),
             query_size_limit_action: Self::query_size_limit_action(),
+            openmetrics_host: Self::openmetrics_host(),
             openmetrics_port: Self::openmetrics_port(),
             openmetrics_namespace: Self::openmetrics_namespace(),
             prepared_statements: Self::prepared_statements(),
@@ -1352,6 +1363,10 @@ impl General {
         Self::env_enum_or_default("PGDOG_QUERY_SIZE_LIMIT_ACTION")
     }
 
+    pub fn openmetrics_host() -> String {
+        Self::env_string_or_default("PGDOG_OPENMETRICS_HOST", "0.0.0.0")
+    }
+
     pub fn openmetrics_port() -> Option<u16> {
         Self::env_option("PGDOG_OPENMETRICS_PORT")
     }
@@ -1779,6 +1794,15 @@ mod tests {
 
         assert_eq!(General::host(), "0.0.0.0");
         assert_eq!(General::port(), 6432);
+    }
+
+    #[test]
+    fn test_env_openmetrics_host() {
+        let _guard = set_env_var("PGDOG_OPENMETRICS_HOST", "127.0.0.1");
+        assert_eq!(General::openmetrics_host(), "127.0.0.1");
+
+        let _guard = remove_env_var("PGDOG_OPENMETRICS_HOST");
+        assert_eq!(General::openmetrics_host(), "0.0.0.0");
     }
 
     #[test]

--- a/pgdog/src/main.rs
+++ b/pgdog/src/main.rs
@@ -128,8 +128,9 @@ async fn pgdog(command: Option<Commands>) -> Result<(), Box<dyn std::error::Erro
     }
 
     if let Some(openmetrics_port) = general.openmetrics_port {
+        let openmetrics_host = general.openmetrics_host.clone();
         pgdog::tasks::spawn("openmetrics server", async move {
-            stats::http_server::server(openmetrics_port).await
+            stats::http_server::server(&openmetrics_host, openmetrics_port).await
         });
     }
 

--- a/pgdog/src/stats/http_server.rs
+++ b/pgdog/src/stats/http_server.rs
@@ -1,5 +1,4 @@
 use std::convert::Infallible;
-use std::net::SocketAddr;
 
 use http_body_util::Full;
 use hyper::body::Bytes;
@@ -68,10 +67,10 @@ async fn metrics(_: Request<hyper::body::Incoming>) -> Result<Response<Full<Byte
     Ok(response)
 }
 
-pub async fn server(port: u16) -> std::io::Result<()> {
-    info!("OpenMetrics endpoint http://0.0.0.0:{}", port);
-    let addr = SocketAddr::from(([0, 0, 0, 0], port));
-    let listener = TcpListener::bind(addr).await?;
+pub async fn server(host: &str, port: u16) -> std::io::Result<()> {
+    let addr = format!("{}:{}", host, port);
+    info!("OpenMetrics endpoint http://{}", addr);
+    let listener = TcpListener::bind(&addr).await?;
     let shutdown = tasks::shutdown_signal();
 
     loop {


### PR DESCRIPTION
- Add `openmetrics_host` (default `0.0.0.0`, env `PGDOG_OPENMETRICS_HOST`) 
- Unit test for default + env override (`test_env_openmetrics_host`)

closes #1349 