### PR TITLE
refactor: cleanup multi-shard state & decoder

### DIFF
--- a/pgdog/src/backend/pool/connection/aggregate.rs
+++ b/pgdog/src/backend/pool/connection/aggregate.rs
@@ -263,7 +263,7 @@ impl<'a> Aggregates<'a> {
         }
 
         for helper in plan.helpers() {
-            let Some(index) = decoder.rd().field_index(&helper.alias) else {
+            let Some(index) = decoder.row_description().field_index(&helper.alias) else {
                 continue;
             };
 
@@ -314,7 +314,7 @@ impl<'a> Aggregates<'a> {
 
     pub(super) fn aggregate(mut self) -> Result<VecDeque<DataRow>, Error> {
         // Determine which columns don't belong to GROUP BY or an aggregate function.
-        let num_cols = self.decoder.rd().fields.len();
+        let num_cols = self.decoder.row_description().fields.len();
         let mut covered_indices = vec![false; num_cols];
 
         for idx in self.aggregate.group_by() {
@@ -375,7 +375,7 @@ impl<'a> Aggregates<'a> {
             for (idx, datum) in grouping.columns {
                 row.insert(
                     idx,
-                    datum.encode(self.decoder.format(idx))?,
+                    datum.encode(self.decoder.get_format(idx))?,
                     datum.is_null(),
                 );
             }
@@ -386,7 +386,7 @@ impl<'a> Aggregates<'a> {
                 let datum = acc.finalize()?;
                 row.insert(
                     target_column,
-                    datum.encode(self.decoder.format(target_column))?,
+                    datum.encode(self.decoder.get_format(target_column))?,
                     datum.is_null(),
                 );
             }
@@ -399,7 +399,7 @@ impl<'a> Aggregates<'a> {
             for (target_column, datum) in state.passthrough {
                 row.insert(
                     target_column,
-                    datum.encode(self.decoder.format(target_column))?,
+                    datum.encode(self.decoder.get_format(target_column))?,
                     datum.is_null(),
                 );
             }

--- a/pgdog/src/backend/pool/connection/binding.rs
+++ b/pgdog/src/backend/pool/connection/binding.rs
@@ -90,7 +90,6 @@ impl Binding {
             Binding::Direct(guard, _) => guard.read().await,
 
             Binding::NotConnected => loop {
-                debug!("binding suspended");
                 safe_sleep(Duration::MAX).await
             },
 
@@ -98,7 +97,6 @@ impl Binding {
             Binding::MultiShard(shards, state) => {
                 if shards.is_empty() {
                     loop {
-                        debug!("multi-shard binding suspended");
                         safe_sleep(Duration::MAX).await;
                     }
                 } else {
@@ -106,7 +104,7 @@ impl Binding {
                     // or there are no more messages to be read.
                     loop {
                         // Return all sorted data rows if any.
-                        if let Some(message) = state.message() {
+                        if let Some(message) = state.get_server_message() {
                             return Ok(message);
                         }
                         let mut read = false;
@@ -118,7 +116,7 @@ impl Binding {
                             let message = server.read().await?;
 
                             read = true;
-                            if let Some(message) = state.forward(message)? {
+                            if let Some(message) = state.handle_server_message(message)? {
                                 return Ok(message);
                             }
                         }
@@ -129,8 +127,7 @@ impl Binding {
                     }
 
                     loop {
-                        state.reset();
-                        debug!("multi-shard binding done");
+                        state.query_complete();
                         safe_sleep(Duration::MAX).await;
                     }
                 }
@@ -155,7 +152,7 @@ impl Binding {
                     // Map positional index to actual shard number.
                     // When only a subset of shards is connected (Shard::Multi binding),
                     // positional indices don't match actual shard numbers.
-                    let shard = state.shard_index(position);
+                    let shard = state.shard_number(position);
                     let send = match client_request.route().shard() {
                         Shard::Direct(s) => {
                             shards_sent = 1;
@@ -213,7 +210,7 @@ impl Binding {
                 if !servers.is_empty() {
                     let mut futures = Vec::new();
                     for (position, server) in servers.iter_mut().enumerate() {
-                        let shard = state.shard_index(position);
+                        let shard = state.shard_number(position);
                         let send = match route.shard() {
                             Shard::Direct(s) => *s == shard,
                             Shard::Multi(shards) => shards.contains(&shard),
@@ -243,7 +240,7 @@ impl Binding {
             Binding::MultiShard(servers, state) => {
                 for row in rows {
                     for (position, server) in servers.iter_mut().enumerate() {
-                        let shard = state.shard_index(position);
+                        let shard = state.shard_number(position);
                         match row.shard() {
                             Shard::Direct(row_shard) => {
                                 if shard == *row_shard {

--- a/pgdog/src/backend/pool/connection/buffer.rs
+++ b/pgdog/src/backend/pool/connection/buffer.rs
@@ -58,21 +58,21 @@ impl Buffer {
             match column {
                 OrderBy::Asc(_) => cols.push(column.clone()),
                 OrderBy::AscColumn(name) => {
-                    if let Some(index) = decoder.rd().field_index(name) {
+                    if let Some(index) = decoder.row_description().field_index(name) {
                         cols.push(OrderBy::Asc(index + 1));
                     }
                     // TODO: Error out instead of silently not sorting.
                 }
                 OrderBy::Desc(_) => cols.push(column.clone()),
                 OrderBy::DescColumn(name) => {
-                    if let Some(index) = decoder.rd().field_index(name) {
+                    if let Some(index) = decoder.row_description().field_index(name) {
                         cols.push(OrderBy::Desc(index + 1));
                     }
                     // TODO: Error out instead of silently not sorting.
                 }
                 OrderBy::AscVectorL2(_, _) => cols.push(column.clone()),
                 OrderBy::AscVectorL2Column(name, vector) => {
-                    if let Some(index) = decoder.rd().field_index(name) {
+                    if let Some(index) = decoder.row_description().field_index(name) {
                         cols.push(OrderBy::AscVectorL2(index + 1, vector.clone()));
                     }
                     // TODO: Error out instead of silently not sorting.
@@ -191,7 +191,7 @@ impl Buffer {
                                 }
 
                                 DistinctColumn::Name(name) => {
-                                    if let Some(index) = decoder.rd().field_index(name)
+                                    if let Some(index) = decoder.row_description().field_index(name)
                                         && let Some(data) = row.column(index)
                                     {
                                         dr.add(data);

--- a/pgdog/src/backend/pool/connection/mod.rs
+++ b/pgdog/src/backend/pool/connection/mod.rs
@@ -414,7 +414,7 @@ impl Connection {
     pub(crate) fn bind(&mut self, bind: &Bind) -> Result<(), Error> {
         match self.binding {
             Binding::MultiShard(_, ref mut state) => {
-                state.set_bind_context(bind);
+                state.push_bind(bind);
                 Ok(())
             }
 

--- a/pgdog/src/backend/pool/connection/multi_shard/mod.rs
+++ b/pgdog/src/backend/pool/connection/multi_shard/mod.rs
@@ -24,7 +24,7 @@ pub use error::Error;
 use validator::Validator;
 
 #[derive(Default, Debug)]
-struct Counters {
+struct RequestState {
     rows: usize,
     ready_for_query: usize,
     command_complete_count: usize,
@@ -55,16 +55,15 @@ pub struct MultiShard {
     /// When all shards are connected, this is `[0, 1, 2, ...]`.
     /// When only a subset is connected (e.g. shards 0 and 2), this is `[0, 2]`.
     shard_indices: Vec<usize>,
-
-    /// Counters
-    counters: Counters,
-
+    /// In-flight request state.
+    request_state: RequestState,
     /// Sorting/aggregate buffer.
     buffer: Buffer,
+    /// Row decoder.
     decoder: Decoder,
     /// Row consistency validator.
     validator: Validator,
-    /// Binds waiting for their BindComplete, in the order they were sent.
+    /// [`Bind`]s waiting for their [`crate::net::BindComplete`], in the order they were sent.
     bound_statements: VecDeque<Bind>,
 }
 
@@ -76,13 +75,17 @@ impl MultiShard {
             shards,
             shard_indices,
             route: route.clone(),
-            counters: Counters::default(),
             ..Default::default()
         }
     }
 
     /// Map a positional index to the actual shard number.
-    pub(super) fn shard_index(&self, position: usize) -> usize {
+    ///
+    /// These can diverge since we can connect to less shards than there
+    /// are in the config, while the query parser will produce shard numbers
+    /// relative to all configured shards.
+    ///
+    pub(super) fn shard_number(&self, position: usize) -> usize {
         self.shard_indices
             .get(position)
             .copied()
@@ -96,248 +99,290 @@ impl MultiShard {
         self.route = route.clone();
     }
 
-    /// Update only the shards count without resetting counters.
-    /// Used for Sync-only requests where we need correct ReadyForQuery counting
-    /// but must preserve buffered CommandComplete from previous queries.
+    /// Update only the shards count without resetting message counters.
+    ///
+    /// Used for [`crate::net::Sync`]-only requests where we need correct [`ReadyForQuery`] counting
+    /// but must preserve buffered [`CommandComplete`] from previous queries.
+    ///
     pub(super) fn update_shards(&mut self, shards: usize) {
         self.shards = shards;
     }
 
-    pub(super) fn reset(&mut self) {
-        self.counters = Counters::default();
-        self.buffer.reset();
-        self.validator.reset();
+    /// Query finished execution, reset any query state.
+    pub(super) fn query_complete(&mut self) {
+        self.reset();
         // Don't reset:
         //  1. Route to keep routing decision
         //  2. Number of shards
         //  3. Decoder
-        //  4. Pending Binds, pushed before this runs
+        //  4. Pending Binds, pushed before this run
     }
 
-    /// Check if the message should be sent to the client, skipped,
+    #[inline]
+    fn reset(&mut self) {
+        self.request_state = RequestState::default();
+        self.buffer.reset();
+        self.validator.reset();
+
+        // Intentionally does not reset:
+        //  1. Route, to keep routing decision
+        //  2. Number of shards
+        //  3. Decoder state
+        //  4. Pending Binds, pushed before this run
+    }
+
+    /// Check if the message we received from Postgres should be sent to the client, skipped,
     /// or modified.
-    pub(super) fn forward(&mut self, message: Message) -> Result<Option<Message>, Error> {
+    ///
+    /// # Arguments
+    ///
+    /// * `message`: [`Message`] received from Postgres.
+    ///
+    /// # Returns
+    ///
+    /// [`Some`] if the message should be sent to the client, [`None`] if it should be dropped.
+    ///
+    pub(super) fn handle_server_message(
+        &mut self,
+        message: Message,
+    ) -> Result<Option<Message>, Error> {
+        Ok(match message.code() {
+            'Z' => self.handle_ready_for_query(message)?,
+            'C' => self.handle_command_complete(message)?,
+            'T' => self.handle_row_description(message)?,
+            'I' => self.handle_empty_query_response(message)?,
+            'D' => self.handle_data_row(message)?,
+            'G' => Self::handle_passthrough(message, &mut self.request_state.copy_in, self.shards),
+            'n' => Self::handle_passthrough(message, &mut self.request_state.no_data, self.shards),
+            '1' => Self::handle_passthrough(
+                message,
+                &mut self.request_state.parse_complete,
+                self.shards,
+            ),
+            '3' => Self::handle_passthrough(
+                message,
+                &mut self.request_state.close_complete,
+                self.shards,
+            ),
+            'c' => {
+                Self::handle_passthrough(message, &mut self.request_state.copy_done, self.shards)
+            }
+            'H' => Self::handle_passthrough(message, &mut self.request_state.copy_out, self.shards),
+            't' => Self::handle_passthrough(
+                message,
+                &mut self.request_state.parameter_description,
+                self.shards,
+            ),
+            '2' => self.handle_bind(message),
+            'd' => self.handle_copy_data(message),
+            _ => Some(message),
+        })
+    }
+
+    fn handle_ready_for_query(&mut self, message: Message) -> Result<Option<Message>, Error> {
+        self.request_state.ready_for_query += 1;
+
+        if message.transaction_error() {
+            self.request_state.transaction_error = true;
+        }
+
+        Ok(
+            if self
+                .request_state
+                .ready_for_query
+                .is_multiple_of(self.shards)
+            {
+                self.bound_statements.clear();
+
+                if self.request_state.transaction_error {
+                    Some(ReadyForQuery::error().message()?)
+                } else {
+                    Some(message)
+                }
+            } else {
+                None
+            },
+        )
+    }
+
+    // Count [`CommandComplete`] messages.
+    //
+    // Once all shards finished executing the command,
+    // we can start aggregating and sorting.
+    fn handle_command_complete(&mut self, message: Message) -> Result<Option<Message>, Error> {
+        let cc = CommandComplete::from_bytes(message.to_bytes())?;
+
+        // DDL commands don't return rows.
+        let has_rows = if let Some(rows) = cc.rows()? {
+            if self.route.is_omnisharded() {
+                // Only use the first shard's row count for consistency with DataRow.
+                if self.request_state.command_complete_count == 0 {
+                    self.request_state.rows = rows;
+                }
+            } else {
+                self.request_state.rows += rows;
+            }
+            true
+        } else {
+            false
+        };
+
+        self.request_state.command_complete_count += 1;
+
+        if self
+            .request_state
+            .command_complete_count
+            .is_multiple_of(self.shards)
+        {
+            self.buffer.full();
+
+            if !self.buffer.is_empty() {
+                self.buffer
+                    .aggregate(
+                        self.route.aggregate(),
+                        &self.decoder,
+                        self.route.aggregate_rewrite_plan(),
+                    )
+                    .map_err(Error::from)?;
+
+                self.buffer.sort(self.route.order_by(), &self.decoder);
+                self.buffer.distinct(self.route.distinct(), &self.decoder);
+                self.buffer.limit(self.route.limit());
+            }
+
+            if has_rows {
+                let rows = if self.should_buffer() {
+                    self.buffer.len()
+                } else {
+                    self.request_state.rows
+                };
+                self.request_state.command_complete = Some(cc.rewrite(rows)?.message()?);
+            } else {
+                return Ok(Some(cc.message()?));
+            }
+        }
+
+        Ok(None)
+    }
+
+    fn handle_row_description(&mut self, message: Message) -> Result<Option<Message>, Error> {
         let mut forward = None;
 
-        match message.code() {
-            'Z' => {
-                self.counters.ready_for_query += 1;
-                if message.transaction_error() {
-                    self.counters.transaction_error = true;
-                }
+        self.request_state.row_description += 1;
+        let rd = RowDescription::from_bytes(message.to_bytes())?;
 
-                forward = if self.counters.ready_for_query.is_multiple_of(self.shards) {
-                    self.bound_statements.clear();
+        // Validate row description consistency inside the group.
+        // we reset after shards processed the group of the same RD
+        let is_first_in_group = self.validator.validate_row_description(&rd)?;
 
-                    if self.counters.transaction_error {
-                        Some(ReadyForQuery::error().message()?)
-                    } else {
-                        Some(message)
-                    }
-                } else {
-                    None
-                };
-            }
+        // Set it as soon as we have it, so the aggregator and sorter
+        // can use it.
+        if is_first_in_group {
+            self.decoder.set_row_description(rd.clone());
+        }
 
-            // Count CommandComplete messages.
-            //
-            // Once all shards finished executing the command,
-            // we can start aggregating and sorting.
-            'C' => {
-                let cc = CommandComplete::from_bytes(message.to_bytes())?;
-                let has_rows = if let Some(rows) = cc.rows()? {
-                    if self.route.is_omnisharded() {
-                        // Only use the first shard's row count for consistency with DataRow.
-                        if self.counters.command_complete_count == 0 {
-                            self.counters.rows = rows;
-                        }
-                    } else {
-                        self.counters.rows += rows;
-                    }
-                    true
-                } else {
-                    false
-                };
-                self.counters.command_complete_count += 1;
-
-                if self
-                    .counters
-                    .command_complete_count
-                    .is_multiple_of(self.shards)
-                {
-                    self.buffer.full();
-
-                    if !self.buffer.is_empty() {
-                        self.buffer
-                            .aggregate(
-                                self.route.aggregate(),
-                                &self.decoder,
-                                self.route.aggregate_rewrite_plan(),
-                            )
-                            .map_err(Error::from)?;
-
-                        self.buffer.sort(self.route.order_by(), &self.decoder);
-                        self.buffer.distinct(self.route.distinct(), &self.decoder);
-                        self.buffer.limit(self.route.limit());
-                    }
-
-                    if has_rows {
-                        let rows = if self.should_buffer() {
-                            self.buffer.len()
-                        } else {
-                            self.counters.rows
-                        };
-                        self.counters.command_complete = Some(cc.rewrite(rows)?.message()?);
-                    } else {
-                        forward = Some(cc.message()?);
-                    }
-                }
-            }
-
-            'T' => {
-                self.counters.row_description += 1;
-                let rd = RowDescription::from_bytes(message.to_bytes())?;
-
-                // Validate row description consistency inside the group.
-                // we reset after shards processed the group of the same RD
-                let is_first_in_group = self.validator.validate_row_description(&rd)?;
-
-                // Set it as soon as we have it, so the aggregator and sorter
-                // can use it.
-                if is_first_in_group {
-                    self.decoder.set_row_description(rd.clone());
-                }
-
-                if self.counters.row_description.is_multiple_of(self.shards) {
-                    // Only send it to the client once all shards sent it,
-                    // so we don't get early requests from clients.
-                    let plan = self.route.aggregate_rewrite_plan();
-                    if plan.is_noop() {
-                        forward = Some(message);
-                    } else {
-                        let client_rd = rd.drop_columns(plan.drop_columns());
-                        forward = Some(client_rd.message()?);
-                    }
-
-                    // The next statement describes a different result set.
-                    self.validator.reset();
-                }
-            }
-
-            'I' => {
-                self.counters.empty_query_response += 1;
-                if self
-                    .counters
-                    .empty_query_response
-                    .is_multiple_of(self.shards)
-                {
-                    forward = Some(message);
-                }
-            }
-
-            'D' => {
-                if self.shards > 1 {
-                    // Validate data row consistency.
-                    let data_row = DataRow::from_bytes(message.to_bytes())?;
-                    self.validator.validate_data_row(&data_row)?;
-                }
-
-                // INVARIANT: omni dedup relies on Source::Backend carrying a
-                // process-unique BackendPid (see BackendPid::seq). Never tag messages
-                // with a non-unique value; doing so silently corrupts row deduplication.
-                if self.counters.first_backend_data.is_none() {
-                    self.counters.first_backend_data = message.source().backend_id();
-                }
-
-                if !self.should_buffer()
-                    && self.counters.row_description.is_multiple_of(self.shards)
-                {
-                    if self.route.is_omnisharded() {
-                        if self.counters.first_backend_data == message.source().backend_id() {
-                            forward = Some(message);
-                        }
-                    } else {
-                        forward = Some(message);
-                    }
-                } else {
-                    self.buffer.add(message).map_err(Error::from)?;
-                }
-            }
-
-            'G' => {
-                self.counters.copy_in += 1;
-                if self.counters.copy_in.is_multiple_of(self.shards) {
-                    forward = Some(message);
-                }
-            }
-
-            'n' => {
-                self.counters.no_data += 1;
-                if self.counters.no_data.is_multiple_of(self.shards) {
-                    forward = Some(message);
-                }
-            }
-
-            '1' => {
-                self.counters.parse_complete += 1;
-                if self.counters.parse_complete.is_multiple_of(self.shards) {
-                    forward = Some(message);
-                }
-            }
-
-            '3' => {
-                self.counters.close_complete += 1;
-                if self.counters.close_complete.is_multiple_of(self.shards) {
-                    forward = Some(message);
-                }
-            }
-
-            '2' => {
-                self.counters.bind_complete += 1;
-
-                if self.counters.bind_complete.is_multiple_of(self.shards) {
-                    forward = Some(message);
-
-                    if let Some(bind) = self.bound_statements.pop_front() {
-                        self.decoder.bind(&bind);
-                    }
-                }
-            }
-
-            'c' => {
-                self.counters.copy_done += 1;
-                if self.counters.copy_done.is_multiple_of(self.shards) {
-                    forward = Some(message);
-                }
-            }
-
-            'd' => {
-                self.counters.copy_data += 1;
+        if self
+            .request_state
+            .row_description
+            .is_multiple_of(self.shards)
+        {
+            // Only send it to the client once all shards sent it,
+            // so we don't get early requests from clients.
+            let plan = self.route.aggregate_rewrite_plan();
+            if plan.is_noop() {
                 forward = Some(message);
+            } else {
+                let client_rd = rd.drop_columns(plan.drop_columns());
+                forward = Some(client_rd.message()?);
             }
 
-            'H' => {
-                self.counters.copy_out += 1;
-                if self.counters.copy_out.is_multiple_of(self.shards) {
-                    forward = Some(message);
-                }
-            }
-
-            't' => {
-                self.counters.parameter_description += 1;
-                if self
-                    .counters
-                    .parameter_description
-                    .is_multiple_of(self.shards)
-                {
-                    forward = Some(message);
-                }
-            }
-
-            _ => forward = Some(message),
+            // The next statement describes a different result set.
+            self.validator.reset();
         }
 
         Ok(forward)
+    }
+
+    fn handle_empty_query_response(&mut self, message: Message) -> Result<Option<Message>, Error> {
+        self.request_state.empty_query_response += 1;
+
+        Ok(
+            if self
+                .request_state
+                .empty_query_response
+                .is_multiple_of(self.shards)
+            {
+                Some(message)
+            } else {
+                None
+            },
+        )
+    }
+
+    fn handle_data_row(&mut self, message: Message) -> Result<Option<Message>, Error> {
+        let mut forward = None;
+
+        if self.shards > 1 {
+            // Validate data row consistency.
+            let data_row = DataRow::from_bytes(message.to_bytes())?;
+            self.validator.validate_data_row(&data_row)?;
+        }
+
+        // INVARIANT: omni dedup relies on Source::Backend carrying a
+        // process-unique BackendPid (see BackendPid::seq). Never tag messages
+        // with a non-unique value; doing so silently corrupts row deduplication.
+        if self.request_state.first_backend_data.is_none() {
+            self.request_state.first_backend_data = message.source().backend_id();
+        }
+
+        if !self.should_buffer()
+            && self
+                .request_state
+                .row_description
+                .is_multiple_of(self.shards)
+        {
+            if self.route.is_omnisharded() {
+                if self.request_state.first_backend_data == message.source().backend_id() {
+                    forward = Some(message);
+                }
+            } else {
+                forward = Some(message);
+            }
+        } else {
+            self.buffer.add(message).map_err(Error::from)?;
+        }
+
+        Ok(forward)
+    }
+
+    fn handle_passthrough(message: Message, counter: &mut usize, shards: usize) -> Option<Message> {
+        *counter += 1;
+
+        if counter.is_multiple_of(shards) {
+            Some(message)
+        } else {
+            None
+        }
+    }
+
+    fn handle_bind(&mut self, message: Message) -> Option<Message> {
+        let mut forward = None;
+        self.request_state.bind_complete += 1;
+
+        if self.request_state.bind_complete.is_multiple_of(self.shards) {
+            forward = Some(message);
+
+            if let Some(bind) = self.bound_statements.pop_front() {
+                self.decoder.set_formats(&bind);
+            }
+        }
+
+        forward
+    }
+
+    fn handle_copy_data(&mut self, message: Message) -> Option<Message> {
+        self.request_state.copy_data += 1;
+        Some(message)
     }
 
     /// Return true if we need to buffer [`DataRow`] messages
@@ -347,23 +392,29 @@ impl MultiShard {
         // 2. The route contains transformations we need to perform, e.g., aggregates, sorting, etc.
         // 3. The route does not concern omnisharded tables which have the same data on all shards
         //    anyway.
-        self.shards > 1 && self.route.should_buffer() && !self.route.is_omnisharded()
+        self.shards > 1 && self.route.requires_post_processing() && !self.route.is_omnisharded()
     }
 
-    /// Multi-shard state is ready to send messages.
-    pub(super) fn message(&mut self) -> Option<Message> {
+    /// Get the next available server message to send to the client.
+    ///
+    /// Used when buffering and transforming messages. This returns [`None`] until
+    /// the state is ready, i.e., we received everything we need to sort/limit/offset, etc.
+    ///
+    pub(super) fn get_server_message(&mut self) -> Option<Message> {
         match self.buffer.take() {
             Some(data_row) => Some(data_row),
-            _ => self.counters.command_complete.take(),
+            _ => self.request_state.command_complete.take(),
         }
     }
 
-    /// Sorted rows or a merged CommandComplete are waiting for the client.
+    /// The state has more messages for the client.
     pub(super) fn has_more_messages(&self) -> bool {
-        self.buffer.can_take() || self.counters.command_complete.is_some()
+        self.buffer.can_take() || self.request_state.command_complete.is_some()
     }
 
-    pub(super) fn set_bind_context(&mut self, bind: &Bind) {
+    /// Push [`Bind`] message into decoding queue. This is used with multi-[`Bind`] extended
+    /// protocol requests to make sure we process them in the right order and with correct decoding.
+    pub(super) fn push_bind(&mut self, bind: &Bind) {
         self.bound_statements.push_back(bind.clone());
     }
 }

--- a/pgdog/src/backend/pool/connection/multi_shard/mod.rs
+++ b/pgdog/src/backend/pool/connection/multi_shard/mod.rs
@@ -179,6 +179,29 @@ impl MultiShard {
         })
     }
 
+    /// Get the next available server message to send to the client.
+    ///
+    /// Used when buffering and transforming messages. This returns [`None`] until
+    /// the state is ready, i.e., we received everything we need to sort/limit/offset, etc.
+    ///
+    pub(super) fn get_server_message(&mut self) -> Option<Message> {
+        match self.buffer.take() {
+            Some(data_row) => Some(data_row),
+            _ => self.request_state.command_complete.take(),
+        }
+    }
+
+    /// The state has more messages for the client.
+    pub(super) fn has_more_messages(&self) -> bool {
+        self.buffer.can_take() || self.request_state.command_complete.is_some()
+    }
+
+    /// Push [`Bind`] message into decoding queue. This is used with multi-[`Bind`] extended
+    /// protocol requests to make sure we process them in the right order and with correct decoding.
+    pub(super) fn push_bind(&mut self, bind: &Bind) {
+        self.bound_statements.push_back(bind.clone());
+    }
+
     fn handle_ready_for_query(&mut self, message: Message) -> Result<Option<Message>, Error> {
         self.request_state.ready_for_query += 1;
 
@@ -393,28 +416,5 @@ impl MultiShard {
         // 3. The route does not concern omnisharded tables which have the same data on all shards
         //    anyway.
         self.shards > 1 && self.route.requires_post_processing() && !self.route.is_omnisharded()
-    }
-
-    /// Get the next available server message to send to the client.
-    ///
-    /// Used when buffering and transforming messages. This returns [`None`] until
-    /// the state is ready, i.e., we received everything we need to sort/limit/offset, etc.
-    ///
-    pub(super) fn get_server_message(&mut self) -> Option<Message> {
-        match self.buffer.take() {
-            Some(data_row) => Some(data_row),
-            _ => self.request_state.command_complete.take(),
-        }
-    }
-
-    /// The state has more messages for the client.
-    pub(super) fn has_more_messages(&self) -> bool {
-        self.buffer.can_take() || self.request_state.command_complete.is_some()
-    }
-
-    /// Push [`Bind`] message into decoding queue. This is used with multi-[`Bind`] extended
-    /// protocol requests to make sure we process them in the right order and with correct decoding.
-    pub(super) fn push_bind(&mut self, bind: &Bind) {
-        self.bound_statements.push_back(bind.clone());
     }
 }

--- a/pgdog/src/backend/pool/connection/multi_shard/test.rs
+++ b/pgdog/src/backend/pool/connection/multi_shard/test.rs
@@ -15,11 +15,13 @@ fn test_inconsistent_row_descriptions() {
     let rd2 = RowDescription::new(&[Field::text("name")]); // Missing column
 
     // First row description should be processed successfully
-    let result = multi_shard.forward(rd1.message().unwrap()).unwrap();
+    let result = multi_shard
+        .handle_server_message(rd1.message().unwrap())
+        .unwrap();
     assert!(result.is_none()); // Not forwarded until all shards respond
 
     // Second inconsistent row description should cause an error
-    let result = multi_shard.forward(rd2.message().unwrap());
+    let result = multi_shard.handle_server_message(rd2.message().unwrap());
     assert!(result.is_err());
 
     if let Err(error) = result {
@@ -36,7 +38,9 @@ fn test_inconsistent_data_rows() {
 
     // Set up row description first
     let rd = RowDescription::new(&[Field::text("name"), Field::bigint("id")]);
-    multi_shard.forward(rd.message().unwrap()).unwrap();
+    multi_shard
+        .handle_server_message(rd.message().unwrap())
+        .unwrap();
 
     // Create data rows with different column counts
     let mut dr1 = DataRow::new();
@@ -46,11 +50,13 @@ fn test_inconsistent_data_rows() {
     dr2.add("only_name"); // Missing id column
 
     // First data row should be processed successfully
-    let result = multi_shard.forward(dr1.message().unwrap()).unwrap();
+    let result = multi_shard
+        .handle_server_message(dr1.message().unwrap())
+        .unwrap();
     assert!(result.is_none()); // Buffered, not forwarded immediately
 
     // Second inconsistent data row should cause an error
-    let result = multi_shard.forward(dr2.message().unwrap());
+    let result = multi_shard.handle_server_message(dr2.message().unwrap());
     assert!(result.is_err());
 
     if let Err(error) = result {
@@ -71,24 +77,26 @@ fn test_rd_before_dr() {
     dr.add(1i64);
     for _ in 0..2 {
         let result = multi_shard
-            .forward(rd.message().unwrap().backend(BackendPid::for_test(1)))
+            .handle_server_message(rd.message().unwrap().backend(BackendPid::for_test(1)))
             .unwrap();
         assert!(result.is_none()); // dropped
         let result = multi_shard
-            .forward(dr.message().unwrap().backend(BackendPid::for_test(1)))
+            .handle_server_message(dr.message().unwrap().backend(BackendPid::for_test(1)))
             .unwrap();
         assert!(result.is_none()); // buffered.
     }
 
-    let result = multi_shard.forward(rd.message().unwrap()).unwrap();
+    let result = multi_shard
+        .handle_server_message(rd.message().unwrap())
+        .unwrap();
     assert_eq!(result, Some(rd.message().unwrap()));
-    let result = multi_shard.message();
+    let result = multi_shard.get_server_message();
     // Waiting for command complete
     assert!(result.is_none());
 
     for _ in 0..3 {
         let result = multi_shard
-            .forward(
+            .handle_server_message(
                 CommandComplete::from_str("SELECT 1")
                     .message()
                     .unwrap()
@@ -99,7 +107,7 @@ fn test_rd_before_dr() {
     }
 
     for _ in 0..2 {
-        let result = multi_shard.message();
+        let result = multi_shard.get_server_message();
         let id = BackendPid::for_test(1);
         assert_eq!(
             result.map(|m| m.backend(id)),
@@ -108,7 +116,7 @@ fn test_rd_before_dr() {
     }
 
     let result = multi_shard
-        .message()
+        .get_server_message()
         .map(|m| m.backend(BackendPid::for_test(1)));
     assert_eq!(
         result,
@@ -121,7 +129,7 @@ fn test_rd_before_dr() {
     );
 
     // Buffer is empty.
-    assert!(multi_shard.message().is_none());
+    assert!(multi_shard.get_server_message().is_none());
 }
 
 #[test]
@@ -134,11 +142,15 @@ fn test_ready_for_query_error_preservation() {
     let rfq_normal = ReadyForQuery::in_transaction(false);
 
     // Forward first ReadyForQuery message with error state
-    let result = multi_shard.forward(rfq_error.message().unwrap()).unwrap();
+    let result = multi_shard
+        .handle_server_message(rfq_error.message().unwrap())
+        .unwrap();
     assert!(result.is_none()); // Should not be forwarded yet (waiting for second shard)
 
     // Forward second normal ReadyForQuery message
-    let result = multi_shard.forward(rfq_normal.message().unwrap()).unwrap();
+    let result = multi_shard
+        .handle_server_message(rfq_normal.message().unwrap())
+        .unwrap();
 
     // Should return the error message, not the normal one
     assert!(result.is_some());
@@ -159,7 +171,7 @@ fn test_omni_command_complete_not_summed() {
 
     // All shards report UPDATE 5
     multi_shard
-        .forward(
+        .handle_server_message(
             CommandComplete::from_str("UPDATE 5")
                 .message()
                 .unwrap()
@@ -167,7 +179,7 @@ fn test_omni_command_complete_not_summed() {
         )
         .unwrap();
     multi_shard
-        .forward(
+        .handle_server_message(
             CommandComplete::from_str("UPDATE 5")
                 .message()
                 .unwrap()
@@ -175,7 +187,7 @@ fn test_omni_command_complete_not_summed() {
         )
         .unwrap();
     multi_shard
-        .forward(
+        .handle_server_message(
             CommandComplete::from_str("UPDATE 5")
                 .message()
                 .unwrap()
@@ -183,7 +195,7 @@ fn test_omni_command_complete_not_summed() {
         )
         .unwrap();
 
-    let result = multi_shard.message();
+    let result = multi_shard.get_server_message();
     let cc = CommandComplete::from_bytes(result.unwrap().to_bytes()).unwrap();
     // Should be 5 (from one shard), not 15 (sum of all shards)
     assert_eq!(cc.rows().unwrap(), Some(5));
@@ -200,7 +212,7 @@ fn test_omni_command_complete_uses_first_shard_row_count() {
 
     // First shard reports 7 rows
     multi_shard
-        .forward(
+        .handle_server_message(
             CommandComplete::from_str("UPDATE 7")
                 .message()
                 .unwrap()
@@ -210,7 +222,7 @@ fn test_omni_command_complete_uses_first_shard_row_count() {
 
     // Second shard reports 9 rows (different, to distinguish first vs last)
     multi_shard
-        .forward(
+        .handle_server_message(
             CommandComplete::from_str("UPDATE 9")
                 .message()
                 .unwrap()
@@ -218,7 +230,7 @@ fn test_omni_command_complete_uses_first_shard_row_count() {
         )
         .unwrap();
 
-    let result = multi_shard.message();
+    let result = multi_shard.get_server_message();
     let cc = CommandComplete::from_bytes(result.unwrap().to_bytes()).unwrap();
     // Should be 7 (from FIRST shard), not 9 (from last)
     assert_eq!(cc.rows().unwrap(), Some(7));
@@ -236,10 +248,10 @@ fn test_omni_data_rows_only_from_first_server() {
     // Setup: send RowDescription from both shards
     let rd = RowDescription::new(&[Field::bigint("id")]);
     multi_shard
-        .forward(rd.message().unwrap().backend(backend1))
+        .handle_server_message(rd.message().unwrap().backend(backend1))
         .unwrap();
     let rd_result = multi_shard
-        .forward(rd.message().unwrap().backend(backend2))
+        .handle_server_message(rd.message().unwrap().backend(backend2))
         .unwrap();
     assert!(rd_result.is_some()); // RowDescription forwarded after all shards
 
@@ -247,7 +259,7 @@ fn test_omni_data_rows_only_from_first_server() {
     let mut dr1 = DataRow::new();
     dr1.add(100_i64);
     let result = multi_shard
-        .forward(dr1.message().unwrap().backend(backend1))
+        .handle_server_message(dr1.message().unwrap().backend(backend1))
         .unwrap();
     assert!(result.is_some()); // Should be forwarded
 
@@ -255,7 +267,7 @@ fn test_omni_data_rows_only_from_first_server() {
     let mut dr2 = DataRow::new();
     dr2.add(200_i64);
     let result = multi_shard
-        .forward(dr2.message().unwrap().backend(backend2))
+        .handle_server_message(dr2.message().unwrap().backend(backend2))
         .unwrap();
     assert!(result.is_none()); // Should be dropped
 
@@ -263,7 +275,7 @@ fn test_omni_data_rows_only_from_first_server() {
     let mut dr3 = DataRow::new();
     dr3.add(101_i64);
     let result = multi_shard
-        .forward(dr3.message().unwrap().backend(backend1))
+        .handle_server_message(dr3.message().unwrap().backend(backend1))
         .unwrap();
     assert!(result.is_some()); // Should be forwarded
 }
@@ -284,7 +296,9 @@ fn test_pipelined_describe_forwards_every_group() {
 
         for description in [&id, &name] {
             for _ in 0..shards {
-                if let Some(message) = multi_shard.forward(description.message().unwrap()).unwrap()
+                if let Some(message) = multi_shard
+                    .handle_server_message(description.message().unwrap())
+                    .unwrap()
                 {
                     forwarded.push(message);
                 }
@@ -312,29 +326,33 @@ fn test_bind_result_formats_apply_per_statement() {
     let text = Bind::new_statement("b2");
     let rd = RowDescription::new(&[Field::bigint("id")]);
 
-    multi_shard.set_bind_context(&binary);
-    multi_shard.set_bind_context(&text);
+    multi_shard.push_bind(&binary);
+    multi_shard.push_bind(&text);
 
     for _ in 0..2 {
         multi_shard
-            .forward(BindComplete.message().unwrap())
+            .handle_server_message(BindComplete.message().unwrap())
             .unwrap();
     }
     for _ in 0..2 {
-        multi_shard.forward(rd.message().unwrap()).unwrap();
+        multi_shard
+            .handle_server_message(rd.message().unwrap())
+            .unwrap();
     }
-    assert_eq!(multi_shard.decoder.format(0), Format::Binary);
+    assert_eq!(multi_shard.decoder.get_format(0), Format::Binary);
 
     // The second statement asked for no formats.
     for _ in 0..2 {
         multi_shard
-            .forward(BindComplete.message().unwrap())
+            .handle_server_message(BindComplete.message().unwrap())
             .unwrap();
     }
     for _ in 0..2 {
-        multi_shard.forward(rd.message().unwrap()).unwrap();
+        multi_shard
+            .handle_server_message(rd.message().unwrap())
+            .unwrap();
     }
-    assert_eq!(multi_shard.decoder.format(0), Format::Text);
+    assert_eq!(multi_shard.decoder.get_format(0), Format::Text);
 }
 
 /// A Bind that never completed is dropped at ReadyForQuery, so the next
@@ -346,20 +364,20 @@ fn test_ready_for_query_drops_pending_binds() {
         &Route::read(ShardWithPriority::new_default_unset(Shard::All)),
     );
 
-    multi_shard.set_bind_context(&Bind::new_statement("b1"));
-    multi_shard.set_bind_context(&Bind::new_statement("b2"));
+    multi_shard.push_bind(&Bind::new_statement("b1"));
+    multi_shard.push_bind(&Bind::new_statement("b2"));
 
     // Only the first statement binds. The second is abandoned.
     for _ in 0..2 {
         multi_shard
-            .forward(BindComplete.message().unwrap())
+            .handle_server_message(BindComplete.message().unwrap())
             .unwrap();
     }
     assert_eq!(multi_shard.bound_statements.len(), 1);
 
     for _ in 0..2 {
         multi_shard
-            .forward(ReadyForQuery::idle().message().unwrap())
+            .handle_server_message(ReadyForQuery::idle().message().unwrap())
             .unwrap();
     }
     assert!(multi_shard.bound_statements.is_empty());

--- a/pgdog/src/frontend/router/parser/route.rs
+++ b/pgdog/src/frontend/router/parser/route.rs
@@ -332,7 +332,7 @@ impl Route {
     /// 3. `DISTINCT` clause
     /// 4. `LIMIT` or `OFFSET` clause
     ///
-    pub fn should_buffer(&self) -> bool {
+    pub fn requires_post_processing(&self) -> bool {
         !self.order_by().is_empty()
             || !self.aggregate().is_empty()
             || self.distinct().is_some()
@@ -743,7 +743,7 @@ mod test {
     #[test]
     fn test_should_buffer_empty_route() {
         let route = Route::default();
-        assert!(!route.should_buffer());
+        assert!(!route.requires_post_processing());
     }
 
     #[test]
@@ -755,7 +755,7 @@ mod test {
             Limit::default(),
             None,
         );
-        assert!(route.should_buffer());
+        assert!(route.requires_post_processing());
     }
 
     #[test]
@@ -770,7 +770,7 @@ mod test {
             },
             None,
         );
-        assert!(!route.should_buffer());
+        assert!(!route.requires_post_processing());
     }
 
     #[test]
@@ -785,7 +785,7 @@ mod test {
             },
             None,
         );
-        assert!(route.should_buffer());
+        assert!(route.requires_post_processing());
     }
 
     #[test]
@@ -800,7 +800,7 @@ mod test {
             },
             None,
         );
-        assert!(route.should_buffer());
+        assert!(route.requires_post_processing());
     }
 
     #[test]
@@ -812,7 +812,7 @@ mod test {
             Limit::default(),
             None,
         );
-        assert!(!route.should_buffer());
+        assert!(!route.requires_post_processing());
     }
 
     #[test]

--- a/pgdog/src/net/decoder.rs
+++ b/pgdog/src/net/decoder.rs
@@ -2,49 +2,52 @@ use crate::frontend::PreparedStatements;
 
 use super::{Bind, Format, RowDescription};
 
-/// Decodes result columns.
+/// Decodes columns returned by Postgres.
 ///
-/// The server owns the column names and types, the client's Bind owns the
-/// wire formats. Neither may overwrite the other.
+/// This is just a helpful interface on top of [`Bind`] and [`RowDescription`]. The
+/// decoding logic in those messages are doing all the work.
+///
 #[derive(Debug, Clone, Default)]
 pub struct Decoder {
-    /// Formats requested by the client's Bind.
+    /// Expected result column formats, as requested by [`Bind`] sent by client.
+    /// For queries using the simple protocol, the format will be text.
     formats: Vec<Format>,
-    rd: RowDescription,
+    /// Row description returned by Postgres.
+    row_description: Option<RowDescription>,
 }
 
 impl Decoder {
-    /// New column decoder.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Describe the rows a Bind is about to produce. Only a statement the
-    /// cache knows replaces the columns, because clearing them would leave
-    /// the sorter with no types at all.
-    pub fn bind(&mut self, bind: &Bind) {
+    /// Set the format the client specified for the request.
+    pub fn set_formats(&mut self, bind: &Bind) {
         self.formats.clear();
         self.formats.extend(bind.result_formats());
 
+        // Unnamed statements will cause the server to return `RowDescription`. Will will
+        // see it and set it. Named statements will often request it separately with `Describe`
+        // as part of a previous request, so we get it from the prepared statements cache.
         if !bind.anonymous()
             && let Some(rd) = PreparedStatements::global()
                 .read()
                 .row_description(bind.statement())
         {
-            self.rd = rd;
+            self.row_description = Some(rd);
         }
     }
 
-    /// Describe the rows the server just announced.
+    /// Set the [`RowDescription`] returned by the server.
+    /// This will be used to identify column names and types.
     pub fn set_row_description(&mut self, rd: RowDescription) {
-        self.rd = rd;
+        self.row_description = Some(rd);
     }
 
-    /// Get format used for column at position.
-    pub fn format(&self, position: usize) -> Format {
+    /// Get format used for column at position. Uses 0-indexed positioning.
+    ///
+    /// BUG(lev): Always returns a format, defaulting to text if the column format is not known.
+    ///
+    pub fn get_format(&self, position: usize) -> Format {
         match self.formats.len() {
             0 => self
-                .rd
+                .row_description()
                 .field(position)
                 .map(|field| field.format())
                 .unwrap_or(Format::Text),
@@ -53,8 +56,12 @@ impl Decoder {
         }
     }
 
-    pub fn rd(&self) -> &RowDescription {
-        &self.rd
+    /// Get a reference to the [`RowDescription`] the server sent
+    /// for the request.
+    pub fn row_description(&self) -> &RowDescription {
+        self.row_description
+            .as_ref()
+            .expect("decoder has no row description set")
     }
 }
 
@@ -64,7 +71,7 @@ mod test_impls {
 
     impl From<RowDescription> for Decoder {
         fn from(value: RowDescription) -> Self {
-            let mut decoder = Decoder::new();
+            let mut decoder = Decoder::default();
             decoder.set_row_description(value);
             decoder
         }
@@ -82,60 +89,60 @@ mod test {
 
     #[test]
     fn test_row_description_decides_without_bind() {
-        let mut decoder = Decoder::new();
+        let mut decoder = Decoder::default();
         decoder.set_row_description(text_rd());
 
-        assert_eq!(decoder.format(0), Format::Text);
-        assert_eq!(decoder.format(1), Format::Text);
+        assert_eq!(decoder.get_format(0), Format::Text);
+        assert_eq!(decoder.get_format(1), Format::Text);
     }
 
     #[test]
     fn test_bind_result_formats_survive_row_description() {
-        let mut decoder = Decoder::new();
+        let mut decoder = Decoder::default();
         let bind = Bind::new_params_codes_results("s1", &[], &[], &[1, 0]);
 
-        decoder.bind(&bind);
+        decoder.set_formats(&bind);
         decoder.set_row_description(text_rd());
 
-        assert_eq!(decoder.format(0), Format::Binary);
-        assert_eq!(decoder.format(1), Format::Text);
+        assert_eq!(decoder.get_format(0), Format::Binary);
+        assert_eq!(decoder.get_format(1), Format::Text);
     }
 
     #[test]
     fn test_row_description_before_bind_gives_the_same_answer() {
-        let mut decoder = Decoder::new();
+        let mut decoder = Decoder::default();
         let bind = Bind::new_params_codes_results("s1", &[], &[], &[1, 0]);
 
         decoder.set_row_description(text_rd());
-        decoder.bind(&bind);
+        decoder.set_formats(&bind);
 
-        assert_eq!(decoder.format(0), Format::Binary);
-        assert_eq!(decoder.format(1), Format::Text);
+        assert_eq!(decoder.get_format(0), Format::Binary);
+        assert_eq!(decoder.get_format(1), Format::Text);
     }
 
     #[test]
     fn test_one_result_format_applies_to_every_column() {
-        let mut decoder = Decoder::new();
+        let mut decoder = Decoder::default();
         decoder.set_row_description(text_rd());
-        decoder.bind(&Bind::new_params_codes_results("s1", &[], &[], &[1]));
+        decoder.set_formats(&Bind::new_params_codes_results("s1", &[], &[], &[1]));
 
-        assert_eq!(decoder.format(0), Format::Binary);
-        assert_eq!(decoder.format(1), Format::Binary);
+        assert_eq!(decoder.get_format(0), Format::Binary);
+        assert_eq!(decoder.get_format(1), Format::Binary);
     }
 
     #[test]
     fn test_bind_keeps_the_server_description_when_the_cache_is_empty() {
-        let mut decoder = Decoder::new();
+        let mut decoder = Decoder::default();
         decoder.set_row_description(text_rd());
-        decoder.bind(&Bind::new_params_codes_results("s1", &[], &[], &[1]));
+        decoder.set_formats(&Bind::new_params_codes_results("s1", &[], &[], &[1]));
 
         // Nothing described s1, so the only columns we have are the ones the
         // server announced. The formats still come from the Bind.
-        assert_eq!(decoder.rd().fields.len(), 2);
-        assert_eq!(decoder.format(0), Format::Binary);
+        assert_eq!(decoder.row_description().fields.len(), 2);
+        assert_eq!(decoder.get_format(0), Format::Binary);
 
-        decoder.bind(&Bind::new_statement("s2"));
+        decoder.set_formats(&Bind::new_statement("s2"));
 
-        assert_eq!(decoder.format(0), Format::Text);
+        assert_eq!(decoder.get_format(0), Format::Text);
     }
 }

--- a/pgdog/src/net/messages/data_row.rs
+++ b/pgdog/src/net/messages/data_row.rs
@@ -120,7 +120,7 @@ impl DataRow {
         index: usize,
         decoder: &'a Decoder,
     ) -> Result<Option<Column<'a>>, Error> {
-        if let Some(field) = decoder.rd().field(index)
+        if let Some(field) = decoder.row_description().field(index)
             && let Some(data) = self.columns.get(index)
         {
             return Ok(Some(Column {
@@ -128,7 +128,7 @@ impl DataRow {
                 value: Datum::new(
                     &data.data,
                     field.data_type(),
-                    decoder.format(index),
+                    decoder.get_format(index),
                     data.is_null,
                 )?,
             }));


### PR DESCRIPTION
All changes are no-ops.

- remove redundant code in multi shard state manager, and move message handling into its own functions
- give methods more intuitive names
- fix a few comments
- remove no longer necessary `debug!`
- panic if row decoder has no row description
