### PR TITLE
fix(lb): use CancellationToken reliable shutdown signal

### DIFF
--- a/pgdog/src/backend/pool/lb/mod.rs
+++ b/pgdog/src/backend/pool/lb/mod.rs
@@ -10,6 +10,7 @@ use std::{
 
 use rand::seq::SliceRandom;
 use tokio::sync::Notify;
+use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
 use crate::{config::config, net::messages::FrontendPid};
@@ -92,8 +93,8 @@ pub struct LoadBalancer {
     pub(super) round_robin: Arc<AtomicUsize>,
     /// Chosen load balancing strategy.
     pub(super) lb_strategy: LoadBalancingStrategy,
-    /// Maintenance. notification.
-    pub(super) maintenance: Arc<Notify>,
+    /// Shutdown signal for the replicas monitor.
+    pub(super) maintenance: CancellationToken,
     /// Role detection waiter.
     pub(super) role_detection: Arc<Notify>,
     /// Read/write split.
@@ -145,7 +146,7 @@ impl LoadBalancer {
             checkout_timeout,
             round_robin: Arc::new(AtomicUsize::new(0)),
             lb_strategy,
-            maintenance: Arc::new(Notify::new()),
+            maintenance: CancellationToken::new(),
             role_detection: Arc::new(Notify::new()),
             rw_split,
         }
@@ -471,7 +472,7 @@ impl LoadBalancer {
             target.pool.shutdown();
         }
 
-        self.maintenance.notify_waiters();
+        self.maintenance.cancel();
     }
 
     fn require_healthcheck_for_new_targets(&self, old_targets: &[Target]) {

--- a/pgdog/src/backend/pool/lb/monitor.rs
+++ b/pgdog/src/backend/pool/lb/monitor.rs
@@ -53,25 +53,9 @@ impl Monitor {
         };
 
         loop {
-            let mut check_offline = false;
-
             select! {
                 _ = interval.tick() => {}
-                _ = self.replicas.maintenance.notified() => {
-                    check_offline = true;
-                }
-            }
-
-            if check_offline {
-                let offline = self
-                    .replicas
-                    .targets
-                    .iter()
-                    .all(|target| !target.pool.lock().online);
-
-                if offline {
-                    break;
-                }
+                _ = self.replicas.maintenance.cancelled() => break,
             }
 
             self.ban_check(&replica_ban_threshold);

--- a/pgdog/src/backend/pool/lb/test.rs
+++ b/pgdog/src/backend/pool/lb/test.rs
@@ -880,7 +880,7 @@ async fn test_read_write_split_exclude_primary_with_round_robin() {
 }
 
 #[tokio::test]
-async fn test_monitor_shuts_down_on_notify() {
+async fn test_monitor_shuts_down_immediately() {
     let pool_config1 = create_test_pool_config("127.0.0.1", 5432);
     let pool_config2 = create_test_pool_config("localhost", 5432);
 
@@ -897,9 +897,6 @@ async fn test_monitor_shuts_down_on_notify() {
         .iter()
         .for_each(|target| target.pool.launch());
     let monitor_handle = Monitor::spawn(&replicas);
-
-    // Give monitor time to start and register notified() future
-    sleep(Duration::from_millis(10)).await;
 
     replicas.shutdown();
 

--- a/pgdog/src/backend/pub_sub/client.rs
+++ b/pgdog/src/backend/pub_sub/client.rs
@@ -9,7 +9,6 @@ use tokio::{select, spawn};
 
 #[derive(Debug)]
 pub struct PubSubClient {
-    shutdown: Arc<Notify>,
     tx: mpsc::Sender<NotificationResponse>,
     rx: mpsc::Receiver<NotificationResponse>,
     unlisten: HashMap<String, Arc<Notify>>,
@@ -26,7 +25,6 @@ impl PubSubClient {
         let (tx, rx) = mpsc::channel(channel_size());
 
         Self {
-            shutdown: Arc::new(Notify::new()),
             tx,
             rx,
             unlisten: HashMap::new(),
@@ -35,7 +33,6 @@ impl PubSubClient {
 
     /// Listen on a channel.
     pub fn listen(&mut self, channel: &str, mut rx: Listener) {
-        let shutdown = self.shutdown.clone();
         let tx = self.tx.clone();
 
         let unlisten = Arc::new(Notify::new());
@@ -44,10 +41,6 @@ impl PubSubClient {
         spawn(async move {
             loop {
                 select! {
-                    _ = shutdown.notified() => {
-                        return;
-                    }
-
                     _ = unlisten.notified() => {
                         return;
                     }

--- a/pgdog/src/backend/replication/logical/subscriber/parallel_connection.rs
+++ b/pgdog/src/backend/replication/logical/subscriber/parallel_connection.rs
@@ -5,18 +5,14 @@
 //!
 use tokio::select;
 use tokio::spawn;
-use tokio::sync::{
-    Notify,
-    mpsc::{Receiver, Sender, channel},
-};
+use tokio::sync::mpsc::{Receiver, Sender, channel};
+use tokio_util::sync::CancellationToken;
 
 use crate::backend::pool::Address;
 use crate::{
     backend::Server,
     net::{Message, ProtocolMessage},
 };
-
-use std::sync::Arc;
 
 use super::super::Error;
 
@@ -42,7 +38,7 @@ enum ParallelReply {
 pub struct ParallelConnection {
     tx: Sender<ParallelMessage>,
     rx: Receiver<ParallelReply>,
-    stop: Arc<Notify>,
+    stop: CancellationToken,
     address: Address,
 }
 
@@ -87,7 +83,7 @@ impl ParallelConnection {
         // can use a lot of memory if this is high.
         let (tx1, rx1) = channel(4096);
         let (tx2, rx2) = channel(4096);
-        let stop = Arc::new(Notify::new());
+        let stop = CancellationToken::new();
         let address = server.addr().clone();
 
         let listener = Listener {
@@ -114,7 +110,7 @@ impl ParallelConnection {
     // Get the connection back from the async task. This will
     // only work if the connection is idle (ReadyForQuery received, no more traffic expected).
     pub async fn reattach(mut self) -> Result<Server, Error> {
-        self.stop.notify_one();
+        self.stop.cancel();
         let server = self.rx.recv().await.ok_or(Error::ParallelConnection)?;
         match server {
             ParallelReply::Server(server) => Ok(*server),
@@ -127,7 +123,7 @@ impl ParallelConnection {
 // Prevents leaks in case the connection is not "reattached".
 impl Drop for ParallelConnection {
     fn drop(&mut self) {
-        self.stop.notify_one();
+        self.stop.cancel();
     }
 }
 
@@ -136,7 +132,7 @@ struct Listener {
     rx: Receiver<ParallelMessage>,
     tx: Sender<ParallelReply>,
     server: Option<Box<Server>>,
-    stop: Arc<Notify>,
+    stop: CancellationToken,
 }
 
 impl Listener {
@@ -192,7 +188,7 @@ impl Listener {
                     self.tx.send(ParallelReply::Message(reply)).await.map_err(|_| Error::ParallelConnection)?;
                 }
 
-                _ = self.stop.notified() => {
+                _ = self.stop.cancelled() => {
                     self.return_server().await?;
                     break;
                 }

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -521,7 +521,7 @@ impl Client {
             let client_state = query_engine.client_state();
 
             select! {
-                _ = shutdown.notified() => {
+                _ = shutdown.cancelled(), if !offline => {
                     continue; // Wake up task.
                 }
 

--- a/pgdog/src/frontend/client/query_engine/two_pc/manager.rs
+++ b/pgdog/src/frontend/client/query_engine/two_pc/manager.rs
@@ -14,6 +14,7 @@ use std::{
     time::Duration,
 };
 use tokio::{select, sync::Notify, time::Instant};
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
 use crate::{
@@ -58,8 +59,7 @@ impl Manager {
             notify: Arc::new(InnerNotify {
                 notify: Notify::new(),
                 offline: AtomicBool::new(false),
-                done_flag: AtomicBool::new(false),
-                done: Notify::new(),
+                done: CancellationToken::new(),
             }),
             stats: Arc::new(TwoPcStats::default()),
             wal: Arc::new(ArcSwapOption::empty()),
@@ -321,8 +321,7 @@ impl Manager {
                 notify.notify.notify_one();
             } else if notify.offline.load(Ordering::Relaxed) {
                 // No more transactions to cleanup.
-                notify.done_flag.store(true, Ordering::Relaxed);
-                notify.done.notify_waiters();
+                notify.done.cancel();
 
                 if let Some(wal) = manager.wal.load_full() {
                     wal.shutdown();
@@ -397,18 +396,17 @@ impl Manager {
     /// Once the monitor has drained the cleanup queue, the WAL is shut
     /// down too so any final End records make it to disk before exit.
     pub async fn shutdown(&self) {
-        if self.notify.done_flag.load(Ordering::Relaxed) {
+        if self.notify.done.is_cancelled() {
             return;
         }
 
-        let waiter = self.notify.done.notified();
         self.notify.offline.store(true, Ordering::Relaxed);
         self.notify.notify.notify_one();
         let transactions = self.inner.lock().queue.len();
 
         info!("[2pc] cleaning up {} two-phase transactions", transactions);
 
-        waiter.await;
+        self.notify.done.cancelled().await;
 
         info!("[2pc] manager shutdown successful");
     }
@@ -431,6 +429,5 @@ struct Inner {
 struct InnerNotify {
     notify: Notify,
     offline: AtomicBool,
-    done_flag: AtomicBool,
-    done: Notify,
+    done: CancellationToken,
 }

--- a/pgdog/src/frontend/comms.rs
+++ b/pgdog/src/frontend/comms.rs
@@ -2,15 +2,12 @@
 
 use std::net::SocketAddr;
 use std::ops::Deref;
-use std::sync::{
-    Arc,
-    atomic::{AtomicBool, Ordering},
-};
+use std::sync::Arc;
 
 use dashmap::DashMap;
 use fnv::FnvHashMap as HashMap;
 use once_cell::sync::Lazy;
-use tokio::sync::Notify;
+use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
 
 use crate::net::Parameters;
@@ -28,8 +25,7 @@ pub fn comms() -> Comms {
 /// Sync primitives shared between all clients.
 #[derive(Debug)]
 struct Global {
-    shutdown: Arc<Notify>,
-    offline: AtomicBool,
+    shutdown: CancellationToken,
     // This uses the FNV hasher, which is safe,
     // because FrontendPid is monotonically minted by us,
     // not derived from untrusted client input.
@@ -54,8 +50,7 @@ impl Comms {
     fn new() -> Self {
         Self {
             global: Arc::new(Global {
-                shutdown: Arc::new(Notify::new()),
-                offline: AtomicBool::new(false),
+                shutdown: CancellationToken::new(),
                 clients: Arc::new(DashMap::default()),
                 tracker: TaskTracker::new(),
             }),
@@ -131,21 +126,20 @@ impl Comms {
             .unwrap_or(false)
     }
 
-    /// Notify clients pgDog is shutting down.
+    /// Tell clients pgDog is shutting down.
     pub fn shutdown(&self) {
-        self.global.offline.store(true, Ordering::Relaxed);
-        self.global.shutdown.notify_waiters();
+        self.global.shutdown.cancel();
         self.global.tracker.close();
     }
 
-    /// Wait for shutdown signal.
-    pub fn shutting_down(&self) -> Arc<Notify> {
+    /// Get the shutdown signal.
+    pub fn shutting_down(&self) -> CancellationToken {
         self.global.shutdown.clone()
     }
 
     /// pgDog is shutting down now.
     pub fn offline(&self) -> bool {
-        self.global.offline.load(Ordering::Relaxed)
+        self.global.shutdown.is_cancelled()
     }
 }
 

--- a/pgdog/src/frontend/listener.rs
+++ b/pgdog/src/frontend/listener.rs
@@ -2,7 +2,6 @@
 
 use std::io::ErrorKind;
 use std::net::SocketAddr;
-use std::sync::Arc;
 
 use crate::backend::databases::{databases, reload, shutdown};
 use crate::config::config;
@@ -13,8 +12,8 @@ use crate::net::{self, Stream, tweak};
 use crate::sighup::Sighup;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::signal::ctrl_c;
-use tokio::sync::Notify;
 use tokio::{select, spawn};
+use tokio_util::sync::CancellationToken;
 
 use tracing::{error, info, warn};
 
@@ -25,7 +24,7 @@ use crate::util::safe_timeout;
 #[derive(Debug, Clone)]
 pub struct Listener {
     addr: String,
-    shutdown: Arc<Notify>,
+    shutdown: CancellationToken,
 }
 
 impl Listener {
@@ -33,7 +32,7 @@ impl Listener {
     pub fn new(addr: impl ToString) -> Self {
         Self {
             addr: addr.to_string(),
-            shutdown: Arc::new(Notify::new()),
+            shutdown: CancellationToken::new(),
         }
     }
 
@@ -43,6 +42,7 @@ impl Listener {
         let listener = TcpListener::bind(&self.addr).await?;
         let shutdown_signal = comms().shutting_down();
         let mut sighup = Sighup::new()?;
+        let mut shutting_down = false;
 
         loop {
             select! {
@@ -67,11 +67,13 @@ impl Listener {
                    }
                 }
 
-                _ = shutdown_signal.notified() => {
+                _ = shutdown_signal.cancelled(), if !shutting_down => {
+                    shutting_down = true;
                     self.start_shutdown();
                 }
 
-                _ = ctrl_c() => {
+                _ = ctrl_c(), if !shutting_down => {
+                    shutting_down = true;
                     self.start_shutdown();
                 }
 
@@ -81,7 +83,7 @@ impl Listener {
                     }
                 }
 
-                _ = self.shutdown.notified() => {
+                _ = self.shutdown.cancelled() => {
                     break;
                 }
             }
@@ -144,7 +146,7 @@ impl Listener {
             }
         }
 
-        self.shutdown.notify_waiters();
+        self.shutdown.cancel();
     }
 
     async fn handle_client(stream: TcpStream, addr: SocketAddr) -> Result<(), Error> {

--- a/pgdog/src/main.rs
+++ b/pgdog/src/main.rs
@@ -287,7 +287,6 @@ async fn pgdog(command: Option<Commands>) -> Result<(), Box<dyn std::error::Erro
         }
     }
 
-    stats_logger.shutdown();
     tasks::shutdown().await;
 
     // Any shutdown routines go below.

--- a/pgdog/src/stats/logger.rs
+++ b/pgdog/src/stats/logger.rs
@@ -1,6 +1,6 @@
-use std::{sync::Arc, time::Duration};
+use std::time::Duration;
 
-use tokio::{select, sync::Notify};
+use tokio::select;
 use tracing::info;
 
 use crate::frontend::router::parser::Cache;
@@ -10,7 +10,6 @@ use crate::util::safe_sleep;
 #[derive(Debug, Clone)]
 pub struct Logger {
     interval: Duration,
-    shutdown: Arc<Notify>,
 }
 
 impl Default for Logger {
@@ -23,12 +22,7 @@ impl Logger {
     pub fn new() -> Self {
         Self {
             interval: Duration::from_secs(10),
-            shutdown: Arc::new(Notify::new()),
         }
-    }
-
-    pub fn shutdown(&self) {
-        self.shutdown.notify_one();
     }
 
     pub fn spawn(&self) {
@@ -46,7 +40,6 @@ impl Logger {
                             stats.direct, stats.multi, stats.hits, stats.misses, len, (stats.direct as f64 / std::cmp::max(stats.direct + stats.multi, 1) as f64 * 100.0)
                         );
                     }
-                    _ = me.shutdown.notified() => break,
                     _ = shutdown.cancelled() => break,
                 }
             }


### PR DESCRIPTION
Replace pack of Notify with CancellationToken to implement the shutdown signal.

One of the issue I faced is the `lb/monitor` that was not shutting down sometimes gracefully. Also, I think this is the reason the complex integration test fails sometime.