### PR TITLE
perf: Box::pin removed for future returned by `self.client_server_exchange(context)`

### DIFF
--- a/pgdog/src/frontend/client/query_engine/query.rs
+++ b/pgdog/src/frontend/client/query_engine/query.rs
@@ -1,3 +1,5 @@
+use std::pin::pin;
+
 use tracing::{info, trace};
 
 use crate::{
@@ -58,12 +60,21 @@ impl QueryEngine {
             }
         }
 
-        match safe_timeout(
-            context.timeouts.query_timeout(&State::Active),
-            Box::pin(self.client_server_exchange(context)),
-        )
-        .await
-        {
+        // Stack-pinned, not `Box::pin`: this runs once per query, and boxing
+        // costs a malloc, a free and a memcpy of the whole exchange future
+        // every time. `Pin<&mut F>` is a `Future`, so `safe_timeout` takes it.
+        //
+        // The inner block matters: unlike the boxed future, which was moved
+        // into `safe_timeout` and dropped by the `.await`, `pin!` binds a local
+        // that would otherwise hold its borrow of `self` and `context` until
+        // the end of the function, past the arms below.
+        let query_timeout = context.timeouts.query_timeout(&State::Active);
+        let result = {
+            let exchange = pin!(self.client_server_exchange(context));
+            safe_timeout(query_timeout, exchange).await
+        };
+
+        match result {
             Ok(response) => response?,
             Err(err) => {
                 // Close the conn, it could be stuck executing a query

--- a/pgdog/src/frontend/client/query_engine/query.rs
+++ b/pgdog/src/frontend/client/query_engine/query.rs
@@ -1,5 +1,3 @@
-use std::pin::pin;
-
 use tracing::{info, trace};
 
 use crate::{
@@ -60,19 +58,8 @@ impl QueryEngine {
             }
         }
 
-        // Stack-pinned, not `Box::pin`: this runs once per query, and boxing
-        // costs a malloc, a free and a memcpy of the whole exchange future
-        // every time. `Pin<&mut F>` is a `Future`, so `safe_timeout` takes it.
-        //
-        // The inner block matters: unlike the boxed future, which was moved
-        // into `safe_timeout` and dropped by the `.await`, `pin!` binds a local
-        // that would otherwise hold its borrow of `self` and `context` until
-        // the end of the function, past the arms below.
         let query_timeout = context.timeouts.query_timeout(&State::Active);
-        let result = {
-            let exchange = pin!(self.client_server_exchange(context));
-            safe_timeout(query_timeout, exchange).await
-        };
+        let result = safe_timeout(query_timeout, self.client_server_exchange(context)).await;
 
         match result {
             Ok(response) => response?,

--- a/pgdog/src/frontend/client/query_engine/query.rs
+++ b/pgdog/src/frontend/client/query_engine/query.rs
@@ -80,8 +80,7 @@ impl QueryEngine {
     ) -> Result<(), Error> {
         match context.rewrite_result.take() {
             Some(RewriteResult::InsertSplit(requests)) => {
-                multi_step::InsertMulti::from_engine(self, requests)
-                    .execute(context)
+                Box::pin(multi_step::InsertMulti::from_engine(self, requests).execute(context))
                     .await?;
             }
 
@@ -100,8 +99,7 @@ impl QueryEngine {
             }
 
             Some(RewriteResult::ShardingKeyUpdate(sharding_key_update)) => {
-                multi_step::UpdateMulti::new(self, &sharding_key_update)
-                    .execute(context)
+                Box::pin(multi_step::UpdateMulti::new(self, &sharding_key_update).execute(context))
                     .await?;
             }
         }


### PR DESCRIPTION
closes #1395 