### PR TITLE
fix: generate random IDs consistent with same shard in multi-step test

### DIFF
--- a/pgdog/src/frontend/client/query_engine/multi_step/test/update.rs
+++ b/pgdog/src/frontend/client/query_engine/multi_step/test/update.rs
@@ -1,5 +1,3 @@
-use rand::{Rng, rng};
-
 use crate::{
     backend::pool::connection::binding::Binding,
     expect_message,

--- a/pgdog/src/frontend/client/query_engine/multi_step/test/update.rs
+++ b/pgdog/src/frontend/client/query_engine/multi_step/test/update.rs
@@ -215,15 +215,17 @@ async fn test_row_same_shard_no_transaction() {
 #[tokio::test]
 async fn test_no_rows_updated() {
     let mut client = TestClient::new_rewrites(Parameters::default()).await;
-    let id = rng().random::<i64>();
+
+    // Ensure that we generate 2 random IDs consistent with the same shard.
+    let shard_0_id_1 = client.random_id_for_shard(0);
+    let shard_0_id_2 = client.random_id_for_shard(0);
 
     // Transaction not required because
     // it'll check for existing row first (on the same shard).
     client
         .send_simple(Query::new(format!(
             "UPDATE sharded SET id = {} WHERE id = {}",
-            id,
-            id + 1
+            shard_0_id_1, shard_0_id_2
         )))
         .await;
     let cc = client.read().await;


### PR DESCRIPTION
The unit test `test_no_rows_updated` was intermittently failing due to a 50/50 chance of two randomly generated sharding keys resolving to different shards when they were intended to be for the same shard. Fixed to randomly generate for the same shard via `random_id_for_shard(0)` x2.