### PR TITLE
fix(schema_sharding): check for previous SearchPath and Set/Comment in cross_shard_omni_check

### DIFF
--- a/integration/complex/cross_shard_omni_check/pgdog.toml
+++ b/integration/complex/cross_shard_omni_check/pgdog.toml
@@ -1,0 +1,25 @@
+[general]
+cross_shard_disabled = true
+
+# Key! It's default but emphasized here due to the default integration config using aggressive.
+read_write_strategy = "conservative"
+
+[[databases]]
+host = "127.0.0.1"
+name = "pgdog"
+shard = 0
+
+[[databases]]
+host = "127.0.0.1"
+name = "pgdog"
+shard = 1
+
+[[sharded_schemas]]
+database = "pgdog"
+name = "customer_a"
+shard = 0
+
+[[sharded_schemas]]
+database = "pgdog"
+name = "customer_b"
+shard = 1

--- a/integration/complex/cross_shard_omni_check/run.py
+++ b/integration/complex/cross_shard_omni_check/run.py
@@ -1,0 +1,66 @@
+"""
+Regression test for <https://github.com/pgdogdev/pgdog/issues/1374>
+This exception throws when not working as intended: asyncpg.exceptions.PostgresSystemError: cannot write to an omnisharded table in a direct-to-shard transaction
+Used to trigger when...
+    (1) in pgdog.toml, read_write_strategy = conservative (default). This is why it's in integration/complex. Integration pgdog.toml uses aggressive.
+    (2) SET pgdog.shard (or comment directive)
+    (3) running within a transaction
+    (4) querying an omnisharded table (SELECT, read)
+
+Being that it's a transaction, it's treated as a write due to read_write_strategy setting.
+SET pgdog.shard is higher priority than search_path, so it overtakes it in `ShardsWithPriority`.
+Thus, when `peek()`` is called in `ShardsWithPriority`, it will show the Set, and therefore,
+when `!is_search_path() -> `requires_full_shard_coverage()` -> `is_omnishard_unsafe()`, it'll return as true (marking it unsafe),
+which did not consider the SET (manual routing) in the schema sharding setup.
+"""
+
+import asyncio
+import sys
+
+import asyncpg
+import psycopg2
+
+from asyncpg import Record
+
+APPLICATION_NAME = "pgdog_cross_shard_omni"
+
+async def test_cross_shard_omni() -> None:
+    conn = await asyncpg.connect(
+        host="127.0.0.1",
+        port=6432,
+        database="pgdog",
+        user="pgdog",
+        password="pgdog",
+    )
+
+    try:
+        await conn.execute(f"SET application_name = '{APPLICATION_NAME}'")
+        await conn.execute("CREATE SCHEMA IF NOT EXISTS customer_a")
+        await conn.execute("CREATE SCHEMA IF NOT EXISTS customer_b")
+
+        async with conn.transaction():
+            await conn.execute("SET LOCAL search_path TO customer_a")
+            await conn.execute("SET LOCAL pgdog.shard TO 0")
+            row = await conn.fetchrow("""
+                    SELECT
+                        typname AS name, oid, typarray AS array_oid,
+                        oid::regtype::text AS regtype, typdelim AS delimiter
+                    FROM pg_type t
+                    WHERE t.oid = to_regtype('int4')
+                    ORDER BY t.oid;
+                    """)
+
+            # Not necessary, the error will bypass to the finally block, but why not?
+            assert row is not None
+            assert type(row) is Record
+            assert row['name'] == "int4"
+
+    finally:
+        try:
+            await conn.close()
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    asyncio.run(test_cross_shard_omni())

--- a/integration/complex/cross_shard_omni_check/run.sh
+++ b/integration/complex/cross_shard_omni_check/run.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source ${SCRIPT_DIR}/../../common.sh
+
+export PGPASSWORD=pgdog
+
+active_venv
+
+run_pgdog "${SCRIPT_DIR}"
+wait_for_pgdog
+
+pushd ${SCRIPT_DIR}
+python run.py
+popd
+
+stop_pgdog

--- a/integration/complex/cross_shard_omni_check/users.toml
+++ b/integration/complex/cross_shard_omni_check/users.toml
@@ -1,0 +1,4 @@
+[[users]]
+name = "pgdog"
+database = "pgdog"
+password = "pgdog"

--- a/integration/complex/run.sh
+++ b/integration/complex/run.sh
@@ -11,4 +11,5 @@ bash passthrough_auth/run.sh
 bash cancel_query/run.sh
 bash session_listen/run.sh
 bash protocol_version/run.sh
+bash cross_shard_omni_check/run.sh
 popd

--- a/pgdog/src/frontend/router/parser/query/mod.rs
+++ b/pgdog/src/frontend/router/parser/query/mod.rs
@@ -116,12 +116,21 @@ impl QueryParser {
                 let is_search_path = context.shards_calculator.is_search_path();
                 route.set_search_path_driven(is_search_path);
 
+                // Was there, at any point in time, a `ShardSource::SearchPath` shard?
+                // We use this for a check in schema sharding for `SearchPath` + `manual_routing`
+                // within the cross-shard omni check.
+                let contains_search_path = context.shards_calculator.contains_search_path();
+                route.set_contains_search_path(contains_search_path);
+
                 let full_shard_coverage = route.requires_full_shard_coverage();
                 let schema_sharding = !context.sharding_schema.schemas.is_empty();
+
                 let manual_routing = matches!(
                     route.shard_with_priority().source(),
                     ShardSource::Comment | ShardSource::Set
                 );
+
+                route.set_manual_routing(manual_routing);
 
                 // This means we are serving the request, not just extracting
                 // which keys we need to lookup in the routing table.

--- a/pgdog/src/frontend/router/parser/route.rs
+++ b/pgdog/src/frontend/router/parser/route.rs
@@ -1,12 +1,11 @@
 use std::{fmt::Display, ops::Deref};
 
-use lazy_static::lazy_static;
-
 use super::{
     Aggregate, DistinctBy, Limit, OrderBy, explain_trace::ExplainTrace,
     rewrite::statement::aggregate::AggregateRewritePlan, statement::AdvisoryLocks,
 };
 use crate::frontend::router::sharding::PendingLookup;
+use lazy_static::lazy_static;
 
 /// The shard destination for a query.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Ord, Eq, Hash, Default)]
@@ -129,6 +128,10 @@ pub struct Route {
     /// The query engine resolves them and routes the query again;
     /// the query doesn't execute while any are unresolved.
     pending_lookups: Vec<PendingLookup>,
+    /// Being routed by `ShardSource::Comment` or `ShardSource::Set`
+    manual_routing: bool,
+    /// Previously (or currently) a `ShardSource::SearchPath` as the source
+    contains_search_path: bool,
 }
 
 impl Display for Route {
@@ -283,12 +286,40 @@ impl Route {
         self.search_path_driven
     }
 
+    pub fn set_contains_search_path(&mut self, contains_search_path: bool) {
+        self.contains_search_path = contains_search_path;
+    }
+
+    /// Returns true if there was ever a `ShardSource::SearchPath` shard
+    /// (even if not highest priority)
+    pub fn contains_search_path(&self) -> bool {
+        self.contains_search_path
+    }
+
+    pub fn set_manual_routing(&mut self, manual_routing: bool) {
+        self.manual_routing = manual_routing;
+    }
+
+    /// Returns true if the shard is being routed by `ShardSource::Comment` or `ShardSource::Set`
+    pub fn is_manual_routing(&self) -> bool {
+        self.manual_routing
+    }
+
     /// Whether an omnisharded write must reach every shard to remain consistent.
     ///
     /// Schema-based sharding intentionally limits the write to the shard selected
-    /// by `search_path`; every other omnisharded write requires full coverage.
+    /// by `search_path`
+    ///
+    /// Furthermore, we check for the manual_routing and contains_search_path combination to see if
+    /// a `ShardSource::Comment` or `ShardSource::Set` is routing this, with a prior
+    /// de-prioritized `ShardSource::SearchPath`. If that's the case, the write is also allowed.
+    ///
+    /// Every other omnisharded write requires full coverage.
     pub(crate) fn requires_full_shard_coverage(&self) -> bool {
-        self.is_omnisharded() && self.is_write() && !self.is_search_path_driven()
+        self.is_omnisharded()
+            && self.is_write()
+            && !self.is_search_path_driven()
+            && !(self.is_manual_routing() && self.contains_search_path())
     }
 
     /// Return true if this route requires result set manipulation to
@@ -613,6 +644,7 @@ impl Deref for ShardWithPriority {
 #[derive(Default, Debug, Clone)]
 pub struct ShardsWithPriority {
     max: Option<ShardWithPriority>,
+    search_path: bool,
 }
 
 impl ShardsWithPriority {
@@ -629,6 +661,11 @@ impl ShardsWithPriority {
     }
 
     pub(crate) fn push(&mut self, shard: ShardWithPriority) {
+        // If there's another push(), it'll be lost without the search_path flag.
+        if matches!(shard.source, ShardSource::SearchPath(_)) {
+            self.search_path = true;
+        }
+
         if let Some(ref max) = self.max {
             if max < &shard {
                 self.max = Some(shard);
@@ -647,6 +684,11 @@ impl ShardsWithPriority {
         self.peek()
             .map(|shard| matches!(shard.source, ShardSource::SearchPath(_)))
             .unwrap_or_default()
+    }
+
+    /// Was there previously (or currently) a `ShardSource::SearchPath` as the source?
+    pub(crate) fn contains_search_path(&self) -> bool {
+        self.search_path
     }
 }
 


### PR DESCRIPTION
Fixed a false-positive from `cross_shard_omni_check` when handling manual routing in schema sharding.

Used to trigger when all these were true:
-  In pgdog.toml, `read_write_strategy `= `conservative` (default). This is why I put the test in integration/complex; the default integration pgdog.toml config uses `aggressive`.
- SET `pgdog.shard` (or comment directive)
- Running within a transaction
- Querying an omnisharded table (SELECT, read)

Resulting in the error: `cannot write to an omnisharded table in a direct-to-shard transaction`

Being that it's a transaction, it's treated as a write due to read_write_strategy setting. SET `pgdog.shard` is higher priority than `SearchPath`, so it overtakes it in `ShardsWithPriority`. Thus, when `peek()` is called in `ShardsWithPriority`, it will show the `Set`, and therefore, when `!is_search_path()` -> `requires_full_shard_coverage()` -> `is_omnishard_unsafe()`, it'll return as true (marking it unsafe). This did not consider the SET (manual routing) in the schema sharding setup, or that it masked the `SearchPath`.

Regression test was implemented, and it now passes.

Fixes https://github.com/pgdogdev/pgdog/issues/1374.