### PR TITLE
Stop holding a whole rewrite plan in `PreparedStatements`

### DIFF
--- a/pgdog/src/frontend/client/query_engine/multi_step/test/update.rs
+++ b/pgdog/src/frontend/client/query_engine/multi_step/test/update.rs
@@ -90,7 +90,6 @@ async fn same_shard_check(request: ClientRequest) -> Result<(), Error> {
         .as_ref()
         .expect("ast to exist")
         .rewrite_plan
-        .clone()
         .sharding_key_update
         .clone()
         .expect("sharding key update to exist");

--- a/pgdog/src/frontend/prepared_statements/global_cache.rs
+++ b/pgdog/src/frontend/prepared_statements/global_cache.rs
@@ -93,9 +93,8 @@ impl GlobalCache {
         if let Some(name) = self.reuse(&cache_key) {
             return (
                 false,
-                self.prepare_and_rewrite(&name)
-                    .expect("prepared to be in cache if reuse is true")
-                    .0,
+                self.prepare(&name)
+                    .expect("prepared to be in cache if reuse is true"),
             );
         }
 
@@ -108,7 +107,7 @@ impl GlobalCache {
         let statement = Statement {
             stmt: StatementType::Prepare {
                 prepare: prepare.clone(),
-                rewrite_plan: Arc::new(rewrite_plan.clone()),
+                unique_ids: rewrite_plan.unique_ids,
             },
             row_description: None,
             cache_key: cache_key.clone(),
@@ -144,8 +143,15 @@ impl GlobalCache {
     }
 
     /// Get the [`Prepare`] message for a globally unique prepare statement name.
-    pub(crate) fn prepare_and_rewrite(&self, name: &str) -> Option<(Prepare, Arc<RewritePlan>)> {
-        self.names.get(name).and_then(|p| p.prepare_and_rewrite())
+    pub(crate) fn prepare(&self, name: &str) -> Option<Prepare> {
+        self.prepare_and_unique_ids(name)
+            .map(|(prepare, _)| prepare)
+    }
+
+    pub(crate) fn prepare_and_unique_ids(&self, name: &str) -> Option<(Prepare, u16)> {
+        self.names
+            .get(name)
+            .and_then(|p| p.prepare_and_unique_ids())
     }
 
     /// Get the rewritten Parse statement.

--- a/pgdog/src/frontend/prepared_statements/mod.rs
+++ b/pgdog/src/frontend/prepared_statements/mod.rs
@@ -140,10 +140,10 @@ impl PreparedStatements {
     }
 
     /// Get a globally unique [`Prepare`] message using the client name as key.
-    pub(crate) fn prepare_and_rewrite(&self, name: &str) -> Option<(Prepare, Arc<RewritePlan>)> {
+    pub(crate) fn prepare_and_unique_ids(&self, name: &str) -> Option<(Prepare, u16)> {
         self.local
             .get(name)
-            .and_then(|name| self.global.read().prepare_and_rewrite(name))
+            .and_then(|name| self.global.read().prepare_and_unique_ids(name))
     }
 
     /// Number of prepared statements in the client's cache.

--- a/pgdog/src/frontend/prepared_statements/statement.rs
+++ b/pgdog/src/frontend/prepared_statements/statement.rs
@@ -1,6 +1,4 @@
-use std::sync::Arc;
-
-use crate::{frontend::RewritePlan, net::Prepare, stats::memory::MemoryUsage};
+use crate::{net::Prepare, stats::memory::MemoryUsage};
 
 use super::prelude::*;
 
@@ -20,7 +18,12 @@ pub(crate) enum StatementType {
 
     Prepare {
         prepare: Prepare,
-        rewrite_plan: Arc<RewritePlan>,
+        /// The number of calls to `pgdog.unique_id` which were previously
+        /// rewritten. If this value is greater than zero, it is expected
+        /// that the query in the [`Parse`] message referenced by
+        /// [`Self::prepare`] was previously rewritten to replace those calls
+        /// with bind parameter placeholder numbered after all others
+        unique_ids: u16,
     },
 }
 
@@ -60,12 +63,12 @@ impl Statement {
         }
     }
 
-    pub(super) fn prepare_and_rewrite(&self) -> Option<(Prepare, Arc<RewritePlan>)> {
-        match self.stmt {
+    pub(super) fn prepare_and_unique_ids(&self) -> Option<(Prepare, u16)> {
+        match &self.stmt {
             StatementType::Prepare {
-                ref prepare,
-                ref rewrite_plan,
-            } => Some((prepare.clone(), rewrite_plan.clone())),
+                prepare,
+                unique_ids,
+            } => Some((prepare.clone(), *unique_ids)),
             _ => None,
         }
     }

--- a/pgdog/src/frontend/router/parser/query/prepare.rs
+++ b/pgdog/src/frontend/router/parser/query/prepare.rs
@@ -51,9 +51,9 @@ impl QueryParser {
         //
         // INVARIANT 1: The prepared statements rewriter places it there.
         // INVARIANT 2: The rewriter renamed the EXECUTE statement to its global name.
-        let (prepare, _) = PreparedStatements::global()
+        let prepare = PreparedStatements::global()
             .read()
-            .prepare_and_rewrite(stmt.name().expect("execute to have a name"))
+            .prepare(stmt.name().expect("execute to have a name"))
             .ok_or(Error::ExecuteRequiresFull)?;
 
         // Make sure we never store unique statement names

--- a/pgdog/src/frontend/router/parser/rewrite/statement/simple_prepared.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/simple_prepared.rs
@@ -104,11 +104,12 @@ fn rewrite_single_prepared<'a>(
 
         NodeMut::ExecuteStmt(mut stmt) => {
             let stmt_name = stmt.name().expect("EXECUTE always has name");
-            let prepare_and_rewrite = prepared_statements.prepare_and_rewrite(stmt_name);
-            if let Some((prepare, rewrite_plan)) = prepare_and_rewrite {
+            if let Some((prepare, unique_ids)) =
+                prepared_statements.prepare_and_unique_ids(stmt_name)
+            {
                 // Rewrite EXECUTE statement to match the rewrite
                 // we did on the PREPARE statement.
-                apply_prepare_rewrite_plan(&mut stmt, mem, &rewrite_plan)?;
+                insert_unique_ids(&mut stmt, mem, unique_ids)?;
 
                 stmt.set_name(Some(mem.copy_string(prepare.name())));
                 Ok(SimplePreparedRewrite::Executed { prepare })
@@ -121,12 +122,12 @@ fn rewrite_single_prepared<'a>(
     }
 }
 
-fn apply_prepare_rewrite_plan<'a>(
+fn insert_unique_ids<'a>(
     stmt: &mut ExecuteStmtMut<'a, '_>,
     mem: MemoryToken<'a>,
-    plan: &RewritePlan,
+    num_unique_ids: u16,
 ) -> Result<(), Error> {
-    for _ in 0..plan.unique_ids {
+    for _ in 0..num_unique_ids {
         let unique_id = UniqueId::generator()?.next_id();
         stmt.params_mut().push(
             mem,
@@ -209,7 +210,7 @@ mod tests {
                 panic!("expected EXECUTE statement");
             };
 
-            apply_prepare_rewrite_plan(&mut execute, mem, plan)?;
+            insert_unique_ids(&mut execute, mem, plan.unique_ids)?;
             Ok::<_, Error>(copy)
         })?;
 


### PR DESCRIPTION
This was attached to the `Prepare` variant of the statement type. We don't need the whole rewrite plan, as the query was already rewritten in the `Parse` step. The only piece of information we were using was how many unique IDs there were so we can insert the correct number of values upon execute.

Holding onto the whole `RewritePlan` required a lot of unneccessary clones, which results in cloning needing to be cheap, inserting atomic synchronization, heap allocation, and indirection unneccesarily.

Instead of doing that, we can instead just hold onto the tiny bit of information we need to execute the query after it was rewritten.