### PR TITLE
Fix code that is only used in tests, but not marked as such

### DIFF
--- a/pgdog/src/backend/error.rs
+++ b/pgdog/src/backend/error.rs
@@ -78,9 +78,6 @@ pub enum Error {
     #[error("rollback left server in inconsistent state")]
     RollbackFailed,
 
-    #[error("read timeout")]
-    ReadTimeout,
-
     #[error("router error: {0}")]
     Router(String),
 
@@ -138,7 +135,6 @@ impl Error {
             // These are recoverable errors.
             Error::Pool(PoolError::CheckoutTimeout) => true,
             Error::Pool(PoolError::AllReplicasDown) => true,
-            Error::Pool(PoolError::Banned) => true,
             _ => false,
         }
     }
@@ -160,8 +156,6 @@ impl Error {
             | Self::MultiShardNotConnected
             | Self::CopyNotConnected
             | Self::ClusterNotConnected => true,
-            // Server stopped responding mid-stream.
-            Self::ReadTimeout => true,
             _ => false,
         }
     }

--- a/pgdog/src/backend/pool/error.rs
+++ b/pgdog/src/backend/pool/error.rs
@@ -11,38 +11,20 @@ pub enum Error {
     #[error("connect timeout")]
     ConnectTimeout,
 
-    #[error("replica checkout timeout")]
-    ReplicaCheckoutTimeout,
-
     #[error("server error")]
     ServerError,
 
     #[error("manual ban")]
     ManualBan,
 
-    #[error("no replicas")]
-    NoReplicas,
-
     #[error("no such shard: {0}")]
     NoShard(usize),
-
-    #[error("pool is banned")]
-    Banned,
-
-    #[error("healthcheck timeout")]
-    HealthcheckTimeout,
 
     #[error("healthcheck error")]
     HealthcheckError,
 
     #[error("server closed")]
     ServerClosed,
-
-    #[error("primary lsn query failed")]
-    PrimaryLsnQueryFailed,
-
-    #[error("replica lsn query failed")]
-    ReplicaLsnQueryFailed,
 
     #[error("pool is shut down")]
     Offline,
@@ -52,9 +34,6 @@ pub enum Error {
 
     #[error("no databases")]
     NoDatabases,
-
-    #[error("config values contain null bytes")]
-    NullBytes,
 
     #[error("all replicas down")]
     AllReplicasDown,
@@ -87,8 +66,7 @@ impl Error {
         !matches!(
             self,
             // Config / wiring errors — retrying changes nothing.
-            Self::NullBytes
-                | Self::NoShard(_)
+            Self::NoShard(_)
                 | Self::NoDatabases
                 | Self::PubSubDisabled
                 // Admin decisions — respect them.
@@ -109,17 +87,11 @@ mod tests {
     fn retryable() {
         assert!(Error::CheckoutTimeout.is_retryable());
         assert!(Error::ConnectTimeout.is_retryable());
-        assert!(Error::ReplicaCheckoutTimeout.is_retryable());
         assert!(Error::NoPrimary.is_retryable());
         assert!(Error::AllReplicasDown.is_retryable());
-        assert!(Error::Banned.is_retryable());
-        assert!(Error::NoReplicas.is_retryable());
         assert!(Error::ServerError.is_retryable());
-        assert!(Error::HealthcheckTimeout.is_retryable());
         assert!(Error::HealthcheckError.is_retryable());
         assert!(Error::ServerClosed.is_retryable());
-        assert!(Error::PrimaryLsnQueryFailed.is_retryable());
-        assert!(Error::ReplicaLsnQueryFailed.is_retryable());
         assert!(Error::Offline.is_retryable());
         assert!(Error::ReplicaLag.is_retryable());
         assert!(Error::PoolUnhealthy.is_retryable());
@@ -128,7 +100,6 @@ mod tests {
     #[test]
     fn not_retryable() {
         assert!(!Error::ManualBan.is_retryable());
-        assert!(!Error::NullBytes.is_retryable());
         assert!(!Error::NoDatabases.is_retryable());
         assert!(!Error::PubSubDisabled.is_retryable());
         assert!(!Error::FastShutdown.is_retryable());

--- a/pgdog/src/backend/pool/inner.rs
+++ b/pgdog/src/backend/pool/inner.rs
@@ -860,7 +860,7 @@ mod test {
         let mut inner = Inner::default();
         let client_id = FrontendPid::new();
         let server_id = BackendPid::for_test(1);
-        let cancel_key = BackendKeyData::legacy(server_id.pid(), 0);
+        let cancel_key = BackendKeyData::legacy(server_id.pid, 0);
 
         assert_eq!(inner.cancel_key(client_id), None);
 
@@ -874,7 +874,7 @@ mod test {
         let mut taken = Taken::default();
         let client_id = FrontendPid::new();
         let server_id = BackendPid::for_test(1);
-        let cancel_key = BackendKeyData::legacy(server_id.pid(), 0);
+        let cancel_key = BackendKeyData::legacy(server_id.pid, 0);
 
         // No mapping yet
         assert_eq!(taken.cancel_key(client_id), None);
@@ -884,7 +884,7 @@ mod test {
 
         // Cancel key should be returned for mapped client, pid matches server_id
         let stored = taken.cancel_key(client_id).unwrap();
-        assert_eq!(stored.pid(), server_id.pid());
+        assert_eq!(stored.pid(), server_id.pid);
         assert_eq!(stored, &cancel_key);
 
         // Different client should return None
@@ -1088,7 +1088,7 @@ mod test {
         assert_eq!(inner.checked_out(), 0);
 
         let mut taken = Taken::default();
-        taken.take(client, server, BackendKeyData::legacy(server.pid(), 0));
+        taken.take(client, server, BackendKeyData::legacy(server.pid, 0));
 
         inner.set_taken(taken);
         assert_eq!(inner.checked_out(), 1);

--- a/pgdog/src/backend/pool/taken.rs
+++ b/pgdog/src/backend/pool/taken.rs
@@ -144,7 +144,7 @@ mod tests {
         let mut taken = Taken::default();
         let frontend = FrontendPid::new();
         let backend = BackendPid::for_test(1);
-        let cancel_key = key(backend.pid());
+        let cancel_key = key(backend.pid);
 
         taken.take(frontend, backend, cancel_key.clone());
         assert_eq!(taken.len(), 1);
@@ -173,10 +173,10 @@ mod tests {
         let frontend = FrontendPid::new();
         let backend = BackendPid::for_test(2);
 
-        taken.take(frontend, backend, key(backend.pid()));
+        taken.take(frontend, backend, key(backend.pid));
         assert_eq!(
             taken.cancel_key(frontend).map(|k| k.pid()),
-            Some(backend.pid())
+            Some(backend.pid)
         );
     }
 
@@ -186,14 +186,14 @@ mod tests {
         let (fa, ba) = (FrontendPid::new(), BackendPid::for_test(3));
         let (fb, bb) = (FrontendPid::new(), BackendPid::for_test(4));
 
-        taken.take(fa, ba, key(ba.pid()));
-        taken.take(fb, bb, key(bb.pid()));
+        taken.take(fa, ba, key(ba.pid));
+        taken.take(fb, bb, key(bb.pid));
         assert_eq!(taken.len(), 2);
 
         taken.check_in(ba).unwrap();
         assert_eq!(taken.len(), 1);
         assert_eq!(taken.cancel_key(fa), None);
-        assert_eq!(taken.cancel_key(fb).map(|k| k.pid()), Some(bb.pid()));
+        assert_eq!(taken.cancel_key(fb).map(|k| k.pid()), Some(bb.pid));
 
         taken.check_in(bb).unwrap();
         assert!(taken.is_empty());
@@ -215,8 +215,8 @@ mod tests {
         let frontend = FrontendPid::new();
         let backend_a = BackendPid::for_test(5);
         let backend_b = BackendPid::for_test(6);
-        let key_a = key(backend_a.pid());
-        let key_b = key(backend_b.pid());
+        let key_a = key(backend_a.pid);
+        let key_b = key(backend_b.pid);
 
         // Step 1: take A.
         taken.take(frontend, backend_a, key_a.clone());
@@ -252,14 +252,14 @@ mod tests {
         let backend_a = BackendPid::for_test(7);
         let backend_b = BackendPid::for_test(8);
 
-        taken.take(frontend, backend_a, key(backend_a.pid()));
+        taken.take(frontend, backend_a, key(backend_a.pid));
         taken.check_in(backend_a).unwrap();
         assert!(taken.is_empty());
 
-        taken.take(frontend, backend_b, key(backend_b.pid()));
+        taken.take(frontend, backend_b, key(backend_b.pid));
         assert_eq!(
             taken.cancel_key(frontend).map(|k| k.pid()),
-            Some(backend_b.pid())
+            Some(backend_b.pid)
         );
         taken.check_in(backend_b).unwrap();
         assert!(taken.is_empty());
@@ -271,8 +271,8 @@ mod tests {
         let (fa, ba) = (FrontendPid::new(), BackendPid::for_test(10));
         let (fb, bb) = (FrontendPid::new(), BackendPid::for_test(11));
 
-        taken.take(fa, ba, key(ba.pid()));
-        taken.take(fb, bb, key(bb.pid()));
+        taken.take(fa, ba, key(ba.pid));
+        taken.take(fb, bb, key(bb.pid));
         assert_eq!(taken.locked_count(), 0);
 
         taken.set_locked(ba, true);
@@ -291,7 +291,7 @@ mod tests {
         let frontend = FrontendPid::new();
         let backend = BackendPid::for_test(12);
 
-        taken.take(frontend, backend, key(backend.pid()));
+        taken.take(frontend, backend, key(backend.pid));
         taken.set_locked(backend, true);
         assert_eq!(taken.locked_count(), 1);
 
@@ -317,8 +317,8 @@ mod tests {
         let backend_a = BackendPid::for_test(14);
         let backend_b = BackendPid::for_test(15);
 
-        taken.take(frontend, backend_a, key(backend_a.pid()));
-        taken.take(frontend, backend_b, key(backend_b.pid()));
+        taken.take(frontend, backend_a, key(backend_a.pid));
+        taken.take(frontend, backend_b, key(backend_b.pid));
 
         // Stale A tries to set locked. Must not affect B.
         taken.set_locked(backend_a, true);
@@ -335,7 +335,7 @@ mod tests {
         let frontend = FrontendPid::new();
         let backend = BackendPid::for_test(9);
 
-        taken.take(frontend, backend, key(backend.pid()));
+        taken.take(frontend, backend, key(backend.pid));
         taken.check_in(backend).unwrap();
         assert_eq!(
             taken.check_in(backend).unwrap_err(),

--- a/pgdog/src/backend/pool/test/mod.rs
+++ b/pgdog/src/backend/pool/test/mod.rs
@@ -89,7 +89,7 @@ async fn test_checkout_replaces_connection_closed_by_server() {
     let killed = conn.id();
     drop(conn);
 
-    terminate_backend(killed.pid()).await;
+    terminate_backend(killed.pid).await;
 
     let conn = pool.get(&Request::default()).await.unwrap();
 
@@ -105,7 +105,7 @@ async fn test_server_closed_does_not_mark_pool_unhealthy() {
     let killed = conn.id();
     drop(conn);
 
-    terminate_backend(killed.pid()).await;
+    terminate_backend(killed.pid).await;
 
     let conn = pool.get(&Request::default()).await.unwrap();
     drop(conn);

--- a/pgdog/src/backend/prepared_statements.rs
+++ b/pgdog/src/backend/prepared_statements.rs
@@ -143,13 +143,9 @@ impl PreparedStatements {
     }
 
     /// Current prepared statement settings.
+    #[cfg(test)]
     pub fn config(&self) -> PreparedStatementsConfig {
         self.config
-    }
-
-    /// Get prepared statements capacity.
-    pub fn capacity(&self) -> usize {
-        self.config.limit
     }
 
     /// Force the server to ignore the response to this message.

--- a/pgdog/src/backend/replication/logical/error.rs
+++ b/pgdog/src/backend/replication/logical/error.rs
@@ -325,9 +325,6 @@ mod tests {
         let io = std::io::Error::new(std::io::ErrorKind::ConnectionReset, "reset");
         assert!(Error::Backend(BE::Io(io)).is_retryable());
 
-        // Read timeout mid-stream.
-        assert!(Error::Backend(BE::ReadTimeout).is_retryable());
-
         // Pool couldn't hand out a connection.
         assert!(Error::Backend(BE::Pool(PE::CheckoutTimeout)).is_retryable());
         assert!(Error::Backend(BE::Pool(PE::NoPrimary)).is_retryable());

--- a/pgdog/src/backend/replication/logical/publisher/publisher_impl.rs
+++ b/pgdog/src/backend/replication/logical/publisher/publisher_impl.rs
@@ -783,7 +783,7 @@ mod test {
             }
             .to_bytes(),
         };
-        CopyData::bytes(xlog.to_bytes())
+        CopyData::new(&xlog.to_bytes())
     }
     fn commit_copy_data(lsn: i64) -> CopyData {
         let xlog = XLogData {
@@ -798,7 +798,7 @@ mod test {
             }
             .to_bytes(),
         };
-        CopyData::bytes(xlog.to_bytes())
+        CopyData::new(&xlog.to_bytes())
     }
 
     // -- handle ---------------------------------------------------------------

--- a/pgdog/src/backend/replication/logical/subscriber/tests.rs
+++ b/pgdog/src/backend/replication/logical/subscriber/tests.rs
@@ -45,7 +45,7 @@ fn xlog_copy_data(payload: Bytes) -> CopyData {
         system_clock: 0,
         bytes: payload,
     };
-    CopyData::bytes(xlog.to_bytes())
+    CopyData::new(&xlog.to_bytes())
 }
 
 fn make_sharded_table() -> Table {

--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -967,18 +967,6 @@ impl Server {
             .collect::<Result<Vec<T>, _>>()?)
     }
 
-    /// Execute a query with text-format parameters using the extended
-    /// protocol and return all rows. Parameters are bound by the server,
-    /// so values don't need to be escaped.
-    pub async fn fetch_all_params<T: From<DataRow>>(
-        &mut self,
-        query: &str,
-        params: &[BindParameter],
-    ) -> Result<Vec<T>, Error> {
-        self.fetch_all(ServerRequest::parameterized(query, params))
-            .await
-    }
-
     /// Perform a healthcheck on this connection using the provided query.
     pub async fn healthcheck(&mut self, query: &str) -> Result<(), Error> {
         debug!("running healthcheck \"{}\" [{}]", query, self.addr);
@@ -1150,13 +1138,6 @@ impl Server {
         instant.duration_since(self.stats().created_at())
     }
 
-    /// Set this connection's lifetime cap directly. Bypasses jitter
-    /// sampling; mainly useful in tests.
-    #[inline]
-    pub fn set_max_age(&mut self, max_age: Duration) {
-        self.max_age = Some(max_age);
-    }
-
     /// Sample and apply a per-connection `max_age` uniformly from
     /// `[base - jitter, base + jitter]`, breaking up synchronized
     /// retirement of connection cohorts. Saturates at zero on
@@ -1274,6 +1255,7 @@ impl Server {
     }
 
     #[inline]
+    #[cfg(test)]
     pub fn prepared_statements(&self) -> &PreparedStatements {
         &self.prepared_statements
     }
@@ -1701,52 +1683,6 @@ pub mod test {
         }
 
         assert!(server.done());
-    }
-
-    #[tokio::test]
-    async fn test_fetch_all_params() {
-        use crate::net::bind::Parameter;
-        let mut server = test_server().await;
-
-        let rows = server
-            .fetch_all_params::<String>("SELECT $1::text", &[Parameter::new(b"hello")])
-            .await
-            .unwrap();
-        assert_eq!(rows, vec!["hello".to_string()]);
-        assert!(server.done());
-
-        // Values are bound by the server, not spliced into the query.
-        let injection = "'; DROP TABLE users; --";
-        let rows = server
-            .fetch_all_params::<String>("SELECT $1::text", &[Parameter::new(injection.as_bytes())])
-            .await
-            .unwrap();
-        assert_eq!(rows, vec![injection.to_string()]);
-        assert!(server.done());
-
-        // No rows.
-        let rows = server
-            .fetch_all_params::<String>(
-                "SELECT relname::text FROM pg_class WHERE relname = $1",
-                &[Parameter::new(b"no_such_table_fetch_all_params")],
-            )
-            .await
-            .unwrap();
-        assert!(rows.is_empty());
-        assert!(server.done());
-
-        // Errors are returned and the connection stays usable.
-        let err = server
-            .fetch_all_params::<String>("SELECT no_such_column", &[])
-            .await;
-        assert!(err.is_err());
-        assert!(server.done());
-
-        let rows = server
-            .fetch_all_params::<String>("SELECT $1::text", &[Parameter::new(b"still works")])
-            .await
-            .unwrap();
-        assert_eq!(rows, vec!["still works".to_string()]);
     }
 
     #[tokio::test]
@@ -2778,7 +2714,6 @@ pub mod test {
                     limit: 3,
                     ..Default::default()
                 });
-            assert_eq!(server.prepared_statements.capacity(), 3);
 
             server
                 .send(
@@ -4491,7 +4426,7 @@ pub mod test {
     #[test]
     fn test_effective_max_age_uses_stored_value() {
         let mut server = Server::default();
-        server.set_max_age(Duration::from_millis(1500));
+        server.max_age = Some(Duration::from_millis(1500));
         let base = Duration::from_secs(60);
         // Stored value wins regardless of the supplied base.
         assert_eq!(Duration::from_millis(1500), server.effective_max_age(base));

--- a/pgdog/src/backend/stats.rs
+++ b/pgdog/src/backend/stats.rs
@@ -364,6 +364,7 @@ impl Stats {
 
     /// Get pool_id (local, no lock).
     #[inline]
+    #[cfg(test)]
     pub fn pool_id(&self) -> u64 {
         self.local.pool_id
     }
@@ -377,12 +378,14 @@ impl Stats {
 
     /// Get total counts (local, no lock).
     #[inline]
+    #[cfg(test)]
     pub fn total(&self) -> Counts {
         self.local.total
     }
 
     /// Get last_checkout counts (local, no lock).
     #[inline]
+    #[cfg(test)]
     pub fn last_checkout(&self) -> Counts {
         self.local.last_checkout
     }

--- a/pgdog/src/frontend/router/parser/aggregate.rs
+++ b/pgdog/src/frontend/router/parser/aggregate.rs
@@ -165,6 +165,7 @@ impl Aggregate {
         &self.group_by
     }
 
+    #[cfg(test)]
     pub fn new_count(column: usize) -> Self {
         Self {
             targets: vec![AggregateTarget {
@@ -176,6 +177,7 @@ impl Aggregate {
         }
     }
 
+    #[cfg(test)]
     pub fn new_count_group_by(column: usize, group_by: &[usize]) -> Self {
         Self {
             targets: vec![AggregateTarget {

--- a/pgdog/src/net/messages/backend_key.rs
+++ b/pgdog/src/net/messages/backend_key.rs
@@ -25,6 +25,7 @@ pub struct SecretKey {
 
 impl SecretKey {
     /// 3.0-compatible secret from a 4-byte integer.
+    #[cfg(test)]
     pub fn legacy(secret: i32) -> Self {
         Self {
             bytes: SmallVec::from_slice(&secret.to_be_bytes()),
@@ -67,10 +68,6 @@ impl SecretKey {
     pub fn constant_time_eq(&self, other: &SecretKey) -> bool {
         crate::util::constant_time_eq(self.as_slice(), other.as_slice())
     }
-
-    pub fn len(&self) -> usize {
-        self.bytes.len()
-    }
 }
 
 /// BackendKeyData (B) — pid + cancel secret on the wire.
@@ -110,6 +107,7 @@ impl BackendKeyData {
         }
     }
 
+    #[cfg(test)]
     pub fn legacy(pid: i32, secret: i32) -> Self {
         Self {
             pid,
@@ -168,7 +166,7 @@ mod tests {
         let key = BackendKeyData::legacy(42, 1234);
         let roundtrip = BackendKeyData::from_bytes(key.to_bytes()).unwrap();
         assert_eq!(roundtrip, key);
-        assert_eq!(roundtrip.secret.len(), 4);
+        assert_eq!(roundtrip.secret.bytes.len(), 4);
     }
 
     #[test]
@@ -179,7 +177,7 @@ mod tests {
         };
         let roundtrip = BackendKeyData::from_bytes(key.to_bytes()).unwrap();
         assert_eq!(roundtrip, key);
-        assert_eq!(roundtrip.secret.len(), 32);
+        assert_eq!(roundtrip.secret.bytes.len(), 32);
     }
 
     #[test]
@@ -190,7 +188,7 @@ mod tests {
         };
         let roundtrip = BackendKeyData::from_bytes(key.to_bytes()).unwrap();
         assert_eq!(roundtrip, key);
-        assert_eq!(roundtrip.secret.len(), 256);
+        assert_eq!(roundtrip.secret.bytes.len(), 256);
     }
 
     #[test]
@@ -198,12 +196,14 @@ mod tests {
         assert_eq!(
             BackendKeyData::new_frontend(ProtocolVersion::V3_0, FrontendPid::new())
                 .secret
+                .bytes
                 .len(),
             4
         );
         assert_eq!(
             BackendKeyData::new_frontend(ProtocolVersion::V3_2, FrontendPid::new())
                 .secret
+                .bytes
                 .len(),
             32
         );

--- a/pgdog/src/net/messages/backend_pid.rs
+++ b/pgdog/src/net/messages/backend_pid.rs
@@ -21,13 +21,6 @@ pub struct BackendPid {
     pub(crate) pid: i32,
 }
 
-impl BackendPid {
-    /// Real Postgres backend pid.
-    pub fn pid(&self) -> i32 {
-        self.pid
-    }
-}
-
 impl From<&BackendKeyData> for BackendPid {
     fn from(key: &BackendKeyData) -> Self {
         Self {

--- a/pgdog/src/net/messages/bind.rs
+++ b/pgdog/src/net/messages/bind.rs
@@ -7,7 +7,6 @@ use super::Vector;
 use super::c_string_bytes;
 use super::code;
 use super::prelude::*;
-use bytes::BytesMut;
 
 use std::fmt::Debug;
 use std::str::from_utf8;
@@ -215,11 +214,6 @@ impl Bind {
         })
     }
 
-    /// Format codes, if any.
-    pub fn codes(&self) -> &[Format] {
-        &self.codes
-    }
-
     pub fn new_statement(name: &str) -> Self {
         Self {
             statement: c_string_bytes(name),
@@ -227,6 +221,7 @@ impl Bind {
         }
     }
 
+    #[cfg(test)]
     pub fn new_params(name: &str, params: &[Parameter]) -> Self {
         Self {
             statement: c_string_bytes(name),
@@ -235,6 +230,7 @@ impl Bind {
         }
     }
 
+    #[cfg(test)]
     pub fn new_name_portal(name: &str, portal: &str) -> Self {
         Self {
             statement: c_string_bytes(name),
@@ -252,6 +248,7 @@ impl Bind {
         }
     }
 
+    #[cfg(test)]
     pub fn new_params_codes_results(
         name: &str,
         params: &[Parameter],
@@ -259,7 +256,7 @@ impl Bind {
         results: &[i16],
     ) -> Self {
         let mut me = Self::new_params_codes(name, params, codes);
-        let mut buf = BytesMut::with_capacity(results.len() * 2);
+        let mut buf = bytes::BytesMut::with_capacity(results.len() * 2);
         for result in results {
             buf.put_i16(*result);
         }
@@ -484,7 +481,7 @@ mod test {
                 },
             ],
             results: {
-                let mut buf = BytesMut::with_capacity(2);
+                let mut buf = bytes::BytesMut::with_capacity(2);
                 buf.put_i16(0);
                 buf.freeze()
             },
@@ -581,7 +578,7 @@ mod test {
         let decoded = Bind::from_bytes(bytes.clone()).unwrap();
 
         assert_eq!(decoded.params_raw().len(), count);
-        assert_eq!(decoded.codes().len(), 0);
+        assert_eq!(decoded.codes.len(), 0);
         assert_eq!(decoded.statement(), "__pgdog_large");
         assert_eq!(bytes.len(), decoded.len());
     }

--- a/pgdog/src/net/messages/close.rs
+++ b/pgdog/src/net/messages/close.rs
@@ -30,6 +30,7 @@ impl Close {
         }
     }
 
+    #[cfg(test)]
     pub fn portal(name: &str) -> Self {
         let mut payload = Payload::named('C');
         payload.put_u8(b'P');

--- a/pgdog/src/net/messages/copy_data.rs
+++ b/pgdog/src/net/messages/copy_data.rs
@@ -24,11 +24,6 @@ impl CopyData {
         }
     }
 
-    /// New copy data from bytes.
-    pub fn bytes(data: Bytes) -> Self {
-        Self { data }
-    }
-
     /// Get copy data.
     pub fn data(&self) -> &[u8] {
         &self.data[..]

--- a/pgdog/src/net/messages/copy_fail.rs
+++ b/pgdog/src/net/messages/copy_fail.rs
@@ -1,4 +1,4 @@
-use super::{c_string_bytes, code, prelude::*};
+use super::{code, prelude::*};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct CopyFail {
@@ -6,9 +6,10 @@ pub struct CopyFail {
 }
 
 impl CopyFail {
+    #[cfg(test)]
     pub fn new(error: impl AsRef<str>) -> Self {
         Self {
-            error: c_string_bytes(error.as_ref()),
+            error: super::c_string_bytes(error.as_ref()),
         }
     }
 }

--- a/pgdog/src/net/messages/describe.rs
+++ b/pgdog/src/net/messages/describe.rs
@@ -94,6 +94,7 @@ impl Describe {
         self.kind() == 'P'
     }
 
+    #[cfg(test)]
     pub fn new_portal(name: &str) -> Describe {
         let mut payload = Payload::named('D');
         payload.put_u8(b'P');

--- a/pgdog/src/net/messages/execute.rs
+++ b/pgdog/src/net/messages/execute.rs
@@ -37,6 +37,7 @@ impl Execute {
         }
     }
 
+    #[cfg(test)]
     pub fn new_portal(name: &str) -> Self {
         let mut payload = Payload::named('E');
         payload.put_string(name);
@@ -49,6 +50,7 @@ impl Execute {
 
     /// Create an Execute message for a named portal with a row limit.
     /// A limit of 0 means fetch all rows.
+    #[cfg(test)]
     pub fn new_portal_limit(name: &str, max_rows: i32) -> Self {
         let mut payload = Payload::named('E');
         payload.put_string(name);
@@ -69,12 +71,6 @@ impl Execute {
             }; // -1 for terminating NULL.
         let buf = &self.payload[start..end];
         from_utf8(buf).unwrap_or("")
-    }
-
-    /// Number of rows to return.
-    pub fn max_rows(&self) -> i32 {
-        let mut buf = &self.payload[5 + self.portal_len..];
-        buf.get_i32()
     }
 
     pub fn len(&self) -> usize {
@@ -118,7 +114,6 @@ mod test {
 
         let execute = Execute::from_bytes(msg).unwrap();
         assert_eq!(execute.portal(), "test");
-        assert_eq!(execute.max_rows(), 25);
 
         let exec = Execute::new_portal("test1");
         assert_eq!(exec.portal(), "test1");

--- a/pgdog/src/net/messages/mod.rs
+++ b/pgdog/src/net/messages/mod.rs
@@ -277,6 +277,8 @@ impl Message {
         self.source
     }
 
+    #[cfg(test)]
+    // FIXME(sage): This and transaction_error should use ReadyForQuery's code
     pub fn in_transaction(&self) -> bool {
         self.code() == 'Z' && matches!(self.payload[5] as char, 'T' | 'E')
     }

--- a/pgdog/src/net/messages/replication/keep_alive.rs
+++ b/pgdog/src/net/messages/replication/keep_alive.rs
@@ -1,8 +1,5 @@
 use bytes::BytesMut;
 
-use crate::net::CopyData;
-use crate::net::replication::ReplicationMeta;
-
 use super::super::code;
 use super::super::prelude::*;
 
@@ -14,10 +11,6 @@ pub struct KeepAlive {
 }
 
 impl KeepAlive {
-    pub fn wrapped(self) -> Result<CopyData, Error> {
-        Ok(CopyData::new(&ReplicationMeta::KeepAlive(self).to_bytes()))
-    }
-
     /// Origin expects reply.
     pub fn reply(&self) -> bool {
         self.reply == 1
@@ -50,6 +43,7 @@ impl ToBytes for KeepAlive {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::net::{CopyData, replication::ReplicationMeta};
 
     #[test]
     fn keep_alive_roundtrip_and_reply_flag() {
@@ -69,7 +63,7 @@ mod tests {
         assert_eq!(decoded.reply, 1);
         assert!(decoded.reply());
 
-        let wrapped = decoded.wrapped().expect("wrap keepalive copydata");
+        let wrapped = CopyData::new(&ReplicationMeta::KeepAlive(decoded).to_bytes());
         let meta = wrapped.replication_meta().expect("decode replication meta");
         matches!(meta, ReplicationMeta::KeepAlive(_))
             .then_some(())

--- a/pgdog/src/net/messages/replication/logical/tuple_data.rs
+++ b/pgdog/src/net/messages/replication/logical/tuple_data.rs
@@ -214,12 +214,6 @@ impl Column {
             },
         }
     }
-
-    /// Get UTF-8 representation of the data,
-    /// if data is encoded with UTF-8.
-    pub fn as_str(&self) -> Option<&str> {
-        from_utf8(&self.data[..]).ok()
-    }
 }
 
 impl FromBytes for TupleData {
@@ -353,11 +347,11 @@ mod test {
         };
         let filled = new.fill_toasted_from(&old).unwrap();
         // col0: from new (unchanged — was present)
-        assert_eq!(filled.columns[0].as_str(), Some("a"));
+        assert_eq!(&*filled.columns[0].data, b"a");
         // col1: from old (was toasted in new)
-        assert_eq!(filled.columns[1].as_str(), Some("b_old"));
+        assert_eq!(&*filled.columns[1].data, b"b_old");
         // col2: from new
-        assert_eq!(filled.columns[2].as_str(), Some("c"));
+        assert_eq!(&*filled.columns[2].data, b"c");
         assert!(
             !filled.has_toasted(),
             "filled tuple must contain no toasted markers"
@@ -374,8 +368,8 @@ mod test {
             columns: vec![text_col("x_old"), text_col("y_old")],
         };
         let filled = new.fill_toasted_from(&old).unwrap();
-        assert_eq!(filled.columns[0].as_str(), Some("x"));
-        assert_eq!(filled.columns[1].as_str(), Some("y"));
+        assert_eq!(&*filled.columns[0].data, b"x");
+        assert_eq!(&*filled.columns[1].data, b"y");
     }
 
     #[test]
@@ -388,8 +382,8 @@ mod test {
             columns: vec![text_col("p"), text_col("q")],
         };
         let filled = new.fill_toasted_from(&old).unwrap();
-        assert_eq!(filled.columns[0].as_str(), Some("p"));
-        assert_eq!(filled.columns[1].as_str(), Some("q"));
+        assert_eq!(&*filled.columns[0].data, b"p");
+        assert_eq!(&*filled.columns[1].data, b"q");
         assert!(!filled.has_toasted());
     }
 


### PR DESCRIPTION
Removed the code entirely if its use in tests was not testing anything useful or the only usage was testing the function itself. Inlined functions when it made sense to do so. `#[cfg(test)]` otherwise