### PR TITLE
Apply rewrite plans to a client request independently of the AST

### DIFF
--- a/pgdog/src/frontend/client/query_engine/rewrite.rs
+++ b/pgdog/src/frontend/client/query_engine/rewrite.rs
@@ -46,17 +46,9 @@ impl QueryEngine {
                     return Ok(false);
                 }
             };
+
+            context.rewrite_result = Some(ast.rewrite_plan.apply(context.client_request)?);
             context.client_request.ast = Some(ast);
-        }
-
-        let plan = context
-            .client_request
-            .ast
-            .as_ref()
-            .map(|ast| ast.rewrite_plan.clone());
-
-        if let Some(plan) = plan {
-            context.rewrite_result = Some(plan.apply(context.client_request)?);
         }
 
         Ok(true)


### PR DESCRIPTION
Prior to this commit, the code was written in such a way that we assign the AST onto the client request, only to get a reference to it later. Because we're then mutably referencing the request itself, this requires cloning the rewrite plan.

As part of an effort to decouple `ClientRequest` and `Ast`, we instead apply the rewrite plan before assigning the AST to it, allowing the borrowing pattern we need without having to clone a field off the request first.