### PR TITLE
revert: publish artifacts on release

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,7 +1,7 @@
 name: release-binaries
 on:
-  push:
-    tags: ['v*']
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       tag:
@@ -14,8 +14,8 @@ jobs:
     permissions:
       contents: write
     env:
-      # Tag pushes supply ref_name; manual runs use the typed input.
-      TAG: ${{ github.event_name == 'push' && github.ref_name || inputs.tag }}
+      # release event supplies the tag; manual runs use the typed input
+      TAG: ${{ github.event.release.tag_name || inputs.tag }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
GitHub draft releases don't create tags, so this doesn't work. Man, GH is making it so hard to do the right thing.