### PR TITLE
fix(lb): avoid NoPrimary errors while waiting for primary election

### DIFF
--- a/pgdog/src/backend/pool/lb/mod.rs
+++ b/pgdog/src/backend/pool/lb/mod.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use rand::seq::SliceRandom;
-use tokio::sync::Notify;
+use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
@@ -95,8 +95,8 @@ pub struct LoadBalancer {
     pub(super) lb_strategy: LoadBalancingStrategy,
     /// Shutdown signal for the replicas monitor.
     pub(super) maintenance: CancellationToken,
-    /// Role detection waiter.
-    pub(super) role_detection: Arc<Notify>,
+    /// Pool elected as primary by automatic role detection.
+    pub(super) elected_primary: Arc<watch::Sender<Option<Pool>>>,
     /// Read/write split.
     pub(super) rw_split: ReadWriteSplit,
 }
@@ -147,7 +147,7 @@ impl LoadBalancer {
             round_robin: Arc::new(AtomicUsize::new(0)),
             lb_strategy,
             maintenance: CancellationToken::new(),
-            role_detection: Arc::new(Notify::new()),
+            elected_primary: Arc::new(watch::Sender::new(None)),
             rw_split,
         }
     }
@@ -194,6 +194,8 @@ impl LoadBalancer {
             .iter()
             .position(|target| !target.0.replica && target.0.valid());
 
+        self.elected_primary.send_replace(None);
+
         if let Some(primary) = primary {
             promoted = targets[primary].1.set_role(Role::Primary);
 
@@ -216,9 +218,7 @@ impl LoadBalancer {
             });
         }
 
-        if promoted {
-            self.role_detection.notify_one();
-        }
+        self.elected_primary.send_replace(self.primary().cloned());
 
         promoted
     }
@@ -324,37 +324,30 @@ impl LoadBalancer {
         result
     }
 
-    /// Block until automatic role detection elects a primary.
+    /// Check out a connection from the primary.
     ///
-    /// Static replica-only configurations return immediately. In automatic
-    /// mode, callers wait until a primary is elected or checkout times out.
-    async fn wait_primary(&self) -> Result<(), Error> {
-        if self.primary_target().is_none() && self.role_detection_enabled() {
-            if safe_timeout(self.checkout_timeout, self.role_detection.notified())
-                .await
-                .is_err()
-            {
-                return Err(Error::CheckoutTimeout);
-            };
-            // Chain the wakeup so any other waiter that arrived after us
-            // also gets released without needing another promotion event.
-            self.role_detection.notify_one();
+    /// In automatic mode, the caller waits until role detection elects a
+    /// primary, or until the checkout times out. Static replica-only
+    /// configurations fail immediately with [`Error::NoPrimary`].
+    pub(super) async fn get_primary(&self, request: &Request) -> Result<Guard, Error> {
+        if let Some(pool) = self.primary() {
+            return pool.get(request).await;
         }
 
-        Ok(())
-    }
+        if !self.role_detection_enabled() {
+            return Err(Error::NoPrimary);
+        }
 
-    pub(super) async fn get_primary(&self, request: &Request) -> Result<Guard, Error> {
-        self.get_primary_internal(request).await
-    }
+        let mut receiver = self.elected_primary.subscribe();
 
-    async fn get_primary_internal(&self, request: &Request) -> Result<Guard, Error> {
-        self.wait_primary().await?;
-        self.primary_target()
-            .ok_or(Error::NoPrimary)?
-            .pool
-            .get(request)
+        let primary = safe_timeout(self.checkout_timeout, receiver.wait_for(|p| p.is_some()))
             .await
+            .map_err(|_| Error::CheckoutTimeout)?
+            .ok()
+            .and_then(|elected| elected.as_ref().cloned())
+            .ok_or(Error::NoPrimary)?;
+
+        primary.get(request).await
     }
 
     async fn get_internal(&self, request: &Request) -> Result<Guard, Error> {

--- a/pgdog/src/backend/pool/lb/mod.rs
+++ b/pgdog/src/backend/pool/lb/mod.rs
@@ -324,11 +324,24 @@ impl LoadBalancer {
         result
     }
 
+    /// Wait until automatic role detection elects a primary.
+    ///
+    /// Fails with [`Error::CheckoutTimeout`] if no election happens in time.
+    async fn wait_primary(&self) -> Result<Pool, Error> {
+        let mut receiver = self.elected_primary.subscribe();
+
+        safe_timeout(self.checkout_timeout, receiver.wait_for(|p| p.is_some()))
+            .await
+            .map_err(|_| Error::CheckoutTimeout)?
+            .ok()
+            .and_then(|elected| elected.as_ref().cloned())
+            .ok_or(Error::NoPrimary)
+    }
+
     /// Check out a connection from the primary.
     ///
-    /// In automatic mode, the caller waits until role detection elects a
-    /// primary, or until the checkout times out. Static replica-only
-    /// configurations fail immediately with [`Error::NoPrimary`].
+    /// In automatic mode, the caller waits for an election. Static
+    /// replica-only configurations fail immediately with [`Error::NoPrimary`].
     pub(super) async fn get_primary(&self, request: &Request) -> Result<Guard, Error> {
         if let Some(pool) = self.primary() {
             return pool.get(request).await;
@@ -338,16 +351,7 @@ impl LoadBalancer {
             return Err(Error::NoPrimary);
         }
 
-        let mut receiver = self.elected_primary.subscribe();
-
-        let primary = safe_timeout(self.checkout_timeout, receiver.wait_for(|p| p.is_some()))
-            .await
-            .map_err(|_| Error::CheckoutTimeout)?
-            .ok()
-            .and_then(|elected| elected.as_ref().cloned())
-            .ok_or(Error::NoPrimary)?;
-
-        primary.get(request).await
+        self.wait_primary().await?.get(request).await
     }
 
     async fn get_internal(&self, request: &Request) -> Result<Guard, Error> {

--- a/pgdog/src/backend/pool/lb/test.rs
+++ b/pgdog/src/backend/pool/lb/test.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::time::Duration;
 use tokio::task::yield_now;
-use tokio::time::sleep;
+use tokio::time::{Instant, sleep};
 
 use crate::backend::pool::{Address, Config, Error, PoolConfig, Request};
 use crate::backend::replication::publisher::Lsn;
@@ -1502,7 +1502,10 @@ async fn test_auto_mode_waits_for_primary_election() {
         Default::default(),
     );
 
-    assert_eq!(lb.wait_primary().await, Err(Error::CheckoutTimeout));
+    assert!(matches!(
+        lb.get_primary(&Request::default()).await,
+        Err(Error::CheckoutTimeout)
+    ));
 }
 
 #[tokio::test]
@@ -1515,16 +1518,21 @@ async fn test_auto_mode_primary_election_releases_writes() {
         ReadWriteSplit::IncludePrimary,
         Default::default(),
     );
+    lb.targets[0].pool.launch();
     let election = lb.clone();
 
-    tokio::spawn(async move {
+    let election = tokio::spawn(async move {
         sleep(Duration::from_millis(10)).await;
         set_lsn_stats(&election.targets[0], false, 100);
         assert!(election.redetect_roles());
     });
 
-    assert_eq!(lb.wait_primary().await, Ok(()));
-    assert!(lb.primary().is_some());
+    let primary = lb.get_primary(&Request::default()).await.unwrap();
+    assert_eq!(primary.pool.addr().host, "127.0.0.1");
+    drop(primary);
+    election.await.unwrap();
+
+    lb.shutdown();
 }
 
 #[tokio::test]
@@ -1581,6 +1589,7 @@ async fn test_auto_mode_waits_for_each_new_primary() {
 
     set_lsn_stats(&lb.targets[1], false, 200);
     assert!(lb.redetect_roles());
+    assert!(!lb.redetect_roles());
     assert!(lb.primary().is_some());
 
     // primary should be resolved to second target
@@ -1602,11 +1611,12 @@ async fn test_static_replica_only_does_not_wait_for_primary() {
         Default::default(),
     );
 
-    assert_eq!(lb.wait_primary().await, Ok(()));
+    let started = Instant::now();
     assert!(matches!(
         lb.get_primary(&Request::default()).await,
         Err(Error::NoPrimary)
     ));
+    assert!(started.elapsed() < Duration::from_millis(100));
 }
 
 #[tokio::test]

--- a/pgdog/src/backend/pool/lb/test.rs
+++ b/pgdog/src/backend/pool/lb/test.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::time::Duration;
 use tokio::task::yield_now;
-use tokio::time::{Instant, sleep};
+use tokio::time::{Instant, sleep, timeout};
 
 use crate::backend::pool::{Address, Config, Error, PoolConfig, Request};
 use crate::backend::replication::publisher::Lsn;
@@ -46,7 +46,7 @@ fn create_auto_test_pool_config(host: &str, port: u16) -> PoolConfig {
     let mut config = create_test_pool_config(host, port);
     config.address.configured_role = Role::Auto;
     config.config.inner.role_detection = true;
-    config.config.inner.checkout_timeout = Duration::from_millis(200);
+    config.config.inner.checkout_timeout = Duration::from_millis(50);
     config
 }
 
@@ -1596,6 +1596,33 @@ async fn test_auto_mode_waits_for_each_new_primary() {
     let primary = spawned.await.unwrap().unwrap();
     assert_eq!(primary.pool.addr().host, "localhost");
     drop(primary);
+
+    lb.shutdown();
+}
+
+#[tokio::test]
+async fn test_election_channel_no_race_condition() {
+    let lb = LoadBalancer::new(
+        &None,
+        &[create_auto_test_pool_config("127.0.0.1", 5432)],
+        LoadBalancingStrategy::Random,
+        ReadWriteSplit::IncludePrimary,
+        Default::default(),
+    );
+    lb.targets[0].pool.launch();
+
+    // make sure there is no primary
+    assert!(lb.primary().is_none());
+
+    // initialize the primary before the wait_primary is called
+    set_lsn_stats(&lb.targets[0], false, 100);
+    assert!(lb.redetect_roles());
+
+    let elected = timeout(Duration::ZERO, lb.wait_primary())
+        .await
+        .expect("wait_primary should resolve")
+        .expect("primary should be elected");
+    assert_eq!(elected.addr().host, "127.0.0.1");
 
     lb.shutdown();
 }

--- a/pgdog/src/backend/pool/lb/test.rs
+++ b/pgdog/src/backend/pool/lb/test.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 use std::time::Duration;
+use tokio::task::yield_now;
 use tokio::time::sleep;
 
 use crate::backend::pool::{Address, Config, Error, PoolConfig, Request};
@@ -45,6 +46,7 @@ fn create_auto_test_pool_config(host: &str, port: u16) -> PoolConfig {
     let mut config = create_test_pool_config(host, port);
     config.address.configured_role = Role::Auto;
     config.config.inner.role_detection = true;
+    config.config.inner.checkout_timeout = Duration::from_millis(200);
     config
 }
 
@@ -1517,12 +1519,76 @@ async fn test_auto_mode_primary_election_releases_writes() {
 
     tokio::spawn(async move {
         sleep(Duration::from_millis(10)).await;
-        election.targets[0].set_role(Role::Primary);
-        election.role_detection.notify_one();
+        set_lsn_stats(&election.targets[0], false, 100);
+        assert!(election.redetect_roles());
     });
 
     assert_eq!(lb.wait_primary().await, Ok(()));
     assert!(lb.primary().is_some());
+}
+
+#[tokio::test]
+async fn test_auto_mode_waits_for_each_new_primary() {
+    let first = create_auto_test_pool_config("127.0.0.1", 5432);
+    let second = create_auto_test_pool_config("localhost", 5432);
+
+    let lb = LoadBalancer::new(
+        &None,
+        &[first, second],
+        LoadBalancingStrategy::Random,
+        ReadWriteSplit::IncludePrimary,
+        Default::default(),
+    );
+    lb.targets.iter().for_each(|target| target.pool.launch());
+
+    // primary is not defined initially
+    assert!(lb.primary().is_none());
+    // spawn the task that will wait for primary to resolve
+    let spawned = {
+        let lb = lb.clone();
+
+        tokio::spawn(async move { lb.get_primary(&Request::default()).await })
+    };
+
+    // assert that the background wait is in progress
+    yield_now().await;
+    assert!(!spawned.is_finished());
+
+    // set the first target to primary and redetect roles
+    set_lsn_stats(&lb.targets[0], false, 100);
+    set_lsn_stats(&lb.targets[1], true, 90);
+    assert!(lb.redetect_roles());
+
+    // primary should be resolved to first primary
+    let primary = spawned.await.unwrap().unwrap();
+    assert_eq!(primary.pool.addr().host, "127.0.0.1");
+    drop(primary);
+
+    // remove primary from first
+    set_lsn_stats(&lb.targets[0], true, 100);
+    lb.redetect_roles();
+    assert!(lb.primary().is_none());
+
+    // spawn another task that should wait for new primary
+    let spawned = {
+        let lb = lb.clone();
+
+        tokio::spawn(async move { lb.get_primary(&Request::default()).await })
+    };
+
+    yield_now().await;
+    assert!(!spawned.is_finished());
+
+    set_lsn_stats(&lb.targets[1], false, 200);
+    assert!(lb.redetect_roles());
+    assert!(lb.primary().is_some());
+
+    // primary should be resolved to second target
+    let primary = spawned.await.unwrap().unwrap();
+    assert_eq!(primary.pool.addr().host, "localhost");
+    drop(primary);
+
+    lb.shutdown();
 }
 
 #[tokio::test]


### PR DESCRIPTION
Fix the issue with the subscription to primary update on load-balancer when the primary temporarily unavailable. 

Please see the test and comment on it for context. 

The issue could generate unnecessary NoPrimary errors instead of actually waiting the new primary to be identified due to the misuse of Notify that always generated +1 permit effectively removing any subscription after first wait.