### PR TITLE
Pin connections when temporary tables are used

### DIFF
--- a/pgdog/src/frontend/client/query_engine/end_transaction.rs
+++ b/pgdog/src/frontend/client/query_engine/end_transaction.rs
@@ -77,6 +77,15 @@ impl QueryEngine {
             && !rollback
             && context.transaction().map(|t| t.write()).unwrap_or(false);
 
+        if rollback {
+            self.temp_tables.retain(|_, state| state.committed);
+        } else {
+            self.temp_tables.retain(|_, state| {
+                state.committed = true;
+                !state.drop_on_commit
+            });
+        }
+
         if two_pc {
             self.end_two_pc(false).await?;
 

--- a/pgdog/src/frontend/client/query_engine/lock.rs
+++ b/pgdog/src/frontend/client/query_engine/lock.rs
@@ -6,7 +6,8 @@ impl QueryEngine {
     pub(super) fn check_lock(&mut self) {
         // The presence of advisory locks or manual pin
         // indicates we cannot release the backend.
-        let locked = self.advisory_locks.locked() || self.manual_lock;
+        let locked =
+            self.advisory_locks.locked() || !self.temp_tables.is_empty() || self.manual_lock;
 
         self.backend.lock(locked);
         self.stats.locked(locked);

--- a/pgdog/src/frontend/client/query_engine/mod.rs
+++ b/pgdog/src/frontend/client/query_engine/mod.rs
@@ -9,7 +9,8 @@ use crate::{
     net::{ErrorResponse, Message, Parameters},
     state::State,
 };
-
+use fnv::FnvHashMap;
+use temp_table::TempTableState;
 use tracing::debug;
 
 pub(crate) mod advisory_lock;
@@ -35,6 +36,7 @@ pub(crate) mod route_query;
 pub(crate) mod set;
 pub(crate) mod split;
 pub(crate) mod start_transaction;
+mod temp_table;
 #[cfg(test)]
 mod test;
 #[cfg(test)]
@@ -48,6 +50,7 @@ pub(crate) use context::QueryEngineContext;
 use notify_buffer::NotifyBuffer;
 pub(crate) use result::QueryEngineResult;
 pub(crate) use split::Pipeline;
+pub(in crate::frontend) use temp_table::TempTableChange;
 use two_pc::TwoPc;
 pub(crate) use two_pc::phase::TwoPcPhase;
 
@@ -70,6 +73,7 @@ pub(crate) struct QueryEngine {
     // They will remain pinned to their connection until they unpin manually
     // or disconnect.
     manual_lock: bool,
+    temp_tables: FnvHashMap<String, TempTableState>,
 }
 
 impl QueryEngine {
@@ -97,6 +101,7 @@ impl QueryEngine {
             router: Router::default(),
             advisory_locks: AdvisoryLocks::default(),
             manual_lock: false,
+            temp_tables: Default::default(),
         })
     }
 

--- a/pgdog/src/frontend/client/query_engine/query.rs
+++ b/pgdog/src/frontend/client/query_engine/query.rs
@@ -238,6 +238,25 @@ impl QueryEngine {
             self.advisory_locks
                 .merge(self.router.command().route().advisory_locks());
 
+            match self.router.command().route().temp_table_change.as_ref() {
+                Some(TempTableChange::Create {
+                    name,
+                    drop_on_commit,
+                }) => {
+                    self.temp_tables.insert(
+                        name.clone(),
+                        TempTableState {
+                            committed: false,
+                            drop_on_commit: *drop_on_commit,
+                        },
+                    );
+                }
+                Some(TempTableChange::Drop(table)) => {
+                    self.temp_tables.remove(table);
+                }
+                None => {}
+            }
+
             self.check_lock();
 
             if !context.in_transaction() {

--- a/pgdog/src/frontend/client/query_engine/temp_table.rs
+++ b/pgdog/src/frontend/client/query_engine/temp_table.rs
@@ -1,0 +1,11 @@
+#[derive(Debug, Clone)]
+pub(super) struct TempTableState {
+    pub(super) committed: bool,
+    pub(super) drop_on_commit: bool,
+}
+
+#[derive(Debug, Clone)]
+pub(in crate::frontend) enum TempTableChange {
+    Create { name: String, drop_on_commit: bool },
+    Drop(String),
+}

--- a/pgdog/src/frontend/client/query_engine/test/mod.rs
+++ b/pgdog/src/frontend/client/query_engine/test/mod.rs
@@ -38,6 +38,7 @@ mod set_schema_sharding;
 mod sharded;
 mod sharded_prepared;
 mod spliced;
+mod temp_table;
 mod test_omnisharded;
 mod transaction_state;
 

--- a/pgdog/src/frontend/client/query_engine/test/temp_table.rs
+++ b/pgdog/src/frontend/client/query_engine/test/temp_table.rs
@@ -1,0 +1,86 @@
+use super::prelude::*;
+
+#[tokio::test]
+async fn test_creating_temp_tables_locks_client() {
+    let mut client = TestClient::new_sharded(Parameters::default()).await;
+
+    client
+        .send_simple(Query::new("CREATE TEMP TABLE foo (id int)"))
+        .await;
+    client.read_until('Z').await.unwrap();
+
+    assert!(client.backend_locked());
+
+    client
+        .send_simple(Query::new("CREATE TEMP TABLE bar (id int)"))
+        .await;
+    client.read_until('Z').await.unwrap();
+
+    assert!(client.backend_locked());
+
+    client.send_simple(Query::new("DROP TABLE foo")).await;
+    client.read_until('Z').await.unwrap();
+
+    assert!(client.backend_locked());
+
+    client.send_simple(Query::new("DROP TABLE bar")).await;
+    client.read_until('Z').await.unwrap();
+
+    assert!(!client.backend_locked());
+}
+
+#[tokio::test]
+async fn test_temp_tables_on_commit() {
+    let mut client = TestClient::new_sharded(Parameters::default()).await;
+
+    client.send_simple(Query::new("BEGIN")).await;
+    client.read_until('Z').await.unwrap();
+    client
+        .send_simple(Query::new("CREATE TEMP TABLE foo (id int) ON COMMIT DROP"))
+        .await;
+    client.read_until('Z').await.unwrap();
+    assert!(client.backend_locked());
+
+    client.send_simple(Query::new("COMMIT")).await;
+    client.read_until('Z').await.unwrap();
+    assert!(!client.backend_locked());
+}
+
+#[tokio::test]
+async fn test_temp_tables_drop_on_rollback() {
+    let mut client = TestClient::new_sharded(Parameters::default()).await;
+
+    client.send_simple(Query::new("BEGIN")).await;
+    client.read_until('Z').await.unwrap();
+    client
+        .send_simple(Query::new("CREATE TEMP TABLE foo (id int)"))
+        .await;
+    client.read_until('Z').await.unwrap();
+    assert!(client.backend_locked());
+
+    client.send_simple(Query::new("COMMIT")).await;
+    client.read_until('Z').await.unwrap();
+    assert!(client.backend_locked());
+
+    client.send_simple(Query::new("BEGIN")).await;
+    client.read_until('Z').await.unwrap();
+    client.send_simple(Query::new("ROLLBACK")).await;
+    client.read_until('Z').await.unwrap();
+    assert!(client.backend_locked());
+
+    client.send_simple(Query::new("DROP TABLE foo")).await;
+    client.read_until('Z').await.unwrap();
+    assert!(!client.backend_locked());
+
+    client.send_simple(Query::new("BEGIN")).await;
+    client.read_until('Z').await.unwrap();
+    client
+        .send_simple(Query::new("CREATE TEMP TABLE foo (id int)"))
+        .await;
+    client.read_until('Z').await.unwrap();
+    assert!(client.backend_locked());
+
+    client.send_simple(Query::new("ROLLBACK")).await;
+    client.read_until('Z').await.unwrap();
+    assert!(!client.backend_locked());
+}

--- a/pgdog/src/frontend/router/parser/query/ddl.rs
+++ b/pgdog/src/frontend/router/parser/query/ddl.rs
@@ -1,3 +1,7 @@
+use crate::frontend::client::query_engine::TempTableChange;
+use pg_raw_parse::raw::OnCommitAction::ONCOMMIT_DROP;
+use std::ffi::c_char;
+
 use super::*;
 
 impl QueryParser {
@@ -24,11 +28,23 @@ impl QueryParser {
         use nodes::ObjectType;
         let mut shard = Shard::All;
         let mut schema_changed = false;
+        let mut temp_table = None;
 
         match node {
             Node::CreateStmt(stmt) => {
                 schema_changed = true;
                 shard = Self::shard_ddl_table(stmt.relation(), schema)?.unwrap_or(Shard::All);
+                if let Some(rv) = stmt.relation()
+                    && rv.relpersistence == b't' as c_char
+                {
+                    temp_table = Some(TempTableChange::Create {
+                        name: rv
+                            .relname()
+                            .expect("CREATE TABLE always has table name")
+                            .to_owned(),
+                        drop_on_commit: stmt.oncommit == ONCOMMIT_DROP,
+                    });
+                }
             }
 
             Node::CreateSeqStmt(stmt) => {
@@ -41,19 +57,20 @@ impl QueryParser {
                 | ObjectType::OBJECT_VIEW
                 | ObjectType::OBJECT_SEQUENCE => {
                     let table = Table::try_from(stmt.objects()).ok();
-                    if let Some(table) = table
-                        && let Some(schema) = schema.schemas.get(table.schema())
-                    {
-                        shard = schema.shard().into();
+                    if let Some(table) = table {
+                        temp_table = Some(TempTableChange::Drop(table.name.to_owned()));
+                        if let Some(schema) = schema.schemas.get(table.schema()) {
+                            shard = schema.shard().into();
+                        }
                     }
                     schema_changed = true;
                 }
 
                 ObjectType::OBJECT_SCHEMA => {
-                    if let Some(string) = stmt.objects().first().and_then(Node::as_str)
-                        && let Some(schema) = schema.schemas.get(Some(string.into()))
-                    {
-                        shard = schema.shard().into();
+                    if let Some(string) = stmt.objects().first().and_then(Node::as_str) {
+                        if let Some(schema) = schema.schemas.get(Some(string.into())) {
+                            shard = schema.shard().into();
+                        }
                     }
                 }
 
@@ -203,7 +220,9 @@ impl QueryParser {
         calculator.push(ShardWithPriority::new_table(shard));
 
         Ok(Command::Query(
-            Route::write(calculator.shard()).with_schema_changed(schema_changed),
+            Route::write(calculator.shard())
+                .with_schema_changed(schema_changed)
+                .with_temp_table_change(temp_table),
         ))
     }
 

--- a/pgdog/src/frontend/router/parser/query/ddl.rs
+++ b/pgdog/src/frontend/router/parser/query/ddl.rs
@@ -68,9 +68,10 @@ impl QueryParser {
 
                 ObjectType::OBJECT_SCHEMA => {
                     if let Some(string) = stmt.objects().first().and_then(Node::as_str)
-                        && let Some(schema) = schema.schemas.get(Some(string.into())) {
-                            shard = schema.shard().into();
-                        }
+                        && let Some(schema) = schema.schemas.get(Some(string.into()))
+                    {
+                        shard = schema.shard().into();
+                    }
                 }
 
                 _ => (),

--- a/pgdog/src/frontend/router/parser/query/ddl.rs
+++ b/pgdog/src/frontend/router/parser/query/ddl.rs
@@ -67,11 +67,10 @@ impl QueryParser {
                 }
 
                 ObjectType::OBJECT_SCHEMA => {
-                    if let Some(string) = stmt.objects().first().and_then(Node::as_str) {
-                        if let Some(schema) = schema.schemas.get(Some(string.into())) {
+                    if let Some(string) = stmt.objects().first().and_then(Node::as_str)
+                        && let Some(schema) = schema.schemas.get(Some(string.into())) {
                             shard = schema.shard().into();
                         }
-                    }
                 }
 
                 _ => (),

--- a/pgdog/src/frontend/router/parser/route.rs
+++ b/pgdog/src/frontend/router/parser/route.rs
@@ -4,7 +4,7 @@ use super::{
     Aggregate, DistinctBy, Limit, OrderBy, explain_trace::ExplainTrace,
     rewrite::statement::aggregate::AggregateRewritePlan, statement::AdvisoryLocks,
 };
-use crate::frontend::router::sharding::PendingLookup;
+use crate::frontend::{client::query_engine::TempTableChange, router::sharding::PendingLookup};
 use lazy_static::lazy_static;
 
 /// The shard destination for a query.
@@ -75,7 +75,7 @@ impl From<Vec<usize>> for Shard {
 
 /// Path a query should take and any transformations
 /// that should be applied to the response.
-#[derive(Debug, Clone, Default, PartialEq, derive_builder::Builder)]
+#[derive(Debug, Clone, Default, derive_builder::Builder)]
 pub(crate) struct Route {
     /// Computed shard. This is where the query carrying
     /// this route will go no matter what.
@@ -120,6 +120,8 @@ pub(crate) struct Route {
     /// The query engine resolves them and routes the query again;
     /// the query doesn't execute while any are unresolved.
     pending_lookups: Vec<PendingLookup>,
+    /// The temporary table being created/dropped if present
+    pub(in crate::frontend) temp_table_change: Option<TempTableChange>,
 }
 
 impl Display for Route {
@@ -369,6 +371,11 @@ impl Route {
 
     pub(crate) fn set_rewrite_plan(&mut self, plan: AggregateRewritePlan) {
         self.rewrite_plan = plan;
+    }
+
+    pub(super) fn with_temp_table_change(mut self, temp_table: Option<TempTableChange>) -> Self {
+        self.temp_table_change = temp_table;
+        self
     }
 }
 


### PR DESCRIPTION
This commit changes the parser to look for `CREATE TEMP TABLE`, locking the connection until all are dropped. Tables can be created with `ON COMMIT DROP` as an option, which causes them to be dropped whenever a transaction is committed. Tables are dropped on rollback regardless of options. They can also be explicitly dropped with `DROP TABLE`.

The behavior here is slightly more complex than that of advisory locks, since temporary tables interact with transactions as normal, so we need to keep track of which tables have been committed and which haven't.

This will, however, incorrectly lock the connection indefinitely if a savepoint is rolled back and doing so would undo the creation of a temp table. Since this same bug affects transaction scope advisory locks, and fixing this bug is non-trivial, I've opted not to handle it here.

Temp tables cannot go in a schema, so we do not need to worry about schema qualification here.

Deallocating temp tables was already handled elsewhere so this commit didn't need to handle it.

Close #1145