### PR TITLE
fix: DISTINCT state was not reset between queries in the same transaction + refactor

### DIFF
--- a/pgdog/src/admin/copy_data.rs
+++ b/pgdog/src/admin/copy_data.rs
@@ -69,8 +69,8 @@ impl Command for CopyData {
 
         Ok(vec![
             RowDescription::new(&[Field::text("task_id"), Field::text("replication_slot")])
-                .message()?,
-            dr.message()?,
+                .message(),
+            dr.message(),
         ])
     }
 }

--- a/pgdog/src/admin/cutover.rs
+++ b/pgdog/src/admin/cutover.rs
@@ -39,8 +39,8 @@ impl Command for Cutover {
         dr.add("OK");
 
         Ok(vec![
-            RowDescription::new(&[Field::text("cutover")]).message()?,
-            dr.message()?,
+            RowDescription::new(&[Field::text("cutover")]).message(),
+            dr.message(),
         ])
     }
 }

--- a/pgdog/src/admin/probe.rs
+++ b/pgdog/src/admin/probe.rs
@@ -46,6 +46,6 @@ impl Command for Probe {
         let rd = RowDescription::new(&[Field::bigint("latency")]);
         let mut dr = DataRow::new();
         dr.add(duration.as_millis() as i64);
-        Ok(vec![rd.message()?, dr.message()?])
+        Ok(vec![rd.message(), dr.message()])
     }
 }

--- a/pgdog/src/admin/replicate.rs
+++ b/pgdog/src/admin/replicate.rs
@@ -67,8 +67,8 @@ impl Command for Replicate {
         dr.add(task_id.to_string());
 
         Ok(vec![
-            RowDescription::new(&[Field::text("task_id")]).message()?,
-            dr.message()?,
+            RowDescription::new(&[Field::text("task_id")]).message(),
+            dr.message(),
         ])
     }
 }

--- a/pgdog/src/admin/reshard.rs
+++ b/pgdog/src/admin/reshard.rs
@@ -71,8 +71,8 @@ impl Command for Reshard {
         dr.add(task_id.to_string());
 
         Ok(vec![
-            RowDescription::new(&[Field::text("task_id")]).message()?,
-            dr.message()?,
+            RowDescription::new(&[Field::text("task_id")]).message(),
+            dr.message(),
         ])
     }
 }

--- a/pgdog/src/admin/schema_sync.rs
+++ b/pgdog/src/admin/schema_sync.rs
@@ -83,8 +83,8 @@ impl Command for SchemaSync {
         dr.add(task_id.to_string());
 
         Ok(vec![
-            RowDescription::new(&[Field::text("task_id")]).message()?,
-            dr.message()?,
+            RowDescription::new(&[Field::text("task_id")]).message(),
+            dr.message(),
         ])
     }
 }

--- a/pgdog/src/admin/server.rs
+++ b/pgdog/src/admin/server.rs
@@ -51,17 +51,17 @@ impl AdminServer {
         let messages = match Parser::parse(&query.query().to_lowercase()) {
             Ok(command) => {
                 let mut messages = command.execute().await?;
-                messages.push(CommandComplete::new(command.name()).message()?);
+                messages.push(CommandComplete::new(command.name()).message());
 
                 messages
             }
             Err(err) => {
-                vec![ErrorResponse::protocol_violation(err.to_string().as_str()).message()?]
+                vec![ErrorResponse::protocol_violation(err.to_string().as_str()).message()]
             }
         };
 
         self.messages.extend(messages);
-        self.messages.push_back(ReadyForQuery::idle().message()?);
+        self.messages.push_back(ReadyForQuery::idle().message());
 
         Ok(())
     }

--- a/pgdog/src/admin/show_bans.rs
+++ b/pgdog/src/admin/show_bans.rs
@@ -35,7 +35,7 @@ impl Command for ShowBans {
             Field::numeric("ban_time_left"),
         ]);
 
-        let mut messages = vec![rd.message()?];
+        let mut messages = vec![rd.message()];
         let now = Instant::now();
 
         for (user, cluster) in databases().all() {
@@ -62,7 +62,7 @@ impl Command for ShowBans {
                         .add(ban.error().map(|err| err.to_string()))
                         .add(time_left);
 
-                    messages.push(row.message()?);
+                    messages.push(row.message());
                 }
             }
         }

--- a/pgdog/src/admin/show_client_memory.rs
+++ b/pgdog/src/admin/show_client_memory.rs
@@ -32,7 +32,7 @@ impl Command for ShowClientMemory {
             Field::numeric("net_buffer_bytes"),
             Field::numeric("total_bytes"),
         ]);
-        let mut messages = vec![rd.message()?];
+        let mut messages = vec![rd.message()];
 
         let clients = comms().clients();
         for (_, client) in clients {
@@ -55,7 +55,7 @@ impl Command for ShowClientMemory {
                 .add(memory.stream as i64)
                 .add((memory.total()) as i64);
 
-            messages.push(row.message()?);
+            messages.push(row.message());
         }
 
         Ok(messages)

--- a/pgdog/src/admin/show_clients.rs
+++ b/pgdog/src/admin/show_clients.rs
@@ -121,10 +121,10 @@ impl Command for ShowClients {
                 .add("locked", client.stats.locked)
                 .add("prepared_statements", client.stats.prepared_statements)
                 .data_row();
-            rows.push(row.message()?);
+            rows.push(row.message());
         }
 
-        let mut messages = vec![self.filter.row_description().message()?];
+        let mut messages = vec![self.filter.row_description().message()];
         messages.extend(rows);
 
         Ok(messages)

--- a/pgdog/src/admin/show_config.rs
+++ b/pgdog/src/admin/show_config.rs
@@ -28,7 +28,7 @@ impl Command for ShowConfig {
         let _databases = databases();
 
         let mut messages =
-            vec![RowDescription::new(&[Field::text("name"), Field::text("value")]).message()?];
+            vec![RowDescription::new(&[Field::text("name"), Field::text("value")]).message()];
 
         // Reflection using JSON.
         let general = serde_json::to_value(&config.config.general)?;
@@ -46,7 +46,7 @@ impl Command for ShowConfig {
                     let mut dr = DataRow::new();
                     let name = prefix.to_string() + key.as_str();
                     dr.add(&name).add(pretty_value(&name, value)?);
-                    messages.push(dr.message()?);
+                    messages.push(dr.message());
                 }
             }
         }

--- a/pgdog/src/admin/show_guc.rs
+++ b/pgdog/src/admin/show_guc.rs
@@ -42,6 +42,6 @@ impl Command for ShowGuc {
         let mut dr = DataRow::new();
         dr.add(&value);
 
-        Ok(vec![rd.message()?, dr.message()?])
+        Ok(vec![rd.message(), dr.message()])
     }
 }

--- a/pgdog/src/admin/show_instance_id.rs
+++ b/pgdog/src/admin/show_instance_id.rs
@@ -21,8 +21,8 @@ impl Command for ShowInstanceId {
         dr.add(instance_id());
 
         Ok(vec![
-            RowDescription::new(&[Field::text("instance_id")]).message()?,
-            dr.message()?,
+            RowDescription::new(&[Field::text("instance_id")]).message(),
+            dr.message(),
         ])
     }
 }

--- a/pgdog/src/admin/show_listeners.rs
+++ b/pgdog/src/admin/show_listeners.rs
@@ -30,7 +30,7 @@ impl Command for ShowListeners {
                 Field::numeric("received"),
                 Field::numeric("dropped"),
             ])
-            .message()?,
+            .message(),
         ];
 
         for (key, stats) in channels {
@@ -43,7 +43,7 @@ impl Command for ShowListeners {
                 .add(stats.listeners as i64)
                 .add(stats.recv as i64)
                 .add(stats.dropped as i64);
-            messages.push(data_row.message()?);
+            messages.push(data_row.message());
         }
 
         Ok(messages)

--- a/pgdog/src/admin/show_lists.rs
+++ b/pgdog/src/admin/show_lists.rs
@@ -51,6 +51,6 @@ impl Command for ShowLists {
             .add(0_i64)
             .add(servers.len() as i64);
 
-        Ok(vec![rd.message()?, dr.message()?])
+        Ok(vec![rd.message(), dr.message()])
     }
 }

--- a/pgdog/src/admin/show_mirrors.rs
+++ b/pgdog/src/admin/show_mirrors.rs
@@ -28,7 +28,7 @@ impl Command for ShowMirrors {
             Field::numeric("queue_length"),
         ];
 
-        let mut messages = vec![RowDescription::new(&fields).message()?];
+        let mut messages = vec![RowDescription::new(&fields).message()];
 
         // Iterate through all clusters and create a row for each
         for (user, cluster) in databases().all() {
@@ -48,7 +48,7 @@ impl Command for ShowMirrors {
                 .add(counts.error_count as i64)
                 .add(counts.queue_length as i64);
 
-            messages.push(dr.message()?);
+            messages.push(dr.message());
         }
 
         Ok(messages)

--- a/pgdog/src/admin/show_peers.rs
+++ b/pgdog/src/admin/show_peers.rs
@@ -39,7 +39,7 @@ impl Command for ShowPeers {
                 Field::text("last_seen"),
                 Field::numeric("clients"),
             ])
-            .message()?,
+            .message(),
         ];
 
         let now = SystemTime::now();
@@ -53,7 +53,7 @@ impl Command for ShowPeers {
                         .unwrap_or(Duration::from_secs(0))
                 ))
                 .add(state.clients);
-            rows.push(row.message()?);
+            rows.push(row.message());
         }
 
         Ok(rows)

--- a/pgdog/src/admin/show_pools.rs
+++ b/pgdog/src/admin/show_pools.rs
@@ -45,7 +45,7 @@ impl Command for ShowPools {
             Field::bool("online"),
             Field::bool("schema_admin"),
         ]);
-        let mut messages = vec![rd.message()?];
+        let mut messages = vec![rd.message()];
         for (user, cluster) in databases().all() {
             for (shard_num, shard) in cluster.shards().iter().enumerate() {
                 for (role, ban, pool) in shard.pools_with_roles_and_bans() {
@@ -80,7 +80,7 @@ impl Command for ShowPools {
                         .add(state.online)
                         .add(cluster.schema_admin());
 
-                    messages.push(row.message()?);
+                    messages.push(row.message());
                 }
             }
         }

--- a/pgdog/src/admin/show_prepared_statements.rs
+++ b/pgdog/src/admin/show_prepared_statements.rs
@@ -29,7 +29,7 @@ impl Command for ShowPreparedStatements {
                 Field::numeric("used_by"),
                 Field::numeric("memory_used"),
             ])
-            .message()?,
+            .message(),
         ];
         for (key, stmt) in statements.statements() {
             let name = stmt.name();
@@ -54,7 +54,7 @@ impl Command for ShowPreparedStatements {
                 })
                 .add(stmt.used)
                 .add(name_memory);
-            messages.push(dr.message()?);
+            messages.push(dr.message());
         }
         Ok(messages)
     }

--- a/pgdog/src/admin/show_query_cache.rs
+++ b/pgdog/src/admin/show_query_cache.rs
@@ -35,7 +35,7 @@ impl Command for ShowQueryCache {
                 Field::numeric("direct"),
                 Field::numeric("multi"),
             ])
-            .message()?,
+            .message(),
         ];
 
         queries.sort_by_cached_key(|v| v.1.stats.lock().hits);
@@ -51,7 +51,7 @@ impl Command for ShowQueryCache {
                 .add(stats.hits)
                 .add(stats.direct)
                 .add(stats.multi);
-            messages.push(data_row.message()?);
+            messages.push(data_row.message());
         }
 
         Ok(messages)

--- a/pgdog/src/admin/show_replication.rs
+++ b/pgdog/src/admin/show_replication.rs
@@ -37,7 +37,7 @@ impl Command for ShowReplication {
             Field::text("lsn_age"),
             Field::text("pg_is_in_recovery"),
         ]);
-        let mut messages = vec![rd.message()?];
+        let mut messages = vec![rd.message()];
         let now = SystemTime::now();
         for (user, cluster) in databases().all() {
             for (shard_num, shard) in cluster.shards().iter().enumerate() {
@@ -83,7 +83,7 @@ impl Command for ShowReplication {
                             Data::null()
                         });
 
-                    messages.push(row.message()?);
+                    messages.push(row.message());
                 }
             }
         }

--- a/pgdog/src/admin/show_replication_slots.rs
+++ b/pgdog/src/admin/show_replication_slots.rs
@@ -35,7 +35,7 @@ impl Command for ShowReplicationSlots {
             Field::text("last_transaction"),
             Field::bigint("last_transaction_ms"),
         ]);
-        let mut messages = vec![rd.message()?];
+        let mut messages = vec![rd.message()];
         let now = SystemTime::now();
 
         for entry in ReplicationSlots::get().iter() {
@@ -70,7 +70,7 @@ impl Command for ShowReplicationSlots {
                     Data::null()
                 });
 
-            messages.push(row.message()?);
+            messages.push(row.message());
         }
 
         Ok(messages)

--- a/pgdog/src/admin/show_schema_sync.rs
+++ b/pgdog/src/admin/show_schema_sync.rs
@@ -35,7 +35,7 @@ impl Command for ShowSchemaSync {
             Field::text("table_name"),
             Field::text("sql"),
         ]);
-        let mut messages = vec![rd.message()?];
+        let mut messages = vec![rd.message()];
         let now = SystemTime::now();
 
         let mut entries: Vec<_> = SchemaStatements::get()
@@ -72,7 +72,7 @@ impl Command for ShowSchemaSync {
                 .add(stmt.table_name.as_deref().unwrap_or(""))
                 .add(stmt.sql.as_str());
 
-            messages.push(row.message()?);
+            messages.push(row.message());
         }
 
         Ok(messages)

--- a/pgdog/src/admin/show_server_memory.rs
+++ b/pgdog/src/admin/show_server_memory.rs
@@ -33,7 +33,7 @@ impl Command for ShowServerMemory {
             Field::numeric("net_buffer_bytes"),
             Field::numeric("total_bytes"),
         ]);
-        let mut messages = vec![rd.message()?];
+        let mut messages = vec![rd.message()];
 
         let stats = stats();
         for server in stats {
@@ -54,7 +54,7 @@ impl Command for ShowServerMemory {
                 .add(memory.stream as i64)
                 .add((memory.total()) as i64);
 
-            messages.push(row.message()?);
+            messages.push(row.message());
         }
 
         Ok(messages)

--- a/pgdog/src/admin/show_servers.rs
+++ b/pgdog/src/admin/show_servers.rs
@@ -73,7 +73,7 @@ impl Command for ShowServers {
     }
 
     async fn execute(&self) -> Result<Vec<Message>, Error> {
-        let mut messages = vec![self.row.row_description().message()?];
+        let mut messages = vec![self.row.row_description().message()];
 
         let stats = stats();
         let now = Instant::now();
@@ -119,7 +119,7 @@ impl Command for ShowServers {
                 .add("age", age.as_secs() as i64)
                 .add("application_name", server.application_name.as_str())
                 .data_row();
-            messages.push(dr.message()?);
+            messages.push(dr.message());
         }
 
         Ok(messages)

--- a/pgdog/src/admin/show_stats.rs
+++ b/pgdog/src/admin/show_stats.rs
@@ -60,7 +60,7 @@ impl Command for ShowStats {
                 .collect::<Vec<Field>>(),
         );
 
-        let mut messages = vec![RowDescription::new(&fields).message()?];
+        let mut messages = vec![RowDescription::new(&fields).message()];
 
         let clusters = databases().all().clone();
 
@@ -110,7 +110,7 @@ impl Command for ShowStats {
                             .add(stat.rows_deleted);
                     }
 
-                    messages.push(dr.message()?);
+                    messages.push(dr.message());
                 }
             }
         }

--- a/pgdog/src/admin/show_table_copies.rs
+++ b/pgdog/src/admin/show_table_copies.rs
@@ -32,7 +32,7 @@ impl Command for ShowTableCopies {
             Field::bigint("elapsed_ms"),
             Field::text("sql"),
         ]);
-        let mut messages = vec![rd.message()?];
+        let mut messages = vec![rd.message()];
         let now = SystemTime::now();
 
         let table_copies = TableCopies::get();
@@ -71,7 +71,7 @@ impl Command for ShowTableCopies {
                 .add(elapsed_ms)
                 .add(state.sql.as_str());
 
-            messages.push(row.message()?);
+            messages.push(row.message());
         }
 
         Ok(messages)

--- a/pgdog/src/admin/show_tasks.rs
+++ b/pgdog/src/admin/show_tasks.rs
@@ -32,7 +32,7 @@ impl Command for ShowTasks {
             Field::text("elapsed"),
             Field::bigint("elapsed_ms"),
         ]);
-        let mut messages = vec![rd.message()?];
+        let mut messages = vec![rd.message()];
         let now = SystemTime::now();
 
         // Most-recent task first (highest id).
@@ -80,7 +80,7 @@ impl Command for ShowTasks {
                     .add(updated_at_str.as_str())
                     .add(elapsed_str.as_str())
                     .add(elapsed_ms);
-                messages.push(row.message()?);
+                messages.push(row.message());
             }
         }
 

--- a/pgdog/src/admin/show_transactions.rs
+++ b/pgdog/src/admin/show_transactions.rs
@@ -23,7 +23,7 @@ impl Command for ShowTransactions {
             Field::text("transaction_state"),
         ];
 
-        let mut messages = vec![RowDescription::new(&fields).message()?];
+        let mut messages = vec![RowDescription::new(&fields).message()];
 
         let manager = Manager::get();
         let transactions = manager.transactions();
@@ -36,7 +36,7 @@ impl Command for ShowTransactions {
                 .add(transaction.to_string())
                 .add(info.phase.to_string());
 
-            messages.push(dr.message()?);
+            messages.push(dr.message());
         }
 
         Ok(messages)

--- a/pgdog/src/admin/show_version.rs
+++ b/pgdog/src/admin/show_version.rs
@@ -22,8 +22,8 @@ impl Command for ShowVersion {
         dr.add(format!("PgDog {}", pgdog_version()));
 
         Ok(vec![
-            RowDescription::new(&[Field::text("version")]).message()?,
-            dr.message()?,
+            RowDescription::new(&[Field::text("version")]).message(),
+            dr.message(),
         ])
     }
 }

--- a/pgdog/src/admin/stop_task.rs
+++ b/pgdog/src/admin/stop_task.rs
@@ -39,8 +39,8 @@ impl Command for StopTask {
         let mut dr = DataRow::new();
         dr.add(result);
 
-        messages.push(RowDescription::new(&[Field::text("stop_task")]).message()?);
-        messages.push(dr.message()?);
+        messages.push(RowDescription::new(&[Field::text("stop_task")]).message());
+        messages.push(dr.message());
 
         Ok(messages)
     }

--- a/pgdog/src/backend/pool/connection/buffer.rs
+++ b/pgdog/src/backend/pool/connection/buffer.rs
@@ -207,7 +207,7 @@ impl Buffer {
     /// Take messages from buffer.
     pub(super) fn take(&mut self) -> Option<Message> {
         if self.full {
-            self.buffer.pop_front().and_then(|s| s.message().ok())
+            self.buffer.pop_front().map(|s| s.message())
         } else {
             None
         }
@@ -252,7 +252,7 @@ mod test {
         for i in 0..25_i64 {
             let mut dr = DataRow::new();
             dr.add(25 - i).add((25 - i).to_string());
-            buf.add(dr.message().unwrap()).unwrap();
+            buf.add(dr.message()).unwrap();
         }
 
         let decoder = Decoder::from(rd);
@@ -282,7 +282,7 @@ mod test {
         for _ in 0..6 {
             let mut dr = DataRow::new();
             dr.add(15_i64);
-            buf.add(dr.message().unwrap()).unwrap();
+            buf.add(dr.message()).unwrap();
         }
 
         buf.aggregate(&agg, &Decoder::from(rd), &AggregateRewritePlan::default())
@@ -308,7 +308,7 @@ mod test {
                 let mut dr = DataRow::new();
                 dr.add(15_i64);
                 dr.add(email);
-                buf.add(dr.message().unwrap()).unwrap();
+                buf.add(dr.message()).unwrap();
             }
         }
 
@@ -343,7 +343,7 @@ mod test {
         for (i, ts) in timestamps.iter().enumerate() {
             let mut dr = DataRow::new();
             dr.add(ts.to_string()).add(format!("item_{}", i));
-            buf.add(dr.message().unwrap()).unwrap();
+            buf.add(dr.message()).unwrap();
         }
 
         let decoder = Decoder::from(rd);
@@ -383,7 +383,7 @@ mod test {
         for (i, price) in prices.iter().enumerate() {
             let mut dr = DataRow::new();
             dr.add(price.to_string()).add(format!("product_{}", i));
-            buf.add(dr.message().unwrap()).unwrap();
+            buf.add(dr.message()).unwrap();
         }
 
         let decoder = Decoder::from(rd);
@@ -439,7 +439,7 @@ mod test {
             let binary_data = create_binary_numeric(price);
             dr.add(Bytes::from(binary_data))
                 .add(format!("product_{}", i));
-            buf.add(dr.message().unwrap()).unwrap();
+            buf.add(dr.message()).unwrap();
         }
 
         let decoder = Decoder::from(rd);
@@ -483,7 +483,7 @@ mod test {
         for (i, value) in values.iter().enumerate() {
             let mut dr = DataRow::new();
             dr.add(value.to_string()).add(format!("case_{}", i));
-            buf.add(dr.message().unwrap()).unwrap();
+            buf.add(dr.message()).unwrap();
         }
 
         let decoder = Decoder::from(rd);
@@ -517,7 +517,7 @@ mod test {
         for i in 0..10_i64 {
             let mut dr = DataRow::new();
             dr.add(i);
-            buf.add(dr.message().unwrap()).unwrap();
+            buf.add(dr.message()).unwrap();
         }
 
         // LIMIT 5
@@ -585,7 +585,7 @@ mod test {
                 let mut dr = DataRow::new();
                 dr.add(i as i64);
                 dr.add(email);
-                buf.add(dr.message().unwrap()).unwrap();
+                buf.add(dr.message()).unwrap();
             }
         }
 
@@ -619,7 +619,7 @@ mod test {
                 let mut dr = DataRow::new();
                 dr.add(5_i64);
                 dr.add(email);
-                buf.add(dr.message().unwrap()).unwrap();
+                buf.add(dr.message()).unwrap();
             }
         }
 

--- a/pgdog/src/backend/pool/connection/buffer.rs
+++ b/pgdog/src/backend/pool/connection/buffer.rs
@@ -1,4 +1,5 @@
-//! Buffer messages to sort and aggregate them later.
+//! Buffer messages to sort and aggregate them
+//! once we received all of them from the servers.
 
 use std::{
     cmp::Ordering,
@@ -40,19 +41,15 @@ impl Buffer {
 
     /// Mark the buffer as full. It will start returning messages now.
     /// Caller is responsible for sorting the buffer if needed.
-    pub(super) fn full(&mut self) {
+    pub(super) fn mark_full(&mut self) {
         self.full = true;
     }
 
-    pub(super) fn reset(&mut self) {
-        self.buffer.clear();
-        self.full = false;
-    }
-
-    /// Sort the buffer.
+    /// Sort the buffer in specified order, using the decoder to convert
+    /// Postgres column values to Rust values we can sort.
     pub(super) fn sort(&mut self, columns: &[OrderBy], decoder: &Decoder) {
         // Calculate column indices once, since
-        // fetching indices by name is O(number of columns).
+        // fetching indices by name is O (number of columns).
         let mut cols = vec![];
         for column in columns {
             match column {
@@ -261,7 +258,7 @@ mod test {
         let decoder = Decoder::from(rd);
 
         buf.sort(&columns, &decoder);
-        buf.full();
+        buf.mark_full();
 
         let mut i = 1;
         while let Some(message) = buf.take() {
@@ -290,7 +287,7 @@ mod test {
 
         buf.aggregate(&agg, &Decoder::from(rd), &AggregateRewritePlan::default())
             .unwrap();
-        buf.full();
+        buf.mark_full();
 
         assert_eq!(buf.len(), 1);
         let row = buf.take().unwrap();
@@ -317,7 +314,7 @@ mod test {
 
         buf.aggregate(&agg, &Decoder::from(rd), &AggregateRewritePlan::default())
             .unwrap();
-        buf.full();
+        buf.mark_full();
 
         assert_eq!(buf.len(), 2);
         for _ in &emails {
@@ -352,7 +349,7 @@ mod test {
         let decoder = Decoder::from(rd);
 
         buf.sort(&columns, &decoder);
-        buf.full();
+        buf.mark_full();
 
         // Verify timestamps are sorted
         let expected_order = [
@@ -392,7 +389,7 @@ mod test {
         let decoder = Decoder::from(rd);
 
         buf.sort(&columns, &decoder);
-        buf.full();
+        buf.mark_full();
 
         // Verify numeric values are sorted in descending order
         let expected_order = [
@@ -447,7 +444,7 @@ mod test {
 
         let decoder = Decoder::from(rd);
         buf.sort(&columns, &decoder);
-        buf.full();
+        buf.mark_full();
 
         let expected_order = [
             "1000.01", "1000.00", "199.99", "199.98", "75.50", "50.25", "0.99",
@@ -491,7 +488,7 @@ mod test {
 
         let decoder = Decoder::from(rd);
         buf.sort(&columns, &decoder);
-        buf.full();
+        buf.mark_full();
 
         // Expected order: ascending numeric sort
         // Note: equal values maintain input order (stable sort)
@@ -545,7 +542,7 @@ mod test {
             limit: Some(4),
             offset: Some(2),
         });
-        b.full();
+        b.mark_full();
         assert_eq!(b.len(), 4);
         for expected in 2..6_i64 {
             let dr = DataRow::from_bytes(b.take().unwrap().to_bytes()).unwrap();

--- a/pgdog/src/backend/pool/connection/mod.rs
+++ b/pgdog/src/backend/pool/connection/mod.rs
@@ -226,7 +226,7 @@ impl Connection {
     pub(crate) async fn read(&mut self) -> Result<Message, Error> {
         select! {
             notification = self.pub_sub.recv() => {
-                Ok(notification.ok_or(Error::ProtocolOutOfSync)?.message()?)
+                Ok(notification.ok_or(Error::ProtocolOutOfSync)?.message())
             }
 
             // This is cancel-safe.

--- a/pgdog/src/backend/pool/connection/multi_shard/mod.rs
+++ b/pgdog/src/backend/pool/connection/multi_shard/mod.rs
@@ -218,7 +218,7 @@ impl MultiShard {
                 self.bound_statements.clear();
 
                 if self.request_state.transaction_error {
-                    Some(ReadyForQuery::error().message()?)
+                    Some(ReadyForQuery::error().message())
                 } else {
                     Some(message)
                 }
@@ -279,9 +279,9 @@ impl MultiShard {
                 } else {
                     self.request_state.rows
                 };
-                self.request_state.command_complete = Some(cc.rewrite(rows)?.message()?);
+                self.request_state.command_complete = Some(cc.rewrite(rows)?.message());
             } else {
-                return Ok(Some(cc.message()?));
+                return Ok(Some(cc.message()));
             }
         }
 
@@ -316,7 +316,7 @@ impl MultiShard {
                 forward = Some(message);
             } else {
                 let client_rd = rd.drop_columns(plan.drop_columns());
-                forward = Some(client_rd.message()?);
+                forward = Some(client_rd.message());
             }
 
             // The next statement describes a different result set.

--- a/pgdog/src/backend/pool/connection/multi_shard/mod.rs
+++ b/pgdog/src/backend/pool/connection/multi_shard/mod.rs
@@ -121,7 +121,7 @@ impl MultiShard {
     #[inline]
     fn reset(&mut self) {
         self.request_state = RequestState::default();
-        self.buffer.reset();
+        self.buffer = Buffer::default();
         self.validator.reset();
 
         // Intentionally does not reset:
@@ -257,7 +257,7 @@ impl MultiShard {
             .command_complete_count
             .is_multiple_of(self.shards)
         {
-            self.buffer.full();
+            self.buffer.mark_full();
 
             if !self.buffer.is_empty() {
                 self.buffer

--- a/pgdog/src/backend/pool/connection/multi_shard/test.rs
+++ b/pgdog/src/backend/pool/connection/multi_shard/test.rs
@@ -1,5 +1,5 @@
 use crate::{
-    frontend::router::parser::{Shard, ShardWithPriority},
+    frontend::router::parser::{DistinctBy, Shard, ShardWithPriority},
     net::{BindComplete, DataRow, Field, Format},
 };
 
@@ -120,6 +120,54 @@ fn test_rd_before_dr() {
 
     // Buffer is empty.
     assert!(multi_shard.get_server_message().is_none());
+}
+
+#[test]
+fn test_distinct_state_resets_between_requests() {
+    let route = Route::select(
+        ShardWithPriority::new_default_unset(Shard::All),
+        vec![],
+        Default::default(),
+        Default::default(),
+        Some(DistinctBy::Row),
+    );
+    let mut multi_shard = MultiShard::new(vec![0, 1], &route);
+    let row_description = RowDescription::new(&[Field::bigint("id")]);
+    let mut data_row = DataRow::new();
+    data_row.add(1_i64);
+
+    // The same DISTINCT query returning the same row in consecutive requests must
+    // produce the row both times. Deduplication state is scoped to one request.
+    for request in 1..=2 {
+        for _ in 0..2 {
+            multi_shard
+                .handle_server_message(row_description.message())
+                .unwrap();
+            multi_shard
+                .handle_server_message(data_row.message())
+                .unwrap();
+            multi_shard
+                .handle_server_message(CommandComplete::from_str("SELECT 1").message())
+                .unwrap();
+        }
+
+        let message = multi_shard
+            .get_server_message()
+            .unwrap_or_else(|| panic!("request {request} should return its distinct row"));
+        assert_eq!(message.code(), 'D', "request {request}");
+
+        let row = DataRow::from_bytes(message.to_bytes()).unwrap();
+        assert_eq!(row.get::<i64>(0, Format::Text).unwrap(), 1);
+
+        let message = multi_shard
+            .get_server_message()
+            .unwrap_or_else(|| panic!("request {request} should return CommandComplete"));
+        let complete = CommandComplete::from_bytes(message.to_bytes()).unwrap();
+        assert_eq!(complete.rows().unwrap(), Some(1), "request {request}");
+        assert!(multi_shard.get_server_message().is_none());
+
+        multi_shard.query_complete();
+    }
 }
 
 #[test]

--- a/pgdog/src/backend/pool/connection/multi_shard/test.rs
+++ b/pgdog/src/backend/pool/connection/multi_shard/test.rs
@@ -15,13 +15,11 @@ fn test_inconsistent_row_descriptions() {
     let rd2 = RowDescription::new(&[Field::text("name")]); // Missing column
 
     // First row description should be processed successfully
-    let result = multi_shard
-        .handle_server_message(rd1.message().unwrap())
-        .unwrap();
+    let result = multi_shard.handle_server_message(rd1.message()).unwrap();
     assert!(result.is_none()); // Not forwarded until all shards respond
 
     // Second inconsistent row description should cause an error
-    let result = multi_shard.handle_server_message(rd2.message().unwrap());
+    let result = multi_shard.handle_server_message(rd2.message());
     assert!(result.is_err());
 
     if let Err(error) = result {
@@ -38,9 +36,7 @@ fn test_inconsistent_data_rows() {
 
     // Set up row description first
     let rd = RowDescription::new(&[Field::text("name"), Field::bigint("id")]);
-    multi_shard
-        .handle_server_message(rd.message().unwrap())
-        .unwrap();
+    multi_shard.handle_server_message(rd.message()).unwrap();
 
     // Create data rows with different column counts
     let mut dr1 = DataRow::new();
@@ -50,13 +46,11 @@ fn test_inconsistent_data_rows() {
     dr2.add("only_name"); // Missing id column
 
     // First data row should be processed successfully
-    let result = multi_shard
-        .handle_server_message(dr1.message().unwrap())
-        .unwrap();
+    let result = multi_shard.handle_server_message(dr1.message()).unwrap();
     assert!(result.is_none()); // Buffered, not forwarded immediately
 
     // Second inconsistent data row should cause an error
-    let result = multi_shard.handle_server_message(dr2.message().unwrap());
+    let result = multi_shard.handle_server_message(dr2.message());
     assert!(result.is_err());
 
     if let Err(error) = result {
@@ -77,19 +71,17 @@ fn test_rd_before_dr() {
     dr.add(1i64);
     for _ in 0..2 {
         let result = multi_shard
-            .handle_server_message(rd.message().unwrap().backend(BackendPid::for_test(1)))
+            .handle_server_message(rd.message().backend(BackendPid::for_test(1)))
             .unwrap();
         assert!(result.is_none()); // dropped
         let result = multi_shard
-            .handle_server_message(dr.message().unwrap().backend(BackendPid::for_test(1)))
+            .handle_server_message(dr.message().backend(BackendPid::for_test(1)))
             .unwrap();
         assert!(result.is_none()); // buffered.
     }
 
-    let result = multi_shard
-        .handle_server_message(rd.message().unwrap())
-        .unwrap();
-    assert_eq!(result, Some(rd.message().unwrap()));
+    let result = multi_shard.handle_server_message(rd.message()).unwrap();
+    assert_eq!(result, Some(rd.message()));
     let result = multi_shard.get_server_message();
     // Waiting for command complete
     assert!(result.is_none());
@@ -99,7 +91,6 @@ fn test_rd_before_dr() {
             .handle_server_message(
                 CommandComplete::from_str("SELECT 1")
                     .message()
-                    .unwrap()
                     .backend(BackendPid::for_test(1)),
             )
             .unwrap();
@@ -111,7 +102,7 @@ fn test_rd_before_dr() {
         let id = BackendPid::for_test(1);
         assert_eq!(
             result.map(|m| m.backend(id)),
-            Some(dr.message().unwrap().backend(id))
+            Some(dr.message().backend(id))
         );
     }
 
@@ -123,7 +114,6 @@ fn test_rd_before_dr() {
         Some(
             CommandComplete::from_str("SELECT 3")
                 .message()
-                .unwrap()
                 .backend(BackendPid::for_test(1))
         )
     );
@@ -143,13 +133,13 @@ fn test_ready_for_query_error_preservation() {
 
     // Forward first ReadyForQuery message with error state
     let result = multi_shard
-        .handle_server_message(rfq_error.message().unwrap())
+        .handle_server_message(rfq_error.message())
         .unwrap();
     assert!(result.is_none()); // Should not be forwarded yet (waiting for second shard)
 
     // Forward second normal ReadyForQuery message
     let result = multi_shard
-        .handle_server_message(rfq_normal.message().unwrap())
+        .handle_server_message(rfq_normal.message())
         .unwrap();
 
     // Should return the error message, not the normal one
@@ -174,7 +164,6 @@ fn test_omni_command_complete_not_summed() {
         .handle_server_message(
             CommandComplete::from_str("UPDATE 5")
                 .message()
-                .unwrap()
                 .backend(backend1),
         )
         .unwrap();
@@ -182,7 +171,6 @@ fn test_omni_command_complete_not_summed() {
         .handle_server_message(
             CommandComplete::from_str("UPDATE 5")
                 .message()
-                .unwrap()
                 .backend(backend2),
         )
         .unwrap();
@@ -190,7 +178,6 @@ fn test_omni_command_complete_not_summed() {
         .handle_server_message(
             CommandComplete::from_str("UPDATE 5")
                 .message()
-                .unwrap()
                 .backend(backend3),
         )
         .unwrap();
@@ -215,7 +202,6 @@ fn test_omni_command_complete_uses_first_shard_row_count() {
         .handle_server_message(
             CommandComplete::from_str("UPDATE 7")
                 .message()
-                .unwrap()
                 .backend(backend1),
         )
         .unwrap();
@@ -225,7 +211,6 @@ fn test_omni_command_complete_uses_first_shard_row_count() {
         .handle_server_message(
             CommandComplete::from_str("UPDATE 9")
                 .message()
-                .unwrap()
                 .backend(backend2),
         )
         .unwrap();
@@ -248,10 +233,10 @@ fn test_omni_data_rows_only_from_first_server() {
     // Setup: send RowDescription from both shards
     let rd = RowDescription::new(&[Field::bigint("id")]);
     multi_shard
-        .handle_server_message(rd.message().unwrap().backend(backend1))
+        .handle_server_message(rd.message().backend(backend1))
         .unwrap();
     let rd_result = multi_shard
-        .handle_server_message(rd.message().unwrap().backend(backend2))
+        .handle_server_message(rd.message().backend(backend2))
         .unwrap();
     assert!(rd_result.is_some()); // RowDescription forwarded after all shards
 
@@ -259,7 +244,7 @@ fn test_omni_data_rows_only_from_first_server() {
     let mut dr1 = DataRow::new();
     dr1.add(100_i64);
     let result = multi_shard
-        .handle_server_message(dr1.message().unwrap().backend(backend1))
+        .handle_server_message(dr1.message().backend(backend1))
         .unwrap();
     assert!(result.is_some()); // Should be forwarded
 
@@ -267,7 +252,7 @@ fn test_omni_data_rows_only_from_first_server() {
     let mut dr2 = DataRow::new();
     dr2.add(200_i64);
     let result = multi_shard
-        .handle_server_message(dr2.message().unwrap().backend(backend2))
+        .handle_server_message(dr2.message().backend(backend2))
         .unwrap();
     assert!(result.is_none()); // Should be dropped
 
@@ -275,7 +260,7 @@ fn test_omni_data_rows_only_from_first_server() {
     let mut dr3 = DataRow::new();
     dr3.add(101_i64);
     let result = multi_shard
-        .handle_server_message(dr3.message().unwrap().backend(backend1))
+        .handle_server_message(dr3.message().backend(backend1))
         .unwrap();
     assert!(result.is_some()); // Should be forwarded
 }
@@ -297,7 +282,7 @@ fn test_pipelined_describe_forwards_every_group() {
         for description in [&id, &name] {
             for _ in 0..shards {
                 if let Some(message) = multi_shard
-                    .handle_server_message(description.message().unwrap())
+                    .handle_server_message(description.message())
                     .unwrap()
                 {
                     forwarded.push(message);
@@ -307,7 +292,7 @@ fn test_pipelined_describe_forwards_every_group() {
 
         assert_eq!(
             forwarded,
-            vec![id.message().unwrap(), name.message().unwrap()],
+            vec![id.message(), name.message()],
             "{shards} shard(s)",
         );
     }
@@ -331,26 +316,22 @@ fn test_bind_result_formats_apply_per_statement() {
 
     for _ in 0..2 {
         multi_shard
-            .handle_server_message(BindComplete.message().unwrap())
+            .handle_server_message(BindComplete.message())
             .unwrap();
     }
     for _ in 0..2 {
-        multi_shard
-            .handle_server_message(rd.message().unwrap())
-            .unwrap();
+        multi_shard.handle_server_message(rd.message()).unwrap();
     }
     assert_eq!(multi_shard.decoder.get_format(0), Format::Binary);
 
     // The second statement asked for no formats.
     for _ in 0..2 {
         multi_shard
-            .handle_server_message(BindComplete.message().unwrap())
+            .handle_server_message(BindComplete.message())
             .unwrap();
     }
     for _ in 0..2 {
-        multi_shard
-            .handle_server_message(rd.message().unwrap())
-            .unwrap();
+        multi_shard.handle_server_message(rd.message()).unwrap();
     }
     assert_eq!(multi_shard.decoder.get_format(0), Format::Text);
 }
@@ -370,14 +351,14 @@ fn test_ready_for_query_drops_pending_binds() {
     // Only the first statement binds. The second is abandoned.
     for _ in 0..2 {
         multi_shard
-            .handle_server_message(BindComplete.message().unwrap())
+            .handle_server_message(BindComplete.message())
             .unwrap();
     }
     assert_eq!(multi_shard.bound_statements.len(), 1);
 
     for _ in 0..2 {
         multi_shard
-            .handle_server_message(ReadyForQuery::idle().message().unwrap())
+            .handle_server_message(ReadyForQuery::idle().message())
             .unwrap();
     }
     assert!(multi_shard.bound_statements.is_empty());

--- a/pgdog/src/backend/prepared_statements.rs
+++ b/pgdog/src/backend/prepared_statements.rs
@@ -281,7 +281,7 @@ impl PreparedStatements {
                     if self.contains(parse.name()) {
                         // TODO(lev): perform the same in errored transaction check
                         // as we do for PREPARE below.
-                        self.state.add_simulated(ParseComplete.message()?);
+                        self.state.add_simulated(ParseComplete.message());
                         return Ok(HandleResult::Drop);
                     } else {
                         self.parses.push_back(parse.name().to_string());
@@ -305,7 +305,7 @@ impl PreparedStatements {
                 if !close.anonymous() {
                     // We don't allow clients to close prepared statements.
                     // We manage them ourselves.
-                    self.state.add_simulated(CloseComplete.message()?);
+                    self.state.add_simulated(CloseComplete.message());
                     return Ok(HandleResult::Drop);
                 } else {
                     self.state.add('3');
@@ -316,10 +316,10 @@ impl PreparedStatements {
                 if self.contains(prepare.name()) {
                     if self.server_state == State::TransactionError {
                         self.state
-                            .add_simulated(ErrorResponse::in_failed_transaction().message()?);
+                            .add_simulated(ErrorResponse::in_failed_transaction().message());
                     } else {
                         self.state
-                            .add_simulated(CommandComplete::from_str("PREPARE").message()?);
+                            .add_simulated(CommandComplete::from_str("PREPARE").message());
                     }
 
                     self.state.add_simulated(
@@ -330,7 +330,7 @@ impl PreparedStatements {
                                 self.server_state == State::IdleInTransaction,
                             )
                         }
-                        .message()?,
+                        .message(),
                     );
                     return Ok(HandleResult::Drop);
                 } else {

--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -1061,10 +1061,10 @@ impl Server {
 
         let mut buf = vec![];
         for close in close {
-            buf.push(close.message()?);
+            buf.push(close.message());
         }
 
-        buf.push(Sync.message()?);
+        buf.push(Sync.message());
 
         debug!(
             "closing {} prepared statements [{}]",

--- a/pgdog/src/frontend/client/query_engine/deallocate.rs
+++ b/pgdog/src/frontend/client/query_engine/deallocate.rs
@@ -10,8 +10,8 @@ impl QueryEngine {
         let bytes_sent = context
             .stream
             .send_many(&[
-                CommandComplete::from_str("DEALLOCATE").message()?,
-                ReadyForQuery::in_transaction(context.in_transaction()).message()?,
+                CommandComplete::from_str("DEALLOCATE").message(),
+                ReadyForQuery::in_transaction(context.in_transaction()).message(),
             ])
             .await?;
 

--- a/pgdog/src/frontend/client/query_engine/discard.rs
+++ b/pgdog/src/frontend/client/query_engine/discard.rs
@@ -13,8 +13,8 @@ impl QueryEngine {
         let bytes_sent = context
             .stream
             .send_many(&[
-                CommandComplete::new("DISCARD").message()?,
-                ReadyForQuery::in_transaction(context.in_transaction()).message()?,
+                CommandComplete::new("DISCARD").message(),
+                ReadyForQuery::in_transaction(context.in_transaction()).message(),
             ])
             .await?;
         self.stats.sent(bytes_sent);

--- a/pgdog/src/frontend/client/query_engine/end_transaction.rs
+++ b/pgdog/src/frontend/client/query_engine/end_transaction.rs
@@ -19,12 +19,12 @@ impl QueryEngine {
                 CommandComplete::new_commit()
             };
             let mut messages = if !context.in_transaction() {
-                vec![NoticeResponse::from(ErrorResponse::no_transaction()).message()?]
+                vec![NoticeResponse::from(ErrorResponse::no_transaction()).message()]
             } else {
                 vec![]
             };
-            messages.push(cmd.message()?);
-            messages.push(ReadyForQuery::idle().message()?);
+            messages.push(cmd.message());
+            messages.push(ReadyForQuery::idle().message());
 
             context.stream.send_many(&messages).await?
         };

--- a/pgdog/src/frontend/client/query_engine/internal_values.rs
+++ b/pgdog/src/frontend/client/query_engine/internal_values.rs
@@ -16,10 +16,10 @@ impl QueryEngine {
         let bytes_sent = context
             .stream
             .send_many(&[
-                RowDescription::new(&[Field::text(&field)]).message()?,
-                DataRow::from_columns(vec![value]).message()?,
-                CommandComplete::from_str("SHOW").message()?,
-                ReadyForQuery::in_transaction(context.in_transaction()).message()?,
+                RowDescription::new(&[Field::text(&field)]).message(),
+                DataRow::from_columns(vec![value]).message(),
+                CommandComplete::from_str("SHOW").message(),
+                ReadyForQuery::in_transaction(context.in_transaction()).message(),
             ])
             .await?;
 
@@ -36,10 +36,10 @@ impl QueryEngine {
         let bytes_sent = context
             .stream
             .send_many(&[
-                RowDescription::new(&[Field::bigint("unique_id")]).message()?,
-                DataRow::from_columns(vec![id.to_string()]).message()?,
-                CommandComplete::from_str("SHOW").message()?,
-                ReadyForQuery::in_transaction(context.in_transaction()).message()?,
+                RowDescription::new(&[Field::bigint("unique_id")]).message(),
+                DataRow::from_columns(vec![id.to_string()]).message(),
+                CommandComplete::from_str("SHOW").message(),
+                ReadyForQuery::in_transaction(context.in_transaction()).message(),
             ])
             .await?;
 

--- a/pgdog/src/frontend/client/query_engine/multi_step/insert.rs
+++ b/pgdog/src/frontend/client/query_engine/multi_step/insert.rs
@@ -120,13 +120,13 @@ impl<'a> InsertMulti<'a> {
 
         if let Some(cc) = self.state.command_complete(CommandType::Insert) {
             self.engine
-                .process_server_message(context, cc.message()?)
+                .process_server_message(context, cc.message())
                 .await?;
         }
 
         if let Some(rfq) = self.state.ready_for_query(context.in_transaction()) {
             self.engine
-                .process_server_message(context, rfq.message()?)
+                .process_server_message(context, rfq.message())
                 .await?;
         }
 

--- a/pgdog/src/frontend/client/query_engine/multi_step/update.rs
+++ b/pgdog/src/frontend/client/query_engine/multi_step/update.rs
@@ -144,12 +144,12 @@ impl<'a> UpdateMulti<'a> {
                 .await?;
 
             self.engine
-                .process_server_message(context, CommandComplete::new("UPDATE 1").message()?) // We only allow to update one row at a time.
+                .process_server_message(context, CommandComplete::new("UPDATE 1").message()) // We only allow to update one row at a time.
                 .await?;
             self.engine
                 .process_server_message(
                     context,
-                    ReadyForQuery::in_transaction(context.in_transaction()).message()?,
+                    ReadyForQuery::in_transaction(context.in_transaction()).message(),
                 )
                 .await?;
 

--- a/pgdog/src/frontend/client/query_engine/pub_sub.rs
+++ b/pgdog/src/frontend/client/query_engine/pub_sub.rs
@@ -61,8 +61,8 @@ impl QueryEngine {
         let bytes_sent = context
             .stream
             .send_many(&[
-                CommandComplete::new(command).message()?,
-                ReadyForQuery::in_transaction(context.in_transaction()).message()?,
+                CommandComplete::new(command).message(),
+                ReadyForQuery::in_transaction(context.in_transaction()).message(),
             ])
             .await?;
 

--- a/pgdog/src/frontend/client/query_engine/query.rs
+++ b/pgdog/src/frontend/client/query_engine/query.rs
@@ -221,7 +221,7 @@ impl QueryEngine {
                 // without the client's knowledge. We need to return a regular RFQ
                 // message and close the transaction.
                 context.transaction = None;
-                message = ReadyForQuery::in_transaction(false).message()?;
+                message = ReadyForQuery::in_transaction(false).message();
             }
 
             self.stats.idle(context.in_transaction());
@@ -274,7 +274,7 @@ impl QueryEngine {
             for line in state.lines.clone() {
                 let mut row = DataRow::new();
                 row.add(line);
-                let message = row.message()?;
+                let message = row.message();
                 let len = message.len();
                 context.stream.send(&message).await?;
                 self.stats.sent(len);

--- a/pgdog/src/frontend/client/query_engine/start_transaction.rs
+++ b/pgdog/src/frontend/client/query_engine/start_transaction.rs
@@ -29,8 +29,8 @@ impl QueryEngine {
                 context
                     .stream
                     .send_many(&[
-                        CommandComplete::new_begin().message()?,
-                        ReadyForQuery::in_transaction(context.in_transaction()).message()?,
+                        CommandComplete::new_begin().message(),
+                        ReadyForQuery::in_transaction(context.in_transaction()).message(),
                     ])
                     .await?
             };
@@ -51,28 +51,27 @@ impl QueryEngine {
         let mut reply = vec![];
         for message in context.client_request.iter() {
             match message.code() {
-                'P' => reply.push(ParseComplete.message()?),
-                'B' => reply.push(BindComplete.message()?),
+                'P' => reply.push(ParseComplete.message()),
+                'B' => reply.push(BindComplete.message()),
                 'D' => {
                     if matches!(message, ProtocolMessage::Describe(d) if d.is_statement()) {
-                        reply.push(ParameterDescription::empty().message()?);
+                        reply.push(ParameterDescription::empty().message());
                     }
-                    reply.push(NoData.message()?);
+                    reply.push(NoData.message());
                 }
                 'H' => (),
                 'E' => reply.push(if in_transaction {
-                    CommandComplete::new_begin().message()?
+                    CommandComplete::new_begin().message()
                 } else if !rollback {
-                    CommandComplete::new_commit().message()?
+                    CommandComplete::new_commit().message()
                 } else {
-                    CommandComplete::new_rollback().message()?
+                    CommandComplete::new_rollback().message()
                 }),
                 'S' => {
                     if rollback && !context.in_transaction() {
-                        reply
-                            .push(NoticeResponse::from(ErrorResponse::no_transaction()).message()?);
+                        reply.push(NoticeResponse::from(ErrorResponse::no_transaction()).message());
                     }
-                    reply.push(ReadyForQuery::in_transaction(in_transaction).message()?)
+                    reply.push(ReadyForQuery::in_transaction(in_transaction).message())
                 }
                 c => return Err(Error::UnexpectedMessage(c)),
             }

--- a/pgdog/src/frontend/client/query_engine/test/rewrite_insert_split.rs
+++ b/pgdog/src/frontend/client/query_engine/test/rewrite_insert_split.rs
@@ -143,7 +143,7 @@ async fn test_insert_split_not_sharded() {
         ProtocolMessage::Parse(Parse::new_anonymous(
             "INSERT INTO test (id, email) VALUES ($1, $2), ($3, $4)",
         )),
-        ProtocolMessage::Other(Flush.message().unwrap()),
+        ProtocolMessage::Other(Flush.message()),
     ]);
     let mut engine = QueryEngine::from_client(&client).unwrap();
     let mut context = QueryEngineContext::new(&mut client);

--- a/pgdog/src/net/messages/describe.rs
+++ b/pgdog/src/net/messages/describe.rs
@@ -128,7 +128,7 @@ mod test {
         let pool = pool();
         let mut conn = pool.get(&Request::default()).await.unwrap();
         let describe = Describe::new_portal("");
-        conn.send(&vec![ProtocolMessage::from(describe.message().unwrap())].into())
+        conn.send(&vec![ProtocolMessage::from(describe.message())].into())
             .await
             .unwrap();
         let res = conn.read().await.unwrap();

--- a/pgdog/src/net/messages/mod.rs
+++ b/pgdog/src/net/messages/mod.rs
@@ -103,8 +103,8 @@ pub trait Protocol: ToBytes + FromBytes + std::fmt::Debug {
     fn code(&self) -> char;
 
     /// Convert to message.
-    fn message(&self) -> Result<Message, Error> {
-        Ok(Message::new(self.to_bytes()))
+    fn message(&self) -> Message {
+        Message::new(self.to_bytes())
     }
 
     /// Message is part of a stream and should not be buffered.

--- a/pgdog/src/net/messages/prepare.rs
+++ b/pgdog/src/net/messages/prepare.rs
@@ -51,8 +51,8 @@ impl Protocol for Prepare {
         'Q'
     }
 
-    fn message(&self) -> Result<Message, Error> {
-        Ok(Message::new(self.to_bytes()).frontend())
+    fn message(&self) -> Message {
+        Message::new(self.to_bytes()).frontend()
     }
 
     fn streaming(&self) -> bool {

--- a/pgdog/src/net/protocol_message.rs
+++ b/pgdog/src/net/protocol_message.rs
@@ -194,7 +194,7 @@ impl From<Sync> for ProtocolMessage {
 
 impl From<Flush> for ProtocolMessage {
     fn from(value: Flush) -> Self {
-        Self::Other(value.message().unwrap())
+        Self::Other(value.message())
     }
 }
 


### PR DESCRIPTION
- fix: reset distinct state when query ends. This affected queries inside transactions only, since after a transaction was over, we re-initialized the multi-shard state completely.
- refactor: rename `Buffer::full` to `Buffer::mark_full`
- refactor: `Protocol::message()` never fails