### PR TITLE
Don't take an owned ShardingKeyUpdate unneccesarily

### DIFF
--- a/pgdog/src/frontend/client/query_engine/multi_step/test/update.rs
+++ b/pgdog/src/frontend/client/query_engine/multi_step/test/update.rs
@@ -84,14 +84,11 @@ async fn same_shard_check(request: ClientRequest) -> Result<(), Error> {
 
     std::assert_matches!(&*client.engine.backend, Binding::Direct(..));
 
-    let rewrite = context
-        .client_request
-        .ast
-        .as_ref()
-        .expect("ast to exist")
+    let ast = context.client_request.ast.clone().expect("ast was set");
+    let rewrite = ast
         .rewrite_plan
         .sharding_key_update
-        .clone()
+        .as_ref()
         .expect("sharding key update to exist");
 
     let mut update = UpdateMulti::new(&mut client.engine, rewrite);

--- a/pgdog/src/frontend/client/query_engine/multi_step/update.rs
+++ b/pgdog/src/frontend/client/query_engine/multi_step/update.rs
@@ -20,13 +20,13 @@ pub(super) struct Row {
 
 #[derive(Debug)]
 pub(crate) struct UpdateMulti<'a> {
-    pub(super) rewrite: ShardingKeyUpdate,
+    pub(super) rewrite: &'a ShardingKeyUpdate,
     pub(super) engine: &'a mut QueryEngine,
 }
 
 impl<'a> UpdateMulti<'a> {
     /// Create new sharding key update handler.
-    pub(crate) fn new(engine: &'a mut QueryEngine, rewrite: ShardingKeyUpdate) -> Self {
+    pub(crate) fn new(engine: &'a mut QueryEngine, rewrite: &'a ShardingKeyUpdate) -> Self {
         Self { rewrite, engine }
     }
 

--- a/pgdog/src/frontend/client/query_engine/query.rs
+++ b/pgdog/src/frontend/client/query_engine/query.rs
@@ -102,7 +102,7 @@ impl QueryEngine {
             }
 
             Some(RewriteResult::ShardingKeyUpdate(sharding_key_update)) => {
-                multi_step::UpdateMulti::new(self, sharding_key_update)
+                multi_step::UpdateMulti::new(self, &sharding_key_update)
                     .execute(context)
                     .await?;
             }


### PR DESCRIPTION
We never actually do anything with this that requires ownership, we can just pass in a reference instead.