### PR TITLE
feat: configurable listener backlog to allow more incoming connection requests

### DIFF
--- a/.schema/pgdog.schema.json
+++ b/.schema/pgdog.schema.json
@@ -59,6 +59,7 @@
         "idle_healthcheck_delay": 5000,
         "idle_healthcheck_interval": 30000,
         "idle_timeout": 60000,
+        "listen_backlog": 1024,
         "load_balancing_strategy": "random",
         "load_schema": "auto",
         "log_connections": true,
@@ -877,6 +878,13 @@
           "type": "integer",
           "format": "uint64",
           "default": 60000,
+          "minimum": 0
+        },
+        "listen_backlog": {
+          "description": "Maximum length of the queue of pending (not yet accepted) client connections,\npassed to `listen(2)`. The kernel caps the effective value at `net.core.somaxconn`,\nso raise both together. Increase this to absorb connection storms, e.g. a large\nclient fleet reconnecting at once after a rolling deploy.\n\n**Note:** This setting cannot be changed at runtime.\n\n_Default:_ `1024`\n\n<https://docs.pgdog.dev/configuration/pgdog.toml/general/#listen_backlog>",
+          "type": "integer",
+          "format": "uint32",
+          "default": 1024,
           "minimum": 0
         },
         "load_balancing_strategy": {

--- a/pgdog-config/src/general.rs
+++ b/pgdog-config/src/general.rs
@@ -95,6 +95,19 @@ pub struct General {
     #[serde(default = "General::port")]
     pub port: u16,
 
+    /// Maximum length of the queue of pending (not yet accepted) client connections,
+    /// passed to `listen(2)`. The kernel caps the effective value at `net.core.somaxconn`,
+    /// so raise both together. Increase this to absorb connection storms, e.g. a large
+    /// client fleet reconnecting at once after a rolling deploy.
+    ///
+    /// **Note:** This setting cannot be changed at runtime.
+    ///
+    /// _Default:_ `1024`
+    ///
+    /// <https://docs.pgdog.dev/configuration/pgdog.toml/general/#listen_backlog>
+    #[serde(default = "General::listen_backlog")]
+    pub listen_backlog: u32,
+
     /// Number of Tokio threads to spawn at pooler startup. In multi-core systems, the recommended setting is two (2) per virtual CPU. The value `0` means to spawn no threads and use the current thread runtime.
     ///
     /// **Note:** This setting cannot be changed at runtime.
@@ -887,6 +900,7 @@ impl Default for General {
         Self {
             host: Self::host(),
             port: Self::port(),
+            listen_backlog: Self::listen_backlog(),
             workers: Self::workers(),
             default_pool_size: Self::default_pool_size(),
             min_pool_size: Self::min_pool_size(),
@@ -1043,6 +1057,10 @@ impl General {
 
     pub fn port() -> u16 {
         Self::env_or_default("PGDOG_PORT", 6432)
+    }
+
+    fn listen_backlog() -> u32 {
+        Self::env_or_default("PGDOG_LISTEN_BACKLOG", 1024)
     }
 
     fn workers() -> usize {

--- a/pgdog/src/frontend/listener.rs
+++ b/pgdog/src/frontend/listener.rs
@@ -44,12 +44,7 @@ impl Listener {
     /// silently dropped onto the retransmission timer.
     async fn bind(addr: &str) -> Result<TcpListener, Error> {
         let backlog = config().config.general.listen_backlog;
-        let addr = lookup_host(addr).await?.next().ok_or_else(|| {
-            std::io::Error::new(
-                ErrorKind::AddrNotAvailable,
-                format!("no address to bind: {}", addr),
-            )
-        })?;
+        let addr = Self::first_addr(addr, lookup_host(addr).await?)?;
         let socket = if addr.is_ipv4() {
             TcpSocket::new_v4()?
         } else {
@@ -59,6 +54,19 @@ impl Listener {
         socket.set_reuseaddr(true)?;
         socket.bind(addr)?;
         Ok(socket.listen(backlog)?)
+    }
+
+    /// First resolved address, or `AddrNotAvailable` when resolution yields none.
+    fn first_addr(
+        requested: &str,
+        mut resolved: impl Iterator<Item = SocketAddr>,
+    ) -> Result<SocketAddr, std::io::Error> {
+        resolved.next().ok_or_else(|| {
+            std::io::Error::new(
+                ErrorKind::AddrNotAvailable,
+                format!("no address to bind: {}", requested),
+            )
+        })
     }
 
     /// Listen for client connections and handle them.
@@ -296,5 +304,18 @@ mod test {
     #[tokio::test]
     async fn test_bind_unresolvable_address_errors() {
         assert!(Listener::bind("host.invalid:0").await.is_err());
+    }
+
+    #[test]
+    fn test_first_addr_empty_resolution_errors() {
+        let err = Listener::first_addr("nowhere:0", std::iter::empty()).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::AddrNotAvailable);
+    }
+
+    #[test]
+    fn test_first_addr_takes_first() {
+        let addrs: Vec<SocketAddr> = vec!["127.0.0.1:6432".parse().unwrap()];
+        let addr = Listener::first_addr("localhost:6432", addrs.into_iter()).unwrap();
+        assert!(addr.is_ipv4());
     }
 }

--- a/pgdog/src/frontend/listener.rs
+++ b/pgdog/src/frontend/listener.rs
@@ -274,3 +274,27 @@ impl Listener {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_bind_ipv4_applies_configured_backlog() {
+        let listener = Listener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        assert!(addr.is_ipv4());
+        assert_ne!(addr.port(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_bind_ipv6() {
+        let listener = Listener::bind("[::1]:0").await.unwrap();
+        assert!(listener.local_addr().unwrap().is_ipv6());
+    }
+
+    #[tokio::test]
+    async fn test_bind_unresolvable_address_errors() {
+        assert!(Listener::bind("host.invalid:0").await.is_err());
+    }
+}

--- a/pgdog/src/frontend/listener.rs
+++ b/pgdog/src/frontend/listener.rs
@@ -10,7 +10,7 @@ use crate::net::messages::{FrontendPid, NegotiateProtocolVersion, Startup, hello
 use crate::net::tls::{acceptor, peer_certificate_present, peer_identity};
 use crate::net::{self, Stream, tweak};
 use crate::sighup::Sighup;
-use tokio::net::{TcpListener, TcpStream};
+use tokio::net::{TcpListener, TcpSocket, TcpStream, lookup_host};
 use tokio::signal::ctrl_c;
 use tokio::{select, spawn};
 use tokio_util::sync::CancellationToken;
@@ -36,10 +36,35 @@ impl Listener {
         }
     }
 
+    /// Bind the listening socket with the configured `listen_backlog`.
+    ///
+    /// `TcpListener::bind` hardcodes a backlog of 1024, which caps the queue of
+    /// pending connections regardless of `net.core.somaxconn`; large client fleets
+    /// reconnecting at once (e.g. a rolling deploy) overflow it and their SYNs are
+    /// silently dropped onto the retransmission timer.
+    async fn bind(addr: &str) -> Result<TcpListener, Error> {
+        let backlog = config().config.general.listen_backlog;
+        let addr = lookup_host(addr).await?.next().ok_or_else(|| {
+            std::io::Error::new(
+                ErrorKind::AddrNotAvailable,
+                format!("no address to bind: {}", addr),
+            )
+        })?;
+        let socket = if addr.is_ipv4() {
+            TcpSocket::new_v4()?
+        } else {
+            TcpSocket::new_v6()?
+        };
+        #[cfg(not(windows))]
+        socket.set_reuseaddr(true)?;
+        socket.bind(addr)?;
+        Ok(socket.listen(backlog)?)
+    }
+
     /// Listen for client connections and handle them.
     pub(crate) async fn listen(&mut self) -> Result<(), Error> {
         info!("🐕 PgDog listening on {}", self.addr);
-        let listener = TcpListener::bind(&self.addr).await?;
+        let listener = Self::bind(&self.addr).await?;
         let shutdown_signal = comms().shutting_down();
         let mut sighup = Sighup::new()?;
         let mut shutting_down = false;

--- a/pgdog/src/frontend/listener.rs
+++ b/pgdog/src/frontend/listener.rs
@@ -44,29 +44,36 @@ impl Listener {
     /// silently dropped onto the retransmission timer.
     async fn bind(addr: &str) -> Result<TcpListener, Error> {
         let backlog = config().config.general.listen_backlog;
-        let addr = Self::first_addr(addr, lookup_host(addr).await?)?;
-        let socket = if addr.is_ipv4() {
-            TcpSocket::new_v4()?
-        } else {
-            TcpSocket::new_v6()?
-        };
-        #[cfg(not(windows))]
-        socket.set_reuseaddr(true)?;
-        socket.bind(addr)?;
-        Ok(socket.listen(backlog)?)
+        Ok(Self::bind_first(lookup_host(addr).await?, backlog, addr)?)
     }
 
-    /// First resolved address, or `AddrNotAvailable` when resolution yields none.
-    fn first_addr(
+    /// Bind to the first candidate address that accepts the bind, like
+    /// `TcpListener::bind` does, but with a configurable listen backlog.
+    fn bind_first(
+        candidates: impl Iterator<Item = SocketAddr>,
+        backlog: u32,
         requested: &str,
-        mut resolved: impl Iterator<Item = SocketAddr>,
-    ) -> Result<SocketAddr, std::io::Error> {
-        resolved.next().ok_or_else(|| {
+    ) -> Result<TcpListener, std::io::Error> {
+        let mut last_err = None;
+        for addr in candidates {
+            let socket = if addr.is_ipv4() {
+                TcpSocket::new_v4()?
+            } else {
+                TcpSocket::new_v6()?
+            };
+            #[cfg(not(windows))]
+            socket.set_reuseaddr(true)?;
+            match socket.bind(addr) {
+                Ok(()) => return socket.listen(backlog),
+                Err(err) => last_err = Some(err),
+            }
+        }
+        Err(last_err.unwrap_or_else(|| {
             std::io::Error::new(
                 ErrorKind::AddrNotAvailable,
                 format!("no address to bind: {}", requested),
             )
-        })
+        }))
     }
 
     /// Listen for client connections and handle them.
@@ -307,15 +314,26 @@ mod test {
     }
 
     #[test]
-    fn test_first_addr_empty_resolution_errors() {
-        let err = Listener::first_addr("nowhere:0", std::iter::empty()).unwrap_err();
+    fn test_bind_first_empty_resolution_errors() {
+        let err = Listener::bind_first(std::iter::empty(), 1024, "nowhere:0").unwrap_err();
         assert_eq!(err.kind(), ErrorKind::AddrNotAvailable);
     }
 
-    #[test]
-    fn test_first_addr_takes_first() {
-        let addrs: Vec<SocketAddr> = vec!["127.0.0.1:6432".parse().unwrap()];
-        let addr = Listener::first_addr("localhost:6432", addrs.into_iter()).unwrap();
-        assert!(addr.is_ipv4());
+    #[tokio::test]
+    async fn test_bind_first_falls_back_to_next_candidate() {
+        // 198.51.100.1 (TEST-NET-2) is not a local interface, so the bind
+        // fails and the next candidate is tried, matching TcpListener::bind.
+        let candidates: Vec<SocketAddr> = vec![
+            "198.51.100.1:0".parse().unwrap(),
+            "127.0.0.1:0".parse().unwrap(),
+        ];
+        let listener = Listener::bind_first(candidates.into_iter(), 1024, "test:0").unwrap();
+        assert!(listener.local_addr().unwrap().ip().is_loopback());
+    }
+
+    #[tokio::test]
+    async fn test_bind_first_reports_last_bind_error() {
+        let candidates: Vec<SocketAddr> = vec!["198.51.100.1:0".parse().unwrap()];
+        assert!(Listener::bind_first(candidates.into_iter(), 1024, "test:0").is_err());
     }
 }


### PR DESCRIPTION
## Problem

`Listener::listen` binds via `TcpListener::bind`, which hardcodes `listen(1024)`. The accept queue is therefore capped at 1024 pending connections regardless of `net.core.somaxconn`. Raising the sysctl has no effect past the application's own argument.

For deployments where clients open a connection per request (e.g. Django with `CONN_MAX_AGE=0` behind PgDog), a rolling deploy of a large client fleet reconnects everyone at once. With `tcp_abort_on_overflow=0` (the Linux default), overflowed handshakes are silently dropped.

## Change

New `[general]` setting `listen_backlog`, default to 1024.

The kernel still caps the effective value at `net.core.somaxconn`, so operators raise both together; the doc comment says so.
