### PR TITLE
fix: clear prepared statement cache on DISCARD

### DIFF
--- a/integration/ruby/ar_spec.rb
+++ b/integration/ruby/ar_spec.rb
@@ -204,6 +204,9 @@ describe 'active record' do
         end
 
         ActiveRecord::Base.connection.execute 'DISCARD ALL'
+        # DISCARD ALL deallocates prepared statements, so ActiveRecord has to
+        # forget the names it cached.
+        ActiveRecord::Base.connection.clear_cache!
 
         5.times do |i|
           record = Sharded.where(value: "test_#{i}").first

--- a/pgdog/src/frontend/client/query_engine/discard.rs
+++ b/pgdog/src/frontend/client/query_engine/discard.rs
@@ -3,13 +3,16 @@ use crate::net::{CommandComplete, Protocol, ReadyForQuery};
 use super::*;
 
 impl QueryEngine {
-    /// Ignore DISCARD command.
+    /// Handle DISCARD. Postgres `DISCARD ALL` deallocates prepared statements;
+    /// PgDog intercepts DISCARD, so the client's cache and global use counts
+    /// must be updated here instead of waiting for disconnect.
     pub(super) async fn discard(
         &mut self,
         context: &mut QueryEngineContext<'_>,
         extended: bool,
     ) -> Result<(), Error> {
         let _extended = extended;
+        context.prepared_statements.close_all();
         let bytes_sent = context
             .stream
             .send_many(&[

--- a/pgdog/src/frontend/client/query_engine/test/discard.rs
+++ b/pgdog/src/frontend/client/query_engine/test/discard.rs
@@ -1,0 +1,32 @@
+use crate::{
+    expect_message,
+    net::{CommandComplete, Parameters, ParseComplete, ReadyForQuery},
+};
+
+use super::prelude::*;
+
+#[tokio::test]
+async fn test_discard_clears_prepared_statement_cache() {
+    let mut client = TestClient::new_replicas(Parameters::default())
+        .await
+        .with_full_prepared_statements();
+
+    client.send(Parse::named("test_stmt", "SELECT $1")).await;
+    client.send(Sync).await;
+    client.try_process().await.unwrap();
+
+    expect_message!(client.read().await, ParseComplete);
+    expect_message!(client.read().await, ReadyForQuery);
+
+    assert_eq!(client.client().prepared_statements.num_statements(), 1);
+    let global = client.client().prepared_statements.global.clone();
+    assert_eq!(global.read().statements().iter().next().unwrap().1.used, 1);
+
+    client.send_simple(Query::new("DISCARD ALL")).await;
+
+    expect_message!(client.read().await, CommandComplete);
+    expect_message!(client.read().await, ReadyForQuery);
+
+    assert_eq!(client.client().prepared_statements.num_statements(), 0);
+    assert_eq!(global.read().statements().iter().next().unwrap().1.used, 0);
+}

--- a/pgdog/src/frontend/client/query_engine/test/mod.rs
+++ b/pgdog/src/frontend/client/query_engine/test/mod.rs
@@ -11,6 +11,7 @@ mod advisory_lock;
 mod close_parse;
 mod close_parse_global_cache;
 mod cross_shard_disabled;
+mod discard;
 mod extended;
 mod extended_anonymous;
 mod extended_transaction;

--- a/pgdog/src/frontend/prepared_statements/mod.rs
+++ b/pgdog/src/frontend/prepared_statements/mod.rs
@@ -168,9 +168,9 @@ impl PreparedStatements {
 
     /// Close all prepared statements on this client.
     ///
-    /// This only happens when the client disconnects. This will update
-    /// the global usage counters of all of client's prepared statements.
-    pub(super) fn close_all(&mut self) {
+    /// Called when the client disconnects or runs `DISCARD`. Updates
+    /// the global usage counters of all of the client's prepared statements.
+    pub(crate) fn close_all(&mut self) {
         if !self.local.is_empty() {
             let mut global = self.global.write();
 


### PR DESCRIPTION
## Summary
- `DISCARD` was acknowledged without dropping the client's prepared statements or decrementing the global use count, so long-lived clients could leak cache entries.
- Reuse `PreparedStatements::close_all()` on `DISCARD`, the same cleanup already used on disconnect.
- closes #1402 

## Test plan
- [x] `cargo nextest run --profile dev test_discard_clears_prepared_statement_cache`