### PR TITLE
refactor: add config reload and failover signals

### DIFF
--- a/pgdog/src/backend/pool/cluster.rs
+++ b/pgdog/src/backend/pool/cluster.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 use super::{
-    Address, CanonicalOids, ClusterMetrics, Config, Error, Guard, Request, Shard, ShardConfig,
+    Address, CanonicalOids, ClusterFailoverSignalWatcher, ClusterMetrics, Config, Error, Guard,
+    Request, Shard, ShardConfig,
 };
 use crate::config::LoadBalancingStrategy;
 use launch::Readiness;
@@ -85,6 +86,7 @@ pub(crate) struct Cluster {
     schema_loader: Box<dyn SchemaLoader>,
     canonical_oids: Option<Arc<CanonicalOids>>,
     read_only: bool,
+    failover_signal: ClusterFailoverSignalWatcher,
 }
 
 /// Bare test clusters carry the same defaults the config would apply,
@@ -133,6 +135,7 @@ impl Default for Cluster {
             schema_loader: Default::default(),
             canonical_oids: Default::default(),
             read_only: Default::default(),
+            failover_signal: ClusterFailoverSignalWatcher::default(),
         }
     }
 }
@@ -351,25 +354,29 @@ impl Cluster {
             ..Default::default()
         }));
 
+        let shard_pools = shards
+            .iter()
+            .enumerate()
+            .map(|(number, config)| {
+                Shard::new(ShardConfig {
+                    number,
+                    primary: config.primary.as_ref(),
+                    replicas: &config.replicas,
+                    lb_strategy,
+                    rw_split,
+                    identifier: identifier.clone(),
+                    lsn_check_interval,
+                    pub_sub_enabled,
+                    schema_cache: schema_cache.clone(),
+                })
+            })
+            .collect::<Vec<_>>();
+
+        let failover_signal = ClusterFailoverSignalWatcher::new(&shard_pools);
+
         Self {
             identifier: identifier.clone(),
-            shards: shards
-                .iter()
-                .enumerate()
-                .map(|(number, config)| {
-                    Shard::new(ShardConfig {
-                        number,
-                        primary: config.primary.as_ref(),
-                        replicas: &config.replicas,
-                        lb_strategy,
-                        rw_split,
-                        identifier: identifier.clone(),
-                        lsn_check_interval,
-                        pub_sub_enabled,
-                        schema_cache: schema_cache.clone(),
-                    })
-                })
-                .collect(),
+            shards: shard_pools,
             passwords,
             pooler_mode,
             sharded_tables,
@@ -407,6 +414,7 @@ impl Cluster {
             schema_loader: Box::new(schema_loader::FromServer),
             canonical_oids,
             read_only,
+            failover_signal,
         }
     }
 
@@ -732,6 +740,12 @@ impl Cluster {
 
     pub(crate) fn is_canonicalizing_oids(&self) -> bool {
         self.canonical_oids.is_some()
+    }
+
+    /// Listen for failover signal from one or more shards.
+    #[allow(unused)]
+    pub(crate) fn failover_signal(&mut self) -> &mut ClusterFailoverSignalWatcher {
+        &mut self.failover_signal
     }
 }
 

--- a/pgdog/src/backend/pool/failover_signal.rs
+++ b/pgdog/src/backend/pool/failover_signal.rs
@@ -1,0 +1,46 @@
+#![allow(unused)]
+use futures::StreamExt;
+use futures::stream::FuturesUnordered;
+
+use super::Address;
+use super::shard::{Shard, failover_signal::*};
+
+#[derive(Default, Clone, Debug)]
+pub(crate) struct ClusterFailoverSignalWatcher {
+    shards: Vec<FailoverSignalWatcher>,
+}
+
+impl ClusterFailoverSignalWatcher {
+    pub(super) fn new(shards: &[Shard]) -> Self {
+        Self {
+            shards: shards
+                .iter()
+                .map(|shard| shard.failover_listener())
+                .collect(),
+        }
+    }
+
+    /// Wait for any shard to trigger a failover.
+    pub(crate) async fn watch_any(&mut self) {
+        let mut futs = self
+            .shards
+            .iter_mut()
+            .map(|shard| shard.recv())
+            .collect::<FuturesUnordered<_>>();
+        futs.next()
+            .await
+            .expect("recv_any called on empty shard vec")
+    }
+
+    /// Wait for _all_ shards to trigger a failover. This is used
+    /// to detect failover event on all primaries.
+    pub(crate) async fn watch_all(&mut self) {
+        let mut futs = self
+            .shards
+            .iter_mut()
+            .map(|shard| shard.recv())
+            .collect::<FuturesUnordered<_>>();
+
+        while let Some(addr) = futs.next().await {}
+    }
+}

--- a/pgdog/src/backend/pool/mod.rs
+++ b/pgdog/src/backend/pool/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod connection;
 pub(crate) mod dns_cache;
 pub(crate) mod ee;
 pub(crate) mod error;
+pub(crate) mod failover_signal;
 pub(crate) mod guard;
 pub(crate) mod healthcheck;
 pub(crate) mod inner;
@@ -31,6 +32,7 @@ pub(crate) use cluster::{Cluster, ClusterConfig, ClusterShardConfig, PoolConfig,
 pub(crate) use cluster_metrics::ClusterMetrics;
 pub(crate) use connection::Connection;
 pub(crate) use error::Error;
+pub(super) use failover_signal::ClusterFailoverSignalWatcher;
 pub(crate) use guard::Guard;
 pub(crate) use healthcheck::Healtcheck;
 pub(crate) use lb::LoadBalancer;

--- a/pgdog/src/backend/pool/shard/failover_signal.rs
+++ b/pgdog/src/backend/pool/shard/failover_signal.rs
@@ -4,34 +4,45 @@
 use once_cell::sync::Lazy;
 use tokio::sync::watch::*;
 
-use crate::backend::pool::Address;
+#[derive(Debug, Clone)]
+pub(super) struct FailoverSignal {
+    tx: Sender<()>,
+}
 
-static WATCH: Lazy<Sender<Address>> = Lazy::new(|| {
-    let (tx, _rx) = channel(Address::default());
-
-    tx
-});
-
-pub(crate) struct FailoverSignal {
-    rx: Receiver<Address>,
+impl Default for FailoverSignal {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl FailoverSignal {
-    pub(crate) async fn recv(&mut self) -> Address {
+    pub(super) fn new() -> Self {
+        let (tx, _) = channel(());
+        Self { tx }
+    }
+
+    pub(super) fn watch(&self) -> FailoverSignalWatcher {
+        FailoverSignalWatcher {
+            rx: self.tx.subscribe(),
+        }
+    }
+
+    pub(super) fn notify(&self) {
+        self.tx.send_replace(());
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct FailoverSignalWatcher {
+    rx: Receiver<()>,
+}
+
+impl FailoverSignalWatcher {
+    pub(crate) async fn recv(&mut self) {
         self.rx
             .changed()
             .await
             .expect("failover signal never closes");
-        self.rx.borrow_and_update().clone()
-    }
-}
-
-pub(super) fn notify(addr: &Address) {
-    WATCH.send_replace(addr.clone());
-}
-
-pub(crate) fn watch() -> FailoverSignal {
-    FailoverSignal {
-        rx: WATCH.subscribe(),
+        self.rx.borrow_and_update();
     }
 }

--- a/pgdog/src/backend/pool/shard/failover_signal.rs
+++ b/pgdog/src/backend/pool/shard/failover_signal.rs
@@ -1,0 +1,37 @@
+#![allow(unused)] // Enterprise is the main consumer.
+//! Failover signal listener.
+
+use once_cell::sync::Lazy;
+use tokio::sync::watch::*;
+
+use crate::backend::pool::Address;
+
+static WATCH: Lazy<Sender<Address>> = Lazy::new(|| {
+    let (tx, _rx) = channel(Address::default());
+
+    tx
+});
+
+pub(crate) struct FailoverSignal {
+    rx: Receiver<Address>,
+}
+
+impl FailoverSignal {
+    pub(crate) async fn recv(&mut self) -> Address {
+        self.rx
+            .changed()
+            .await
+            .expect("failover signal never closes");
+        self.rx.borrow_and_update().clone()
+    }
+}
+
+pub(super) fn notify(addr: &Address) {
+    WATCH.send_replace(addr.clone());
+}
+
+pub(crate) fn watch() -> FailoverSignal {
+    FailoverSignal {
+        rx: WATCH.subscribe(),
+    }
+}

--- a/pgdog/src/backend/pool/shard/mod.rs
+++ b/pgdog/src/backend/pool/shard/mod.rs
@@ -27,6 +27,7 @@ pub(crate) mod monitor;
 mod oids;
 pub(crate) mod role_detector;
 
+use failover_signal::{FailoverSignal, FailoverSignalWatcher};
 use monitor::*;
 pub(crate) use oids::{CanonicalOids, Oids};
 use role_detector::*;
@@ -80,11 +81,6 @@ impl Shard {
     /// Get connection to the primary database.
     pub(crate) async fn primary(&self, request: &Request) -> Result<Guard, Error> {
         self.lb.get_primary(request).await
-    }
-
-    /// Get the primary connection pool.
-    pub(super) fn primary_target(&self) -> Option<&Pool> {
-        self.lb.primary()
     }
 
     /// Get connection to one of the replica databases, using the configured
@@ -316,6 +312,18 @@ impl Shard {
         }
     }
 
+    /// Signal that a failover has taken place.
+    pub(super) fn signal_failover(&self) {
+        if self.lb.primary().is_some() {
+            self.failover_signal.notify();
+        }
+    }
+
+    /// Listen for a failover event in real-time.
+    pub(crate) fn failover_listener(&self) -> FailoverSignalWatcher {
+        self.failover_signal.watch()
+    }
+
     /// Shutdown pub/sub listener.
     fn shutdown_pub_sub(&self) {
         if let Some(pub_sub) = self.inner.pub_sub.swap(Arc::new(None)).deref() {
@@ -346,6 +354,7 @@ pub(crate) struct ShardInner {
     pub_sub_enabled: bool,
     schema_cache: SchemaCache,
     oids: Arc<Oids>,
+    failover_signal: FailoverSignal,
 }
 
 impl ShardInner {
@@ -379,6 +388,7 @@ impl ShardInner {
             pub_sub_enabled,
             schema_cache,
             oids,
+            failover_signal: FailoverSignal::new(),
         }
     }
 }

--- a/pgdog/src/backend/pool/shard/mod.rs
+++ b/pgdog/src/backend/pool/shard/mod.rs
@@ -22,6 +22,7 @@ use crate::net::messages::FrontendPid;
 
 use super::{Error, Guard, LoadBalancer, Pool, PoolConfig, Request};
 
+pub(crate) mod failover_signal;
 pub(crate) mod monitor;
 mod oids;
 pub(crate) mod role_detector;
@@ -79,6 +80,11 @@ impl Shard {
     /// Get connection to the primary database.
     pub(crate) async fn primary(&self, request: &Request) -> Result<Guard, Error> {
         self.lb.get_primary(request).await
+    }
+
+    /// Get the primary connection pool.
+    pub(super) fn primary_target(&self) -> Option<&Pool> {
+        self.lb.primary()
     }
 
     /// Get connection to one of the replica databases, using the configured

--- a/pgdog/src/backend/pool/shard/monitor.rs
+++ b/pgdog/src/backend/pool/shard/monitor.rs
@@ -95,9 +95,7 @@ impl ShardMonitor {
                     self.shard.identifier()
                 );
 
-                if let Some(primary) = self.shard.primary_target() {
-                    failover_signal::notify(primary.addr());
-                }
+                self.shard.signal_failover();
             }
 
             update_replica_lag(&self.shard.pools());

--- a/pgdog/src/backend/pool/shard/monitor.rs
+++ b/pgdog/src/backend/pool/shard/monitor.rs
@@ -94,6 +94,10 @@ impl ShardMonitor {
                     self.shard.number(),
                     self.shard.identifier()
                 );
+
+                if let Some(primary) = self.shard.primary_target() {
+                    failover_signal::notify(primary.addr());
+                }
             }
 
             update_replica_lag(&self.shard.pools());

--- a/pgdog/src/config/changed.rs
+++ b/pgdog/src/config/changed.rs
@@ -22,9 +22,7 @@ impl ConfigWatcher {
             .await
             .expect("config watcher never closes");
 
-        let val = self.rx.borrow_and_update().clone();
-
-        val
+        self.rx.borrow_and_update().clone()
     }
 }
 

--- a/pgdog/src/config/changed.rs
+++ b/pgdog/src/config/changed.rs
@@ -1,0 +1,39 @@
+#![allow(unused)] // Enterprise consumes this.
+
+use once_cell::sync::Lazy;
+use pgdog_config::ConfigAndUsers;
+use std::sync::Arc;
+use tokio::sync::watch::*;
+
+static WATCHER: Lazy<Sender<Arc<ConfigAndUsers>>> = Lazy::new(|| {
+    let (tx, _rx) = channel(Arc::new(ConfigAndUsers::default()));
+
+    tx
+});
+
+pub(crate) struct ConfigWatcher {
+    rx: Receiver<Arc<ConfigAndUsers>>,
+}
+
+impl ConfigWatcher {
+    pub(crate) async fn recv(&mut self) -> Arc<ConfigAndUsers> {
+        self.rx
+            .changed()
+            .await
+            .expect("config watcher never closes");
+
+        let val = self.rx.borrow_and_update().clone();
+
+        val
+    }
+}
+
+pub(super) fn notify(config: Arc<ConfigAndUsers>) {
+    WATCHER.send_replace(config);
+}
+
+pub(crate) fn watch() -> ConfigWatcher {
+    ConfigWatcher {
+        rx: WATCHER.subscribe(),
+    }
+}

--- a/pgdog/src/config/mod.rs
+++ b/pgdog/src/config/mod.rs
@@ -1,6 +1,7 @@
 //! Configuration.
 
 // Submodules
+pub(crate) mod changed;
 pub(crate) mod convert;
 pub(crate) mod core;
 pub(crate) mod database;
@@ -70,6 +71,7 @@ pub(crate) fn set(mut config: ConfigAndUsers) -> Result<ConfigAndUsers, Error> {
         table.load_centroids()?;
     }
     CONFIG.store(Arc::new(config.clone()));
+    changed::notify(CONFIG.load_full());
     Ok(config)
 }
 


### PR DESCRIPTION
Add hooks for config reloading and failover. Any code can listen for changes in these systems in real-time. Primary consumer currently is the Enterprise edition, to push these signals to the control plane as quickly as possible.