### PR TITLE
refactor: allow parser to flag multi-statement queries to the query engine

### DIFF
--- a/pgdog/src/frontend/client/query_engine/fake.rs
+++ b/pgdog/src/frontend/client/query_engine/fake.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 use tokio::io::AsyncWriteExt;
 
 use crate::net::{
@@ -7,49 +8,65 @@ use crate::net::{
 
 use super::*;
 
+#[derive(Debug, Clone)]
+pub(super) struct FakeResponse {
+    pub(super) row_description: RowDescription,
+    pub(super) row: DataRow,
+}
+
+impl FakeResponse {
+    pub(super) fn new_params<'a>(
+        columns: &[&str],
+        values: impl IntoIterator<Item = Option<&'a ParameterValue>> + Clone,
+    ) -> Self {
+        let row_description =
+            RowDescription::new(&columns.iter().map(|col| Field::text(col)).collect_vec());
+
+        let mut row = DataRow::new();
+        for val in values {
+            row.add(val);
+        }
+
+        Self {
+            row_description,
+            row,
+        }
+    }
+}
+
 impl QueryEngine {
     /// Respond to a command sent by the client
     /// in a way that won't make it suspicious.
-    pub(crate) async fn fake_command_response(
+    pub(super) async fn fake_command_response(
         &mut self,
         context: &mut QueryEngineContext<'_>,
         command: &str,
-        return_value: Option<impl IntoIterator<Item = Option<&'_ ParameterValue>> + Clone>,
+        fake_response: Option<FakeResponse>,
     ) -> Result<(), Error> {
         let mut sent = 0;
-        let return_fields = return_value
-            .clone()
-            .into_iter()
-            .flatten()
-            // FIXME(sage): Don't assume `set_config` is the only consumer
-            .map(|_| Field::text("set_config"))
-            .collect::<Vec<_>>();
-        let row_description = RowDescription::new(&return_fields);
-        let data_row = return_value.map(|return_value| {
-            let mut row = DataRow::new();
-            for val in return_value {
-                row.add(val);
-            }
-            row
-        });
+
         for message in context.client_request.iter() {
             sent += match message {
                 ProtocolMessage::Parse(_) => context.stream.send(&ParseComplete).await?,
                 ProtocolMessage::Bind(_) => context.stream.send(&BindComplete).await?,
                 ProtocolMessage::Describe(describe) => {
                     if describe.is_statement() {
-                        context
-                            .stream
-                            .send(&ParameterDescription::default())
-                            .await?
-                            + context.stream.send(&row_description).await?
+                        if let Some(fake_response) = fake_response.as_ref() {
+                            context
+                                .stream
+                                .send(&ParameterDescription::default())
+                                .await?
+                                + context.stream.send(&fake_response.row_description).await?
+                        } else {
+                            context.stream.send(&NoData).await?
+                        }
                     } else {
                         context.stream.send(&NoData).await?
                     }
                 }
                 ProtocolMessage::Execute(_) => {
-                    (if let Some(row) = data_row.as_ref() {
-                        context.stream.send(row).await?
+                    (if let Some(fake_response) = fake_response.as_ref() {
+                        context.stream.send(&fake_response.row).await?
                     } else {
                         0
                     }) + context.stream.send(&CommandComplete::new(command)).await?
@@ -61,9 +78,9 @@ impl QueryEngine {
                         .await?
                 }
                 ProtocolMessage::Query(_) => {
-                    (if let Some(row) = data_row.as_ref() {
-                        context.stream.send(&row_description).await?
-                            + context.stream.send(row).await?
+                    (if let Some(fake_response) = fake_response.as_ref() {
+                        context.stream.send(&fake_response.row_description).await?
+                            + context.stream.send(&fake_response.row).await?
                     } else {
                         0
                     }) + context.stream.send(&CommandComplete::new(command)).await?

--- a/pgdog/src/frontend/client/query_engine/fake.rs
+++ b/pgdog/src/frontend/client/query_engine/fake.rs
@@ -51,15 +51,15 @@ impl QueryEngine {
                 ProtocolMessage::Bind(_) => context.stream.send(&BindComplete).await?,
                 ProtocolMessage::Describe(describe) => {
                     if describe.is_statement() {
-                        if let Some(fake_response) = fake_response.as_ref() {
-                            context
-                                .stream
-                                .send(&ParameterDescription::default())
-                                .await?
-                                + context.stream.send(&fake_response.row_description).await?
-                        } else {
-                            context.stream.send(&NoData).await?
-                        }
+                        context
+                            .stream
+                            .send(&ParameterDescription::default())
+                            .await?
+                            + if let Some(fake_response) = fake_response.as_ref() {
+                                context.stream.send(&fake_response.row_description).await?
+                            } else {
+                                context.stream.send(&NoData).await?
+                            }
                     } else {
                         context.stream.send(&NoData).await?
                     }

--- a/pgdog/src/frontend/client/query_engine/mod.rs
+++ b/pgdog/src/frontend/client/query_engine/mod.rs
@@ -256,12 +256,10 @@ impl QueryEngine {
             }
             Command::Unlisten(channel) => self.unlisten(context, &channel.clone()).await?,
             Command::Set {
-                params,
-                behave_like_select,
-                ..
+                params, set_config, ..
             } => {
                 let params = params.clone();
-                self.set(context, &params, *behave_like_select).await?;
+                self.set(context, &params, *set_config).await?;
             }
             Command::ResetAll => {
                 self.reset_all(context).await?;
@@ -269,6 +267,14 @@ impl QueryEngine {
             Command::Copy(_) => self.execute(context).await?,
             Command::Deallocate => self.deallocate(context).await?,
             Command::Discard { extended } => self.discard(context, *extended).await?,
+            Command::Split(_) => {
+                use crate::frontend::router::parser::Error as ParserError;
+                self.error_response(
+                    context,
+                    ErrorResponse::from_err(&Error::Parser(ParserError::MultiStatementMixedSet)),
+                )
+                .await?;
+            }
         }
 
         self.hooks.after_execution(context)?;

--- a/pgdog/src/frontend/client/query_engine/multi_step/update.rs
+++ b/pgdog/src/frontend/client/query_engine/multi_step/update.rs
@@ -81,7 +81,7 @@ impl<'a> UpdateMulti<'a> {
             // This happens, but the UPDATE's WHERE clause
             // doesn't match any rows, so this whole thing is a no-op.
             self.engine
-                .fake_command_response(context, "UPDATE 0", None::<Option<_>>)
+                .fake_command_response(context, "UPDATE 0", None)
                 .await?;
         }
 

--- a/pgdog/src/frontend/client/query_engine/set.rs
+++ b/pgdog/src/frontend/client/query_engine/set.rs
@@ -1,4 +1,5 @@
 use crate::frontend::SetParam;
+use crate::frontend::client::query_engine::fake::FakeResponse;
 use crate::frontend::router::parameter_hints::{PGDOG_PIN, PGDOG_SHARD, PGDOG_SHARDING_KEY};
 use crate::net::messages::ErrorResponse;
 
@@ -11,11 +12,12 @@ use super::*;
 const SHARD_TARGETING_PARAMS: [&str; 2] = [PGDOG_SHARD, PGDOG_SHARDING_KEY];
 
 impl QueryEngine {
+    /// Handle a `SET` statement or equivalent `SELECT set_config([...])` query.
     pub(crate) async fn set(
         &mut self,
         context: &mut QueryEngineContext<'_>,
         params: &[SetParam],
-        behave_like_select: bool,
+        set_config: bool,
     ) -> Result<(), Error> {
         // Make sure client isn't changing route mid-transaction.
         if self.route_change_check(context, params).await? {
@@ -58,9 +60,10 @@ impl QueryEngine {
         if self.backend.connected() {
             self.execute(context).await?;
         } else {
-            let values_to_return =
-                behave_like_select.then(|| params.iter().map(|p| p.value.as_ref()));
-            self.fake_command_response(context, fake_command, values_to_return)
+            let fake_response = set_config
+                .then(|| params.iter().map(|p| p.value.as_ref()))
+                .and_then(|values| Some(FakeResponse::new_params(&["set_config"], values)));
+            self.fake_command_response(context, fake_command, fake_response)
                 .await?;
         }
 
@@ -101,8 +104,7 @@ impl QueryEngine {
         if self.backend.connected() {
             self.execute(context).await?;
         } else {
-            self.fake_command_response(context, "RESET", None::<Option<_>>)
-                .await?;
+            self.fake_command_response(context, "RESET", None).await?;
         }
 
         Ok(())

--- a/pgdog/src/frontend/client/query_engine/set.rs
+++ b/pgdog/src/frontend/client/query_engine/set.rs
@@ -62,7 +62,7 @@ impl QueryEngine {
         } else {
             let fake_response = set_config
                 .then(|| params.iter().map(|p| p.value.as_ref()))
-                .and_then(|values| Some(FakeResponse::new_params(&["set_config"], values)));
+                .map(|values| FakeResponse::new_params(&["set_config"], values));
             self.fake_command_response(context, fake_command, fake_response)
                 .await?;
         }

--- a/pgdog/src/frontend/client/query_engine/test/set.rs
+++ b/pgdog/src/frontend/client/query_engine/test/set.rs
@@ -2,7 +2,10 @@ use crate::{
     backend::databases::reload_from_existing,
     config::{config, load_test_sharded, set},
     expect_message,
-    net::{CommandComplete, ErrorResponse, ReadyForQuery, parameter::ParameterValue},
+    net::{
+        BindComplete, CommandComplete, ErrorResponse, NoData, ParameterDescription, ParseComplete,
+        ReadyForQuery, parameter::ParameterValue,
+    },
 };
 
 use super::prelude::*;
@@ -40,6 +43,34 @@ async fn test_set() {
     );
 
     assert!(!test_client.backend_locked());
+}
+
+#[tokio::test]
+async fn test_set_statement_describe() {
+    let mut test_client = TestClient::new_sharded(Parameters::default()).await;
+
+    test_client
+        .send(Parse::named("set", "SET application_name TO 'described'"))
+        .await;
+    test_client.send(Bind::new_statement("set")).await;
+    test_client.send(Describe::new_statement("set")).await;
+    test_client.send(Execute::new()).await;
+    test_client.send(Sync).await;
+    test_client.try_process().await.unwrap();
+
+    assert!(!test_client.backend_connected());
+    expect_message!(test_client.read().await, ParseComplete);
+    expect_message!(test_client.read().await, BindComplete);
+    expect_message!(test_client.read().await, ParameterDescription);
+    expect_message!(test_client.read().await, NoData);
+    assert_eq!(
+        expect_message!(test_client.read().await, CommandComplete).command(),
+        "SET"
+    );
+    assert_eq!(
+        expect_message!(test_client.read().await, ReadyForQuery).status,
+        'I'
+    );
 }
 
 #[tokio::test]

--- a/pgdog/src/frontend/router/parser/cache/ast.rs
+++ b/pgdog/src/frontend/router/parser/cache/ast.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 use pg_raw_parse::{Node, Owned, StmtList, make};
 use std::fmt::Debug;
 use std::ops::Deref;
@@ -93,7 +94,8 @@ impl Ast {
         let mut rewrite_plan = Default::default();
         let ast = make::try_owned(|mem| {
             let mut ast = mem.parse(query.query_without_comment)?;
-            if let Some(stmt) = ast.as_mut().into_iter().next() {
+            // Parser should not receive multi-query requests.
+            if let Ok(stmt) = ast.as_mut().into_iter().exactly_one() {
                 rewrite_plan = rewriter.maybe_rewrite(stmt, mem)?;
             }
             Ok::<_, Error>(ast)

--- a/pgdog/src/frontend/router/parser/command.rs
+++ b/pgdog/src/frontend/router/parser/command.rs
@@ -12,6 +12,7 @@ pub struct SetParam {
     pub local: bool,
 }
 
+/// Query parser result.
 #[derive(Debug, Clone)]
 pub enum Command {
     Query(Route),
@@ -31,8 +32,9 @@ pub enum Command {
     Set {
         params: Vec<SetParam>,
         route: Route,
-        behave_like_select: bool,
+        set_config: bool,
     },
+    Split(#[allow(unused)] Vec<String>),
     ResetAll,
     InternalField {
         name: String,

--- a/pgdog/src/frontend/router/parser/query/mod.rs
+++ b/pgdog/src/frontend/router/parser/query/mod.rs
@@ -31,6 +31,7 @@ mod set;
 mod set_config;
 mod shared;
 mod show;
+mod split;
 mod transaction;
 mod update;
 
@@ -335,10 +336,7 @@ impl QueryParser {
             .run()?;
         }
 
-        // Handle multi-statement SET commands (e.g. "SET x TO 1; SET y TO 2").
-        if stmts.len() > 1
-            && let Some(command) = self.try_multi_set(&**stmts, context)?
-        {
+        if let Some(command) = self.check_multi_statement(statement, context)? {
             return Ok(command);
         }
 

--- a/pgdog/src/frontend/router/parser/query/set.rs
+++ b/pgdog/src/frontend/router/parser/query/set.rs
@@ -27,7 +27,7 @@ impl QueryParser {
             Ok(Command::Set {
                 params: vec![param],
                 route: Route::write(context.shards_calculator.shard()),
-                behave_like_select: false,
+                set_config: false,
             })
         }
     }
@@ -65,7 +65,7 @@ impl QueryParser {
     /// In session mode, returns `Ok(Some(Command::Query(..)))` immediately so that
     /// all multi-statement queries are forwarded to the server verbatim.
     pub(super) fn try_multi_set<'a>(
-        &mut self,
+        &self,
         stmts: impl IntoIterator<Item = &'a nodes::RawStmt>,
         context: &QueryParserContext,
     ) -> Result<Option<Command>, Error> {
@@ -99,7 +99,7 @@ impl QueryParser {
             Ok(Some(Command::Set {
                 params,
                 route: Route::write(context.shards_calculator.shard()),
-                behave_like_select: false,
+                set_config: false,
             }))
         }
     }

--- a/pgdog/src/frontend/router/parser/query/set_config.rs
+++ b/pgdog/src/frontend/router/parser/query/set_config.rs
@@ -14,7 +14,7 @@ impl QueryParser {
             Command::Set {
                 params: vec![param],
                 route: Route::write(context.shards_calculator.shard()),
-                behave_like_select: true,
+                set_config: true,
             }
         } else {
             Command::Query(

--- a/pgdog/src/frontend/router/parser/query/split.rs
+++ b/pgdog/src/frontend/router/parser/query/split.rs
@@ -1,0 +1,39 @@
+use pg_raw_parse::deparse;
+
+use super::*;
+
+impl QueryParser {
+    /// Check if the statement contains multiple queries.
+    ///
+    /// If that's the case, return it back to the query engine for separate
+    /// re-execution.
+    pub(super) fn check_multi_statement(
+        &self,
+        ast: &Ast,
+        context: &QueryParserContext<'_>,
+    ) -> Result<Option<Command>, Error> {
+        if ast.ast.stmts().count() <= 1 {
+            return Ok(None);
+        }
+
+        let stmts = &ast.ast;
+
+        match self.try_multi_set(&**stmts, context) {
+            Ok(Some(set)) => Ok(Some(set)),
+            Ok(None) => Ok(None),
+            Err(Error::MultiStatementMixedSet) => {
+                let queries = stmts
+                    .stmts()
+                    .map(|stmt| {
+                        let query = deparse(stmt)?;
+                        Ok::<_, Error>(query.as_str().to_owned())
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+
+                Ok(Some(Command::Split(queries)))
+            }
+
+            Err(err) => return Err(err),
+        }
+    }
+}

--- a/pgdog/src/frontend/router/parser/query/split.rs
+++ b/pgdog/src/frontend/router/parser/query/split.rs
@@ -33,7 +33,7 @@ impl QueryParser {
                 Ok(Some(Command::Split(queries)))
             }
 
-            Err(err) => return Err(err),
+            Err(err) => Err(err),
         }
     }
 }

--- a/pgdog/src/frontend/router/parser/query/test/test_set.rs
+++ b/pgdog/src/frontend/router/parser/query/test/test_set.rs
@@ -29,16 +29,13 @@ fn test_mixed_set_passthrough_in_session_mode() {
 }
 
 #[test]
-fn test_mixed_set_rejected_in_transaction_mode() {
+fn test_mixed_set_split_in_transaction_mode() {
     let mut test = QueryParserTest::new();
 
-    let result = test.try_execute(vec![
+    let command = test.execute(vec![
         Query::new("SET DateStyle='ISO'; show transaction_isolation").into(),
     ]);
-    assert!(
-        result.is_err(),
-        "expected error for mixed SET in transaction mode, got {result:#?}",
-    );
+    assert!(matches!(command, Command::Split(queries) if queries.len() == 2));
 }
 
 #[test]
@@ -119,13 +116,14 @@ fn test_set_multi_statement_mixed_local() {
 }
 
 #[test]
-fn test_set_multi_statement_mixed_returns_error() {
+fn test_set_multi_statement_mixed_returns_split() {
     let mut test = QueryParserTest::new();
 
-    let result = test.try_execute(vec![
+    let command = test.execute(vec![
         Query::new("SET statement_timeout TO 1; SELECT 1").into(),
     ]);
-    assert!(result.is_err());
+
+    assert!(matches!(command, Command::Split(queries) if queries.len() == 2));
 }
 
 #[test]

--- a/pgdog/src/frontend/router/parser/query/test/test_set.rs
+++ b/pgdog/src/frontend/router/parser/query/test/test_set.rs
@@ -66,15 +66,13 @@ fn test_set_config_null_value() {
 
     match command {
         Command::Set {
-            params,
-            behave_like_select,
-            ..
+            params, set_config, ..
         } => {
             assert_eq!(params.len(), 1);
             assert_eq!(params[0].name, "lock_timeout");
             assert_eq!(params[0].value, None);
             assert!(!params[0].local);
-            assert!(behave_like_select);
+            assert!(set_config);
         }
         _ => panic!("expected Command::Set, got {command:#?}"),
     }


### PR DESCRIPTION
- Query rewriter will no longer rewrite multi-statement requests we were never gonna execute anyway
- Split queries in the parser and bubble them up to the query engine; the engine still returns the same error
- Refactor handling of rows returned by fake command

reviewers, just fyi