### PR TITLE
feat(pg_raw_parse): use our own version of normalize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2969,7 +2969,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "pg_raw_parse"
 version = "0.1.0"
-source = "git+https://github.com/pgdogdev/pg_raw_parse.git?rev=86acb50#86acb506272a38c3fd0b12ae559be6de61d1e50e"
+source = "git+https://github.com/pgdogdev/pg_raw_parse.git?rev=c5b3b75#c5b3b75345881621e889fc9c9b0b9f47d53f8e8f"
 dependencies = [
  "bindgen 0.72.1",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ edition = "2024"
 pgdog-plugin = { path = "./pgdog-plugin", version = "0.4.0", default-features = false }
 pgdog-config = { path = "./pgdog-config", version = "0.1.0" }
 pgdog-postgres-types = { path = "./pgdog-postgres-types"}
-pg_raw_parse = { git = "https://github.com/pgdogdev/pg_raw_parse.git", rev = "86acb50" }
+pg_raw_parse = { git = "https://github.com/pgdogdev/pg_raw_parse.git", rev = "c5b3b75" }
 bon = "3.9"
 schemars = { version = "1.2.1", features = ["uuid1"] }
 serde_json = "1.0"

--- a/integration/dry_run/test/sequelize.js
+++ b/integration/dry_run/test/sequelize.js
@@ -38,7 +38,7 @@ describe("sequelize", async function () {
     let found = false;
     for (let i = 0; i < cache.rows.length; i++) {
       let row = cache.rows[i];
-      if (row.query.startsWith('SELECT "id", "email", "createdAt"')) {
+      if (row.query.startsWith('SELECT id, email, "createdAt"')) {
         assert(parseInt(row.direct) > 0);
         found = true;
       }

--- a/pgdog/src/frontend/router/parser/cache/cache_impl.rs
+++ b/pgdog/src/frontend/router/parser/cache/cache_impl.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use parking_lot::Mutex;
+use pg_raw_parse::nodes;
 use std::sync::Arc;
 use tracing::debug;
 
@@ -212,19 +213,20 @@ impl Cache {
     /// Used by dry run mode to keep stats on what queries are routed correctly,
     /// and which are not.
     ///
-    pub fn record_normalized(&self, query: &str, route: &Route) -> Result<(), Error> {
-        let normalized = normalize(query)?;
+    pub fn record_normalized(&self, query: &nodes::RawStmt, route: &Route) -> Result<(), Error> {
+        let normalized = normalize(query);
+        let normalized = normalized.stmt().as_str().ok_or(Error::EmptyQuery)?;
 
         {
             let mut guard = self.inner.lock();
-            if let Some(entry) = guard.queries.get(normalized.as_str()) {
+            if let Some(entry) = guard.queries.get(normalized) {
                 entry.update_stats(route);
                 guard.stats.hits += 1;
                 return Ok(());
             }
         }
 
-        let entry = Ast::new_record(&normalized)?;
+        let entry = Ast::new_record(normalized)?;
         entry.update_stats(route);
 
         let mut guard = self.inner.lock();

--- a/pgdog/src/frontend/router/parser/cache/cache_impl.rs
+++ b/pgdog/src/frontend/router/parser/cache/cache_impl.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use parking_lot::Mutex;
-use pg_raw_parse::nodes;
+use pg_raw_parse::{deparse, nodes};
 use std::sync::Arc;
 use tracing::debug;
 
@@ -215,7 +215,8 @@ impl Cache {
     ///
     pub fn record_normalized(&self, query: &nodes::RawStmt, route: &Route) -> Result<(), Error> {
         let normalized = normalize(query);
-        let normalized = normalized.stmt().as_str().ok_or(Error::EmptyQuery)?;
+        let normalized = deparse(normalized.stmt())?;
+        let normalized = normalized.as_str();
 
         {
             let mut guard = self.inner.lock();

--- a/pgdog/src/frontend/router/parser/query/mod.rs
+++ b/pgdog/src/frontend/router/parser/query/mod.rs
@@ -528,8 +528,10 @@ impl QueryParser {
         if context.dry_run {
             // Record statement in cache with normalized parameters.
             if !statement.cached {
-                let query = context.query()?.query();
-                Cache::get().record_normalized(query, command.route())?;
+                Cache::get().record_normalized(
+                    statement.ast.into_iter().next().ok_or(Error::EmptyQuery)?,
+                    command.route(),
+                )?;
             }
             Ok(command.dry_run())
         } else {


### PR DESCRIPTION
Updates pg_raw_parse rev to https://github.com/pgdogdev/pg_raw_parse/pull/41 to use our own version of `normalize`.