### PR TITLE
feat(lb): route specific users to replicas

### DIFF
--- a/pgdog/src/backend/pool/cluster.rs
+++ b/pgdog/src/backend/pool/cluster.rs
@@ -46,6 +46,7 @@ pub struct PoolConfig {
 
 /// A collection of sharded replicas and primaries
 /// belonging to the same database cluster.
+/// Mapped to a singular `User`, see "databases: HashMap<User, Cluster>" in backend/databases.rs
 #[derive(Clone, Debug)]
 pub struct Cluster {
     identifier: Arc<DatabaseUser>,
@@ -89,6 +90,7 @@ pub struct Cluster {
     #[debug(skip)]
     schema_loader: Box<dyn SchemaLoader>,
     canonical_oids: Option<Arc<CanonicalOids>>,
+    read_only: bool,
 }
 
 /// Bare test clusters carry the same defaults the config would apply,
@@ -140,6 +142,7 @@ impl Default for Cluster {
             tls_client_certificate_required: Default::default(),
             schema_loader: Default::default(),
             canonical_oids: Default::default(),
+            read_only: Default::default(),
         }
     }
 }
@@ -233,6 +236,7 @@ pub struct ClusterConfig<'a> {
     tls_client_certificate_required: bool,
     schema_cache: SchemaCache,
     canonicalize_oids: bool,
+    read_only: bool,
 }
 
 impl<'a> ClusterConfig<'a> {
@@ -306,6 +310,7 @@ impl<'a> ClusterConfig<'a> {
             tls_client_certificate_required: user.tls_client_certificate_required.unwrap_or(true),
             schema_cache,
             canonicalize_oids: general.canonicalize_type_information,
+            read_only: user.read_only.unwrap_or(false),
         }
     }
 }
@@ -356,6 +361,7 @@ impl Cluster {
             tls_client_certificate_required,
             schema_cache,
             canonicalize_oids,
+            read_only,
         } = config;
 
         let identifier = Arc::new(DatabaseUser {
@@ -428,6 +434,7 @@ impl Cluster {
             tls_client_certificate_required,
             schema_loader: Box::new(schema_loader::FromServer),
             canonical_oids,
+            read_only,
         }
     }
 
@@ -559,8 +566,13 @@ impl Cluster {
         self.pub_sub_channel_size > 0
     }
 
-    /// A cluster is read_only if zero shards have a primary.
+    /// A cluster is read_only if zero shards have a primary,
+    /// or if `read_only` for the corresponding `User` is set to true.
     pub fn read_only(&self) -> bool {
+        if self.read_only {
+            return true;
+        }
+
         for shard in &self.shards {
             if shard.has_primary() {
                 return false;

--- a/pgdog/src/backend/pool/lb/mod.rs
+++ b/pgdog/src/backend/pool/lb/mod.rs
@@ -371,21 +371,23 @@ impl LoadBalancer {
             .filter(|target| !target.pool.config().resharding_only) // Don't let reads on resharding-only replicas.
             .collect();
 
+        let has_unbanned_replica = candidates
+            .iter()
+            .any(|target| target.role() == Role::Replica && !target.ban.banned());
+        // If `read_only` is true, only allow if there's no replicas.
         let primary_reads = match self.rw_split {
-            IncludePrimary => true,
+            IncludePrimary => !(request.read_only && has_unbanned_replica),
             IncludePrimaryIfReplicaBanned => {
-                candidates.iter().any(|target| target.ban.banned()) || candidates.len() == 1 // The second condition is for when there is only the primary (just one target, doesn't matter what role it is).
+                !(request.read_only && has_unbanned_replica)
+                    && (candidates.iter().any(|target| target.ban.banned())
+                        || candidates.len() == 1) // The second condition is for when there is only the primary (just one target, doesn't matter what role it is).
             }
             // we read from the primary if we have no replicas
-            ExcludePrimary => !candidates
-                .iter()
-                .any(|target| target.role() == Role::Replica),
+            ExcludePrimary => !has_unbanned_replica,
             // PreferPrimary makes all queries writes. If a query lands here,
             // it's because of pgdog.role=replica. Let it use the primary only if
             // no replicas are available.
-            PreferPrimary => !candidates
-                .iter()
-                .any(|target| target.role() == Role::Replica && !target.ban.banned()),
+            PreferPrimary => !has_unbanned_replica,
         };
 
         if !primary_reads {

--- a/pgdog/src/backend/pool/lb/test.rs
+++ b/pgdog/src/backend/pool/lb/test.rs
@@ -402,6 +402,95 @@ async fn test_read_write_split_exclude_primary() {
     replicas.shutdown();
 }
 
+/// Sets the `Request.read_only` (normally derived from `User.read_only`) to true,
+/// then ensures that the primary is not chosen for reads. We have replicas available.
+#[tokio::test]
+async fn test_user_read_only_include_primary() {
+    let primary_config = create_test_pool_config("127.0.0.1", 5432);
+    let primary_pool = Pool::new(&primary_config);
+    primary_pool.launch();
+
+    let replica_configs = [
+        create_test_pool_config("localhost", 5432),
+        create_test_pool_config("127.0.0.1", 5432),
+    ];
+
+    // Use `IncludePrimary`
+    let replicas = LoadBalancer::new(
+        &Some(primary_pool),
+        &replica_configs,
+        LoadBalancingStrategy::Random,
+        ReadWriteSplit::IncludePrimary,
+        Default::default(),
+    );
+    replicas.launch();
+
+    // Notice that we `read` to true and `read_only` to true.
+    let request = Request::new(Default::default(), true, true);
+
+    // Try getting connections multiple times and verify primary is never used
+    let mut replica_ids = HashSet::new();
+    for _ in 0..100 {
+        let conn = replicas.get(&request).await.unwrap();
+        replica_ids.insert(conn.pool.id());
+    }
+
+    // Should only use replica pools, not primary
+    assert_eq!(replica_ids.len(), 2);
+
+    // Verify primary pool ID is not in the set of used pools
+    let primary_id = replicas.primary().unwrap().id();
+    assert!(!replica_ids.contains(&primary_id));
+
+    // Shutdown both primary and replicas
+    replicas.shutdown();
+}
+
+/// Sets the `Request.read_only` (normally derived from `User.read_only`) to true,
+/// then ensures that the primary IS chosen for reads. We have no usable replicas.
+#[tokio::test]
+async fn test_user_read_only_include_primary_no_replicas() {
+    let primary_config = create_test_pool_config("127.0.0.1", 5432);
+    let primary_pool = Pool::new(&primary_config);
+    primary_pool.launch();
+
+    let replica_configs = [create_test_pool_config("localhost", 5432)];
+
+    let replicas = LoadBalancer::new(
+        &Some(primary_pool),
+        &replica_configs,
+        LoadBalancingStrategy::Random,
+        ReadWriteSplit::IncludePrimary,
+        Default::default(),
+    );
+    replicas.launch();
+
+    // Ban the replica
+    let replica_ban = &replicas.targets[0].ban;
+    replica_ban.ban(Error::ServerError, Duration::from_millis(1000));
+
+    // `read_only` is set to true. This would usually override `IncludePrimary`,
+    // but we have no replicas available.
+    let request = Request::new(Default::default(), true, true);
+
+    // Should only use primary since replica is banned
+    let mut used_pool_ids = HashSet::new();
+    for _ in 0..10 {
+        let conn = replicas.get(&request).await.unwrap();
+        used_pool_ids.insert(conn.pool.id());
+    }
+
+    // Should only use primary pool since replica is banned
+    assert_eq!(used_pool_ids.len(), 1);
+
+    // Verify primary pool ID is in the set of used pools
+    let primary_id = replicas.targets.last().unwrap().pool.id();
+    assert!(used_pool_ids.contains(&primary_id));
+
+    // Shutdown both primary and replicas
+    replicas.shutdown();
+}
+
 #[tokio::test]
 async fn test_read_write_split_include_primary() {
     let primary_config = create_test_pool_config("127.0.0.1", 5432);

--- a/pgdog/src/backend/pool/request.rs
+++ b/pgdog/src/backend/pool/request.rs
@@ -8,14 +8,19 @@ pub struct Request {
     pub id: FrontendPid,
     pub created_at: Instant,
     pub read: bool,
+
+    // Load balancer uses this to determine if primary should be allowed to read.
+    // Propagated from `User.read_only` setting.
+    pub read_only: bool,
 }
 
 impl Request {
-    pub fn new(id: FrontendPid, read: bool) -> Self {
+    pub fn new(id: FrontendPid, read: bool, read_only: bool) -> Self {
         Self {
             id,
             created_at: Instant::now(),
             read,
+            read_only,
         }
     }
 
@@ -24,6 +29,7 @@ impl Request {
             id,
             created_at: Instant::now(),
             read: false,
+            read_only: false,
         }
     }
 }

--- a/pgdog/src/backend/pool/request.rs
+++ b/pgdog/src/backend/pool/request.rs
@@ -11,7 +11,7 @@ pub struct Request {
 
     // Load balancer uses this to determine if primary should be allowed to read.
     // Propagated from `User.read_only` setting.
-    pub read_only: bool,
+    pub(crate) read_only: bool,
 }
 
 impl Request {

--- a/pgdog/src/frontend/client/query_engine/connect.rs
+++ b/pgdog/src/frontend/client/query_engine/connect.rs
@@ -29,7 +29,10 @@ impl QueryEngine {
 
         let connect_route = connect_route.unwrap_or(context.client_request.route());
 
-        let request = Request::new(context.id, connect_route.is_read());
+        // Pass through the cluster's `read_only` flag (propagated from `User.read_only`)
+        // to determine if we should exclude the primary from being allowed to read.
+        let read_only = self.backend.cluster()?.read_only();
+        let request = Request::new(context.id, connect_route.is_read(), read_only);
 
         self.stats.waiting(request.created_at);
         self.comms.update_stats(self.stats);


### PR DESCRIPTION
When the `read_only` flag in users.toml is set true for a given `User`, this will now route that `User` strictly to replicas, assuming that there's replicas available. When we have no replicas, the primary will still be used. This change only affects using `include_primary` or `include_primary_if_replica_banned` as the read_write_split option.

Also: I found what I suspect to be a bug where we previously weren't checking for `&& !target.ban.banned()` in the LoadBalancer for `exclude_primary`.

Fixes #979.