### PR TITLE
Remove pointless async

### DIFF
--- a/pgdog/src/frontend/client/query_engine/mod.rs
+++ b/pgdog/src/frontend/client/query_engine/mod.rs
@@ -126,8 +126,14 @@ impl QueryEngine {
         }
 
         // Rewrite statement if necessary.
-        if !self.parse_and_rewrite(context).await? {
-            return Ok(());
+        match self.parse_and_rewrite(context) {
+            Ok(true) => {}
+            Ok(false) => return Ok(()),
+            Err(e) => {
+                self.error_response(context, ErrorResponse::syntax(e.to_string()))
+                    .await?;
+                return Ok(());
+            }
         }
 
         // Intercept commands we don't have to forward to a server.

--- a/pgdog/src/frontend/client/query_engine/multi_step/test/insert.rs
+++ b/pgdog/src/frontend/client/query_engine/multi_step/test/insert.rs
@@ -23,7 +23,7 @@ async fn test_same_shard_insert_uses_direct_route() {
     ]);
 
     let mut context = QueryEngineContext::new(&mut client.client);
-    client.engine.parse_and_rewrite(&mut context).await.unwrap();
+    client.engine.parse_and_rewrite(&mut context).unwrap();
     client.engine.route_query(&mut context).await.unwrap();
     client.engine.execute(&mut context).await.unwrap();
 
@@ -50,7 +50,7 @@ async fn test_cross_shard_insert_uses_all_shards() {
     ]);
 
     let mut context = QueryEngineContext::new(&mut client.client);
-    client.engine.parse_and_rewrite(&mut context).await.unwrap();
+    client.engine.parse_and_rewrite(&mut context).unwrap();
     client.engine.route_query(&mut context).await.unwrap();
     client.engine.execute(&mut context).await.unwrap();
 

--- a/pgdog/src/frontend/client/query_engine/multi_step/test/update.rs
+++ b/pgdog/src/frontend/client/query_engine/multi_step/test/update.rs
@@ -72,7 +72,7 @@ async fn same_shard_check(request: ClientRequest) -> Result<(), Error> {
     client.client().client_request.extend(request.messages);
 
     let mut context = QueryEngineContext::new(&mut client.client);
-    client.engine.parse_and_rewrite(&mut context).await?;
+    client.engine.parse_and_rewrite(&mut context)?;
     client.engine.route_query(&mut context).await?;
 
     assert!(
@@ -188,7 +188,7 @@ async fn test_row_same_shard_no_transaction() {
 
     let mut context = QueryEngineContext::new(&mut client.client);
 
-    client.engine.parse_and_rewrite(&mut context).await.unwrap();
+    client.engine.parse_and_rewrite(&mut context).unwrap();
 
     assert!(
         context

--- a/pgdog/src/frontend/client/query_engine/rewrite.rs
+++ b/pgdog/src/frontend/client/query_engine/rewrite.rs
@@ -20,7 +20,7 @@ impl QueryEngine {
     }
 
     /// Parse client request and rewrite it, if necessary.
-    pub(super) async fn parse_and_rewrite(
+    pub(super) fn parse_and_rewrite(
         &mut self,
         context: &mut QueryEngineContext<'_>,
     ) -> Result<bool, Error> {
@@ -38,14 +38,7 @@ impl QueryEngine {
         if let Some(query) = query {
             let cluster = self.backend.cluster()?;
             let ast_ctx = AstContext::from_cluster(cluster, context.params);
-            let ast = match Cache::get().query(&query, &ast_ctx, context.prepared_statements) {
-                Ok(ast) => ast,
-                Err(err) => {
-                    self.error_response(context, ErrorResponse::syntax(err.to_string().as_str()))
-                        .await?;
-                    return Ok(false);
-                }
-            };
+            let ast = Cache::get().query(&query, &ast_ctx, context.prepared_statements)?;
 
             context.rewrite_result = Some(ast.rewrite_plan.apply(context.client_request)?);
             context.client_request.ast = Some(ast);

--- a/pgdog/src/frontend/client/query_engine/test/rewrite_insert_split.rs
+++ b/pgdog/src/frontend/client/query_engine/test/rewrite_insert_split.rs
@@ -13,7 +13,7 @@ async fn run_test(messages: Vec<ProtocolMessage>) -> Vec<ClientRequest> {
     let mut context = QueryEngineContext::new(&mut client);
 
     engine.rewrite_extended(&mut context).unwrap();
-    engine.parse_and_rewrite(&mut context).await.unwrap();
+    engine.parse_and_rewrite(&mut context).unwrap();
 
     assert!(
         matches!(context.rewrite_result, Some(RewriteResult::InsertSplit(_))),
@@ -147,7 +147,7 @@ async fn test_insert_split_not_sharded() {
     ]);
     let mut engine = QueryEngine::from_client(&client).unwrap();
     let mut context = QueryEngineContext::new(&mut client);
-    engine.parse_and_rewrite(&mut context).await.unwrap();
+    engine.parse_and_rewrite(&mut context).unwrap();
 
     assert!(context.rewrite_result.is_none());
 }

--- a/pgdog/src/frontend/client/query_engine/test/rewrite_offset.rs
+++ b/pgdog/src/frontend/client/query_engine/test/rewrite_offset.rs
@@ -15,7 +15,7 @@ async fn run_test(messages: Vec<ProtocolMessage>) -> Option<OffsetPlan> {
     let mut engine = QueryEngine::from_client(&client).unwrap();
     let mut context = QueryEngineContext::new(&mut client);
 
-    engine.parse_and_rewrite(&mut context).await.unwrap();
+    engine.parse_and_rewrite(&mut context).unwrap();
 
     match context.rewrite_result {
         Some(RewriteResult::InPlace { offset }) => offset,
@@ -102,7 +102,7 @@ async fn test_offset_limit_not_sharded() {
     let mut engine = QueryEngine::from_client(&client).unwrap();
     let mut context = QueryEngineContext::new(&mut client);
 
-    engine.parse_and_rewrite(&mut context).await.unwrap();
+    engine.parse_and_rewrite(&mut context).unwrap();
 
     assert!(context.rewrite_result.is_none());
 }
@@ -127,7 +127,7 @@ async fn test_offset_with_unique_id_simple() {
     let mut engine = QueryEngine::from_client(&client).unwrap();
     let mut context = QueryEngineContext::new(&mut client);
 
-    engine.parse_and_rewrite(&mut context).await.unwrap();
+    engine.parse_and_rewrite(&mut context).unwrap();
 
     // After parse_and_rewrite, the Query message should have unique_id replaced.
     let rewritten_sql = match &context.client_request.messages[0] {
@@ -199,7 +199,7 @@ async fn test_offset_with_unique_id_extended() {
     let mut engine = QueryEngine::from_client(&client).unwrap();
     let mut context = QueryEngineContext::new(&mut client);
 
-    engine.parse_and_rewrite(&mut context).await.unwrap();
+    engine.parse_and_rewrite(&mut context).unwrap();
 
     // After parse_and_rewrite, Parse should have unique_id rewritten to $4::bigint.
     let rewritten_sql = match &context.client_request.messages[0] {

--- a/pgdog/src/frontend/client/query_engine/test/rewrite_simple_prepared.rs
+++ b/pgdog/src/frontend/client/query_engine/test/rewrite_simple_prepared.rs
@@ -10,7 +10,7 @@ async fn run_test(client: &mut Client, messages: &[ProtocolMessage]) -> Vec<Prot
     let mut engine = QueryEngine::from_client(client).unwrap();
     let mut context = QueryEngineContext::new(client);
 
-    assert!(engine.parse_and_rewrite(&mut context).await.unwrap());
+    assert!(engine.parse_and_rewrite(&mut context).unwrap());
 
     client.client_request.messages.clone()
 }

--- a/pgdog/src/net/messages/error_response.rs
+++ b/pgdog/src/net/messages/error_response.rs
@@ -216,7 +216,7 @@ impl ErrorResponse {
         }
     }
 
-    pub fn syntax(err: &str) -> ErrorResponse {
+    pub fn syntax<T: Into<String>>(err: T) -> ErrorResponse {
         Self {
             severity: "ERROR".into(),
             code: "42601".into(),


### PR DESCRIPTION
`parse_and_rewrite` was marked as an async function returning a `Result`. However, it never actually returned any value other than `Ok` outside of catastrophic scenarios, as it caught any errors that were returned and reported them to the client.

Since that error reporting was the only thing this function did which was actually async, we can make it synchronous and move the error reporting up a level. This loosens the restriction on what the body of `parse_and_rewrite` can do, as keeping it async requires a `'static` bound where one wouldn't otherwise be needed.