### PR TITLE
refactor(sharding_key_update): remove SELECT from old shard; add RETURNING * to DELETE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2969,7 +2969,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "pg_raw_parse"
 version = "0.1.0"
-source = "git+https://github.com/pgdogdev/pg_raw_parse.git?rev=6870860#68708609b9bf6b0569257026b2e6d4c1b1748fef"
+source = "git+https://github.com/pgdogdev/pg_raw_parse.git?rev=86acb50#86acb506272a38c3fd0b12ae559be6de61d1e50e"
 dependencies = [
  "bindgen 0.72.1",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ edition = "2024"
 pgdog-plugin = { path = "./pgdog-plugin", version = "0.4.0", default-features = false }
 pgdog-config = { path = "./pgdog-config", version = "0.1.0" }
 pgdog-postgres-types = { path = "./pgdog-postgres-types"}
-pg_raw_parse = { git = "https://github.com/pgdogdev/pg_raw_parse.git", rev = "6870860" }
+pg_raw_parse = { git = "https://github.com/pgdogdev/pg_raw_parse.git", rev = "86acb50" }
 bon = "3.9"
 schemars = { version = "1.2.1", features = ["uuid1"] }
 serde_json = "1.0"

--- a/pgdog/src/frontend/client/query_engine/multi_step/update.rs
+++ b/pgdog/src/frontend/client/query_engine/multi_step/update.rs
@@ -77,12 +77,7 @@ impl<'a> UpdateMulti<'a> {
             return Ok(());
         }
 
-        // Fetch the old row from whatever shard it is on.
-        let row = self.fetch_row(context).await?;
-
-        if let Some(row) = row {
-            self.insert_row(context, row).await?;
-        } else {
+        if self.move_row(context).await?.is_none() {
             // This happens, but the UPDATE's WHERE clause
             // doesn't match any rows, so this whole thing is a no-op.
             self.engine
@@ -93,12 +88,21 @@ impl<'a> UpdateMulti<'a> {
         Ok(())
     }
 
-    /// Create row.
-    pub(super) async fn insert_row(
+    /// Delete the row from the original shard and move it to the new one.
+    ///
+    /// Returns `None` if no row was returned by the DELETE query.
+    pub(super) async fn move_row(
         &mut self,
         context: &mut QueryEngineContext<'_>,
-        row: Row,
-    ) -> Result<(), Error> {
+    ) -> Result<Option<()>, Error> {
+        if self.has_destructive_on_delete_reference(context)? {
+            return Err(UpdateError::ForeignKeyOnDelete.into());
+        }
+
+        let Some(row) = self.delete_and_fetch_row(context).await? else {
+            return Ok(None);
+        };
+
         let mut request = self.rewrite.build_insert_request(
             context.client_request,
             &row.row_description,
@@ -106,55 +110,39 @@ impl<'a> UpdateMulti<'a> {
         )?;
         self.route(&mut request, context)?;
 
-        let original_shard = context.client_request.route().shard();
-        let new_shard = request.route().shard();
+        debug!("[update] executing multi-shard insert/delete");
 
-        // The new row maps to the same shard as the old row.
-        // We don't need to do the multi-step UPDATE anymore.
-        // Forward the original request as-is.
-        if original_shard.is_direct() && new_shard == original_shard {
-            debug!("[update] selected row is on the same shard");
-            self.execute_original(context).await
-        } else {
-            debug!("[update] executing multi-shard insert/delete");
-
-            // Check if we are allowed to do this operation by the config.
-            if self.engine.backend.cluster()?.rewrite().shard_key == RewriteMode::Error {
-                self.engine
-                    .error_response(context, ErrorResponse::from_err(&UpdateError::Disabled))
-                    .await?;
-                return Ok(());
-            }
-
-            if !context.in_transaction() || !self.engine.backend.is_multishard()
-            // Do this check at the last possible moment.
-            // Just in case we change how transactions are
-            // routed in the future.
-            {
-                self.engine.cleanup_backend(context)?;
-                return Err(UpdateError::TransactionRequired.into());
-            }
-
-            if self.has_destructive_on_delete_reference(context)? {
-                return Err(UpdateError::ForeignKeyOnDelete.into());
-            }
-
-            self.delete_row(context).await?;
-            self.execute_request_internal(context, &mut request, self.rewrite.is_returning())
-                .await?;
-
+        // Check if we are allowed to do this operation by the config.
+        if self.engine.backend.cluster()?.rewrite().shard_key == RewriteMode::Error {
             self.engine
-                .process_server_message(context, CommandComplete::new("UPDATE 1").message()) // We only allow to update one row at a time.
+                .error_response(context, ErrorResponse::from_err(&UpdateError::Disabled))
                 .await?;
-            self.engine
-                .process_server_message(
-                    context,
-                    ReadyForQuery::in_transaction(context.in_transaction()).message(),
-                )
-                .await?;
-
-            Ok(())
+            return Ok(Some(()));
         }
+
+        if !context.in_transaction() || !self.engine.backend.is_multishard()
+        // Do this check at the last possible moment.
+        // Just in case we change how transactions are
+        // routed in the future.
+        {
+            self.engine.cleanup_backend(context)?;
+            return Err(UpdateError::TransactionRequired.into());
+        }
+
+        self.execute_request_internal(context, &mut request, self.rewrite.is_returning())
+            .await?;
+
+        self.engine
+            .process_server_message(context, CommandComplete::new("UPDATE 1").message()) // We only allow to update one row at a time.
+            .await?;
+        self.engine
+            .process_server_message(
+                context,
+                ReadyForQuery::in_transaction(context.in_transaction()).message(),
+            )
+            .await?;
+
+        Ok(Some(()))
     }
 
     fn has_destructive_on_delete_reference(
@@ -232,22 +220,11 @@ impl<'a> UpdateMulti<'a> {
         Ok(())
     }
 
-    pub(super) async fn delete_row(
-        &mut self,
-        context: &mut QueryEngineContext<'_>,
-    ) -> Result<(), Error> {
-        let mut request = self.rewrite.delete.build_request(context.client_request)?;
-        self.route(&mut request, context)?;
-
-        self.execute_request_internal(context, &mut request, false)
-            .await
-    }
-
-    pub(super) async fn fetch_row(
+    pub(super) async fn delete_and_fetch_row(
         &mut self,
         context: &mut QueryEngineContext<'_>,
     ) -> Result<Option<Row>, Error> {
-        let mut request = self.rewrite.select.build_request(context.client_request)?;
+        let mut request = self.rewrite.delete.build_request(context.client_request)?;
         self.route(&mut request, context)?;
 
         self.engine

--- a/pgdog/src/frontend/client/query_engine/multi_step/update.rs
+++ b/pgdog/src/frontend/client/query_engine/multi_step/update.rs
@@ -95,6 +95,15 @@ impl<'a> UpdateMulti<'a> {
         &mut self,
         context: &mut QueryEngineContext<'_>,
     ) -> Result<Option<()>, Error> {
+        if !context.in_transaction() || !self.engine.backend.is_multishard()
+        // Do this check at the last possible moment.
+        // Just in case we change how transactions are
+        // routed in the future.
+        {
+            self.engine.cleanup_backend(context)?;
+            return Err(UpdateError::TransactionRequired.into());
+        }
+
         if self.has_destructive_on_delete_reference(context)? {
             return Err(UpdateError::ForeignKeyOnDelete.into());
         }
@@ -118,15 +127,6 @@ impl<'a> UpdateMulti<'a> {
                 .error_response(context, ErrorResponse::from_err(&UpdateError::Disabled))
                 .await?;
             return Ok(Some(()));
-        }
-
-        if !context.in_transaction() || !self.engine.backend.is_multishard()
-        // Do this check at the last possible moment.
-        // Just in case we change how transactions are
-        // routed in the future.
-        {
-            self.engine.cleanup_backend(context)?;
-            return Err(UpdateError::TransactionRequired.into());
         }
 
         self.execute_request_internal(context, &mut request, self.rewrite.is_returning())

--- a/pgdog/src/frontend/router/parser/rewrite/statement/update.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/update.rs
@@ -123,8 +123,6 @@ impl ShardingKeyUpdate {
 
 #[derive(Debug)]
 pub(crate) struct Inner {
-    /// Fetch the whole old row.
-    pub(crate) select: Statement,
     /// Check that the row actually moves shards.
     pub(crate) check: Statement,
     /// Delete old row from shard.
@@ -350,22 +348,6 @@ fn create_stmts<'a>(
     });
 
     let mut params = IndexSet::new();
-    let select = owned(|mem| {
-        let mut select_stmt = mem.make_unique(&*select_star);
-        select_stmt
-            .as_mut()
-            .set_where_clause(mem.make_unique(stmt.where_clause()));
-        params = rewrite_params(select_stmt.as_mut().into());
-        mem.make_list(&[mem.make_raw_stmt(select_stmt.uncast())])
-    });
-
-    let select = Statement {
-        stmt: deparse(select.first().unwrap())?.as_str().to_owned(),
-        ast: Ast::from_raw_stmts(select),
-        params,
-    };
-
-    let mut params = IndexSet::new();
     let delete = owned(|mem| {
         let mut delete = mem.make_node::<nodes::DeleteStmt>();
         delete
@@ -374,6 +356,21 @@ fn create_stmts<'a>(
         delete
             .as_mut()
             .set_where_clause(mem.make_unique(stmt.where_clause()));
+        delete.as_mut().set_returning_clause(
+            mem.make_returning_clause(
+                mem.make_list(&[mem
+                    .make_res_target(
+                        None,
+                        mem.empty(),
+                        mem.make_column_ref(
+                            mem.make_list(&[mem.make_node::<nodes::A_Star>().uncast()]),
+                        )
+                        .uncast(),
+                    )
+                    .uncast()]),
+            )
+            .as_option(),
+        );
         params = rewrite_params(delete.as_mut().into());
         mem.make_list(&[mem.make_raw_stmt(delete.uncast())])
     });
@@ -409,7 +406,6 @@ fn create_stmts<'a>(
 
     Ok(ShardingKeyUpdate {
         inner: Arc::new(Inner {
-            select,
             delete,
             check,
             from_update: owned(|mem| mem.make_unique(stmt)),
@@ -490,8 +486,11 @@ mod test {
             .unwrap();
 
         // SELECT should have WHERE clause with param renumbered to $1
-        assert_eq!(result.select.stmt, "SELECT * FROM sharded WHERE email = $1");
-        assert_eq!(result.select.params, indexset![2]);
+        assert_eq!(
+            result.delete.stmt,
+            "DELETE FROM sharded WHERE email = $1 RETURNING *"
+        );
+        assert_eq!(result.delete.params, indexset![2]);
 
         let schema = default_schema();
         let tables = schema.tables.tables();
@@ -506,10 +505,10 @@ mod test {
             .unwrap();
 
         assert_eq!(
-            result.select.stmt,
-            "SELECT * FROM sharded WHERE email = $1 AND name = $2"
+            result.delete.stmt,
+            "DELETE FROM sharded WHERE email = $1 AND name = $2 RETURNING *"
         );
-        assert_eq!(result.select.params, indexset![2, 3]);
+        assert_eq!(result.delete.params, indexset![2, 3]);
         assert!(!result.is_returning());
     }
 
@@ -523,10 +522,10 @@ mod test {
         .unwrap();
 
         assert_eq!(
-            result.select.stmt,
-            "SELECT * FROM sharded WHERE email = $1 AND name = $2"
+            result.delete.stmt,
+            "DELETE FROM sharded WHERE email = $1 AND name = $2 RETURNING *"
         );
-        assert_eq!(result.select.params, indexset![3, 5]);
+        assert_eq!(result.delete.params, indexset![3, 5]);
     }
 
     #[test]
@@ -535,8 +534,11 @@ mod test {
             .unwrap()
             .unwrap();
 
-        assert_eq!(result.select.stmt, "SELECT * FROM sharded WHERE email = $1");
-        assert_eq!(result.select.params, indexset![2]);
+        assert_eq!(
+            result.delete.stmt,
+            "DELETE FROM sharded WHERE email = $1 RETURNING *"
+        );
+        assert_eq!(result.delete.params, indexset![2]);
     }
 
     #[test]
@@ -545,7 +547,10 @@ mod test {
             .unwrap()
             .unwrap();
 
-        assert_eq!(result.delete.stmt, "DELETE FROM sharded WHERE email = $1");
+        assert_eq!(
+            result.delete.stmt,
+            "DELETE FROM sharded WHERE email = $1 RETURNING *"
+        );
 
         assert!(result.sharded_table(&[]).is_none());
         assert!(
@@ -576,7 +581,7 @@ mod test {
 
         assert_eq!(
             result.delete.stmt,
-            "DELETE FROM sharded WHERE email = $1 AND name = $2"
+            "DELETE FROM sharded WHERE email = $1 AND name = $2 RETURNING *"
         );
     }
 
@@ -587,10 +592,10 @@ mod test {
             .unwrap();
 
         assert_eq!(
-            result.select.stmt,
-            "SELECT * FROM sharded WHERE email = 'test@example.com'"
+            result.delete.stmt,
+            "DELETE FROM sharded WHERE email = 'test@example.com' RETURNING *"
         );
-        assert!(result.select.params.is_empty());
+        assert!(result.delete.params.is_empty());
     }
 
     #[test]
@@ -600,10 +605,10 @@ mod test {
             .unwrap();
 
         assert_eq!(
-            result.select.stmt,
-            "SELECT * FROM sharded WHERE email IN ($1, $2, $3)"
+            result.delete.stmt,
+            "DELETE FROM sharded WHERE email IN ($1, $2, $3) RETURNING *"
         );
-        assert_eq!(result.select.params, indexset![2, 3, 4]);
+        assert_eq!(result.delete.params, indexset![2, 3, 4]);
     }
 
     #[test]
@@ -613,10 +618,10 @@ mod test {
             .unwrap();
 
         assert_eq!(
-            result.select.stmt,
-            "SELECT * FROM sharded WHERE count > $1 AND count < $2"
+            result.delete.stmt,
+            "DELETE FROM sharded WHERE count > $1 AND count < $2 RETURNING *"
         );
-        assert_eq!(result.select.params, indexset![2, 3]);
+        assert_eq!(result.delete.params, indexset![2, 3]);
     }
 
     #[test]
@@ -626,10 +631,10 @@ mod test {
             .unwrap();
 
         assert_eq!(
-            result.select.stmt,
-            "SELECT * FROM sharded WHERE email = $1 OR name = $2"
+            result.delete.stmt,
+            "DELETE FROM sharded WHERE email = $1 OR name = $2 RETURNING *"
         );
-        assert_eq!(result.select.params, indexset![2, 3]);
+        assert_eq!(result.delete.params, indexset![2, 3]);
     }
 
     #[test]
@@ -639,10 +644,10 @@ mod test {
             .unwrap();
 
         assert_eq!(
-            result.select.stmt,
-            "SELECT * FROM sharded WHERE email = $1 AND name = $2"
+            result.delete.stmt,
+            "DELETE FROM sharded WHERE email = $1 AND name = $2 RETURNING *"
         );
-        assert_eq!(result.select.params, indexset![20, 30]);
+        assert_eq!(result.delete.params, indexset![20, 30]);
     }
 
     #[test]
@@ -659,10 +664,10 @@ mod test {
             .unwrap();
 
         assert_eq!(
-            result.select.stmt,
-            "SELECT * FROM sharded WHERE email LIKE $1"
+            result.delete.stmt,
+            "DELETE FROM sharded WHERE email LIKE $1 RETURNING *"
         );
-        assert_eq!(result.select.params, indexset![2]);
+        assert_eq!(result.delete.params, indexset![2]);
     }
 
     #[test]
@@ -672,10 +677,10 @@ mod test {
             .unwrap();
 
         assert_eq!(
-            result.select.stmt,
-            "SELECT * FROM sharded WHERE email = $1 AND deleted_at IS NULL"
+            result.delete.stmt,
+            "DELETE FROM sharded WHERE email = $1 AND deleted_at IS NULL RETURNING *"
         );
-        assert_eq!(result.select.params, indexset![2]);
+        assert_eq!(result.delete.params, indexset![2]);
     }
 
     #[test]
@@ -685,10 +690,10 @@ mod test {
             .unwrap();
 
         assert_eq!(
-            result.select.stmt,
-            "SELECT * FROM sharded WHERE created_at BETWEEN $1 AND $2"
+            result.delete.stmt,
+            "DELETE FROM sharded WHERE created_at BETWEEN $1 AND $2 RETURNING *"
         );
-        assert_eq!(result.select.params, indexset![2, 3]);
+        assert_eq!(result.delete.params, indexset![2, 3]);
     }
 
     #[test]
@@ -700,11 +705,11 @@ mod test {
 
         // Both occurrences should be renumbered to $1
         assert_eq!(
-            result.select.stmt,
-            "SELECT * FROM sharded WHERE email = $1 OR name = $1"
+            result.delete.stmt,
+            "DELETE FROM sharded WHERE email = $1 OR name = $1 RETURNING *"
         );
         // Only one unique param in the mapping
-        assert_eq!(result.select.params, indexset![2]);
+        assert_eq!(result.delete.params, indexset![2]);
     }
 
     #[test]
@@ -715,10 +720,10 @@ mod test {
             .unwrap();
 
         assert_eq!(
-            result.select.stmt,
-            "SELECT * FROM sharded WHERE a = $1 AND b = $1 AND c = $1"
+            result.delete.stmt,
+            "DELETE FROM sharded WHERE a = $1 AND b = $1 AND c = $1 RETURNING *"
         );
-        assert_eq!(result.select.params, indexset![2]);
+        assert_eq!(result.delete.params, indexset![2]);
     }
 
     #[test]
@@ -729,10 +734,10 @@ mod test {
             .unwrap();
 
         assert_eq!(
-            result.select.stmt,
-            "SELECT * FROM sharded WHERE a = $1 AND b = $2 AND c = $1"
+            result.delete.stmt,
+            "DELETE FROM sharded WHERE a = $1 AND b = $2 AND c = $1 RETURNING *"
         );
-        assert_eq!(result.select.params, indexset![2, 3]);
+        assert_eq!(result.delete.params, indexset![2, 3]);
     }
 
     #[test]
@@ -743,10 +748,10 @@ mod test {
             .unwrap();
 
         assert_eq!(
-            result.select.stmt,
-            "SELECT * FROM sharded WHERE email IN ($1, $2, $1)"
+            result.delete.stmt,
+            "DELETE FROM sharded WHERE email IN ($1, $2, $1) RETURNING *"
         );
-        assert_eq!(result.select.params, indexset![2, 3]);
+        assert_eq!(result.delete.params, indexset![2, 3]);
     }
 
     #[test]
@@ -757,7 +762,7 @@ mod test {
 
         assert_eq!(
             result.delete.stmt,
-            "DELETE FROM sharded WHERE email = $1 OR name = $1"
+            "DELETE FROM sharded WHERE email = $1 OR name = $1 RETURNING *"
         );
         assert_eq!(result.delete.params, indexset![2]);
     }


### PR DESCRIPTION
Removes the unnecessary `SELECT` query from the old shard at the beginning of sharding key updates. Moves the row fetch to a `RETURNING *` clause in the `DELETE` achieving equivalent functionality with one less query.

Co-authored-by: Sage <sagetheprogrammer.com>