### PR TITLE
refactor: extended request splitting

### DIFF
--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -602,7 +602,7 @@ impl Client {
                     match query_engine
                         .handle(
                             &mut QueryEngineContext::new(self)
-                                .spliced(&mut request, requests.len()),
+                                .extended_pipeline(&mut request, requests.len()),
                         )
                         .await?
                     {

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -24,7 +24,7 @@ use crate::backend::{
 use crate::config::convert::user_from_params;
 use crate::config::{self, AuthType, ConfigAndUsers, config};
 use crate::frontend::ClientComms;
-use crate::frontend::client::query_engine::{QueryEngine, QueryEngineContext};
+use crate::frontend::client::query_engine::{QueryEngine, QueryEngineContext, QueryEngineResult};
 use crate::net::messages::{
     Authentication, BackendKeyData, ErrorResponse, FromBytes, FrontendPid, Message, Password,
     Protocol, ProtocolVersion, ReadyForQuery, ToBytes,
@@ -566,49 +566,51 @@ impl Client {
         Ok(())
     }
 
-    /// Handle client messages.
-    async fn client_messages(&mut self, query_engine: &mut QueryEngine) -> Result<(), Error> {
-        // Check maintenance mode.
+    /// Suspend client execution if the pooler is set in maintenance mode.
+    ///
+    /// This can happen only between transactions. The admin client ignores maintenance
+    /// mode because it can be used to turn it off.
+    ///
+    /// # Arguments
+    ///
+    /// * `query_engine`: Query engine to set the client state into `waiting`.
+    ///
+    async fn check_maintenance_mode(&self, query_engine: &mut QueryEngine) {
         if !self.in_transaction()
             && !self.admin
             && let Some(waiter) = maintenance_mode::waiter(&self.database)
         {
-            let state = query_engine.get_state();
-            query_engine.set_state(State::Waiting);
+            let _guard = query_engine.set_maintenance_mode();
             waiter.await;
-            query_engine.set_state(state);
         }
+    }
 
-        // If client sent multiple requests, split them up and execute individually.
-        let spliced = self.client_request.spliced()?;
-        if spliced.is_empty() {
-            let mut context = QueryEngineContext::new(self);
-            query_engine.handle(&mut context).await?;
-            self.transaction = context.transaction();
-        } else {
-            let total = spliced.len();
-            let mut reqs = spliced.into_iter().enumerate();
-            self.transaction.get_or_insert(TransactionType::Implicit);
-            while let Some((num, mut req)) = reqs.next() {
-                debug!("processing spliced request {}/{}", num + 1, total);
-                let mut context = QueryEngineContext::new(self).spliced(&mut req, reqs.len());
-                query_engine.handle(&mut context).await?;
-                self.transaction = context.transaction();
+    /// Handle client messages.
+    async fn client_messages(&mut self, query_engine: &mut QueryEngine) -> Result<(), Error> {
+        self.check_maintenance_mode(query_engine).await;
 
-                // If pipeline is aborted due to error, skip to Sync to complete the pipeline.
-                // Postgres ignores all commands after an error until it receives Sync.
-                if query_engine.out_of_sync() && !req.is_sync_only() {
-                    debug!("pipeline aborted, skipping to Sync");
-                    for (_, mut next_req) in reqs.by_ref() {
-                        if next_req.is_sync_only() {
-                            debug!("processing Sync to complete aborted pipeline");
-                            let mut ctx = QueryEngineContext::new(self).spliced(&mut next_req, 0);
-                            query_engine.handle(&mut ctx).await?;
-                            self.transaction = ctx.transaction();
-                            break;
+        match query_engine
+            .handle(&mut QueryEngineContext::new(self))
+            .await?
+        {
+            QueryEngineResult::Done(transaction) => self.transaction = transaction,
+            QueryEngineResult::Split(requests) => {
+                let mut requests = requests.into_iter();
+                self.transaction.get_or_insert(TransactionType::Implicit);
+
+                while let Some(mut request) = requests.next() {
+                    match query_engine
+                        .handle(
+                            &mut QueryEngineContext::new(self)
+                                .spliced(&mut request, requests.len()),
+                        )
+                        .await?
+                    {
+                        QueryEngineResult::Done(transaction) => {
+                            self.transaction = transaction;
                         }
+                        _ => panic!("query engine cannot split requests twice"),
                     }
-                    break;
                 }
             }
         }

--- a/pgdog/src/frontend/client/query_engine/context.rs
+++ b/pgdog/src/frontend/client/query_engine/context.rs
@@ -18,8 +18,8 @@ pub struct QueryEngineContext<'a> {
     pub(super) params: &'a mut Parameters,
     /// Request.
     pub(super) client_request: &'a mut ClientRequest,
-    /// Request position in a splice.
-    pub(super) requests_left: usize,
+    /// How many requests are left to execute in an extended pipeline.
+    pub(super) extended_pipeline_requests_left: usize,
     /// Client's socket to send responses to.
     pub(super) stream: &'a mut Stream,
     /// Client in transaction?
@@ -59,7 +59,7 @@ impl<'a> QueryEngineContext<'a> {
             cross_shard_disabled: None,
             memory_stats,
             admin: client.admin,
-            requests_left: 0,
+            extended_pipeline_requests_left: 0,
             rollback: false,
             sticky: client.sticky,
             rewrite_result: None,
@@ -68,9 +68,15 @@ impl<'a> QueryEngineContext<'a> {
         }
     }
 
-    pub fn spliced(mut self, req: &'a mut ClientRequest, request_left: usize) -> Self {
+    /// The request is an extended protocol pipeline
+    /// with a counter of how many requests are left to process.
+    pub(crate) fn extended_pipeline(
+        mut self,
+        req: &'a mut ClientRequest,
+        request_left: usize,
+    ) -> Self {
         self.client_request = req;
-        self.requests_left = request_left;
+        self.extended_pipeline_requests_left = request_left;
         self
     }
 
@@ -87,7 +93,7 @@ impl<'a> QueryEngineContext<'a> {
             cross_shard_disabled: None,
             memory_stats: MemoryStats::default(),
             admin: false,
-            requests_left: 0,
+            extended_pipeline_requests_left: 0,
             rollback: false,
             sticky: Sticky::new(),
             rewrite_result: None,

--- a/pgdog/src/frontend/client/query_engine/maintenance_mode.rs
+++ b/pgdog/src/frontend/client/query_engine/maintenance_mode.rs
@@ -1,0 +1,33 @@
+use super::*;
+
+/// Set maintenance mode on the query engine
+/// and automatically unset it when done.
+pub(crate) struct EngineMaintenanceMode<'a> {
+    engine: &'a mut QueryEngine,
+    state: State,
+}
+
+impl<'a> EngineMaintenanceMode<'a> {
+    /// Active maintenance mode on the engine immediately.
+    ///
+    /// The maintenance mode is disabled when the returned guard is dropped.
+    pub(crate) fn new(engine: &'a mut QueryEngine) -> Self {
+        let state = engine.stats.state;
+        engine.set_state(State::Waiting);
+
+        Self { engine, state }
+    }
+}
+
+impl Drop for EngineMaintenanceMode<'_> {
+    fn drop(&mut self) {
+        self.engine.set_state(self.state);
+    }
+}
+
+impl QueryEngine {
+    /// Set the query engine into maintenance mode.
+    pub(crate) fn set_maintenance_mode(&mut self) -> EngineMaintenanceMode<'_> {
+        EngineMaintenanceMode::new(self)
+    }
+}

--- a/pgdog/src/frontend/client/query_engine/mod.rs
+++ b/pgdog/src/frontend/client/query_engine/mod.rs
@@ -119,6 +119,10 @@ impl QueryEngine {
         &mut self,
         context: &mut QueryEngineContext<'_>,
     ) -> Result<QueryEngineResult, Error> {
+        if let Some(result) = Self::check_extended_request_split(context.client_request)? {
+            return Ok(result);
+        }
+
         self.stats
             .received(context.client_request.total_message_len());
         self.set_state(State::Active); // Client is active.
@@ -134,10 +138,6 @@ impl QueryEngine {
 
         if let ClusterCheck::Offline = self.cluster_check(context).await? {
             return Ok(QueryEngineResult::Done(context.transaction()));
-        }
-
-        if let Some(result) = Self::check_extended_request_split(context.client_request)? {
-            return Ok(result);
         }
 
         // Rewrite statement if necessary.

--- a/pgdog/src/frontend/client/query_engine/mod.rs
+++ b/pgdog/src/frontend/client/query_engine/mod.rs
@@ -23,14 +23,17 @@ pub mod hooks;
 pub mod incomplete_requests;
 pub mod internal_values;
 pub mod lock;
+pub mod maintenance_mode;
 pub mod multi_step;
 pub mod notify_buffer;
 pub mod pub_sub;
 pub mod query;
 mod query_log_stdout;
+pub mod result;
 pub mod rewrite;
 pub mod route_query;
 pub mod set;
+pub mod split;
 pub mod start_transaction;
 #[cfg(test)]
 mod test;
@@ -43,6 +46,7 @@ use self::query_log_stdout::log_query_stdout;
 pub(crate) use advisory_lock::AdvisoryLocks;
 pub use context::QueryEngineContext;
 use notify_buffer::NotifyBuffer;
+pub(crate) use result::QueryEngineResult;
 use two_pc::TwoPc;
 pub use two_pc::phase::TwoPcPhase;
 
@@ -111,10 +115,17 @@ impl QueryEngine {
     }
 
     /// Handle client request.
-    pub async fn handle(&mut self, context: &mut QueryEngineContext<'_>) -> Result<(), Error> {
+    pub async fn handle(
+        &mut self,
+        context: &mut QueryEngineContext<'_>,
+    ) -> Result<QueryEngineResult, Error> {
         self.stats
             .received(context.client_request.total_message_len());
         self.set_state(State::Active); // Client is active.
+
+        if self.extended_in_sync_check(context) {
+            return Ok(QueryEngineResult::Done(context.transaction()));
+        }
 
         log_query_stdout(context);
 
@@ -122,31 +133,35 @@ impl QueryEngine {
         self.rewrite_extended(context)?;
 
         if let ClusterCheck::Offline = self.cluster_check(context).await? {
-            return Ok(());
+            return Ok(QueryEngineResult::Done(context.transaction()));
+        }
+
+        if let Some(result) = Self::check_extended_request_split(context.client_request)? {
+            return Ok(result);
         }
 
         // Rewrite statement if necessary.
         match self.parse_and_rewrite(context) {
             Ok(true) => {}
-            Ok(false) => return Ok(()),
+            Ok(false) => return Ok(QueryEngineResult::Done(context.transaction())),
             Err(e) => {
                 self.error_response(context, ErrorResponse::syntax(e.to_string()))
                     .await?;
-                return Ok(());
+                return Ok(QueryEngineResult::Done(context.transaction()));
             }
         }
 
         // Intercept commands we don't have to forward to a server.
         if self.intercept_incomplete(context).await? {
             self.update_stats(context);
-            return Ok(());
+            return Ok(QueryEngineResult::Done(context.transaction()));
         }
 
         // Route transaction to the right servers.
         if !self.route_query(context).await? {
             self.update_stats(context);
             debug!("query has nowhere to go");
-            return Ok(());
+            return Ok(QueryEngineResult::Done(context.transaction()));
         }
 
         self.hooks.before_execution(context)?;
@@ -268,7 +283,7 @@ impl QueryEngine {
 
         self.update_stats(context);
 
-        Ok(())
+        Ok(QueryEngineResult::Done(context.transaction()))
     }
 
     fn update_stats(&mut self, context: &mut QueryEngineContext<'_>) {
@@ -290,17 +305,10 @@ impl QueryEngine {
         self.comms.update_stats(self.stats);
     }
 
-    pub fn set_state(&mut self, state: State) {
+    /// Set client execution state and update
+    /// it immediately in the global store.
+    fn set_state(&mut self, state: State) {
         self.stats.state = state;
         self.comms.update_stats(self.stats);
-    }
-
-    pub fn get_state(&self) -> State {
-        self.stats.state
-    }
-
-    /// Check if the backend protocol is out of sync due to an error in extended protocol.
-    pub fn out_of_sync(&self) -> bool {
-        self.backend.out_of_sync()
     }
 }

--- a/pgdog/src/frontend/client/query_engine/query.rs
+++ b/pgdog/src/frontend/client/query_engine/query.rs
@@ -291,7 +291,7 @@ impl QueryEngine {
 
             // Release the connection back into the pool before flushing data to client.
             // Flushing can take a minute and we don't want to block the connection from being reused.
-            if !self.backend.session_mode() && context.requests_left == 0 {
+            if !self.backend.session_mode() && context.extended_pipeline_requests_left == 0 {
                 self.backend.disconnect();
             }
 

--- a/pgdog/src/frontend/client/query_engine/result.rs
+++ b/pgdog/src/frontend/client/query_engine/result.rs
@@ -1,0 +1,10 @@
+use crate::frontend::{ClientRequest, client::TransactionType};
+
+/// Query engine execution result.
+pub(crate) enum QueryEngineResult {
+    /// Query engine is done executing the request.
+    Done(Option<TransactionType>),
+    /// Query engine requests the request to be resubmitted
+    /// as a series of separate requests.
+    Split(Vec<ClientRequest>),
+}

--- a/pgdog/src/frontend/client/query_engine/split.rs
+++ b/pgdog/src/frontend/client/query_engine/split.rs
@@ -1,0 +1,30 @@
+use super::*;
+use crate::frontend::ClientRequest;
+
+impl QueryEngine {
+    /// Check if the request needs splitting and perform the split if necessary.
+    ///
+    /// Caller is expected to abort the request and return the result back to the caller
+    /// for resubmission.
+    pub(super) fn check_extended_request_split(
+        request: &ClientRequest,
+    ) -> Result<Option<QueryEngineResult>, Error> {
+        if request.is_multi_exec() {
+            Ok(Some(QueryEngineResult::Split(request.split_extended()?)))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Return true if we should ignore this request because
+    /// the extended protocol state is out of sync, e.g., in error state.
+    ///
+    /// This is identical behavior to Postgres.
+    ///
+    /// If we see a [`crate::net::Sync`]-only request, we execute it to restore servers
+    /// back to normal state.
+    ///
+    pub(super) fn extended_in_sync_check(&self, context: &QueryEngineContext<'_>) -> bool {
+        self.backend.out_of_sync() && !context.client_request.is_sync_only()
+    }
+}

--- a/pgdog/src/frontend/client/query_engine/split.rs
+++ b/pgdog/src/frontend/client/query_engine/split.rs
@@ -27,6 +27,6 @@ impl QueryEngine {
     pub(super) fn extended_in_sync_check(&self, context: &QueryEngineContext<'_>) -> bool {
         self.backend.out_of_sync()
             && !context.client_request.is_sync_only()
-            && context.requests_left > 0
+            && context.extended_pipeline_requests_left > 0
     }
 }

--- a/pgdog/src/frontend/client/query_engine/split.rs
+++ b/pgdog/src/frontend/client/query_engine/split.rs
@@ -25,6 +25,8 @@ impl QueryEngine {
     /// back to normal state.
     ///
     pub(super) fn extended_in_sync_check(&self, context: &QueryEngineContext<'_>) -> bool {
-        self.backend.out_of_sync() && !context.client_request.is_sync_only()
+        self.backend.out_of_sync()
+            && !context.client_request.is_sync_only()
+            && context.requests_left > 0
     }
 }

--- a/pgdog/src/frontend/client_request.rs
+++ b/pgdog/src/frontend/client_request.rs
@@ -311,8 +311,14 @@ impl ClientRequest {
         self.route.as_ref().unwrap_or(&DEFAULT_ROUTE)
     }
 
+    /// The request contains multiple queries
+    /// sent via the extended protocol.
+    pub(crate) fn is_multi_exec(&self) -> bool {
+        self.messages.iter().filter(|m| m.code() == 'E').count() > 1
+    }
+
     /// Split request into multiple serviceable requests by the query engine.
-    pub fn spliced(&self) -> Result<Vec<Self>, Error> {
+    pub(crate) fn split_extended(&self) -> Result<Vec<Self>, Error> {
         // Splice iff using extended protocol and it executes
         // more than one statement.
         let req_count = self.messages.iter().filter(|m| m.code() == 'E').count();
@@ -430,7 +436,7 @@ mod test {
             Sync::new().into(),
         ];
         let req = ClientRequest::from(messages);
-        let splice = req.spliced().unwrap();
+        let splice = req.split_extended().unwrap();
         assert_eq!(splice.len(), 4);
 
         // First slice should contain: Parse("start"), Bind("start"), Execute, Flush
@@ -488,7 +494,7 @@ mod test {
             Sync.into(),
         ];
         let req = ClientRequest::from(messages);
-        let splice = req.spliced().unwrap();
+        let splice = req.split_extended().unwrap();
         assert!(splice.is_empty());
 
         let messages = vec![
@@ -501,7 +507,7 @@ mod test {
             Flush.into(),
         ];
         let req = ClientRequest::from(messages);
-        let splice = req.spliced().unwrap();
+        let splice = req.split_extended().unwrap();
         assert_eq!(splice.len(), 2);
 
         // First slice: Parse("test"), Bind("test"), Execute, Flush
@@ -563,7 +569,7 @@ mod test {
             Sync::new().into(),
         ];
         let req = ClientRequest::from(messages);
-        let splice = req.spliced().unwrap();
+        let splice = req.split_extended().unwrap();
         assert_eq!(splice.len(), 3);
 
         // First slice should contain: Parse("stmt"), Describe("stmt"), Flush, Bind("stmt"), Execute, Flush


### PR DESCRIPTION
- Move extended protocol split detection into the query engine
- Move request ignoring during extended pipeline error state to the query engine
- Use RAII for maintenance mode check

Reviewers, just fyi.