### PR TITLE
feat: support SCRAM-SHA-256-PLUS for client connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4098,7 +4098,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "scram"
 version = "0.6.0"
-source = "git+https://github.com/abnegate/scram.git?rev=b641be3932a3e4b24705aa3a6848d4aa0e8d2fa9#b641be3932a3e4b24705aa3a6848d4aa0e8d2fa9"
+source = "git+https://github.com/pgdogdev/scram.git?rev=ee15a47f1051dc79589e8db666be7014c1e23fba#ee15a47f1051dc79589e8db666be7014c1e23fba"
 dependencies = [
  "aws-lc-rs",
  "base64 0.13.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4098,7 +4098,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "scram"
 version = "0.6.0"
-source = "git+https://github.com/pgdogdev/scram.git?rev=053e108210a35232efe60023ec43288fd601d8c4#053e108210a35232efe60023ec43288fd601d8c4"
+source = "git+https://github.com/abnegate/scram.git?rev=b641be3932a3e4b24705aa3a6848d4aa0e8d2fa9#b641be3932a3e4b24705aa3a6848d4aa0e8d2fa9"
 dependencies = [
  "aws-lc-rs",
  "base64 0.13.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2439,8 +2439,10 @@ dependencies = [
  "chrono",
  "futures-util",
  "libc",
+ "native-tls",
  "ordered-float",
  "parking_lot",
+ "postgres-native-tls",
  "rand 0.9.4",
  "reqwest",
  "rust_decimal",
@@ -3394,6 +3396,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "postgres-native-tls"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fef4de47bb81477e0c3deaf153a1b10ae176484713ff1640969f4cb96b653ebc"
+dependencies = [
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-postgres",
 ]
 
 [[package]]
@@ -4901,6 +4915,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]

--- a/integration/rust/Cargo.toml
+++ b/integration/rust/Cargo.toml
@@ -8,6 +8,8 @@ test = true
 
 [dependencies]
 tokio-postgres = {version = "0.7.13", features = ["with-uuid-1"]}
+postgres-native-tls = "0.5"
+native-tls = "0.2"
 sqlx = { version = "0.8.6", features = ["postgres", "runtime-tokio", "tls-native-tls", "bigdecimal", "chrono", "json", "rust_decimal"]}
 tokio = { version = "1", features = ["full"]}
 futures-util.workspace = true

--- a/integration/rust/tests/integration/mod.rs
+++ b/integration/rust/tests/integration/mod.rs
@@ -31,6 +31,7 @@ pub mod reset;
 pub mod rewrite;
 pub mod rewrite_omni;
 pub mod savepoint;
+pub mod scram_plus;
 pub mod set_config;
 pub mod set_in_transaction;
 pub mod set_sharding_key;

--- a/integration/rust/tests/integration/scram_plus.rs
+++ b/integration/rust/tests/integration/scram_plus.rs
@@ -1,0 +1,99 @@
+use crate::setup::admin_sqlx;
+use native_tls::TlsConnector;
+use postgres_native_tls::MakeTlsConnector;
+use serial_test::serial;
+use sqlx::Executor;
+use tokio_postgres::{
+    Client, SimpleQueryMessage,
+    config::{ChannelBinding, SslMode},
+};
+
+fn make_tls() -> MakeTlsConnector {
+    let connector = TlsConnector::builder()
+        .danger_accept_invalid_certs(true)
+        .danger_accept_invalid_hostnames(true)
+        .build()
+        .expect("native-tls connector");
+    MakeTlsConnector::new(connector)
+}
+
+async fn connect(
+    user: &str,
+    password: &str,
+    channel_binding: ChannelBinding,
+) -> Result<Client, tokio_postgres::Error> {
+    let mut config = tokio_postgres::Config::new();
+    config
+        .host("127.0.0.1")
+        .port(6432)
+        .user(user)
+        .password(password)
+        .dbname("pgdog")
+        .ssl_mode(SslMode::Require)
+        .channel_binding(channel_binding);
+
+    let (client, connection) = config.connect(make_tls()).await?;
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+    Ok(client)
+}
+
+async fn select_one(client: &Client) {
+    let messages = client.simple_query("SELECT 1").await.unwrap();
+    let row = messages.iter().find_map(|message| match message {
+        SimpleQueryMessage::Row(row) => Some(row),
+        _ => None,
+    });
+    let row = row.expect("SELECT 1 returned a row");
+    assert_eq!(row.get(0), Some("1"));
+}
+
+#[tokio::test]
+#[serial]
+async fn rust_client_requires_plus_on_tls() {
+    admin_sqlx().await.execute("RELOAD").await.unwrap();
+
+    let client = connect("pgdog", "pgdog", ChannelBinding::Require)
+        .await
+        .expect("tokio-postgres channel_binding=require must complete PLUS");
+    select_one(&client).await;
+}
+
+#[tokio::test]
+#[serial]
+async fn rust_client_requires_plus_with_hashed_password() {
+    admin_sqlx().await.execute("RELOAD").await.unwrap();
+
+    let client = connect("pgdog_hashed", "pgdog", ChannelBinding::Require)
+        .await
+        .expect("hashed SCRAM user must complete PLUS");
+    select_one(&client).await;
+}
+
+#[tokio::test]
+#[serial]
+async fn rust_client_require_plus_rejects_wrong_password() {
+    admin_sqlx().await.execute("RELOAD").await.unwrap();
+
+    let err = connect("pgdog", "wrong", ChannelBinding::Require)
+        .await
+        .err()
+        .expect("wrong password must fail PLUS");
+    let err = err.to_string();
+    assert!(
+        err.contains("password for user") || err.contains("authentication"),
+        "unexpected PLUS failure: {err}"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn rust_client_can_disable_channel_binding_over_tls() {
+    admin_sqlx().await.execute("RELOAD").await.unwrap();
+
+    let client = connect("pgdog", "pgdog", ChannelBinding::Disable)
+        .await
+        .expect("channel_binding=disable over TLS must still use SCRAM-SHA-256");
+    select_one(&client).await;
+}

--- a/integration/rust/tests/integration/scram_plus.rs
+++ b/integration/rust/tests/integration/scram_plus.rs
@@ -78,8 +78,7 @@ async fn rust_client_require_plus_rejects_wrong_password() {
 
     let err = connect("pgdog", "wrong", ChannelBinding::Require)
         .await
-        .err()
-        .expect("wrong password must fail PLUS");
+        .expect_err("wrong password must fail PLUS");
     let err = err.to_string();
     assert!(
         err.contains("password for user") || err.contains("authentication"),

--- a/integration/rust/tests/integration/scram_plus.rs
+++ b/integration/rust/tests/integration/scram_plus.rs
@@ -76,14 +76,9 @@ async fn rust_client_requires_plus_with_hashed_password() {
 async fn rust_client_require_plus_rejects_wrong_password() {
     admin_sqlx().await.execute("RELOAD").await.unwrap();
 
-    let err = connect("pgdog", "wrong", ChannelBinding::Require)
+    connect("pgdog", "wrong", ChannelBinding::Require)
         .await
         .expect_err("wrong password must fail PLUS");
-    let err = err.to_string();
-    assert!(
-        err.contains("password for user") || err.contains("authentication"),
-        "unexpected PLUS failure: {err}"
-    );
 }
 
 #[tokio::test]

--- a/pgdog/Cargo.toml
+++ b/pgdog/Cargo.toml
@@ -41,7 +41,7 @@ tokio-util = { version = "0.7", features = ["rt"] }
 fnv = "1"
 itoa = "1"
 ryu = "1"
-scram = { git = "https://github.com/abnegate/scram.git", rev = "b641be3932a3e4b24705aa3a6848d4aa0e8d2fa9" }
+scram = { git = "https://github.com/pgdogdev/scram.git", rev = "ee15a47f1051dc79589e8db666be7014c1e23fba" }
 base64 = "0.22"
 md5 = "0.7"
 futures = "0.3"

--- a/pgdog/Cargo.toml
+++ b/pgdog/Cargo.toml
@@ -41,7 +41,7 @@ tokio-util = { version = "0.7", features = ["rt"] }
 fnv = "1"
 itoa = "1"
 ryu = "1"
-scram = { git = "https://github.com/pgdogdev/scram.git", rev = "053e108210a35232efe60023ec43288fd601d8c4" }
+scram = { git = "https://github.com/abnegate/scram.git", rev = "b641be3932a3e4b24705aa3a6848d4aa0e8d2fa9" }
 base64 = "0.22"
 md5 = "0.7"
 futures = "0.3"

--- a/pgdog/src/auth/scram/server.rs
+++ b/pgdog/src/auth/scram/server.rs
@@ -434,6 +434,13 @@ mod tests {
         Authentication::from_bytes(message.to_bytes()).expect("parse auth")
     }
 
+    fn sasl_continue(auth: Authentication) -> Option<String> {
+        match auth {
+            Authentication::SaslContinue(data) => Some(data),
+            _ => None,
+        }
+    }
+
     fn spawn_handle(
         mut stream: Stream,
         cbind: &[u8],
@@ -465,9 +472,7 @@ mod tests {
             .await
             .unwrap();
 
-        let Authentication::SaslContinue(data) = read_auth(&mut client_stream).await else {
-            panic!("expected SaslContinue");
-        };
+        let data = sasl_continue(read_auth(&mut client_stream).await).expect("SaslContinue");
         let scram_client = scram_client
             .handle_server_first(&data)
             .expect("server first");
@@ -575,9 +580,7 @@ mod tests {
             .await
             .unwrap();
 
-        let Authentication::SaslContinue(data) = read_auth(&mut client_stream).await else {
-            panic!("expected SaslContinue");
-        };
+        let data = sasl_continue(read_auth(&mut client_stream).await).expect("SaslContinue");
         client.server_first(&data).expect("server first");
         client_stream
             .send_flush(&Password::PasswordMessage {
@@ -592,5 +595,168 @@ mod tests {
             .expect("join")
             .expect("handle");
         assert!(ok);
+    }
+
+    #[test]
+    fn sasl_continue_none_unless_continue() {
+        assert_eq!(sasl_continue(Authentication::Ok), None);
+        assert_eq!(
+            sasl_continue(Authentication::SaslContinue("r=nonce".into())).as_deref(),
+            Some("r=nonce")
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_rejects_non_sasl_initial() {
+        let (mut server_stream, mut client_stream) = connected_pair().await;
+        client_stream
+            .send_flush(&Password::new_password("pgdog"))
+            .await
+            .unwrap();
+
+        let ok = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            hashed_server().handle(&mut server_stream),
+        )
+        .await
+        .expect("non-SASL initial must fail without waiting for a proof")
+        .expect("handle");
+        assert!(!ok);
+    }
+
+    #[tokio::test]
+    async fn handle_rejects_error_response() {
+        let (mut server_stream, mut client_stream) = connected_pair().await;
+        client_stream
+            .send_flush(&ErrorResponse::syntax("client aborted"))
+            .await
+            .unwrap();
+
+        let ok = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            hashed_server().handle(&mut server_stream),
+        )
+        .await
+        .expect("ErrorResponse must fail without waiting for a proof")
+        .expect("handle");
+        assert!(!ok);
+    }
+
+    #[tokio::test]
+    async fn handle_plus_rejects_wrong_password() {
+        let cb_data = b"tls-server-end-point-bytes";
+        let (server_stream, mut client_stream) = connected_pair().await;
+        let task = spawn_handle(server_stream, cb_data);
+
+        let scram_client = scram::ScramClient::new_with_channel_binding(
+            "user",
+            "wrong",
+            None,
+            "tls-server-end-point",
+            cb_data.to_vec(),
+        );
+        let (scram_client, client_first) = scram_client.client_first();
+        client_stream
+            .send_flush(&Password::SASLInitialResponse {
+                name: Authentication::SCRAM_SHA_256_PLUS.to_string(),
+                response: client_first,
+            })
+            .await
+            .unwrap();
+
+        let data = sasl_continue(read_auth(&mut client_stream).await).expect("SaslContinue");
+        let scram_client = scram_client
+            .handle_server_first(&data)
+            .expect("server first");
+        let (_scram_client, client_final) = scram_client.client_final();
+        client_stream
+            .send_flush(&Password::PasswordMessage {
+                response: client_final,
+            })
+            .await
+            .unwrap();
+
+        let ok = tokio::time::timeout(std::time::Duration::from_secs(5), task)
+            .await
+            .expect("wrong-password PLUS handshake timed out")
+            .expect("join")
+            .expect("handle");
+        assert!(!ok);
+    }
+
+    #[tokio::test]
+    async fn handle_plain_plus_accepts_correct_password() {
+        let cb_data = b"tls-server-end-point-bytes";
+        let (mut server_stream, mut client_stream) = connected_pair().await;
+        server_stream.set_tls_server_end_point(cb_data.to_vec());
+        let server = Server::new(&[PasswordKind::Plain("pgdog".to_string())]);
+        let task = tokio::spawn(async move { server.handle(&mut server_stream).await });
+
+        let scram_client = scram::ScramClient::new_with_channel_binding(
+            "user",
+            "pgdog",
+            None,
+            "tls-server-end-point",
+            cb_data.to_vec(),
+        );
+        let (scram_client, client_first) = scram_client.client_first();
+        client_stream
+            .send_flush(&Password::SASLInitialResponse {
+                name: Authentication::SCRAM_SHA_256_PLUS.to_string(),
+                response: client_first,
+            })
+            .await
+            .unwrap();
+
+        let data = sasl_continue(read_auth(&mut client_stream).await).expect("SaslContinue");
+        let scram_client = scram_client
+            .handle_server_first(&data)
+            .expect("server first");
+        let (_scram_client, client_final) = scram_client.client_final();
+        client_stream
+            .send_flush(&Password::PasswordMessage {
+                response: client_final,
+            })
+            .await
+            .unwrap();
+
+        let ok = tokio::time::timeout(std::time::Duration::from_secs(5), task)
+            .await
+            .expect("plain PLUS handshake timed out")
+            .expect("join")
+            .expect("handle");
+        assert!(ok);
+    }
+
+    #[tokio::test]
+    async fn handle_rejects_sasl_initial_as_client_final() {
+        let cb_data = b"tls-server-end-point-bytes";
+        let (server_stream, mut client_stream) = connected_pair().await;
+        let task = spawn_handle(server_stream, cb_data);
+
+        let mut client = Client::new("user", "pgdog");
+        client_stream
+            .send_flush(&Password::SASLInitialResponse {
+                name: Authentication::SCRAM_SHA_256.to_string(),
+                response: client.first().expect("client first"),
+            })
+            .await
+            .unwrap();
+
+        let _data = sasl_continue(read_auth(&mut client_stream).await).expect("SaslContinue");
+        client_stream
+            .send_flush(&Password::SASLInitialResponse {
+                name: Authentication::SCRAM_SHA_256.to_string(),
+                response: "n,,n=user,r=nonce".to_string(),
+            })
+            .await
+            .unwrap();
+
+        let ok = tokio::time::timeout(std::time::Duration::from_secs(5), task)
+            .await
+            .expect("client-final SASLInitial must fail without hanging")
+            .expect("join")
+            .expect("handle");
+        assert!(!ok);
     }
 }

--- a/pgdog/src/auth/scram/server.rs
+++ b/pgdog/src/auth/scram/server.rs
@@ -147,14 +147,15 @@ impl Server {
         provider: P,
         plus: bool,
         cbind: Option<Vec<u8>>,
-    ) -> ScramServer<P> {
+    ) -> Result<ScramServer<P>, Error> {
         match (plus, cbind) {
-            (true, Some(data)) => ScramServer::new_with_channel_binding(
+            (true, Some(data)) => Ok(ScramServer::new_with_channel_binding(
                 provider,
                 "tls-server-end-point".to_string(),
                 data,
-            ),
-            _ => ScramServer::new(provider),
+            )),
+            (true, None) => Err(Error::UnexpectedMessage('p')),
+            (false, _) => Ok(ScramServer::new(provider)),
         }
     }
 
@@ -176,9 +177,13 @@ impl Server {
         }
 
         let cbind = stream.tls_server_end_point().map(ToOwned::to_owned);
+        if cbind.is_some() && client_response.starts_with("y,") {
+            return Ok(false);
+        }
+
         let scram = match self.provider {
-            Provider::Plain(plain) => Scram::Plain(Self::scram_server(plain, plus, cbind)),
-            Provider::Hashed(hashed) => Scram::Hashed(Self::scram_server(hashed, plus, cbind)),
+            Provider::Plain(plain) => Scram::Plain(Self::scram_server(plain, plus, cbind)?),
+            Provider::Hashed(hashed) => Scram::Hashed(Self::scram_server(hashed, plus, cbind)?),
         };
 
         let (scram_final, reply) = match &scram {
@@ -335,7 +340,8 @@ mod tests {
         let provider = HashedPassword {
             hash: hash.to_string(),
         };
-        let scram_server = Server::scram_server(provider, true, Some(cb_data.to_vec()));
+        let scram_server = Server::scram_server(provider, true, Some(cb_data.to_vec()))
+            .expect("PLUS server requires cbind");
         let scram_client = scram::ScramClient::new_with_channel_binding(
             "user",
             password,
@@ -395,5 +401,152 @@ mod tests {
             scram_login("user", "wrong", &hash),
             AuthenticationStatus::NotAuthenticated,
         );
+    }
+
+    #[test]
+    fn scram_server_plus_without_cbind_errors() {
+        let provider = HashedPassword {
+            hash: SCRAM_HASH.to_string(),
+        };
+        assert!(matches!(
+            Server::scram_server(provider, true, None),
+            Err(Error::UnexpectedMessage('p'))
+        ));
+    }
+
+    async fn connected_pair() -> (Stream, Stream) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let peer = tokio::spawn(async move { tokio::net::TcpStream::connect(addr).await.unwrap() });
+        let (ours, _) = listener.accept().await.unwrap();
+        (
+            Stream::plain(ours, 4096),
+            Stream::plain(peer.await.unwrap(), 4096),
+        )
+    }
+
+    fn hashed_server() -> Server {
+        Server::new(&[PasswordKind::Hashed(SCRAM_HASH.to_string())])
+    }
+
+    async fn read_auth(stream: &mut Stream) -> Authentication {
+        let message = stream.read().await.expect("auth message");
+        Authentication::from_bytes(message.to_bytes()).expect("parse auth")
+    }
+
+    fn spawn_handle(
+        mut stream: Stream,
+        cbind: &[u8],
+    ) -> tokio::task::JoinHandle<Result<bool, Error>> {
+        stream.set_tls_server_end_point(cbind.to_vec());
+        let server = hashed_server();
+        tokio::spawn(async move { server.handle(&mut stream).await })
+    }
+
+    #[tokio::test]
+    async fn handle_plus_accepts_correct_password() {
+        let cb_data = b"tls-server-end-point-bytes";
+        let (server_stream, mut client_stream) = connected_pair().await;
+        let task = spawn_handle(server_stream, cb_data);
+
+        let scram_client = scram::ScramClient::new_with_channel_binding(
+            "user",
+            "pgdog",
+            None,
+            "tls-server-end-point",
+            cb_data.to_vec(),
+        );
+        let (scram_client, client_first) = scram_client.client_first();
+        client_stream
+            .send_flush(&Password::SASLInitialResponse {
+                name: Authentication::SCRAM_SHA_256_PLUS.to_string(),
+                response: client_first,
+            })
+            .await
+            .unwrap();
+
+        let Authentication::SaslContinue(data) = read_auth(&mut client_stream).await else {
+            panic!("expected SaslContinue");
+        };
+        let scram_client = scram_client
+            .handle_server_first(&data)
+            .expect("server first");
+        let (_scram_client, client_final) = scram_client.client_final();
+        client_stream
+            .send_flush(&Password::PasswordMessage {
+                response: client_final,
+            })
+            .await
+            .unwrap();
+
+        let ok = tokio::time::timeout(std::time::Duration::from_secs(5), task)
+            .await
+            .expect("PLUS handshake timed out")
+            .expect("join")
+            .expect("handle");
+        assert!(ok);
+    }
+
+    #[tokio::test]
+    async fn handle_rejects_y_when_cbind_present() {
+        let (mut server_stream, mut client_stream) = connected_pair().await;
+        server_stream.set_tls_server_end_point(b"tls-server-end-point-bytes".to_vec());
+
+        client_stream
+            .send_flush(&Password::SASLInitialResponse {
+                name: Authentication::SCRAM_SHA_256.to_string(),
+                response: "y,,n=user,r=nonce".to_string(),
+            })
+            .await
+            .unwrap();
+
+        let ok = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            hashed_server().handle(&mut server_stream),
+        )
+        .await
+        .expect("y downgrade must fail without waiting for a proof")
+        .expect("handle");
+        assert!(!ok);
+    }
+
+    #[tokio::test]
+    async fn handle_sha256_n_succeeds_with_cbind() {
+        let cb_data = b"tls-server-end-point-bytes";
+        let (server_stream, mut client_stream) = connected_pair().await;
+        let task = spawn_handle(server_stream, cb_data);
+
+        let mut client = Client::new("user", "pgdog");
+        let client_first = client.first().expect("client first");
+        assert!(
+            client_first.starts_with("n,,"),
+            "non-PLUS client first must use GS2 n: {client_first}"
+        );
+
+        client_stream
+            .send_flush(&Password::SASLInitialResponse {
+                name: Authentication::SCRAM_SHA_256.to_string(),
+                response: client_first,
+            })
+            .await
+            .unwrap();
+
+        let Authentication::SaslContinue(data) = read_auth(&mut client_stream).await else {
+            panic!("expected SaslContinue");
+        };
+        client.server_first(&data).expect("server first");
+        client_stream
+            .send_flush(&Password::PasswordMessage {
+                response: client.last().expect("client final"),
+            })
+            .await
+            .unwrap();
+
+        let ok = tokio::time::timeout(std::time::Duration::from_secs(5), task)
+            .await
+            .expect("n handshake timed out")
+            .expect("join")
+            .expect("handle");
+        assert!(ok);
     }
 }

--- a/pgdog/src/auth/scram/server.rs
+++ b/pgdog/src/auth/scram/server.rs
@@ -488,6 +488,50 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn handle_plus_without_cbind_refuses() {
+        let (mut server_stream, mut client_stream) = connected_pair().await;
+        client_stream
+            .send_flush(&Password::SASLInitialResponse {
+                name: Authentication::SCRAM_SHA_256_PLUS.to_string(),
+                response: "p=tls-server-end-point,,n=user,r=nonce".to_string(),
+            })
+            .await
+            .unwrap();
+
+        let ok = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            hashed_server().handle(&mut server_stream),
+        )
+        .await
+        .expect("PLUS without cbind must fail without waiting for a proof")
+        .expect("handle");
+        assert!(!ok);
+    }
+
+    #[tokio::test]
+    async fn handle_unknown_mechanism_refuses() {
+        let (mut server_stream, mut client_stream) = connected_pair().await;
+        server_stream.set_tls_server_end_point(b"tls-server-end-point-bytes".to_vec());
+
+        client_stream
+            .send_flush(&Password::SASLInitialResponse {
+                name: "SCRAM-SHA-1".to_string(),
+                response: "n,,n=user,r=nonce".to_string(),
+            })
+            .await
+            .unwrap();
+
+        let ok = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            hashed_server().handle(&mut server_stream),
+        )
+        .await
+        .expect("unknown mechanism must fail without waiting for a proof")
+        .expect("handle");
+        assert!(!ok);
+    }
+
+    #[tokio::test]
     async fn handle_rejects_y_when_cbind_present() {
         let (mut server_stream, mut client_stream) = connected_pair().await;
         server_stream.set_tls_server_end_point(b"tls-server-end-point-bytes".to_vec());

--- a/pgdog/src/auth/scram/server.rs
+++ b/pgdog/src/auth/scram/server.rs
@@ -143,18 +143,42 @@ impl Server {
         }
     }
 
+    fn scram_server<P: AuthenticationProvider>(
+        provider: P,
+        plus: bool,
+        cbind: Option<Vec<u8>>,
+    ) -> ScramServer<P> {
+        match (plus, cbind) {
+            (true, Some(data)) => ScramServer::new_with_channel_binding(
+                provider,
+                "tls-server-end-point".to_string(),
+                data,
+            ),
+            _ => ScramServer::new(provider),
+        }
+    }
+
     /// Handle authentication.
     pub(crate) async fn handle(self, stream: &mut Stream) -> Result<bool, Error> {
-        let scram = match self.provider {
-            Provider::Plain(plain) => Scram::Plain(ScramServer::new(plain)),
-            Provider::Hashed(hashed) => Scram::Hashed(ScramServer::new(hashed)),
-        };
-
         // SASLInitialResponse / client-first phase.
-        let client_response = match Self::read_password(stream).await? {
-            Some(Password::SASLInitialResponse { response, .. }) => response,
+        let (mechanism, client_response) = match Self::read_password(stream).await? {
+            Some(Password::SASLInitialResponse { name, response }) => (name, response),
             Some(_) => return Ok(false),
             None => return Ok(false),
+        };
+
+        let plus = mechanism == Authentication::SCRAM_SHA_256_PLUS;
+        if plus && stream.tls_server_end_point().is_none() {
+            return Ok(false);
+        }
+        if !plus && mechanism != Authentication::SCRAM_SHA_256 {
+            return Ok(false);
+        }
+
+        let cbind = stream.tls_server_end_point().map(ToOwned::to_owned);
+        let scram = match self.provider {
+            Provider::Plain(plain) => Scram::Plain(Self::scram_server(plain, plus, cbind)),
+            Provider::Hashed(hashed) => Scram::Hashed(Self::scram_server(hashed, plus, cbind)),
         };
 
         let (scram_final, reply) = match &scram {
@@ -304,6 +328,60 @@ mod tests {
         assert_eq!(
             scram_login("user", "pgdog", &hash),
             AuthenticationStatus::Authenticated,
+        );
+    }
+
+    fn scram_plus_login(password: &str, hash: &str, cb_data: &[u8]) -> AuthenticationStatus {
+        let provider = HashedPassword {
+            hash: hash.to_string(),
+        };
+        let scram_server = Server::scram_server(provider, true, Some(cb_data.to_vec()));
+        let scram_client = scram::ScramClient::new_with_channel_binding(
+            "user",
+            password,
+            None,
+            "tls-server-end-point",
+            cb_data.to_vec(),
+        );
+
+        let (scram_client, client_first) = scram_client.client_first();
+        let server_first_state = scram_server
+            .handle_client_first(&client_first)
+            .expect("server handle client first");
+        let (server_client_final, server_first_msg) = server_first_state.server_first();
+        let scram_client = scram_client
+            .handle_server_first(&server_first_msg)
+            .expect("client handle server first");
+        let (scram_client, client_final) = scram_client.client_final();
+        let server_final = server_client_final
+            .handle_client_final(&client_final)
+            .expect("server handle client final");
+        let (status, server_final_msg) = server_final.server_final();
+
+        if status == AuthenticationStatus::Authenticated {
+            scram_client
+                .handle_server_final(&server_final_msg)
+                .expect("client verify server final");
+        }
+
+        status
+    }
+
+    #[test]
+    fn hashed_scram_plus_accepts_correct_password() {
+        let cb_data = b"tls-server-end-point-bytes";
+        assert_eq!(
+            scram_plus_login("pgdog", SCRAM_HASH, cb_data),
+            AuthenticationStatus::Authenticated,
+        );
+    }
+
+    #[test]
+    fn hashed_scram_plus_rejects_wrong_password() {
+        let cb_data = b"tls-server-end-point-bytes";
+        assert_eq!(
+            scram_plus_login("wrong", SCRAM_HASH, cb_data),
+            AuthenticationStatus::NotAuthenticated,
         );
     }
 

--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -286,7 +286,8 @@ impl Server {
                     Ok(tls_stream) => {
                         debug!("TLS handshake successful with {}", addr.host);
                         let cipher = tokio_rustls::TlsStream::Client(tls_stream);
-                        stream = Stream::tls(cipher, config.config.memory.net_buffer, None, false);
+                        stream =
+                            Stream::tls(cipher, config.config.memory.net_buffer, None, false, None);
                     }
                     Err(e) => {
                         error!("TLS handshake failed with {:?} [{}]", e, addr);

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -26,7 +26,7 @@ use crate::config::{self, AuthType, ConfigAndUsers, config};
 use crate::frontend::ClientComms;
 use crate::net::messages::{
     Authentication, BackendKeyData, ErrorResponse, FromBytes, FrontendPid, Message, Password,
-    Protocol, ProtocolVersion, ReadyForQuery, ToBytes,
+    Protocol, ProtocolVersion, ReadyForQuery, ToBytes, scram_challenge,
 };
 use crate::net::{MessageBuffer, ProtocolMessage, Stream, parameter::Parameters};
 use crate::state::State;
@@ -203,11 +203,7 @@ impl Client {
             }
 
             AuthType::Scram => {
-                let challenge = if stream.tls_server_end_point().is_some() {
-                    Authentication::scram_plus()
-                } else {
-                    Authentication::scram()
-                };
+                let challenge = scram_challenge(stream.tls_server_end_point());
                 stream.send_flush(&challenge).await?;
 
                 let scram = Server::new(passwords);

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -203,7 +203,12 @@ impl Client {
             }
 
             AuthType::Scram => {
-                stream.send_flush(&Authentication::scram()).await?;
+                let challenge = if stream.tls_server_end_point().is_some() {
+                    Authentication::scram_plus()
+                } else {
+                    Authentication::scram()
+                };
+                stream.send_flush(&challenge).await?;
 
                 let scram = Server::new(passwords);
                 let res = scram.handle(stream).await;

--- a/pgdog/src/frontend/listener.rs
+++ b/pgdog/src/frontend/listener.rs
@@ -241,6 +241,7 @@ impl Listener {
                             config.config.memory.net_buffer,
                             tls_identity,
                             tls_client_certificate,
+                            tls.server_end_point().map(|data| data.to_vec()),
                         );
                     } else {
                         stream.send_flush(&SslReply::No).await?;

--- a/pgdog/src/net/messages/auth/mod.rs
+++ b/pgdog/src/net/messages/auth/mod.rs
@@ -15,7 +15,7 @@ pub(crate) enum Authentication {
     /// AuthenticationOk (F)
     Ok,
     /// AuthenticationSASL (B)
-    Sasl(String),
+    Sasl(Vec<String>),
     /// AuthenticationSASLContinue (B)
     SaslContinue(String),
     /// AuthenticationSASLFinal (B)
@@ -27,9 +27,23 @@ pub(crate) enum Authentication {
 }
 
 impl Authentication {
-    /// Request SCRAM-SHA-256 auth.
+    pub(crate) const SCRAM_SHA_256: &'static str = "SCRAM-SHA-256";
+    pub(crate) const SCRAM_SHA_256_PLUS: &'static str = "SCRAM-SHA-256-PLUS";
+
+    /// Request SCRAM-SHA-256 auth (no channel binding).
     pub(crate) fn scram() -> Authentication {
-        Authentication::Sasl("SCRAM-SHA-256".to_string())
+        Authentication::Sasl(vec![Self::SCRAM_SHA_256.to_string()])
+    }
+
+    /// Request SCRAM-SHA-256-PLUS, falling back to SCRAM-SHA-256.
+    ///
+    /// PLUS is listed first so clients that pick the first advertised
+    /// mechanism get channel binding, matching PostgreSQL.
+    pub(crate) fn scram_plus() -> Authentication {
+        Authentication::Sasl(vec![
+            Self::SCRAM_SHA_256_PLUS.to_string(),
+            Self::SCRAM_SHA_256.to_string(),
+        ])
     }
 }
 
@@ -57,8 +71,18 @@ impl FromBytes for Authentication {
                 Ok(Authentication::Md5(Bytes::from(salt)))
             }
             10 => {
-                let mechanism = c_string_buf(&mut bytes);
-                Ok(Authentication::Sasl(mechanism))
+                let mut mechanisms = Vec::new();
+                loop {
+                    let mechanism = c_string_buf(&mut bytes);
+                    if mechanism.is_empty() {
+                        break;
+                    }
+                    mechanisms.push(mechanism);
+                }
+                if mechanisms.is_empty() {
+                    return Err(Error::UnexpectedPayload);
+                }
+                Ok(Authentication::Sasl(mechanisms))
             }
             11 => {
                 let data = c_string_buf(&mut bytes);
@@ -102,9 +126,11 @@ impl ToBytes for Authentication {
                 payload.freeze()
             }
 
-            Authentication::Sasl(mechanism) => {
+            Authentication::Sasl(mechanisms) => {
                 payload.put_i32(10);
-                payload.put_string(mechanism);
+                for mechanism in mechanisms {
+                    payload.put_string(mechanism);
+                }
                 payload.put_u8(0);
 
                 payload.freeze()
@@ -123,6 +149,39 @@ impl ToBytes for Authentication {
 
                 payload.freeze()
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scram_advertises_sha_256_only() {
+        let auth = Authentication::from_bytes(Authentication::scram().to_bytes()).unwrap();
+        match auth {
+            Authentication::Sasl(mechanisms) => {
+                assert_eq!(mechanisms, vec![Authentication::SCRAM_SHA_256]);
+            }
+            other => panic!("expected Sasl, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn scram_plus_advertises_plus_then_sha_256() {
+        let auth = Authentication::from_bytes(Authentication::scram_plus().to_bytes()).unwrap();
+        match auth {
+            Authentication::Sasl(mechanisms) => {
+                assert_eq!(
+                    mechanisms,
+                    vec![
+                        Authentication::SCRAM_SHA_256_PLUS,
+                        Authentication::SCRAM_SHA_256
+                    ]
+                );
+            }
+            other => panic!("expected Sasl, got {other:?}"),
         }
     }
 }

--- a/pgdog/src/net/messages/auth/mod.rs
+++ b/pgdog/src/net/messages/auth/mod.rs
@@ -220,4 +220,15 @@ mod tests {
             other => panic!("expected Sasl, got {other:?}"),
         }
     }
+
+    #[test]
+    fn sasl_without_mechanisms_is_unexpected_payload() {
+        let mut payload = Payload::named('R');
+        payload.put_i32(10);
+        payload.put_u8(0);
+        assert!(matches!(
+            Authentication::from_bytes(payload.freeze()),
+            Err(Error::UnexpectedPayload)
+        ));
+    }
 }

--- a/pgdog/src/net/messages/auth/mod.rs
+++ b/pgdog/src/net/messages/auth/mod.rs
@@ -164,61 +164,62 @@ impl ToBytes for Authentication {
 mod tests {
     use super::*;
 
+    fn sasl_mechanisms(auth: Authentication) -> Option<Vec<String>> {
+        match auth {
+            Authentication::Sasl(mechanisms) => Some(mechanisms),
+            _ => None,
+        }
+    }
+
+    fn decoded(auth: Authentication) -> Authentication {
+        Authentication::from_bytes(auth.to_bytes()).unwrap()
+    }
+
+    #[test]
+    fn sasl_mechanisms_none_unless_sasl() {
+        assert_eq!(sasl_mechanisms(Authentication::Ok), None);
+        assert_eq!(
+            sasl_mechanisms(Authentication::Sasl(vec!["SCRAM-SHA-256".into()])),
+            Some(vec!["SCRAM-SHA-256".into()])
+        );
+    }
+
     #[test]
     fn scram_advertises_sha_256_only() {
-        let auth = Authentication::from_bytes(Authentication::scram().to_bytes()).unwrap();
-        match auth {
-            Authentication::Sasl(mechanisms) => {
-                assert_eq!(mechanisms, vec![Authentication::SCRAM_SHA_256]);
-            }
-            other => panic!("expected Sasl, got {other:?}"),
-        }
+        assert_eq!(
+            sasl_mechanisms(decoded(Authentication::scram())).expect("Sasl"),
+            vec![Authentication::SCRAM_SHA_256]
+        );
     }
 
     #[test]
     fn scram_plus_advertises_plus_then_sha_256() {
-        let auth = Authentication::from_bytes(Authentication::scram_plus().to_bytes()).unwrap();
-        match auth {
-            Authentication::Sasl(mechanisms) => {
-                assert_eq!(
-                    mechanisms,
-                    vec![
-                        Authentication::SCRAM_SHA_256_PLUS,
-                        Authentication::SCRAM_SHA_256
-                    ]
-                );
-            }
-            other => panic!("expected Sasl, got {other:?}"),
-        }
+        assert_eq!(
+            sasl_mechanisms(decoded(Authentication::scram_plus())).expect("Sasl"),
+            vec![
+                Authentication::SCRAM_SHA_256_PLUS,
+                Authentication::SCRAM_SHA_256
+            ]
+        );
     }
 
     #[test]
     fn scram_challenge_encodes_plus_then_sha_256_when_cbind_present() {
-        let auth =
-            Authentication::from_bytes(scram_challenge(Some(&[1, 2, 3])).to_bytes()).unwrap();
-        match auth {
-            Authentication::Sasl(mechanisms) => {
-                assert_eq!(
-                    mechanisms,
-                    vec![
-                        Authentication::SCRAM_SHA_256_PLUS,
-                        Authentication::SCRAM_SHA_256
-                    ]
-                );
-            }
-            other => panic!("expected Sasl, got {other:?}"),
-        }
+        assert_eq!(
+            sasl_mechanisms(decoded(scram_challenge(Some(&[1, 2, 3])))).expect("Sasl"),
+            vec![
+                Authentication::SCRAM_SHA_256_PLUS,
+                Authentication::SCRAM_SHA_256
+            ]
+        );
     }
 
     #[test]
     fn scram_challenge_encodes_sha_256_only_when_cbind_absent() {
-        let auth = Authentication::from_bytes(scram_challenge(None).to_bytes()).unwrap();
-        match auth {
-            Authentication::Sasl(mechanisms) => {
-                assert_eq!(mechanisms, vec![Authentication::SCRAM_SHA_256]);
-            }
-            other => panic!("expected Sasl, got {other:?}"),
-        }
+        assert_eq!(
+            sasl_mechanisms(decoded(scram_challenge(None))).expect("Sasl"),
+            vec![Authentication::SCRAM_SHA_256]
+        );
     }
 
     #[test]

--- a/pgdog/src/net/messages/auth/mod.rs
+++ b/pgdog/src/net/messages/auth/mod.rs
@@ -47,6 +47,13 @@ impl Authentication {
     }
 }
 
+pub(crate) fn scram_challenge(tls_server_end_point: Option<&[u8]>) -> Authentication {
+    match tls_server_end_point {
+        Some(_) => Authentication::scram_plus(),
+        None => Authentication::scram(),
+    }
+}
+
 impl FromBytes for Authentication {
     fn from_bytes(mut bytes: Bytes) -> Result<Self, Error> {
         code!(bytes, 'R');
@@ -180,6 +187,35 @@ mod tests {
                         Authentication::SCRAM_SHA_256
                     ]
                 );
+            }
+            other => panic!("expected Sasl, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn scram_challenge_encodes_plus_then_sha_256_when_cbind_present() {
+        let auth =
+            Authentication::from_bytes(scram_challenge(Some(&[1, 2, 3])).to_bytes()).unwrap();
+        match auth {
+            Authentication::Sasl(mechanisms) => {
+                assert_eq!(
+                    mechanisms,
+                    vec![
+                        Authentication::SCRAM_SHA_256_PLUS,
+                        Authentication::SCRAM_SHA_256
+                    ]
+                );
+            }
+            other => panic!("expected Sasl, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn scram_challenge_encodes_sha_256_only_when_cbind_absent() {
+        let auth = Authentication::from_bytes(scram_challenge(None).to_bytes()).unwrap();
+        match auth {
+            Authentication::Sasl(mechanisms) => {
+                assert_eq!(mechanisms, vec![Authentication::SCRAM_SHA_256]);
             }
             other => panic!("expected Sasl, got {other:?}"),
         }

--- a/pgdog/src/net/messages/mod.rs
+++ b/pgdog/src/net/messages/mod.rs
@@ -40,7 +40,7 @@ pub(crate) mod row_description;
 pub(crate) mod sync;
 pub(crate) mod terminate;
 
-pub(crate) use auth::{Authentication, Password};
+pub(crate) use auth::{Authentication, Password, scram_challenge};
 pub(crate) use backend_key::BackendKeyData;
 pub(crate) use backend_pid::BackendPid;
 pub(crate) use bind::{Bind, Format, ParameterWithFormat};

--- a/pgdog/src/net/stream.rs
+++ b/pgdog/src/net/stream.rs
@@ -170,6 +170,11 @@ impl Stream {
         self.tls_server_end_point.as_deref()
     }
 
+    #[cfg(test)]
+    pub(crate) fn set_tls_server_end_point(&mut self, data: Vec<u8>) {
+        self.tls_server_end_point = Some(data);
+    }
+
     /// Get peer address if any. We're not using UNIX sockets (yet)
     /// so the peer address should always be available.
     pub(crate) fn peer_addr(&self) -> PeerAddr {

--- a/pgdog/src/net/stream.rs
+++ b/pgdog/src/net/stream.rs
@@ -42,6 +42,7 @@ pub(crate) struct Stream {
     capacity: usize,
     tls_identity: Option<String>,
     tls_client_certificate: bool,
+    tls_server_end_point: Option<Vec<u8>>,
 }
 
 impl AsyncRead for Stream {
@@ -112,6 +113,7 @@ impl Stream {
             capacity,
             tls_identity: None,
             tls_client_certificate: false,
+            tls_server_end_point: None,
         }
     }
 
@@ -121,6 +123,7 @@ impl Stream {
         capacity: usize,
         tls_identity: Option<String>,
         tls_client_certificate: bool,
+        tls_server_end_point: Option<Vec<u8>>,
     ) -> Self {
         Self {
             inner: StreamInner::Tls(BufStream::with_capacity(capacity, capacity, stream)),
@@ -128,6 +131,7 @@ impl Stream {
             capacity,
             tls_identity,
             tls_client_certificate,
+            tls_server_end_point,
         }
     }
 
@@ -139,6 +143,7 @@ impl Stream {
             capacity: 0,
             tls_identity: None,
             tls_client_certificate: false,
+            tls_server_end_point: None,
         }
     }
 
@@ -156,6 +161,13 @@ impl Stream {
     /// This is a TLS stream.
     pub(crate) fn is_tls(&self) -> bool {
         matches!(self.inner, StreamInner::Tls(_))
+    }
+
+    /// `tls-server-end-point` binding for the certificate this connection
+    /// presented, snapshotted at accept so a later TLS reload cannot
+    /// change the hash mid-handshake.
+    pub(crate) fn tls_server_end_point(&self) -> Option<&[u8]> {
+        self.tls_server_end_point.as_deref()
     }
 
     /// Get peer address if any. We're not using UNIX sockets (yet)
@@ -426,6 +438,7 @@ mod tests {
         assert!(!stream.is_tls());
         assert!(!stream.tls_client_certificate());
         assert_eq!(stream.tls_identity(), None);
+        assert_eq!(stream.tls_server_end_point(), None);
 
         client.await.unwrap();
     }

--- a/pgdog/src/net/tls.rs
+++ b/pgdog/src/net/tls.rs
@@ -114,9 +114,9 @@ pub(crate) fn acceptor() -> Option<Arc<TlsListener>> {
 /// DER-encoded end-entity certificate, using the certificate's own
 /// signature hash (MD5 and SHA-1 are upgraded to SHA-256).
 ///
-/// Returns `None` when the signature algorithm does not name a single
-/// hash (Ed25519, Ed448, RSASSA-PSS, …). PostgreSQL leaves PLUS undefined
-/// in those cases; we do the same and simply do not advertise it.
+/// Returns `None` when we cannot name a single hash from the signature
+/// OID (Ed25519, Ed448, RSASSA-PSS, …). RSA-PSS parameters are not
+/// parsed, so we do not advertise PLUS in those cases.
 pub(crate) fn tls_server_end_point(cert: &CertificateDer<'_>) -> Option<Vec<u8>> {
     use aws_lc_rs::digest::{self, digest};
     use x509_parser::certificate::X509Certificate;

--- a/pgdog/src/net/tls.rs
+++ b/pgdog/src/net/tls.rs
@@ -1,6 +1,7 @@
 //! TLS configuration.
 
 use std::{
+    ops::Deref,
     path::{Path, PathBuf},
     sync::{
         Arc,
@@ -25,7 +26,31 @@ use crate::config::config;
 
 use super::Error;
 
-static ACCEPTOR: ArcSwapOption<TlsAcceptor> = ArcSwapOption::const_empty();
+/// TLS acceptor plus the `tls-server-end-point` binding for the leaf
+/// certificate it will present. Kept together so a reload cannot pair a
+/// new acceptor with an old hash (or the reverse) on an in-flight login.
+pub(crate) struct TlsListener {
+    acceptor: TlsAcceptor,
+    server_end_point: Option<Vec<u8>>,
+}
+
+impl TlsListener {
+    /// Channel-binding data for SCRAM-SHA-256-PLUS, if the leaf certificate
+    /// uses a hash RFC 5929 can name.
+    pub(crate) fn server_end_point(&self) -> Option<&[u8]> {
+        self.server_end_point.as_deref()
+    }
+}
+
+impl Deref for TlsListener {
+    type Target = TlsAcceptor;
+
+    fn deref(&self) -> &Self::Target {
+        &self.acceptor
+    }
+}
+
+static ACCEPTOR: ArcSwapOption<TlsListener> = ArcSwapOption::const_empty();
 static ACCEPTOR_BUILD_COUNT: AtomicUsize = AtomicUsize::new(0);
 
 static CONNECTOR: ArcSwapOption<ConnectorCacheEntry> = ArcSwapOption::const_empty();
@@ -81,8 +106,54 @@ fn increment_connector_build_count() {
 fn increment_connector_build_count() {}
 
 /// Get the current TLS acceptor snapshot, if TLS is enabled.
-pub(crate) fn acceptor() -> Option<Arc<TlsAcceptor>> {
+pub(crate) fn acceptor() -> Option<Arc<TlsListener>> {
     ACCEPTOR.load_full()
+}
+
+/// RFC 5929 `tls-server-end-point` channel-binding data: the hash of the
+/// DER-encoded end-entity certificate, using the certificate's own
+/// signature hash (MD5 and SHA-1 are upgraded to SHA-256).
+///
+/// Returns `None` when the signature algorithm does not name a single
+/// hash (Ed25519, Ed448, RSASSA-PSS, …). PostgreSQL leaves PLUS undefined
+/// in those cases; we do the same and simply do not advertise it.
+pub(crate) fn tls_server_end_point(cert: &CertificateDer<'_>) -> Option<Vec<u8>> {
+    use aws_lc_rs::digest::{self, digest};
+    use x509_parser::certificate::X509Certificate;
+
+    let (_, parsed) = X509Certificate::from_der(cert.as_ref()).ok()?;
+    let oid = parsed.signature_algorithm.algorithm.to_id_string();
+
+    let algorithm = match oid.as_str() {
+        // MD5 / SHA-1 → SHA-256 (RFC 5929 §4.1)
+        "1.2.840.113549.1.1.4" // md5WithRSAEncryption
+        | "1.2.840.113549.1.1.5" // sha1WithRSAEncryption
+        | "1.2.840.10045.4.1" // ecdsa-with-SHA1
+        | "1.2.840.10040.4.3" // dsaWithSHA1
+        | "1.2.840.113549.2.5" // md5
+        | "1.3.14.3.2.26" // sha1
+        // SHA-256
+        | "1.2.840.113549.1.1.11" // sha256WithRSAEncryption
+        | "1.2.840.10045.4.3.2" // ecdsa-with-SHA256
+        | "2.16.840.1.101.3.4.3.2" // dsa-with-sha256
+        | "2.16.840.1.101.3.4.2.1" => &digest::SHA256, // id-sha256
+        // SHA-384
+        "1.2.840.113549.1.1.12" // sha384WithRSAEncryption
+        | "1.2.840.10045.4.3.3" // ecdsa-with-SHA384
+        | "2.16.840.1.101.3.4.2.2" => &digest::SHA384, // id-sha384
+        // SHA-512
+        "1.2.840.113549.1.1.13" // sha512WithRSAEncryption
+        | "1.2.840.10045.4.3.4" // ecdsa-with-SHA512
+        | "2.16.840.1.101.3.4.2.3" => &digest::SHA512, // id-sha512
+        // SHA-224
+        "1.2.840.113549.1.1.14" // sha224WithRSAEncryption
+        | "1.2.840.10045.4.3.1" // ecdsa-with-SHA224
+        | "2.16.840.1.101.3.4.3.1" // dsa-with-sha224
+        | "2.16.840.1.101.3.4.2.4" => &digest::SHA224, // id-sha224
+        _ => return None,
+    };
+
+    Some(digest(algorithm, cert.as_ref()).as_ref().to_vec())
 }
 
 /// Extract the hostname identity from the peer's TLS certificate, if present.
@@ -183,8 +254,9 @@ pub(crate) fn reload() -> Result<(), Error> {
     Ok(())
 }
 
-fn build_acceptor(cert: &Path, key: &Path, client_ca: Option<&Path>) -> Result<TlsAcceptor, Error> {
+fn build_acceptor(cert: &Path, key: &Path, client_ca: Option<&Path>) -> Result<TlsListener, Error> {
     let pem = CertificateDer::from_pem_file(cert)?;
+    let server_end_point = tls_server_end_point(&pem);
     let key = PrivateKeyDer::from_pem_file(key)?;
 
     let builder = rustls::ServerConfig::builder();
@@ -199,7 +271,10 @@ fn build_acceptor(cert: &Path, key: &Path, client_ca: Option<&Path>) -> Result<T
 
     ACCEPTOR_BUILD_COUNT.fetch_add(1, Ordering::SeqCst);
 
-    Ok(TlsAcceptor::from(Arc::new(config)))
+    Ok(TlsListener {
+        acceptor: TlsAcceptor::from(Arc::new(config)),
+        server_end_point,
+    })
 }
 
 /// Build a client certificate verifier. Presented certificates are verified
@@ -582,6 +657,10 @@ mod tests {
         let second = super::acceptor().expect("acceptor initialized");
 
         assert!(Arc::ptr_eq(&first, &second), "cached acceptor reused");
+        assert!(
+            first.server_end_point().is_some(),
+            "test cert must produce tls-server-end-point data so PLUS can be advertised"
+        );
         assert_eq!(
             super::test_acceptor_build_count(),
             1,
@@ -843,6 +922,25 @@ mod tests {
         );
 
         super::test_reset_connector();
+    }
+
+    #[test]
+    fn tls_server_end_point_matches_sha256_of_test_cert() {
+        let pem = include_str!("../../tests/tls/cert.pem");
+        let cert: CertificateDer<'static> =
+            rustls_pki_types::CertificateDer::pem_slice_iter(pem.as_bytes())
+                .next()
+                .expect("test cert PEM has one block")
+                .expect("test cert parses");
+
+        let binding =
+            super::tls_server_end_point(&cert).expect("test cert uses a hash RFC 5929 can name");
+
+        // tests/tls/cert.pem is sha256WithRSAEncryption, so the binding is
+        // SHA-256 of the DER — the same value openssl x509 -fingerprint -sha256
+        // prints.
+        let expected = aws_lc_rs::digest::digest(&aws_lc_rs::digest::SHA256, cert.as_ref());
+        assert_eq!(binding, expected.as_ref());
     }
 
     #[test]

--- a/pgdog/src/net/tls.rs
+++ b/pgdog/src/net/tls.rs
@@ -110,21 +110,11 @@ pub(crate) fn acceptor() -> Option<Arc<TlsListener>> {
     ACCEPTOR.load_full()
 }
 
-/// RFC 5929 `tls-server-end-point` channel-binding data: the hash of the
-/// DER-encoded end-entity certificate, using the certificate's own
-/// signature hash (MD5 and SHA-1 are upgraded to SHA-256).
-///
-/// Returns `None` when we cannot name a single hash from the signature
-/// OID (Ed25519, Ed448, RSASSA-PSS, …). RSA-PSS parameters are not
-/// parsed, so we do not advertise PLUS in those cases.
-pub(crate) fn tls_server_end_point(cert: &CertificateDer<'_>) -> Option<Vec<u8>> {
-    use aws_lc_rs::digest::{self, digest};
-    use x509_parser::certificate::X509Certificate;
-
-    let (_, parsed) = X509Certificate::from_der(cert.as_ref()).ok()?;
-    let oid = parsed.signature_algorithm.algorithm.to_id_string();
-
-    let algorithm = match oid.as_str() {
+/// RFC 5929 hash named by a signature OID. MD5 and SHA-1 upgrade to SHA-256.
+/// `None` for algorithms that do not name a single hash (Ed25519, RSASSA-PSS, …).
+fn digest_for_signature_oid(oid: &str) -> Option<&'static aws_lc_rs::digest::Algorithm> {
+    use aws_lc_rs::digest;
+    Some(match oid {
         // MD5 / SHA-1 → SHA-256 (RFC 5929 §4.1)
         "1.2.840.113549.1.1.4" // md5WithRSAEncryption
         | "1.2.840.113549.1.1.5" // sha1WithRSAEncryption
@@ -151,8 +141,23 @@ pub(crate) fn tls_server_end_point(cert: &CertificateDer<'_>) -> Option<Vec<u8>>
         | "2.16.840.1.101.3.4.3.1" // dsa-with-sha224
         | "2.16.840.1.101.3.4.2.4" => &digest::SHA224, // id-sha224
         _ => return None,
-    };
+    })
+}
 
+/// RFC 5929 `tls-server-end-point` channel-binding data: the hash of the
+/// DER-encoded end-entity certificate, using the certificate's own
+/// signature hash (MD5 and SHA-1 are upgraded to SHA-256).
+///
+/// Returns `None` when we cannot name a single hash from the signature
+/// OID (Ed25519, Ed448, RSASSA-PSS, …). RSA-PSS parameters are not
+/// parsed, so we do not advertise PLUS in those cases.
+pub(crate) fn tls_server_end_point(cert: &CertificateDer<'_>) -> Option<Vec<u8>> {
+    use aws_lc_rs::digest::digest;
+    use x509_parser::certificate::X509Certificate;
+
+    let (_, parsed) = X509Certificate::from_der(cert.as_ref()).ok()?;
+    let oid = parsed.signature_algorithm.algorithm.to_id_string();
+    let algorithm = digest_for_signature_oid(&oid)?;
     Some(digest(algorithm, cert.as_ref()).as_ref().to_vec())
 }
 
@@ -941,6 +946,75 @@ mod tests {
         // prints.
         let expected = aws_lc_rs::digest::digest(&aws_lc_rs::digest::SHA256, cert.as_ref());
         assert_eq!(binding, expected.as_ref());
+    }
+
+    #[test]
+    fn digest_for_signature_oid_maps_every_named_rfc5929_hash() {
+        // Outcome is the digest length RFC 5929 / the OID name imply.
+        // SHA-1 and MD5 must upgrade to SHA-256 (32 bytes).
+        const SHA256: &[&str] = &[
+            "1.2.840.113549.1.1.4",
+            "1.2.840.113549.1.1.5",
+            "1.2.840.10045.4.1",
+            "1.2.840.10040.4.3",
+            "1.2.840.113549.2.5",
+            "1.3.14.3.2.26",
+            "1.2.840.113549.1.1.11",
+            "1.2.840.10045.4.3.2",
+            "2.16.840.1.101.3.4.3.2",
+            "2.16.840.1.101.3.4.2.1",
+        ];
+        const SHA384: &[&str] = &[
+            "1.2.840.113549.1.1.12",
+            "1.2.840.10045.4.3.3",
+            "2.16.840.1.101.3.4.2.2",
+        ];
+        const SHA512: &[&str] = &[
+            "1.2.840.113549.1.1.13",
+            "1.2.840.10045.4.3.4",
+            "2.16.840.1.101.3.4.2.3",
+        ];
+        const SHA224: &[&str] = &[
+            "1.2.840.113549.1.1.14",
+            "1.2.840.10045.4.3.1",
+            "2.16.840.1.101.3.4.3.1",
+            "2.16.840.1.101.3.4.2.4",
+        ];
+
+        let len = |oid: &str| {
+            super::digest_for_signature_oid(oid)
+                .map(|algo| aws_lc_rs::digest::digest(algo, b"").as_ref().len())
+        };
+
+        for oid in SHA256 {
+            assert_eq!(len(oid), Some(32), "{oid} must name SHA-256");
+        }
+        for oid in SHA384 {
+            assert_eq!(len(oid), Some(48), "{oid} must name SHA-384");
+        }
+        for oid in SHA512 {
+            assert_eq!(len(oid), Some(64), "{oid} must name SHA-512");
+        }
+        for oid in SHA224 {
+            assert_eq!(len(oid), Some(28), "{oid} must name SHA-224");
+        }
+
+        assert_eq!(
+            len("1.3.101.112"),
+            None,
+            "Ed25519 does not name a single hash"
+        );
+        assert_eq!(
+            len("1.2.840.113549.1.1.10"),
+            None,
+            "RSASSA-PSS parameters are not parsed"
+        );
+    }
+
+    #[test]
+    fn tls_server_end_point_none_for_unparseable_der() {
+        let cert = CertificateDer::from(b"not-a-certificate".to_vec());
+        assert_eq!(super::tls_server_end_point(&cert), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- On connections PgDog terminates TLS for, advertise `SCRAM-SHA-256-PLUS` first (then `SCRAM-SHA-256`), matching PostgreSQL.
- Bind PLUS handshakes to `tls-server-end-point` from the leaf cert presented on that connection, snapshotted at accept so a later TLS reload cannot change the hash mid-login.
- Clients that pick `SCRAM-SHA-256` still work. PLUS is not advertised on plaintext, or when the cert's signature algorithm does not name a single hash (Ed25519 / RSASSA-PSS).

Fixes https://github.com/pgdogdev/pgdog/issues/1453

`scram` is pinned to merged `pgdogdev/scram` @ `ee15a47` (https://github.com/pgdogdev/scram/pull/6).

## Test plan
- [x] AuthenticationSASL encodes `SCRAM-SHA-256-PLUS\0SCRAM-SHA-256\0\0` and still encodes SHA-256-only for plaintext
- [x] `tls-server-end-point` for `tests/tls/cert.pem` matches SHA-256 of the DER
- [x] Every named RFC 5929 signature OID maps to the right digest length; Ed25519 / RSASSA-PSS / garbage DER return `None`
- [x] Hashed-password PLUS handshake succeeds / wrong password fails
- [x] `handle()` refuses PLUS with no cbind, unknown mechanisms, GS2 `y`, non-SASL initial, ErrorResponse, and a SASLInitial sent as client-final
- [x] Plain-password PLUS `handle()` accepts the correct password
- [x] Empty AuthenticationSASL mechanism list is `UnexpectedPayload`
- [x] `scram` pin points at `pgdogdev/scram` @ `ee15a47`
- [x] `integration/rust` tokio-postgres client: `sslmode=require` + `channel_binding=require` (plain + hashed users); wrong password fails; `channel_binding=disable` still works over TLS
- [x] `channel_binding=require` against this branch as a TLS PgDog (psql 18.6 / rust-postgres 0.19)

Made with [Cursor](https://cursor.com)