### PR TITLE
perf: replace ToString with AsRef

### DIFF
--- a/pgdog/src/backend/replication/logical/subscriber/stream.rs
+++ b/pgdog/src/backend/replication/logical/subscriber/stream.rs
@@ -87,7 +87,7 @@ impl Statement {
     fn new(query: &str) -> Result<Self, Error> {
         let name = statement_name();
         Ok(Self {
-            parse: Parse::named(name, query.to_string()),
+            parse: Parse::named(name, query),
         })
     }
 }

--- a/pgdog/src/frontend/client/query_engine/test/sharded_prepared.rs
+++ b/pgdog/src/frontend/client/query_engine/test/sharded_prepared.rs
@@ -3,7 +3,7 @@ use crate::net::{CommandComplete, DataRow, Message};
 use super::prelude::*;
 use super::*;
 
-async fn query(client: &mut TestClient, sql: impl ToString) -> Vec<Message> {
+async fn query(client: &mut TestClient, sql: impl AsRef<str>) -> Vec<Message> {
     client.send_simple(Query::new(sql)).await;
     client.read_until('Z').await.unwrap()
 }

--- a/pgdog/src/frontend/router/parser/query/test/setup.rs
+++ b/pgdog/src/frontend/router/parser/query/test/setup.rs
@@ -166,7 +166,7 @@ impl QueryParserTest {
     /// Set a parameter value.
     pub(crate) fn with_param(
         mut self,
-        name: impl ToString,
+        name: impl AsRef<str>,
         value: impl Into<ParameterValue>,
     ) -> Self {
         self.params.insert(name, value);

--- a/pgdog/src/net/messages/auth/password.rs
+++ b/pgdog/src/net/messages/auth/password.rs
@@ -24,9 +24,9 @@ impl Password {
         }
     }
 
-    pub fn new_password(response: impl ToString) -> Self {
+    pub fn new_password(response: impl AsRef<str>) -> Self {
         Self::PasswordMessage {
-            response: response.to_string() + "\0",
+            response: [response.as_ref(), "\0"].concat(),
         }
     }
 

--- a/pgdog/src/net/messages/bind.rs
+++ b/pgdog/src/net/messages/bind.rs
@@ -5,6 +5,7 @@ use uuid::Uuid;
 use super::Error;
 use super::FromDataType;
 use super::Vector;
+use super::c_string_bytes;
 use super::code;
 use super::prelude::*;
 use bytes::BytesMut;
@@ -186,8 +187,8 @@ impl Bind {
     }
 
     /// Rename this Bind message to a different prepared statement.
-    pub fn rename(&mut self, name: impl ToString) {
-        self.statement = Bytes::from(name.to_string() + "\0");
+    pub fn rename(&mut self, name: impl AsRef<str>) {
+        self.statement = c_string_bytes(name.as_ref());
         self.original = None;
     }
 
@@ -227,14 +228,14 @@ impl Bind {
 
     pub fn new_statement(name: &str) -> Self {
         Self {
-            statement: Bytes::from(name.to_string() + "\0"),
+            statement: c_string_bytes(name),
             ..Default::default()
         }
     }
 
     pub fn new_params(name: &str, params: &[Parameter]) -> Self {
         Self {
-            statement: Bytes::from(name.to_string() + "\0"),
+            statement: c_string_bytes(name),
             params: params.to_vec(),
             ..Default::default()
         }
@@ -242,15 +243,15 @@ impl Bind {
 
     pub fn new_name_portal(name: &str, portal: &str) -> Self {
         Self {
-            statement: Bytes::from(name.to_string() + "\0"),
-            portal: Bytes::from(portal.to_string() + "\0"),
+            statement: c_string_bytes(name),
+            portal: c_string_bytes(portal),
             ..Default::default()
         }
     }
 
     pub fn new_params_codes(name: &str, params: &[Parameter], codes: &[Format]) -> Self {
         Self {
-            statement: Bytes::from(name.to_string() + "\0"),
+            statement: c_string_bytes(name),
             codes: codes.to_vec(),
             params: params.to_vec(),
             ..Default::default()

--- a/pgdog/src/net/messages/command_complete.rs
+++ b/pgdog/src/net/messages/command_complete.rs
@@ -79,8 +79,8 @@ impl CommandComplete {
         Self::from_str("COMMIT")
     }
 
-    pub fn new(command: impl ToString) -> Self {
-        Self::from_str(command.to_string().as_str())
+    pub fn new(command: impl AsRef<str>) -> Self {
+        Self::from_str(command.as_ref())
     }
 }
 

--- a/pgdog/src/net/messages/copy_fail.rs
+++ b/pgdog/src/net/messages/copy_fail.rs
@@ -1,4 +1,4 @@
-use super::{code, prelude::*};
+use super::{c_string_bytes, code, prelude::*};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct CopyFail {
@@ -6,10 +6,9 @@ pub struct CopyFail {
 }
 
 impl CopyFail {
-    pub fn new(error: impl ToString) -> Self {
-        let error = error.to_string();
+    pub fn new(error: impl AsRef<str>) -> Self {
         Self {
-            error: Bytes::from(format!("{}\0", error)),
+            error: c_string_bytes(error.as_ref()),
         }
     }
 }

--- a/pgdog/src/net/messages/describe.rs
+++ b/pgdog/src/net/messages/describe.rs
@@ -62,10 +62,10 @@ impl Describe {
         self.kind() != 'S' || self.statement().is_empty()
     }
 
-    pub fn rename(&mut self, name: impl ToString) {
+    pub fn rename(&mut self, name: impl AsRef<str>) {
         let mut payload = Payload::named('D');
         payload.put_u8(self.kind() as u8);
-        payload.put_string(&name.to_string());
+        payload.put_string(name.as_ref());
         self.payload = payload.freeze();
         self.original = None;
     }

--- a/pgdog/src/net/messages/mod.rs
+++ b/pgdog/src/net/messages/mod.rs
@@ -83,6 +83,11 @@ use crate::{net::Error, stats::memory::MemoryUsage};
 
 use bytes::Bytes;
 
+/// Encode a string as a NULL-terminated C string in a single allocation.
+pub(crate) fn c_string_bytes(value: &str) -> Bytes {
+    Bytes::from([value.as_bytes(), b"\0"].concat())
+}
+
 /// Convert a Rust struct to a PostgreSQL wire protocol message.
 pub trait ToBytes {
     /// Create the protocol message as an array of bytes.

--- a/pgdog/src/net/messages/parse.rs
+++ b/pgdog/src/net/messages/parse.rs
@@ -11,9 +11,7 @@ use std::str::from_utf8_unchecked;
 use super::code;
 use super::prelude::*;
 
-fn c_string(value: &str) -> Bytes {
-    Bytes::from([value.as_bytes(), b"\0"].concat())
-}
+use super::c_string_bytes;
 
 /// Parse (F) message.
 #[derive(Clone, Hash, Eq, PartialEq, Default)]
@@ -48,17 +46,17 @@ impl Parse {
     pub fn new_anonymous(query: &str) -> Self {
         Self {
             name: Bytes::from("\0"),
-            query: c_string(query),
+            query: c_string_bytes(query),
             data_types: Bytes::copy_from_slice(&0i16.to_be_bytes()),
             original: None,
         }
     }
 
     /// New prepared statement.
-    pub fn named(name: impl ToString, query: impl ToString) -> Self {
+    pub fn named(name: impl AsRef<str>, query: impl AsRef<str>) -> Self {
         Self {
-            name: c_string(&name.to_string()),
-            query: c_string(&query.to_string()),
+            name: c_string_bytes(name.as_ref()),
+            query: c_string_bytes(query.as_ref()),
             data_types: Bytes::copy_from_slice(&0i16.to_be_bytes()),
             original: None,
         }
@@ -90,7 +88,7 @@ impl Parse {
         // won't pin any original buffers (allowing to modify them without new allocation)
         // and the new allocation memory size will be just limited by the actual data, not buffers
         Parse {
-            name: c_string(name),
+            name: c_string_bytes(name),
             query: Bytes::copy_from_slice(&self.query),
             data_types: Bytes::copy_from_slice(&self.data_types),
             original: None,
@@ -98,8 +96,8 @@ impl Parse {
     }
 
     /// Rename the prepared statement with minimal allocations.
-    pub fn rename(&mut self, name: &str) {
-        self.name = c_string(name);
+    pub fn rename(&mut self, name: impl AsRef<str>) {
+        self.name = c_string_bytes(name.as_ref());
         self.original = None;
     }
 
@@ -116,7 +114,7 @@ impl Parse {
 
     /// Update the SQL for this prepared statement.
     pub fn set_query(&mut self, query: &str) {
-        self.query = c_string(query);
+        self.query = c_string_bytes(query);
         self.original = None;
     }
 

--- a/pgdog/src/net/messages/query.rs
+++ b/pgdog/src/net/messages/query.rs
@@ -26,9 +26,9 @@ impl Query {
     }
 
     /// Create new query.
-    pub fn new(query: impl ToString) -> Self {
+    pub fn new(query: impl AsRef<str>) -> Self {
         let mut payload = Payload::named('Q');
-        payload.put_string(&query.to_string());
+        payload.put_string(query.as_ref());
         let payload = payload.freeze();
 
         Self { payload }
@@ -74,7 +74,7 @@ impl Protocol for Query {
     }
 }
 
-impl<T: ToString> From<T> for Query {
+impl<T: AsRef<str>> From<T> for Query {
     fn from(value: T) -> Self {
         Query::new(value)
     }

--- a/pgdog/src/net/parameter.rs
+++ b/pgdog/src/net/parameter.rs
@@ -219,10 +219,10 @@ impl Parameters {
     /// Lowercase all param names.
     pub fn insert(
         &mut self,
-        name: impl ToString,
+        name: impl AsRef<str>,
         value: impl Into<ParameterValue>,
     ) -> Option<ParameterValue> {
-        let name = name.to_string().to_lowercase();
+        let name = name.as_ref().to_lowercase();
         let result = self.params.insert(name, value.into());
 
         self.hash = Self::compute_hash(&self.params);
@@ -255,11 +255,11 @@ impl Parameters {
     /// Insert a parameter, but only for the duration of the transaction.
     pub fn insert_transaction(
         &mut self,
-        name: impl ToString,
+        name: impl AsRef<str>,
         value: impl Into<ParameterValue>,
         local: bool,
     ) -> Option<ParameterValue> {
-        let name = name.to_string().to_lowercase();
+        let name = name.as_ref().to_lowercase();
         if local {
             self.transaction_local_params.insert(name, value.into())
         } else {
@@ -269,8 +269,8 @@ impl Parameters {
 
     /// Remove parameter from params temporarily. The transaction
     /// is comitted, it will be removed permanently.
-    pub fn reset(&mut self, name: impl ToString) {
-        let name = name.to_string().to_lowercase();
+    pub fn reset(&mut self, name: impl AsRef<str>) {
+        let name = name.as_ref().to_lowercase();
 
         if let Some(value) = self.params.remove(&name) {
             self.reset_params.insert(name.clone(), value);


### PR DESCRIPTION
Avoid allocations when possible for different net messages by avoiding ToString trait and using AsRef<str>.

before -> after
<img width="1125" height="196" alt="image" src="https://github.com/user-attachments/assets/558c9f5c-7ad5-40f9-85db-512e805a2e6a" />

before
<img width="2076" height="1085" alt="image" src="https://github.com/user-attachments/assets/f2eb8578-2edd-4a40-abe1-ebfda0a39d01" />

after 
<img width="2081" height="1274" alt="image" src="https://github.com/user-attachments/assets/c46e8508-470b-42e4-8ce2-c23e0bc3fa5a" />

I have to come up with very specific shape of benchmark sql to see the good performance boost, otherwise it was not hurting performance anyway in most cases, but better to overprovision.