### PR TITLE
Box our largest futures

### DIFF
--- a/pgdog/src/admin/probe.rs
+++ b/pgdog/src/admin/probe.rs
@@ -28,12 +28,12 @@ impl Command for Probe {
     async fn execute(&self) -> Result<Vec<Message>, Error> {
         let mut conn = safe_timeout(
             Duration::from_millis(config().config.general.connect_timeout),
-            Server::connect(
+            Box::pin(Server::connect(
                 &Address::try_from(self.url.clone()).map_err(|_| Error::InvalidAddress)?,
                 ServerOptions::default(),
                 ConnectReason::Probe,
                 Default::default(),
-            ),
+            )),
         )
         .await?
         .map_err(|err| Error::Backend(Box::new(err)))?;

--- a/pgdog/src/backend/pool/monitor.rs
+++ b/pgdog/src/backend/pool/monitor.rs
@@ -120,10 +120,10 @@ impl Monitor {
         // Token refresh loop — one task per pool, tied to pool lifetime.
         // Only spawned for pools that use an external identity provider.
         if self.pool.addr().server_auth.is_external_identity() {
-            let pool = self.pool.clone();
-            tasks::spawn("pool token refresh", async move {
-                Self::token_refresh(pool).await
-            });
+            tasks::spawn(
+                "pool token refresh",
+                Box::pin(Self::token_refresh(self.pool.clone())),
+            );
         }
 
         loop {
@@ -203,7 +203,7 @@ impl Monitor {
             select! {
                 _ = safe_sleep(sleep_duration) => {
                     let result = match addr.server_auth {
-                        ServerAuth::RdsIam => rds_iam::token(addr.clone()).await.map(
+                        ServerAuth::RdsIam => Box::pin(rds_iam::token(addr.clone())).await.map(
                             |(token, expires_at)| {
                                 TokenCache::global().set(&addr, token, expires_at)
                             },
@@ -445,12 +445,12 @@ impl Monitor {
         for attempt in 0..connect_attempts {
             match safe_timeout(
                 connect_timeout,
-                Server::connect(
+                Box::pin(Server::connect(
                     pool.addr(),
                     options.clone(),
                     reason,
                     Arc::clone(&pool.inner().oids),
-                ),
+                )),
             )
             .await
             {

--- a/pgdog/src/backend/pool/token_cache.rs
+++ b/pgdog/src/backend/pool/token_cache.rs
@@ -212,7 +212,7 @@ impl TokenCache {
 
         // Cold miss — block once to prime the cache.
         // After this the monitor's refresh loop takes over.
-        let (token, expires_at) = fetcher(addr.clone()).await?;
+        let (token, expires_at) = Box::pin(fetcher(addr.clone())).await?;
         self.set(addr, token.clone(), expires_at);
         Ok(token)
     }
@@ -258,7 +258,7 @@ impl TokenCache {
 
         // Cold miss — block once to prime the cache.
         // After this the monitor's refresh loop takes over.
-        let fetched = fetcher(addr.clone()).await?;
+        let fetched = Box::pin(fetcher(addr.clone())).await?;
         let credentials = fetched.credentials.clone();
         self.set_credentials(addr, fetched);
         Ok(credentials)

--- a/pgdog/src/backend/replication/logical/orchestrator.rs
+++ b/pgdog/src/backend/replication/logical/orchestrator.rs
@@ -37,7 +37,7 @@ pub(crate) struct PublicationGuard {
 impl PublicationGuard {
     /// Drop any replication slots the publisher still owns.
     pub(crate) async fn cleanup(self) -> Result<(), Error> {
-        self.publisher.lock().await.cleanup().await
+        Box::pin(self.publisher.lock().await.cleanup()).await
     }
 }
 

--- a/pgdog/src/backend/replication/logical/publisher/parallel_sync.rs
+++ b/pgdog/src/backend/replication/logical/publisher/parallel_sync.rs
@@ -63,10 +63,14 @@ impl ParallelSync {
         let mut attempt = 0usize;
 
         loop {
-            match self
-                .table
-                .data_sync(&self.addr, &self.source, &self.dest, &self.cancel, tracker)
-                .await
+            match Box::pin(self.table.data_sync(
+                &self.addr,
+                &self.source,
+                &self.dest,
+                &self.cancel,
+                tracker,
+            ))
+            .await
             {
                 Ok(_) => return Ok(self.table),
                 Err(err) if !err.is_retryable() || attempt >= max_retries => {

--- a/pgdog/src/backend/replication/logical/publisher/publisher_impl.rs
+++ b/pgdog/src/backend/replication/logical/publisher/publisher_impl.rs
@@ -181,7 +181,7 @@ impl Publisher {
                 Some(self.slot_name.clone()),
                 number,
             );
-            slot.create_slot().await?;
+            Box::pin(slot.create_slot()).await?;
 
             self.slots.insert(number, slot);
         }
@@ -204,7 +204,7 @@ impl Publisher {
 
         // Create replication slots if we haven't already.
         if self.slots.is_empty() {
-            self.create_slots(source, &stop).await?;
+            Box::pin(self.create_slots(source, &stop)).await?;
         }
 
         let n_sources = source.shards().len();

--- a/pgdog/src/backend/replication/logical/publisher/slot.rs
+++ b/pgdog/src/backend/replication/logical/publisher/slot.rs
@@ -104,12 +104,12 @@ impl ReplicationSlot {
     /// Connect to database using replication mode.
     pub async fn connect(&mut self) -> Result<(), Error> {
         self.server = Some(
-            Server::connect(
+            Box::pin(Server::connect(
                 &self.address,
                 ServerOptions::new_replication(),
                 ConnectReason::Replication,
                 Default::default(),
-            )
+            ))
             .await?,
         );
 

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -143,7 +143,7 @@ impl Client {
 
         match safe_timeout(
             login_timeout,
-            Self::login(stream, params, addr, config, protocol_version),
+            Box::pin(Self::login(stream, params, addr, config, protocol_version)),
         )
         .await
         {
@@ -472,7 +472,7 @@ impl Client {
 
     /// Run the client and log disconnect.
     async fn spawn_internal(&mut self) {
-        match self.run().await {
+        match Box::pin(self.run()).await {
             Ok(_) => {
                 if config().config.general.log_disconnections {
                     let (user, database) = user_database_from_params(&self.params);

--- a/pgdog/src/frontend/client/query_engine/query.rs
+++ b/pgdog/src/frontend/client/query_engine/query.rs
@@ -60,7 +60,7 @@ impl QueryEngine {
 
         match safe_timeout(
             context.timeouts.query_timeout(&State::Active),
-            self.client_server_exchange(context),
+            Box::pin(self.client_server_exchange(context)),
         )
         .await
         {

--- a/pgdog/src/frontend/listener.rs
+++ b/pgdog/src/frontend/listener.rs
@@ -236,7 +236,7 @@ impl Listener {
                             .await?;
                     }
 
-                    Client::spawn(stream, params, addr, config, negotiated).await?;
+                    Box::pin(Client::spawn(stream, params, addr, config, negotiated)).await?;
                     break;
                 }
 

--- a/pgdog/src/main.rs
+++ b/pgdog/src/main.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::result_unit_err)]
 #![deny(clippy::print_stdout)]
 #![allow(clippy::enum_variant_names)]
+#![warn(clippy::large_futures)]
 
 //! pgDog, modern PostgreSQL proxy, pooler and query router.
 


### PR DESCRIPTION
Async code needs to have a much lower stack size threshold to justify boxing vs sync code. The compiler's coroutine implementation can generate extremely [not ideal
code](https://github.com/rust-lang/rust/issues/69826), and in general async types are more likely be unable to have move memcpys elided.

This boxes any future that is greater than 10k in size across our codebase. This mostly addresses the root cause #1360 was targeting, though I've left that change in place as the doubling in size with the previous code was legit and this appears in enough hot paths to justify it.