### PR TITLE
fix: use keyless cosign attestations

### DIFF
--- a/.github/actions/sign-and-attest-image/action.yml
+++ b/.github/actions/sign-and-attest-image/action.yml
@@ -1,0 +1,67 @@
+name: Sign and attest image
+description: Keylessly sign an image digest and publish SLSA v1 provenance
+
+inputs:
+  image:
+    description: Fully qualified image digest
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install Cosign
+      uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      with:
+        cosign-release: v3.0.6
+
+    - name: Sign and attest image
+      env:
+        IMAGE: ${{ inputs.image }}
+        BUILDER_ID: https://github.com/${{ github.workflow_ref }}
+        INVOCATION_ID: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
+        REPOSITORY_ID: ${{ github.repository_id }}
+        REPOSITORY_OWNER_ID: ${{ github.repository_owner_id }}
+        RUNNER_ENVIRONMENT: ${{ runner.environment }}
+      run: |
+        workflow="${GITHUB_WORKFLOW_REF#${GITHUB_REPOSITORY}/}"
+        workflow_path="${workflow%@*}"
+        workflow_ref="${GITHUB_WORKFLOW_REF##*@}"
+        jq -n \
+          --arg build_type "https://actions.github.io/buildtypes/workflow/v1" \
+          --arg repository "https://github.com/${GITHUB_REPOSITORY}" \
+          --arg workflow_path "${workflow_path}" \
+          --arg workflow_ref "${workflow_ref}" \
+          --arg source_ref "${GITHUB_REF}" \
+          --arg sha "${GITHUB_SHA}" \
+          --arg event_name "${GITHUB_EVENT_NAME}" \
+          --arg repository_id "${REPOSITORY_ID}" \
+          --arg repository_owner_id "${REPOSITORY_OWNER_ID}" \
+          --arg runner_environment "${RUNNER_ENVIRONMENT}" \
+          --arg builder_id "${BUILDER_ID}" \
+          --arg invocation_id "${INVOCATION_ID}" \
+          '{
+            buildDefinition: {
+              buildType: $build_type,
+              externalParameters: {
+                workflow: {path: $workflow_path, ref: $workflow_ref, repository: $repository}
+              },
+              internalParameters: {github: {
+                event_name: $event_name,
+                repository_id: $repository_id,
+                repository_owner_id: $repository_owner_id,
+                runner_environment: $runner_environment
+              }},
+              resolvedDependencies: [{
+                uri: ("git+" + $repository + "@" + $source_ref),
+                digest: {gitCommit: $sha}
+              }]
+            },
+            runDetails: {
+              builder: {id: $builder_id},
+              metadata: {invocationId: $invocation_id}
+            }
+          }' > provenance.json
+        # Keyless signing records the workflow identity in Sigstore's public transparency log.
+        cosign sign --yes "${IMAGE}"
+        cosign attest --yes --type slsaprovenance1 --predicate provenance.json "${IMAGE}"
+      shell: bash

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -25,7 +25,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      attestations: write
       id-token: write
     steps:
       - name: Checkout repository
@@ -83,12 +82,10 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-      - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v2
+      - name: Sign and attest artifact
+        uses: ./.github/actions/sign-and-attest-image
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
-          subject-digest: ${{ steps.build.outputs.digest }}
-          push-to-registry: true
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
 
   merge:
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -97,7 +94,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      attestations: write
       id-token: write
     steps:
       - name: Checkout repository
@@ -168,12 +164,10 @@ jobs:
             --format '{{json .Manifest}}' | jq -r '.digest')
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
 
-      - name: Generate merged artifact attestation
-        uses: actions/attest-build-provenance@v2
+      - name: Sign and attest merged artifact
+        uses: ./.github/actions/sign-and-attest-image
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
-          subject-digest: ${{ steps.manifest.outputs.digest }}
-          push-to-registry: true
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.manifest.outputs.digest }}
 
       - name: Inspect image
         run: |


### PR DESCRIPTION
# Motivation

Publish verifiable image signatures and SLSA provenance without depending on GitHub's artifact-attestation service, which requires GitHub Enterprise Cloud for private repositories. This provides a reference that can also be used by the private Enterprise and Control image workflows.

# Summary of Changes

- Add a reusable composite action that keylessly signs image digests with Cosign.
- Publish SLSA v1 provenance for architecture manifests and the final multi-architecture index.
- Remove the GitHub-specific `attestations: write` permission while retaining OIDC and package permissions.
- Pin Cosign Installer to the verified v4.1.2 commit and Cosign to v3.0.6.

# Testing

- YAML parsing and `git diff --check` pass locally.
- After a workflow run, verify the final digest with `cosign verify` and `cosign verify-attestation --type slsaprovenance1`, constrained to the package workflow identity and GitHub Actions OIDC issuer.

# Dependencies/Special Considerations

Keyless signing records the repository and workflow identity in Sigstore's public transparency log. This is harmless for this public repository, but should be an explicit decision before copying the action into a private repository.