### PR TITLE
Detect advisory locks at query_parser = auto on single-primary clusters

### DIFF
--- a/pgdog/src/frontend/regex_parser.rs
+++ b/pgdog/src/frontend/regex_parser.rs
@@ -60,9 +60,17 @@ impl RegexParser {
 
     /// Check if we should enable the parser just for this request.
     pub(crate) fn use_parser(&self, request: &ClientRequest) -> bool {
-        let with_locks = self.level == QueryParserLevel::SessionControlAndLocks;
-        let session_control =
-            self.level == QueryParserLevel::SessionControl || self.level == QueryParserLevel::Auto;
+        // Auto must detect advisory locks even when nothing else needs the
+        // parser (single primary, no sharding): session advisory locks taken
+        // through a transaction-mode pool are a correctness hazard — without
+        // detection the client isn't pinned, the unlock can land on a
+        // different backend, and the lock strands on the pooled server
+        // connection.
+        let with_locks = matches!(
+            self.level,
+            QueryParserLevel::SessionControlAndLocks | QueryParserLevel::Auto
+        );
+        let session_control = self.level == QueryParserLevel::SessionControl;
 
         if (with_locks || session_control)
             && let Ok(Some(query)) = request.query()
@@ -196,6 +204,27 @@ mod test {
             "SELECT pg_advisory_lock(1)",
             QueryParserLevel::SessionControl
         ));
+    }
+
+    #[test]
+    fn test_advisory_lock_auto_level() {
+        // Auto must detect advisory locks even on clusters where nothing else
+        // enables the parser (single primary, no sharding); otherwise session
+        // locks taken through a transaction-mode pool strand on pooled
+        // backends when the unlock routes to a different server connection.
+        let l = QueryParserLevel::Auto;
+        assert!(matches_at("SELECT pg_advisory_lock(1)", l));
+        assert!(matches_at("SELECT pg_try_advisory_lock(1, 2)", l));
+        assert!(matches_at(
+            "SELECT pg_try_advisory_lock(1, 2) AS t0abc /* app lock */",
+            l
+        ));
+        assert!(matches_at("SELECT pg_advisory_unlock(1, 2)", l));
+        assert!(matches_at("SELECT pg_advisory_unlock_all()", l));
+        // Base session-control statements still match at Auto.
+        assert!(matches_at("NOTIFY test_channel", l));
+        // Plain queries still bypass the parser at Auto.
+        assert!(!matches_at("SELECT 1", l));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #1407.

## Root cause

Debugging #1407 against a local build showed the leaked locks were a detection problem, not a cleanup problem. At `query_parser = "auto"` (the default), `RegexParser::use_parser` matches only the base session-control command set — `CMD_RE`, not `CMD_RE_ADVISORY`. On a cluster where nothing else engages the query parser (single primary, no sharding, no replicas — `router_needed()` is false), advisory lock statements therefore bypass the parser entirely:

- the client is never marked locked, so it isn't pinned to its backend;
- `pg_advisory_unlock` can route to a different server connection (Postgres emits a `WARNING` the app never sees) and the session lock strands on the pooled backend;
- on abrupt client disconnect mid-hold, the server isn't flagged dirty, so the existing `pg_advisory_unlock_all()` cleanup never runs — `[cleanup] no cleanup needed` with `AdvisoryLocks { locks: {} }` in the debug log.

Sharded and read/write-split clusters are unaffected because the parser is already fully engaged for routing.

## Fix

Match the advisory regex set (base + advisory patterns) at `auto` as well, so session advisory locks pin, unlock on the right backend, and get cleaned up on disconnect. The regex gate still only enables the per-request parse for matching statements, so plain traffic is untouched.

## Verification

- New unit test `test_advisory_lock_auto_level` (plus the existing advisory tests all pass).
- End-to-end: local pgdog (transaction mode, single primary, default `auto`), client runs `SELECT pg_try_advisory_lock(424242, 0)` and is SIGKILLed while holding the lock.
  - Before: lock remains granted to the pooled backend indefinitely (`pg_locks` on the server).
  - After: pgdog logs `[cleanup] running 3 cleanup queries` → `SELECT pg_advisory_unlock_all()` and the lock is released.
  - Same repro with the client killed mid-query: the backend drains the running statement, then cleanup releases the lock.
