### PR TITLE
Add missing empty set tests

### DIFF
--- a/pgdog/src/backend/pool/connection/aggregate/cmp.rs
+++ b/pgdog/src/backend/pool/connection/aggregate/cmp.rs
@@ -85,4 +85,12 @@ mod tests {
         state.accumulate(1i64.into()).unwrap();
         assert_matches!(state.accumulate(1f64.into()), Err(_));
     }
+
+    #[test]
+    fn empty_state_returns_null() {
+        let mut state = Cmp::max(0);
+        state.accumulate(Datum::Null).unwrap();
+        state.accumulate(Datum::Null).unwrap();
+        assert_eq!(state.finalize(), Datum::Null);
+    }
 }

--- a/pgdog/src/backend/pool/connection/aggregate/count.rs
+++ b/pgdog/src/backend/pool/connection/aggregate/count.rs
@@ -4,15 +4,12 @@ use crate::net::messages::Datum;
 #[derive(Debug)]
 pub(super) struct Count {
     pub(super) column: usize,
-    total: Option<i64>,
+    total: i64,
 }
 
 impl Count {
     pub(super) fn new(column: usize) -> Self {
-        Self {
-            column,
-            total: None,
-        }
+        Self { column, total: 0 }
     }
 
     pub(super) fn accumulate(&mut self, value: Datum) -> Result<(), TypeError> {
@@ -20,7 +17,7 @@ impl Count {
             return Ok(());
         }
 
-        *self.total.get_or_insert(0) += value.as_i64()?;
+        self.total += value.as_i64()?;
         Ok(())
     }
 
@@ -28,7 +25,7 @@ impl Count {
         self.finalize_i64().into()
     }
 
-    pub(super) fn finalize_i64(self) -> Option<i64> {
+    pub(super) fn finalize_i64(self) -> i64 {
         self.total
     }
 }
@@ -48,5 +45,5 @@ fn count_with_only_null() {
     let mut state = Count::new(0);
     state.accumulate(Datum::Null).unwrap();
     state.accumulate(Datum::Null).unwrap();
-    assert_eq!(state.finalize(), Datum::Null);
+    assert_eq!(state.finalize(), 0i64.into());
 }

--- a/pgdog/src/backend/pool/connection/aggregate/sum.rs
+++ b/pgdog/src/backend/pool/connection/aggregate/sum.rs
@@ -53,4 +53,12 @@ mod tests {
         state.accumulate(1i64.into()).unwrap();
         assert_matches!(state.accumulate(1f64.into()), Err(_));
     }
+
+    #[test]
+    fn empty_sum_returns_null() {
+        let mut state = Sum::new(0);
+        state.accumulate(Datum::Null).unwrap();
+        state.accumulate(Datum::Null).unwrap();
+        assert_eq!(state.finalize(), Datum::Null);
+    }
 }

--- a/pgdog/src/backend/pool/connection/aggregate/variance.rs
+++ b/pgdog/src/backend/pool/connection/aggregate/variance.rs
@@ -59,9 +59,7 @@ impl Variance {
         // ref https://open.maricopa.edu/haasstatistics/chapter/4-4-calculating-variance/
         let sumsq = self.sumsq.finalize();
         let sum = self.sum.finalize();
-        let Some(count) = self.count.finalize_i64() else {
-            return Ok(Datum::Null);
-        };
+        let count = self.count.finalize_i64();
 
         match (sumsq, sum) {
             (Datum::Numeric(sumsq), Datum::Numeric(sum)) => {


### PR DESCRIPTION
We've had two aggregate functions panic from division by zero. Even though all the remaining aggregate functions should handle empty sets just fine, let's add some tests to ensure that's the case.

I also noticed an "incorrect" behavior for count, since counting an empty set returns 0 instead of null. I put scare quotes there because the shards would never return NULL for us, they would always return 0, so that behavior wasn't actually possible in practice. But I've updated the code to reflect that.