### PR TITLE
fix(admin): preserve casing for admin command string

### DIFF
--- a/pgdog/src/admin/parser.rs
+++ b/pgdog/src/admin/parser.rs
@@ -157,13 +157,18 @@ pub(crate) struct Parser;
 impl Parser {
     /// Parse the query and return a command we can execute.
     pub(crate) fn parse(sql: &str) -> Result<ParseResult, Error> {
+        let sql = sql.trim();
+
         // Handle SET separately because
         // we're about to clobber valid SQL syntax below.
         if is_set_statement(sql) {
-            return Ok(ParseResult::Set(Set::parse(sql)?));
+            return Ok(ParseResult::Set(Set::parse(&sql.to_lowercase())?));
         }
 
         if let Ok(show) = get_show_variable(sql) {
+            let sql = sql.to_lowercase();
+            let sql = sql.as_str();
+
             return Ok(match show.as_str() {
                 "clients" => ParseResult::ShowClients(ShowClients::parse(sql)?),
                 "pools" => ParseResult::ShowPools(ShowPools::parse(sql)?),
@@ -193,7 +198,7 @@ impl Parser {
             });
         }
 
-        let sql = sql.trim().replace(";", "").to_lowercase();
+        let sql = sql.replace(";", "").to_lowercase();
         let mut iter = sql.split(" ");
 
         Ok(match iter.next().ok_or(Error::Syntax)?.trim() {

--- a/pgdog/src/admin/server.rs
+++ b/pgdog/src/admin/server.rs
@@ -48,7 +48,7 @@ impl AdminServer {
 
         let query = Query::from_bytes(message.to_bytes())?;
 
-        let messages = match Parser::parse(&query.query().to_lowercase()) {
+        let messages = match Parser::parse(query.query()) {
             Ok(command) => {
                 let mut messages = command.execute().await?;
                 messages.push(CommandComplete::new(command.name()).message());


### PR DESCRIPTION
The original `Parser::parse(&query.query().to_lowercase())` can cause issue if we rely on what is inside the query. So, move the normalization inside the parser and not the caller side