### PR TITLE
feat: partial multi-query support

### DIFF
--- a/integration/js/pg_tests/test/sequelize.js
+++ b/integration/js/pg_tests/test/sequelize.js
@@ -200,22 +200,12 @@ describe("Sequelize multi-statement SET", function () {
     await seq.close();
   });
 
-  it("mixed SET and non-SET returns error", async function () {
+  it("mixed SET and non-SET returns query result", async function () {
     const seq = createSequelize();
 
-    try {
-      await seq.query("SET statement_timeout TO '10s'; SELECT 1");
-      assert.fail("expected error for mixed SET + SELECT");
-    } catch (err) {
-      assert.ok(
-        err.message.includes(
-          "multi-statement queries cannot mix SET with other commands",
-        ),
-        `unexpected error: ${err.message}`,
-      );
-    }
-
-    const [rows] = await seq.query("SELECT 1 AS val");
+    const [rows] = await seq.query(
+      "SET statement_timeout TO '10s'; SELECT 1 AS val",
+    );
     assert.strictEqual(rows[0].val, 1);
 
     await seq.close();

--- a/integration/rust/tests/integration/multi_set.rs
+++ b/integration/rust/tests/integration/multi_set.rs
@@ -48,8 +48,7 @@ async fn test_multi_set_with_timezone_interval() {
 #[tokio::test]
 async fn test_multi_set_mixed_works() {
     for conn in connections_tokio().await {
-        let _ = conn
-            .batch_execute("SET statement_timeout TO '10s'; SELECT 1")
+        conn.batch_execute("SET statement_timeout TO '10s'; SELECT 1")
             .await
             .unwrap();
     }

--- a/integration/rust/tests/integration/multi_set.rs
+++ b/integration/rust/tests/integration/multi_set.rs
@@ -46,17 +46,11 @@ async fn test_multi_set_with_timezone_interval() {
 }
 
 #[tokio::test]
-async fn test_multi_set_mixed_returns_error() {
+async fn test_multi_set_mixed_works() {
     for conn in connections_tokio().await {
-        let err = conn
+        let _ = conn
             .batch_execute("SET statement_timeout TO '10s'; SELECT 1")
             .await
-            .unwrap_err();
-        let db_err = err.as_db_error().expect("Expected a DbError");
-        let msg = db_err.message();
-        assert!(
-            msg.contains("multi-statement queries cannot mix SET with other commands"),
-            "unexpected error: {msg}",
-        );
+            .unwrap();
     }
 }

--- a/integration/rust/tests/sqlx/multi_set.rs
+++ b/integration/rust/tests/sqlx/multi_set.rs
@@ -76,15 +76,9 @@ async fn test_multi_set_mixed_returns_error() {
     for pool in connections_sqlx().await {
         let mut conn = pool.acquire().await.unwrap();
 
-        let err = conn
-            .execute("SET statement_timeout TO '10s'; SELECT 1")
+        conn.execute("SET statement_timeout TO '10s'; SELECT 1")
             .await
-            .unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("multi-statement queries cannot mix SET with other commands"),
-            "unexpected error: {err}",
-        );
+            .unwrap();
 
         // Connection should still be usable after the error.
         let val: String = sqlx::query_scalar("SHOW server_version")

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -24,7 +24,6 @@ use crate::backend::{
 use crate::config::convert::user_from_params;
 use crate::config::{self, AuthType, ConfigAndUsers, config};
 use crate::frontend::ClientComms;
-use crate::frontend::client::query_engine::{QueryEngine, QueryEngineContext, QueryEngineResult};
 use crate::net::messages::{
     Authentication, BackendKeyData, ErrorResponse, FromBytes, FrontendPid, Message, Password,
     Protocol, ProtocolVersion, ReadyForQuery, ToBytes,
@@ -39,6 +38,7 @@ pub mod sticky;
 pub mod timeouts;
 pub mod transaction_type;
 
+use query_engine::QueryEngine;
 pub(crate) use sticky::Sticky;
 pub use transaction_type::TransactionType;
 
@@ -557,6 +557,8 @@ impl Client {
         query_engine: &mut QueryEngine,
         message: Message,
     ) -> Result<(), Error> {
+        use query_engine::QueryEngineContext;
+
         let mut context = QueryEngineContext::new(self);
         query_engine
             .process_server_message(&mut context, message)
@@ -587,6 +589,7 @@ impl Client {
 
     /// Handle client messages.
     async fn client_messages(&mut self, query_engine: &mut QueryEngine) -> Result<(), Error> {
+        use query_engine::{Pipeline, QueryEngineContext, QueryEngineResult};
         self.check_maintenance_mode(query_engine).await;
 
         match query_engine
@@ -594,15 +597,17 @@ impl Client {
             .await?
         {
             QueryEngineResult::Done(transaction) => self.transaction = transaction,
-            QueryEngineResult::Split(requests) => {
+            QueryEngineResult::Split { requests, extended } => {
                 let mut requests = requests.into_iter();
-                self.transaction.get_or_insert(TransactionType::Implicit);
+                if extended {
+                    self.transaction.get_or_insert(TransactionType::Implicit);
+                }
 
                 while let Some(mut request) = requests.next() {
                     match query_engine
                         .handle(
                             &mut QueryEngineContext::new(self)
-                                .extended_pipeline(&mut request, requests.len()),
+                                .pipelined(&mut request, Pipeline::new(requests.len(), extended)),
                         )
                         .await?
                     {

--- a/pgdog/src/frontend/client/query_engine/context.rs
+++ b/pgdog/src/frontend/client/query_engine/context.rs
@@ -8,6 +8,8 @@ use crate::{
     net::{FrontendPid, Parameters, Stream},
 };
 
+use super::split::Pipeline;
+
 /// Context passed to the query engine to execute a query.
 pub struct QueryEngineContext<'a> {
     /// Client ID running the query.
@@ -19,7 +21,7 @@ pub struct QueryEngineContext<'a> {
     /// Request.
     pub(super) client_request: &'a mut ClientRequest,
     /// How many requests are left to execute in an extended pipeline.
-    pub(super) extended_pipeline_requests_left: usize,
+    pub(super) pipeline: Pipeline,
     /// Client's socket to send responses to.
     pub(super) stream: &'a mut Stream,
     /// Client in transaction?
@@ -59,7 +61,7 @@ impl<'a> QueryEngineContext<'a> {
             cross_shard_disabled: None,
             memory_stats,
             admin: client.admin,
-            extended_pipeline_requests_left: 0,
+            pipeline: Pipeline::None,
             rollback: false,
             sticky: client.sticky,
             rewrite_result: None,
@@ -70,13 +72,9 @@ impl<'a> QueryEngineContext<'a> {
 
     /// The request is an extended protocol pipeline
     /// with a counter of how many requests are left to process.
-    pub(crate) fn extended_pipeline(
-        mut self,
-        req: &'a mut ClientRequest,
-        request_left: usize,
-    ) -> Self {
+    pub(crate) fn pipelined(mut self, req: &'a mut ClientRequest, pipeline: Pipeline) -> Self {
         self.client_request = req;
-        self.extended_pipeline_requests_left = request_left;
+        self.pipeline = pipeline;
         self
     }
 
@@ -93,7 +91,7 @@ impl<'a> QueryEngineContext<'a> {
             cross_shard_disabled: None,
             memory_stats: MemoryStats::default(),
             admin: false,
-            extended_pipeline_requests_left: 0,
+            pipeline: Pipeline::None,
             rollback: false,
             sticky: Sticky::new(),
             rewrite_result: None,

--- a/pgdog/src/frontend/client/query_engine/end_transaction.rs
+++ b/pgdog/src/frontend/client/query_engine/end_transaction.rs
@@ -24,7 +24,10 @@ impl QueryEngine {
                 vec![]
             };
             messages.push(cmd.message());
-            messages.push(ReadyForQuery::idle().message());
+
+            if context.pipeline.is_done() || !context.pipeline.is_simple() {
+                messages.push(ReadyForQuery::idle().message());
+            }
 
             context.stream.send_many(&messages).await?
         };

--- a/pgdog/src/frontend/client/query_engine/fake.rs
+++ b/pgdog/src/frontend/client/query_engine/fake.rs
@@ -84,10 +84,16 @@ impl QueryEngine {
                     } else {
                         0
                     }) + context.stream.send(&CommandComplete::new(command)).await?
-                        + context
-                            .stream
-                            .send(&ReadyForQuery::in_transaction(context.in_transaction()))
-                            .await?
+                        + if context.pipeline.is_simple() && !context.pipeline.is_done() {
+                            // Don't send ReadyForQuery for intermediate queries in a simple query
+                            // pipeline.
+                            0
+                        } else {
+                            context
+                                .stream
+                                .send(&ReadyForQuery::in_transaction(context.in_transaction()))
+                                .await?
+                        }
                 }
                 // TODO(lev): Elixir closes the statement it just asked us to prepare.
                 // That's very memory-conscious of it, and we appreciate it.

--- a/pgdog/src/frontend/client/query_engine/mod.rs
+++ b/pgdog/src/frontend/client/query_engine/mod.rs
@@ -128,7 +128,7 @@ impl QueryEngine {
             .received(context.client_request.total_message_len());
         self.set_state(State::Active); // Client is active.
 
-        if self.extended_in_sync_check(context) {
+        if self.extended_pipeline_check(context) {
             return Ok(QueryEngineResult::Done(context.transaction()));
         }
 

--- a/pgdog/src/frontend/client/query_engine/mod.rs
+++ b/pgdog/src/frontend/client/query_engine/mod.rs
@@ -47,6 +47,7 @@ pub(crate) use advisory_lock::AdvisoryLocks;
 pub use context::QueryEngineContext;
 use notify_buffer::NotifyBuffer;
 pub(crate) use result::QueryEngineResult;
+pub(crate) use split::Pipeline;
 use two_pc::TwoPc;
 pub use two_pc::phase::TwoPcPhase;
 
@@ -267,14 +268,7 @@ impl QueryEngine {
             Command::Copy(_) => self.execute(context).await?,
             Command::Deallocate => self.deallocate(context).await?,
             Command::Discard { extended } => self.discard(context, *extended).await?,
-            Command::Split(_) => {
-                use crate::frontend::router::parser::Error as ParserError;
-                self.error_response(
-                    context,
-                    ErrorResponse::from_err(&Error::Parser(ParserError::MultiStatementMixedSet)),
-                )
-                .await?;
-            }
+            Command::Split(queries) => return Ok(Self::build_simple_split(queries)),
         }
 
         self.hooks.after_execution(context)?;

--- a/pgdog/src/frontend/client/query_engine/mod.rs
+++ b/pgdog/src/frontend/client/query_engine/mod.rs
@@ -120,7 +120,7 @@ impl QueryEngine {
         &mut self,
         context: &mut QueryEngineContext<'_>,
     ) -> Result<QueryEngineResult, Error> {
-        if let Some(result) = Self::check_extended_request_split(context.client_request)? {
+        if let Some(result) = Self::check_extended_pipeline_rewrite(context.client_request)? {
             return Ok(result);
         }
 
@@ -128,7 +128,7 @@ impl QueryEngine {
             .received(context.client_request.total_message_len());
         self.set_state(State::Active); // Client is active.
 
-        if self.extended_pipeline_check(context) {
+        if self.in_extended_pipeline_error(context) {
             return Ok(QueryEngineResult::Done(context.transaction()));
         }
 

--- a/pgdog/src/frontend/client/query_engine/query.rs
+++ b/pgdog/src/frontend/client/query_engine/query.rs
@@ -31,7 +31,7 @@ impl QueryEngine {
 
         // Skip statements inside a simple pipeline
         // if we are inside an errored-out transaction.
-        if self.simple_pipeline_check(context) {
+        if self.in_simple_pipeline_error(context) {
             return Ok(());
         }
 

--- a/pgdog/src/frontend/client/query_engine/query.rs
+++ b/pgdog/src/frontend/client/query_engine/query.rs
@@ -238,12 +238,18 @@ impl QueryEngine {
         // Do this before flushing, because flushing can take time.
         self.cleanup_backend(context)?;
 
-        trace!("{:#?} >>> {:?}", message, context.stream.peer_addr());
+        // Pipelined requests only return
+        // one ReadyForQuery message.
+        let drop_message =
+            message.code() == 'Z' && !context.pipeline.is_done() && context.pipeline.is_simple();
+        if !drop_message {
+            trace!("{:#?} >>> {:?}", message, context.stream.peer_addr());
 
-        if flush {
-            context.stream.send_flush(&message).await?;
-        } else {
-            context.stream.send(&message).await?;
+            if flush {
+                context.stream.send_flush(&message).await?;
+            } else {
+                context.stream.send(&message).await?;
+            }
         }
 
         if code == 'Z' {
@@ -291,7 +297,7 @@ impl QueryEngine {
 
             // Release the connection back into the pool before flushing data to client.
             // Flushing can take a minute and we don't want to block the connection from being reused.
-            if !self.backend.session_mode() && context.extended_pipeline_requests_left == 0 {
+            if !self.backend.session_mode() && context.pipeline.is_done() {
                 self.backend.disconnect();
             }
 

--- a/pgdog/src/frontend/client/query_engine/query.rs
+++ b/pgdog/src/frontend/client/query_engine/query.rs
@@ -29,6 +29,12 @@ impl QueryEngine {
             return Ok(());
         }
 
+        // Skip statements inside a simple pipeline
+        // if we are inside an errored-out transaction.
+        if self.simple_pipeline_check(context) {
+            return Ok(());
+        }
+
         // Check if we need to do 2pc automatically
         // for single-statement writes.
         self.two_pc_check(context);
@@ -240,8 +246,10 @@ impl QueryEngine {
 
         // Pipelined requests only return
         // one ReadyForQuery message.
-        let drop_message =
-            message.code() == 'Z' && !context.pipeline.is_done() && context.pipeline.is_simple();
+        let drop_message = message.code() == 'Z'
+            && !context.pipeline.is_done()
+            && context.pipeline.is_simple()
+            && !context.in_error(); // On error, pipeline is done executing.
         if !drop_message {
             trace!("{:#?} >>> {:?}", message, context.stream.peer_addr());
 

--- a/pgdog/src/frontend/client/query_engine/result.rs
+++ b/pgdog/src/frontend/client/query_engine/result.rs
@@ -6,5 +6,8 @@ pub(crate) enum QueryEngineResult {
     Done(Option<TransactionType>),
     /// Query engine requests the request to be resubmitted
     /// as a series of separate requests.
-    Split(Vec<ClientRequest>),
+    Split {
+        requests: Vec<ClientRequest>,
+        extended: bool,
+    },
 }

--- a/pgdog/src/frontend/client/query_engine/split.rs
+++ b/pgdog/src/frontend/client/query_engine/split.rs
@@ -45,7 +45,7 @@ impl QueryEngine {
     ///
     /// Caller is expected to abort the request and return the result back to the caller
     /// for resubmission.
-    pub(super) fn check_extended_request_split(
+    pub(super) fn check_extended_pipeline_rewrite(
         request: &ClientRequest,
     ) -> Result<Option<QueryEngineResult>, Error> {
         if request.is_multi_exec() {
@@ -66,7 +66,7 @@ impl QueryEngine {
     /// If we see a [`crate::net::Sync`]-only request, we execute it to restore servers
     /// back to normal state.
     ///
-    pub(super) fn extended_pipeline_check(&self, context: &QueryEngineContext<'_>) -> bool {
+    pub(super) fn in_extended_pipeline_error(&self, context: &QueryEngineContext<'_>) -> bool {
         self.backend.out_of_sync()
             && !context.client_request.is_sync_only()
             && !context.pipeline.is_done()
@@ -75,7 +75,7 @@ impl QueryEngine {
     /// Return true if we should ignore this query because
     /// the simple query pipeline is in an error state, i.e., inside a failed
     /// transaction.
-    pub(super) fn simple_pipeline_check(&self, context: &QueryEngineContext<'_>) -> bool {
+    pub(super) fn in_simple_pipeline_error(&self, context: &QueryEngineContext<'_>) -> bool {
         context.pipeline.is_simple() && context.in_error()
     }
 

--- a/pgdog/src/frontend/client/query_engine/split.rs
+++ b/pgdog/src/frontend/client/query_engine/split.rs
@@ -1,5 +1,44 @@
+use itertools::Itertools;
+
 use super::*;
-use crate::frontend::ClientRequest;
+use crate::{frontend::ClientRequest, net::Query};
+
+/// Query engine pipeline state.
+pub(crate) enum Pipeline {
+    Extended { requests_left: usize },
+    Simple { requests_left: usize },
+    None,
+}
+
+impl Pipeline {
+    /// Create new pipeline.
+    pub(crate) fn new(requests_left: usize, extended: bool) -> Self {
+        if extended {
+            Self::Extended { requests_left }
+        } else {
+            Self::Simple { requests_left }
+        }
+    }
+
+    /// How many requests left in the pipeline.
+    pub(super) fn requests_left(&self) -> usize {
+        match self {
+            Self::Extended { requests_left } => *requests_left,
+            Self::Simple { requests_left } => *requests_left,
+            Self::None => 0,
+        }
+    }
+
+    /// Is the pipeline finished executing?
+    pub(super) fn is_done(&self) -> bool {
+        self.requests_left() == 0
+    }
+
+    /// Is the pipeline consists of simple queries only?
+    pub(super) fn is_simple(&self) -> bool {
+        matches!(self, Self::Simple { .. })
+    }
+}
 
 impl QueryEngine {
     /// Check if the request needs splitting and perform the split if necessary.
@@ -10,7 +49,10 @@ impl QueryEngine {
         request: &ClientRequest,
     ) -> Result<Option<QueryEngineResult>, Error> {
         if request.is_multi_exec() {
-            Ok(Some(QueryEngineResult::Split(request.split_extended()?)))
+            Ok(Some(QueryEngineResult::Split {
+                requests: request.split_extended()?,
+                extended: true,
+            }))
         } else {
             Ok(None)
         }
@@ -27,6 +69,19 @@ impl QueryEngine {
     pub(super) fn extended_in_sync_check(&self, context: &QueryEngineContext<'_>) -> bool {
         self.backend.out_of_sync()
             && !context.client_request.is_sync_only()
-            && context.extended_pipeline_requests_left > 0
+            && !context.pipeline.is_done()
+    }
+
+    /// Build a multi-query split.
+    pub(super) fn build_simple_split(queries: &[String]) -> QueryEngineResult {
+        let requests = queries
+            .iter()
+            .map(|query| ClientRequest::from(vec![Query::new(query).into()]))
+            .collect_vec();
+
+        QueryEngineResult::Split {
+            requests,
+            extended: false,
+        }
     }
 }

--- a/pgdog/src/frontend/client/query_engine/split.rs
+++ b/pgdog/src/frontend/client/query_engine/split.rs
@@ -67,21 +67,16 @@ impl QueryEngine {
     /// back to normal state.
     ///
     pub(super) fn extended_pipeline_check(&self, context: &QueryEngineContext<'_>) -> bool {
-        let extended_error = self.backend.out_of_sync()
+        self.backend.out_of_sync()
             && !context.client_request.is_sync_only()
-            && !context.pipeline.is_done();
-
-        extended_error
+            && !context.pipeline.is_done()
     }
 
     /// Return true if we should ignore this query because
     /// the simple query pipeline is in an error state, i.e., inside a failed
     /// transaction.
     pub(super) fn simple_pipeline_check(&self, context: &QueryEngineContext<'_>) -> bool {
-        // Simple pipeline ignores all subsequent requests.
-        let simple_error = context.pipeline.is_simple() && context.in_error();
-
-        simple_error
+        context.pipeline.is_simple() && context.in_error()
     }
 
     /// Build a multi-query split.

--- a/pgdog/src/frontend/client/query_engine/split.rs
+++ b/pgdog/src/frontend/client/query_engine/split.rs
@@ -66,10 +66,22 @@ impl QueryEngine {
     /// If we see a [`crate::net::Sync`]-only request, we execute it to restore servers
     /// back to normal state.
     ///
-    pub(super) fn extended_in_sync_check(&self, context: &QueryEngineContext<'_>) -> bool {
-        self.backend.out_of_sync()
+    pub(super) fn extended_pipeline_check(&self, context: &QueryEngineContext<'_>) -> bool {
+        let extended_error = self.backend.out_of_sync()
             && !context.client_request.is_sync_only()
-            && !context.pipeline.is_done()
+            && !context.pipeline.is_done();
+
+        extended_error
+    }
+
+    /// Return true if we should ignore this query because
+    /// the simple query pipeline is in an error state, i.e., inside a failed
+    /// transaction.
+    pub(super) fn simple_pipeline_check(&self, context: &QueryEngineContext<'_>) -> bool {
+        // Simple pipeline ignores all subsequent requests.
+        let simple_error = context.pipeline.is_simple() && context.in_error();
+
+        simple_error
     }
 
     /// Build a multi-query split.

--- a/pgdog/src/frontend/client/query_engine/start_transaction.rs
+++ b/pgdog/src/frontend/client/query_engine/start_transaction.rs
@@ -26,13 +26,14 @@ impl QueryEngine {
                 self.extended_transaction_reply(context, true, false)
                     .await?
             } else {
-                context
-                    .stream
-                    .send_many(&[
-                        CommandComplete::new_begin().message(),
-                        ReadyForQuery::in_transaction(context.in_transaction()).message(),
-                    ])
-                    .await?
+                let mut messages = vec![CommandComplete::new_begin().message()];
+
+                if context.pipeline.is_done() || !context.pipeline.is_simple() {
+                    messages
+                        .push(ReadyForQuery::in_transaction(context.in_transaction()).message());
+                }
+
+                context.stream.send_many(&messages).await?
             };
 
             self.stats.sent(bytes_sent);

--- a/pgdog/src/frontend/client/query_engine/test/multi_statement.rs
+++ b/pgdog/src/frontend/client/query_engine/test/multi_statement.rs
@@ -58,3 +58,24 @@ async fn mixed_set_more_than_one_query_error() {
     assert!(!client.backend_connected());
     assert_connection_usable(&mut client).await;
 }
+
+#[tokio::test]
+async fn simple_split_stops_after_transaction_error() {
+    let mut client = TestClient::new_sharded(Parameters::default()).await;
+
+    client
+        .send_simple(Query::new(
+            "BEGIN; SET pgdog.shard TO 0; SELECT 1 / 0; COMMIT;",
+        ))
+        .await;
+
+    let error = client.read_until('Z').await.unwrap_err();
+    assert_eq!(error.code, "22012");
+    assert_eq!(
+        expect_message!(client.read().await, ReadyForQuery).status,
+        'E'
+    );
+    assert!(!client.backend_connected());
+
+    assert_connection_usable(&mut client).await;
+}

--- a/pgdog/src/frontend/client/query_engine/test/multi_statement.rs
+++ b/pgdog/src/frontend/client/query_engine/test/multi_statement.rs
@@ -1,3 +1,5 @@
+use itertools::Itertools;
+
 use crate::{
     expect_message,
     net::{ErrorResponse, Parameters, ReadyForQuery},
@@ -28,41 +30,31 @@ async fn mixed_set_simple_returns_error() {
     let mut client = TestClient::new_sharded(Parameters::default()).await;
 
     client
-        .send(Query::new("SET statement_timeout TO '10s'; SELECT 1"))
+        .send_simple(Query::new("SET statement_timeout TO '10s'; SELECT 1"))
         .await;
-    client.try_process().await.unwrap();
+    let messages = client.read_until('Z').await.unwrap();
+    let codes = messages.iter().map(|m| m.code()).collect_vec();
 
-    assert_mixed_set_error(expect_message!(client.read().await, ErrorResponse));
-    assert_eq!(
-        expect_message!(client.read().await, ReadyForQuery).status,
-        'I'
-    );
+    assert_eq!(codes, ['C', 'T', 'D', 'C', 'Z']);
     assert!(!client.backend_connected());
-
     assert_connection_usable(&mut client).await;
 }
 
 #[tokio::test]
-async fn mixed_set_extended_returns_error() {
+async fn mixed_set_more_than_one_query_error() {
     let mut client = TestClient::new_sharded(Parameters::default()).await;
 
     client
-        .send(Parse::named(
-            "mixed",
-            "SET statement_timeout TO '10s'; SELECT 1",
+        .send_simple(Query::new(
+            "SET statement_timeout TO '10s'; SELECT 1; SELECT 2;",
         ))
         .await;
-    client.send(Bind::new_statement("mixed")).await;
-    client.send(Execute::new()).await;
-    client.send(Sync).await;
-    client.try_process().await.unwrap();
-
-    assert_mixed_set_error(expect_message!(client.read().await, ErrorResponse));
+    let err = client.read_until('Z').await.unwrap_err();
+    assert_mixed_set_error(err);
     assert_eq!(
         expect_message!(client.read().await, ReadyForQuery).status,
         'I'
     );
     assert!(!client.backend_connected());
-
     assert_connection_usable(&mut client).await;
 }

--- a/pgdog/src/frontend/client/query_engine/test/multi_statement.rs
+++ b/pgdog/src/frontend/client/query_engine/test/multi_statement.rs
@@ -7,7 +7,7 @@ use crate::{
 
 use super::prelude::*;
 
-const MIXED_SET_ERROR: &str = "multi-statement queries cannot mix SET with other commands";
+const MIXED_SET_ERROR: &str = "multi-query statement cannot be safely executed";
 
 fn assert_mixed_set_error(error: ErrorResponse) {
     assert!(

--- a/pgdog/src/frontend/router/context.rs
+++ b/pgdog/src/frontend/router/context.rs
@@ -37,6 +37,8 @@ pub struct RouterContext<'a> {
     /// reads these before the lookup cache, so a second routing pass
     /// after resolving lookups can't miss.
     pub(super) resolved_lookups: ResolvedLookups,
+    /// Using extended protocol.
+    pub(super) extended: bool,
 }
 
 impl<'a> RouterContext<'a> {
@@ -52,6 +54,10 @@ impl<'a> RouterContext<'a> {
         let copy_mode = buffer.is_copy();
 
         Ok(Self {
+            extended: query
+                .as_ref()
+                .map(|query| query.extended())
+                .unwrap_or_default(),
             bind,
             parameter_hints: ParameterHints::from(params),
             cluster,

--- a/pgdog/src/frontend/router/parser/error.rs
+++ b/pgdog/src/frontend/router/parser/error.rs
@@ -109,6 +109,9 @@ pub enum Error {
     #[error("multi-statement queries cannot mix SET with other commands")]
     MultiStatementMixedSet,
 
+    #[error("multi-statement queries cannot be safely executed")]
+    MultiStatementSafety,
+
     #[error("unmapped sharding key was specified")]
     UnmappedShardKey(String),
 

--- a/pgdog/src/frontend/router/parser/error.rs
+++ b/pgdog/src/frontend/router/parser/error.rs
@@ -109,7 +109,7 @@ pub enum Error {
     #[error("multi-statement queries cannot mix SET with other commands")]
     MultiStatementMixedSet,
 
-    #[error("multi-statement queries cannot be safely executed")]
+    #[error("multi-query statement cannot be safely executed")]
     MultiStatementSafety,
 
     #[error("unmapped sharding key was specified")]

--- a/pgdog/src/frontend/router/parser/query/mod.rs
+++ b/pgdog/src/frontend/router/parser/query/mod.rs
@@ -336,7 +336,7 @@ impl QueryParser {
             .run()?;
         }
 
-        if let Some(command) = self.check_multi_statement(statement, context)? {
+        if let Some(command) = self.check_multi_query_statement(statement, context)? {
             return Ok(command);
         }
 

--- a/pgdog/src/frontend/router/parser/query/set.rs
+++ b/pgdog/src/frontend/router/parser/query/set.rs
@@ -69,13 +69,6 @@ impl QueryParser {
         stmts: impl IntoIterator<Item = &'a nodes::RawStmt>,
         context: &QueryParserContext,
     ) -> Result<Option<Command>, Error> {
-        // In session mode, pass through without validation — the server
-        // owns the session and can handle mixed SET + other statements.
-        if context.is_session_mode() {
-            return Ok(Some(Command::Query(Route::write(
-                context.shards_calculator.shard(),
-            ))));
-        }
         let mut has_other = false;
 
         let params = stmts

--- a/pgdog/src/frontend/router/parser/query/split.rs
+++ b/pgdog/src/frontend/router/parser/query/split.rs
@@ -41,12 +41,16 @@ impl QueryParser {
 
                 // /* pgdog_shard */ manual override makes this a safe, direct-to-shard query
                 // without splitting.
-                let comment_override =
+                let direct_to_shard =
                     context.shards > 1 && context.shards_calculator.shard().is_direct();
 
-                if no_sharding || extended || comment_override {
+                let safe_not_to_split =
+                    no_sharding || extended || direct_to_shard || check.only_ddl();
+
+                if safe_not_to_split {
+                    // Safe to use the first statement for routing.
                     Ok(None)
-                } else if check.no_txn_dml == 0 && !check.open_txn {
+                } else if check.no_txn_dml <= 1 && !check.open_txn {
                     Ok(Some(Self::split(ast)?))
                 } else {
                     Err(Error::MultiStatementSafety)
@@ -54,7 +58,7 @@ impl QueryParser {
             }
             Err(Error::MultiStatementMixedSet) => {
                 let check = Self::split_execution_no_transaction_safe(ast);
-                if check.statements() != 0 {
+                if check.statements() > 1 {
                     Err(Error::MultiStatementSafety)
                 } else {
                     Ok(Some(Self::split(ast)?))
@@ -126,16 +130,18 @@ impl QueryParser {
         }
 
         check.open_txn = txn_stmts % 2 != 0;
+        check.txn = txn_stmts / 2;
 
         check
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct CheckResult {
     no_txn_dml: u32,
     no_txn_ddl: u32,
     open_txn: bool,
+    txn: u32,
 }
 
 impl CheckResult {
@@ -144,5 +150,13 @@ impl CheckResult {
     // starting another transaction.
     fn statements(&self) -> u32 {
         self.no_txn_dml + self.no_txn_ddl
+    }
+
+    fn no_transactions(&self) -> bool {
+        self.txn == 0 && !self.open_txn
+    }
+
+    fn only_ddl(&self) -> bool {
+        self.no_txn_dml == 0 && self.no_transactions()
     }
 }

--- a/pgdog/src/frontend/router/parser/query/split.rs
+++ b/pgdog/src/frontend/router/parser/query/split.rs
@@ -16,16 +16,30 @@ impl QueryParser {
             return Ok(None);
         }
 
-        let stmts = &ast.ast;
-
-        if !Self::split_execution_safe(ast) {
-            return Err(Error::MultiStatementSafety);
+        // In session mode, you can do whatever you want.
+        if context.is_session_mode() {
+            return Ok(None);
         }
+
+        let stmts = &ast.ast;
 
         match self.try_multi_set(&**stmts, context) {
             Ok(Some(set)) => Ok(Some(set)),
-            Err(Error::MultiStatementMixedSet) | Ok(None) => {
-                if !Self::split_execution_safe(ast) {
+            Ok(None) => {
+                // TODO(lev): We can still mis-route things here, e.g.,
+                // SELECT 1; INSERT INTO [...];
+                // will use the first statement for routing and send the whole
+                // thing to a replica, causing an error.
+                if context.shards == 1 {
+                    Ok(None)
+                } else if Self::split_execution_no_transaction_safe(ast) {
+                    Ok(Some(Self::split(ast)?))
+                } else {
+                    Err(Error::MultiStatementSafety)
+                }
+            }
+            Err(Error::MultiStatementMixedSet) => {
+                if !Self::split_execution_no_transaction_safe(ast) {
                     Err(Error::MultiStatementSafety)
                 } else {
                     let queries = stmts
@@ -44,12 +58,26 @@ impl QueryParser {
         }
     }
 
+    fn split(ast: &Ast) -> Result<Command, Error> {
+        let stmts = &ast.ast;
+
+        let queries = stmts
+            .stmts()
+            .map(|stmt| {
+                let query = deparse(stmt)?;
+                Ok::<_, Error>(query.as_str().to_owned())
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Command::Split(queries))
+    }
+
     // Check that all statements in the request are safe to be executed
     // without a transactional guarantee.
     //
     // TODO(lev): start implicit transaction for multi-statement queries.
     //
-    fn split_execution_safe(ast: &Ast) -> bool {
+    fn split_execution_no_transaction_safe(ast: &Ast) -> bool {
         let mut stmts = 0;
         let mut txn_stmts = 0;
         let mut inside_txn = false;

--- a/pgdog/src/frontend/router/parser/query/split.rs
+++ b/pgdog/src/frontend/router/parser/query/split.rs
@@ -1,4 +1,4 @@
-use pg_raw_parse::deparse;
+use pg_raw_parse::{deparse, raw::TransactionStmtKind::*};
 
 use super::*;
 
@@ -18,11 +18,16 @@ impl QueryParser {
 
         let stmts = &ast.ast;
 
+        if !Self::split_execution_safe(ast) {
+            return Err(Error::MultiStatementSafety);
+        }
+
         match self.try_multi_set(&**stmts, context) {
             Ok(Some(set)) => Ok(Some(set)),
-            Ok(None) => Ok(None),
-            Err(Error::MultiStatementMixedSet) => {
-                if Self::no_transaction_safe(ast) {
+            Err(Error::MultiStatementMixedSet) | Ok(None) => {
+                if !Self::split_execution_safe(ast) {
+                    Err(Error::MultiStatementSafety)
+                } else {
                     let queries = stmts
                         .stmts()
                         .map(|stmt| {
@@ -32,8 +37,6 @@ impl QueryParser {
                         .collect::<Result<Vec<_>, _>>()?;
 
                     Ok(Some(Command::Split(queries)))
-                } else {
-                    Err(Error::MultiStatementMixedSet)
                 }
             }
 
@@ -44,28 +47,40 @@ impl QueryParser {
     // Check that all statements in the request are safe to be executed
     // without a transactional guarantee.
     //
-    // Implementation is simple: caller can execute as many `SET`, `RESET` and `SHOW`
-    // commands as they want, but only _one_ real query, e.g., `SELECT`.
-    //
-    // The state mutations done by `SET` and `RESET` are tracked by the query engine, and we're
-    // able to restore the client and server state back to what it was. `SHOW` is harmless.
-    //
-    // All other statements can modify the database and require transactional guarantees, so we
-    // can only execute one of them at a time (for now).
-    //
     // TODO(lev): start implicit transaction for multi-statement queries.
     //
-    fn no_transaction_safe(ast: &Ast) -> bool {
+    fn split_execution_safe(ast: &Ast) -> bool {
         let mut stmts = 0;
+        let mut txn_stmts = 0;
+        let mut inside_txn = false;
 
         for stmt in ast.ast.stmts() {
             match stmt {
+                Node::TransactionStmt(stmt) => {
+                    if matches!(stmt.kind, TRANS_STMT_BEGIN | TRANS_STMT_START) {
+                        inside_txn = true;
+                        txn_stmts += 1;
+                    }
+
+                    if matches!(stmt.kind, TRANS_STMT_ROLLBACK | TRANS_STMT_COMMIT) {
+                        inside_txn = false;
+                        txn_stmts += 1
+                    }
+                }
+
                 Node::VariableSetStmt(_) => (),
                 Node::VariableShowStmt(_) => (),
-                _ => stmts += 1,
+                Node::DeallocateStmt(_) => (),
+                Node::VacuumRelation(_) | Node::VacuumStmt(_) => (),
+                Node::PrepareStmt(_) => (), // We intercept prepared statements and handle them ourselves.
+                _ => {
+                    if !inside_txn {
+                        stmts += 1;
+                    }
+                }
             }
         }
 
-        stmts < 2
+        stmts <= 1 && txn_stmts % 2 == 0
     }
 }

--- a/pgdog/src/frontend/router/parser/query/split.rs
+++ b/pgdog/src/frontend/router/parser/query/split.rs
@@ -5,8 +5,9 @@ use super::*;
 impl QueryParser {
     /// Check if the statement contains multiple queries.
     ///
-    /// If that's the case, return it back to the query engine for separate
-    /// re-execution.
+    /// If that's the case, check that we can execute it safely, and if we can,
+    /// either return it as-is or ask the query engine to re-execute statements separately.
+    ///
     pub(super) fn check_multi_query_statement(
         &self,
         ast: &Ast,
@@ -49,15 +50,7 @@ impl QueryParser {
                 if !Self::split_execution_no_transaction_safe(ast) {
                     Err(Error::MultiStatementSafety)
                 } else {
-                    let queries = stmts
-                        .stmts()
-                        .map(|stmt| {
-                            let query = deparse(stmt)?;
-                            Ok::<_, Error>(query.as_str().to_owned())
-                        })
-                        .collect::<Result<Vec<_>, _>>()?;
-
-                    Ok(Some(Command::Split(queries)))
+                    Ok(Some(Self::split(ast)?))
                 }
             }
 

--- a/pgdog/src/frontend/router/parser/query/split.rs
+++ b/pgdog/src/frontend/router/parser/query/split.rs
@@ -7,7 +7,7 @@ impl QueryParser {
     ///
     /// If that's the case, return it back to the query engine for separate
     /// re-execution.
-    pub(super) fn check_multi_statement(
+    pub(super) fn check_multi_query_statement(
         &self,
         ast: &Ast,
         context: &QueryParserContext<'_>,
@@ -18,7 +18,9 @@ impl QueryParser {
 
         // In session mode, you can do whatever you want.
         if context.is_session_mode() {
-            return Ok(None);
+            return Ok(Some(Command::Query(Route::write(
+                context.shards_calculator.shard(),
+            ))));
         }
 
         let stmts = &ast.ast;
@@ -32,7 +34,10 @@ impl QueryParser {
                 // thing to a replica, causing an error.
                 //
                 // Extended protocol containing multiple statements will be rejected by Postgres.
-                if context.shards == 1 || context.router_context.extended {
+                if context.shards == 1
+                    || context.router_context.extended
+                    || (context.shards > 1 && context.shards_calculator.shard().is_direct())
+                {
                     Ok(None)
                 } else if Self::split_execution_no_transaction_safe(ast) {
                     Ok(Some(Self::split(ast)?))

--- a/pgdog/src/frontend/router/parser/query/split.rs
+++ b/pgdog/src/frontend/router/parser/query/split.rs
@@ -30,7 +30,9 @@ impl QueryParser {
                 // SELECT 1; INSERT INTO [...];
                 // will use the first statement for routing and send the whole
                 // thing to a replica, causing an error.
-                if context.shards == 1 {
+                //
+                // Extended protocol containing multiple statements will be rejected by Postgres.
+                if context.shards == 1 || context.router_context.extended {
                     Ok(None)
                 } else if Self::split_execution_no_transaction_safe(ast) {
                     Ok(Some(Self::split(ast)?))

--- a/pgdog/src/frontend/router/parser/query/split.rs
+++ b/pgdog/src/frontend/router/parser/query/split.rs
@@ -47,10 +47,14 @@ impl QueryParser {
                 let safe_not_to_split =
                     no_sharding || extended || direct_to_shard || check.only_ddl();
 
+                let safe_to_split = !check.open_txn
+                    && (check.txn == 1 && check.statements() == 0
+                        || check.statements() == 1 && check.txn == 0);
+
                 if safe_not_to_split {
                     // Safe to use the first statement for routing.
                     Ok(None)
-                } else if check.statements() <= 1 && !check.open_txn {
+                } else if safe_to_split {
                     Ok(Some(Self::split(ast)?))
                 } else {
                     Err(Error::MultiStatementSafety)

--- a/pgdog/src/frontend/router/parser/query/split.rs
+++ b/pgdog/src/frontend/router/parser/query/split.rs
@@ -109,6 +109,7 @@ impl QueryParser {
                 Node::VacuumRelation(_) | Node::VacuumStmt(_) => (),
                 Node::PrepareStmt(_) => (), // We intercept prepared statements and handle them ourselves.
                 Node::SelectStmt(_)
+                | Node::ExecuteStmt(_)
                 | Node::InsertStmt(_)
                 | Node::UpdateStmt(_)
                 | Node::DeleteStmt(_) => {

--- a/pgdog/src/frontend/router/parser/query/split.rs
+++ b/pgdog/src/frontend/router/parser/query/split.rs
@@ -22,18 +22,50 @@ impl QueryParser {
             Ok(Some(set)) => Ok(Some(set)),
             Ok(None) => Ok(None),
             Err(Error::MultiStatementMixedSet) => {
-                let queries = stmts
-                    .stmts()
-                    .map(|stmt| {
-                        let query = deparse(stmt)?;
-                        Ok::<_, Error>(query.as_str().to_owned())
-                    })
-                    .collect::<Result<Vec<_>, _>>()?;
+                if Self::no_transaction_safe(ast) {
+                    let queries = stmts
+                        .stmts()
+                        .map(|stmt| {
+                            let query = deparse(stmt)?;
+                            Ok::<_, Error>(query.as_str().to_owned())
+                        })
+                        .collect::<Result<Vec<_>, _>>()?;
 
-                Ok(Some(Command::Split(queries)))
+                    Ok(Some(Command::Split(queries)))
+                } else {
+                    Err(Error::MultiStatementMixedSet)
+                }
             }
 
             Err(err) => Err(err),
         }
+    }
+
+    // Check that all statements in the request are safe to be executed
+    // without a transactional guarantee.
+    //
+    // Implementation is simple: caller can execute as many `SET`, `RESET` and `SHOW`
+    // commands as they want, but only _one_ real query, e.g., `SELECT`.
+    //
+    // The state mutations done by `SET` and `RESET` are tracked by the query engine, and we're
+    // able to restore the client and server state back to what it was. `SHOW` is harmless.
+    //
+    // All other statements can modify the database and require transactional guarantees, so we
+    // can only execute one of them at a time (for now).
+    //
+    // TODO(lev): start implicit transaction for multi-statement queries.
+    //
+    fn no_transaction_safe(ast: &Ast) -> bool {
+        let mut stmts = 0;
+
+        for stmt in ast.ast.stmts() {
+            match stmt {
+                Node::VariableSetStmt(_) => (),
+                Node::VariableShowStmt(_) => (),
+                _ => stmts += 1,
+            }
+        }
+
+        stmts < 2
     }
 }

--- a/pgdog/src/frontend/router/parser/query/split.rs
+++ b/pgdog/src/frontend/router/parser/query/split.rs
@@ -50,7 +50,7 @@ impl QueryParser {
                 if safe_not_to_split {
                     // Safe to use the first statement for routing.
                     Ok(None)
-                } else if check.no_txn_dml <= 1 && !check.open_txn {
+                } else if check.statements() <= 1 && !check.open_txn {
                     Ok(Some(Self::split(ast)?))
                 } else {
                     Err(Error::MultiStatementSafety)

--- a/pgdog/src/frontend/router/parser/query/split.rs
+++ b/pgdog/src/frontend/router/parser/query/split.rs
@@ -29,25 +29,32 @@ impl QueryParser {
         match self.try_multi_set(&**stmts, context) {
             Ok(Some(set)) => Ok(Some(set)),
             Ok(None) => {
+                let check = Self::split_execution_no_transaction_safe(ast);
                 // TODO(lev): We can still mis-route things here, e.g.,
                 // SELECT 1; INSERT INTO [...];
                 // will use the first statement for routing and send the whole
                 // thing to a replica, causing an error.
-                //
-                // Extended protocol containing multiple statements will be rejected by Postgres.
-                if context.shards == 1
-                    || context.router_context.extended
-                    || (context.shards > 1 && context.shards_calculator.shard().is_direct())
-                {
+                let no_sharding = context.shards == 1;
+                // Postgres will abort a multi-statement extended protocol execution,
+                // we don't need to worry about it.
+                let extended = context.router_context.extended;
+
+                // /* pgdog_shard */ manual override makes this a safe, direct-to-shard query
+                // without splitting.
+                let comment_override =
+                    context.shards > 1 && context.shards_calculator.shard().is_direct();
+
+                if no_sharding || extended || comment_override {
                     Ok(None)
-                } else if Self::split_execution_no_transaction_safe(ast) {
+                } else if check.no_txn_dml == 0 && !check.open_txn {
                     Ok(Some(Self::split(ast)?))
                 } else {
                     Err(Error::MultiStatementSafety)
                 }
             }
             Err(Error::MultiStatementMixedSet) => {
-                if !Self::split_execution_no_transaction_safe(ast) {
+                let check = Self::split_execution_no_transaction_safe(ast);
+                if check.statements() != 0 {
                     Err(Error::MultiStatementSafety)
                 } else {
                     Ok(Some(Self::split(ast)?))
@@ -77,8 +84,8 @@ impl QueryParser {
     //
     // TODO(lev): start implicit transaction for multi-statement queries.
     //
-    fn split_execution_no_transaction_safe(ast: &Ast) -> bool {
-        let mut stmts = 0;
+    fn split_execution_no_transaction_safe(ast: &Ast) -> CheckResult {
+        let mut check = CheckResult::default();
         let mut txn_stmts = 0;
         let mut inside_txn = false;
 
@@ -101,14 +108,40 @@ impl QueryParser {
                 Node::DeallocateStmt(_) => (),
                 Node::VacuumRelation(_) | Node::VacuumStmt(_) => (),
                 Node::PrepareStmt(_) => (), // We intercept prepared statements and handle them ourselves.
+                Node::SelectStmt(_)
+                | Node::InsertStmt(_)
+                | Node::UpdateStmt(_)
+                | Node::DeleteStmt(_) => {
+                    if !inside_txn {
+                        check.no_txn_dml += 1;
+                    }
+                }
                 _ => {
                     if !inside_txn {
-                        stmts += 1;
+                        check.no_txn_ddl += 1;
                     }
                 }
             }
         }
 
-        stmts <= 1 && txn_stmts % 2 == 0
+        check.open_txn = txn_stmts % 2 != 0;
+
+        check
+    }
+}
+
+#[derive(Default)]
+struct CheckResult {
+    no_txn_dml: u32,
+    no_txn_ddl: u32,
+    open_txn: bool,
+}
+
+impl CheckResult {
+    // Any statements executed outside an explicit
+    // transaction cannot be safely replayed without us
+    // starting another transaction.
+    fn statements(&self) -> u32 {
+        self.no_txn_dml + self.no_txn_ddl
     }
 }

--- a/pgdog/src/frontend/router/parser/query/test/mod.rs
+++ b/pgdog/src/frontend/router/parser/query/test/mod.rs
@@ -39,6 +39,7 @@ pub mod test_session_control;
 pub mod test_set;
 pub mod test_sharding;
 pub mod test_special;
+pub mod test_split;
 pub mod test_subqueries;
 pub mod test_transaction;
 

--- a/pgdog/src/frontend/router/parser/query/test/test_set.rs
+++ b/pgdog/src/frontend/router/parser/query/test/test_set.rs
@@ -49,7 +49,7 @@ fn test_mixed_set_multiple_queries_error() {
         ])
         .unwrap_err();
 
-    assert!(matches!(result, Error::MultiStatementMixedSet));
+    assert!(matches!(result, Error::MultiStatementSafety));
 }
 
 #[test]
@@ -154,13 +154,23 @@ fn test_set_multi_statement_mixed_returns_split() {
 
 #[test]
 fn test_multi_statement_no_set_falls_through() {
-    let mut test = QueryParserTest::new();
+    let mut test = QueryParserTest::new_single_shard(&config());
 
     let command = test.execute(vec![Query::new("SELECT 1; SELECT 2").into()]);
     assert!(
         matches!(command, Command::Query(_)),
         "multi-statement without SET should fall through, got {command:#?}",
     );
+}
+
+#[test]
+fn test_multi_statement_no_set_cross_shard_requires_transaction() {
+    let mut test = QueryParserTest::new();
+
+    let result = test
+        .try_execute(vec![Query::new("SELECT 1; SELECT 2").into()])
+        .unwrap_err();
+    assert!(matches!(result, Error::MultiStatementSafety))
 }
 
 #[test]

--- a/pgdog/src/frontend/router/parser/query/test/test_set.rs
+++ b/pgdog/src/frontend/router/parser/query/test/test_set.rs
@@ -10,6 +10,7 @@ use crate::{
     net::parameter::ParameterValue,
 };
 
+use super::Error;
 use super::setup::*;
 
 #[test]
@@ -36,6 +37,31 @@ fn test_mixed_set_split_in_transaction_mode() {
         Query::new("SET DateStyle='ISO'; show transaction_isolation").into(),
     ]);
     assert!(matches!(command, Command::Split(queries) if queries.len() == 2));
+}
+
+#[test]
+fn test_mixed_set_multiple_queries_error() {
+    let mut test = QueryParserTest::new();
+
+    let result = test
+        .try_execute(vec![
+            Query::new("SET application_name TO 'test'; SELECT 1; SELECT 2;").into(),
+        ])
+        .unwrap_err();
+
+    assert!(matches!(result, Error::MultiStatementMixedSet));
+}
+
+#[test]
+fn test_mixed_set_reset_query_works() {
+    let mut test = QueryParserTest::new();
+
+    let command = test
+        .execute(vec![
+            Query::new("SET application_name TO 'test'; SELECT 1; RESET application_name; SHOW application_name;").into(),
+        ]);
+
+    assert!(matches!(command, Command::Split(queries) if queries.len() == 4));
 }
 
 #[test]

--- a/pgdog/src/frontend/router/parser/query/test/test_split.rs
+++ b/pgdog/src/frontend/router/parser/query/test/test_split.rs
@@ -154,6 +154,11 @@ fn test_multiple_statements_after_transaction_are_unsafe() {
 }
 
 #[test]
+fn test_one_statement_after_transaction_are_unsafe() {
+    assert_unsafe("BEGIN; SELECT 1; COMMIT; SELECT 2;");
+}
+
+#[test]
 fn test_ddl_in_explicit_transaction_is_split() {
     assert_split(
         "BEGIN; CREATE TABLE split_test (id bigint); DROP TABLE split_test; COMMIT",

--- a/pgdog/src/frontend/router/parser/query/test/test_split.rs
+++ b/pgdog/src/frontend/router/parser/query/test/test_split.rs
@@ -1,0 +1,174 @@
+use crate::{config::config, frontend::Command};
+
+use super::{Error, setup::*};
+
+fn execute(query: &str) -> Command {
+    QueryParserTest::new().execute(vec![Query::new(query).into()])
+}
+
+fn assert_split(query: &str, expected: &[&str]) {
+    let command = execute(query);
+
+    match command {
+        Command::Split(queries) => assert_eq!(
+            queries, expected,
+            "unexpected statements produced by splitting `{query}`",
+        ),
+        _ => panic!("expected Command::Split for `{query}`, got {command:#?}"),
+    }
+}
+
+fn assert_unsafe(query: &str) {
+    let result = QueryParserTest::new()
+        .try_execute(vec![Query::new(query).into()])
+        .expect_err("query should not be safe to execute without a transaction");
+
+    assert!(
+        matches!(result, Error::MultiStatementSafety),
+        "expected MultiStatementSafety for `{query}`, got {result:#?}",
+    );
+}
+
+#[test]
+fn test_single_statement_is_not_split() {
+    let command = execute("SELECT 1");
+
+    assert!(
+        matches!(command, Command::Query(_)),
+        "expected Command::Query, got {command:#?}",
+    );
+}
+
+#[test]
+fn test_session_mode_multi_statement_is_passed_through_as_write() {
+    let mut test = QueryParserTest::new_session_mode(&config());
+    let command = test.execute(vec![Query::new("SELECT 1; SELECT 2").into()]);
+
+    assert!(
+        matches!(command, Command::Query(ref route) if route.is_write()),
+        "expected a write Command::Query, got {command:#?}",
+    );
+}
+
+#[test]
+fn test_extended_protocol_multi_statement_is_not_split() {
+    let mut test = QueryParserTest::new();
+    let command = test.execute(vec![Parse::new_anonymous("SELECT 1; SELECT 2").into()]);
+
+    assert!(
+        matches!(command, Command::Query(_)),
+        "expected Command::Query, got {command:#?}",
+    );
+}
+
+#[test]
+fn test_direct_shard_multi_statement_is_not_split() {
+    let command = execute("/* pgdog_shard: 1 */ SELECT 1; SELECT 2");
+
+    assert!(
+        matches!(command, Command::Query(ref route) if route.shard().is_direct()),
+        "expected a direct-shard Command::Query, got {command:#?}",
+    );
+}
+
+#[test]
+fn test_ddl_only_multi_statement_is_not_split() {
+    let command = execute("CREATE TABLE split_test (id bigint); DROP TABLE split_test");
+
+    assert!(
+        matches!(command, Command::Query(ref route) if route.is_write()),
+        "expected a write Command::Query, got {command:#?}",
+    );
+}
+
+#[test]
+fn test_one_dml_with_non_mutating_statements_is_split() {
+    for (query, expected) in [
+        (
+            "SHOW application_name; SELECT 1",
+            &["SHOW application_name", "SELECT 1"] as &[_],
+        ),
+        (
+            "DEALLOCATE ALL; SELECT 1",
+            &["DEALLOCATE ALL", "SELECT 1"] as &[_],
+        ),
+        (
+            "VACUUM split_test; SELECT 1",
+            &["VACUUM split_test", "SELECT 1"] as &[_],
+        ),
+        (
+            "PREPARE split_stmt AS SELECT 1; SELECT 2",
+            &["PREPARE split_stmt AS SELECT 1", "SELECT 2"] as &[_],
+        ),
+    ] {
+        assert_split(query, expected);
+    }
+}
+
+#[test]
+fn test_each_dml_kind_counts_toward_the_safety_limit() {
+    for query in [
+        "SELECT 1; SELECT 2",
+        "INSERT INTO split_test VALUES (1); SELECT 1",
+        "UPDATE split_test SET id = 2; SELECT 1",
+        "DELETE FROM split_test; SELECT 1",
+        "EXECUTE split_stmt; SELECT 1",
+    ] {
+        assert_unsafe(query);
+    }
+}
+
+#[test]
+fn test_dml_and_ddl_outside_transaction_is_unsafe() {
+    assert_unsafe("SELECT 1; CREATE TABLE split_test (id bigint)");
+}
+
+#[test]
+fn test_complete_transactions_are_split() {
+    for (query, expected) in [
+        (
+            "BEGIN; SELECT 1; SELECT 2; COMMIT",
+            &["BEGIN", "SELECT 1", "SELECT 2", "COMMIT"] as &[_],
+        ),
+        (
+            "START TRANSACTION; INSERT INTO split_test VALUES (1); ROLLBACK",
+            &[
+                "START TRANSACTION",
+                "INSERT INTO split_test VALUES (1)",
+                "ROLLBACK",
+            ] as &[_],
+        ),
+    ] {
+        assert_split(query, expected);
+    }
+}
+
+#[test]
+fn test_open_transaction_is_unsafe() {
+    assert_unsafe("BEGIN; SELECT 1");
+}
+
+#[test]
+fn test_multiple_statements_after_transaction_are_unsafe() {
+    assert_unsafe("BEGIN; SELECT 1; COMMIT; SELECT 2; SELECT 3");
+}
+
+#[test]
+fn test_ddl_in_explicit_transaction_is_split() {
+    assert_split(
+        "BEGIN; CREATE TABLE split_test (id bigint); DROP TABLE split_test; COMMIT",
+        &[
+            "BEGIN",
+            "CREATE TABLE split_test (id bigint)",
+            "DROP TABLE split_test",
+            "COMMIT",
+        ],
+    );
+}
+
+#[test]
+fn test_mixed_set_and_multiple_ddl_statements_are_unsafe() {
+    assert_unsafe(
+        "SET application_name TO 'split_test'; CREATE TABLE split_test (id bigint); DROP TABLE split_test",
+    );
+}


### PR DESCRIPTION
## What

Support multi-statement queries sent via the simple protocol if they can be safely executed without us having to do anything fancy with transactions.

## Preface

A multi-statement query looks something like this:

```sql
SELECT 1; SELECT 2;
```

They are sent inside a single `Query` message and Postgres is expected to process all commands sequentially and inside a single, implicit transaction.

This presents an issue for sharded deployments, since queries might need to go to different shards. So, what can we do about this?

## Split and execute

Since we have the Postgres parser handy, we can split the query and execute each statement separately. One caveat here is we **won't** start a transaction inside Postgres automatically (at least, not yet), so we have to be careful about which statements we can execute safely.

### `SET` mixed with _one_ query

This is totally safe (and quite common):

```sql
SET statement_timeout TO 0; SELECT * FROM users;
```

We can split these up, execute them separately, without breaking transactional guarantees. Only one statement actually reads data, while PgDog handles `SET` internally. This type of query will, as of this PR, be executed normally. Yay!

Conversely, the following cannot be split safely (yet) and will continue to return an error from us:

```sql
SET statement_timeout TO 0; SELECT * FROM users; SELECT * FROM orders;
```

You can set as many things as you want:

```sql
SET statement_timeout TO 0;
SET lock_timeout TO 0;
SELECT * FROM pg_type;
SHOW lock_timeout;
RESET statement_timeout;
RESET lock_timeout;
```

This is safe to execute because only _one_ query actually cares about data, and the rest is handled by PgDog or is inconsequential if executed outside a transaction.

### DDL

```sql
CREATE TABLE x [...];
CREATE TABLE y [...];
```

This is quite common (e.g., in migration scripts) and is quite safe to execute without splitting at all. We send this query to all shards concurrently. No problems.

### Manual transactions

This happens sometimes and now works correctly:

```sql
BEGIN; SELECT * FROM users WHERE id = 1; SELECT * FROM orders WHERE user_id = 2; COMMIT;
```

This is safe to split and execute because client starts a transaction and we can handle those no problem. If the transaction returns an error, the remaining statements are not executed; same behavior as regular Postgres.

### Checks

Other things we check for and block now:

1. Unclosed transactions, e.g., `BEGIN; SELECT 1;`. Bad! Blocked.
2. Multi-statement queries outside transactions, bad, blocked!
3. Mix of transactions and not, bad, blocked!

This is only relevant for a single `Query` message. Normal query flow is not affected by this change.

