### PR TITLE
Fix clippy

### DIFF
--- a/pgdog/src/main.rs
+++ b/pgdog/src/main.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::len_without_is_empty)]
 #![allow(clippy::result_unit_err)]
 #![deny(clippy::print_stdout)]
+#![allow(clippy::enum_variant_names)]
 
 //! pgDog, modern PostgreSQL proxy, pooler and query router.
 


### PR DESCRIPTION
I have no clue why removing the dead code caused this lint to start firing when it wasn't before, but for now let's just allow it