### PR TITLE
refactor(api): move task definitions to pgdog-stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3288,6 +3288,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
+ "serde_with",
 ]
 
 [[package]]
@@ -4083,7 +4084,9 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
+ "chrono",
  "dyn-clone",
+ "indexmap 2.14.0",
  "ref-cast",
  "schemars_derive",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ pgdog-postgres-types = { path = "./pgdog-postgres-types"}
 pg_raw_parse = { git = "https://github.com/pgdogdev/pg_raw_parse.git", rev = "c5b3b75" }
 bon = "3.9"
 derive_more = { version = "2", features = ["display", "from"] }
-schemars = { version = "1.2.1", features = ["uuid1"] }
+schemars = { version = "1.2.1", features = ["uuid1", "chrono04", "indexmap2"] }
 serde_json = "1.0"
 indexmap = { version = "2.14", features = ["serde"] }
 serde_with = { version = "3.22", features = ["macros", "schemars_1"] }

--- a/pgdog-stats/Cargo.toml
+++ b/pgdog-stats/Cargo.toml
@@ -5,12 +5,13 @@ edition = "2024"
 
 [dependencies]
 serde = {version = "*", features = ["derive", "rc"]}
+serde_with.workspace = true
 pgdog-config = { path = "../pgdog-config" }
 pgdog-postgres-types = { path = "../pgdog-postgres-types" }
 bytes.workspace = true
 indexmap.workspace = true
 schemars.workspace = true
-derive_more = { workspace = true, features = ["from_str"] }
+derive_more = { workspace = true, features = ["error", "from_str"] }
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/pgdog-stats/src/task.rs
+++ b/pgdog-stats/src/task.rs
@@ -3,11 +3,15 @@
 use std::borrow::Cow;
 use std::fmt;
 use std::sync::Arc;
+use std::time::{Duration, SystemTime};
 
-use derive_more::{Display, From, FromStr};
+use indexmap::IndexMap;
+
+use derive_more::{Display, Error, From, FromStr};
 use pgdog_postgres_types::ToDataRowColumn;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use serde_with::{TimestampMilliSeconds, serde_as, skip_serializing_none};
 
 use crate::{Lsn, SyncState};
 
@@ -62,6 +66,197 @@ pub enum TaskStatus {
     #[display("-")]
     #[serde(other)]
     Other,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Display, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum TaskProgress {
+    #[display("started")]
+    Started,
+    #[display("running")]
+    Running,
+    #[display("finished")]
+    Finished,
+    /// Cancellation has been requested; the task is winding down
+    /// cooperatively and has not yet reached a terminal state.
+    #[display("cancelling")]
+    Cancelling,
+    #[display("cancelled")]
+    Cancelled,
+    #[display("failed: {message}")]
+    Error { message: String },
+    #[display("panicked: {message}")]
+    Panic { message: String },
+    /// Fallback value for the communication protocol,
+    /// to cover versions mismatches
+    #[default]
+    #[display("unknown")]
+    #[serde(other)]
+    Unknown,
+}
+
+impl TaskProgress {
+    pub fn error(message: impl Into<String>) -> Self {
+        Self::Error {
+            message: message.into(),
+        }
+    }
+
+    pub fn panic(message: impl Into<String>) -> Self {
+        Self::Panic {
+            message: message.into(),
+        }
+    }
+
+    pub fn is_terminal(&self) -> bool {
+        matches!(
+            self,
+            Self::Finished | Self::Cancelled | Self::Error { .. } | Self::Panic { .. }
+        )
+    }
+
+    pub fn is_error(&self) -> bool {
+        matches!(self, Self::Error { .. } | Self::Panic { .. })
+    }
+}
+
+/// Tasks representation used by EE
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct TaskEntry {
+    pub id: TaskId,
+    #[serde_as(as = "TimestampMilliSeconds<i64>")]
+    pub started_at: SystemTime,
+    #[serde_as(as = "TimestampMilliSeconds<i64>")]
+    pub updated_at: SystemTime,
+    pub progress: TaskProgress,
+    pub status: TaskStatus,
+    pub definition: Arc<TaskDefinition>,
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+    pub subtasks: IndexMap<TaskId, TaskEntry>,
+}
+
+/// Updates for the tasks that could omit some fields from [`TaskEntry`]
+/// and omit unchanged subtasks. A child list is partial: only changed
+/// are present.
+#[serde_as]
+#[skip_serializing_none]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TaskUpdate {
+    pub id: TaskId,
+    #[serde_as(as = "TimestampMilliSeconds<i64>")]
+    pub started_at: SystemTime,
+    #[serde_as(as = "TimestampMilliSeconds<i64>")]
+    pub updated_at: SystemTime,
+    /// `None` when the task did not change since the receiver's cursor.
+    pub progress: Option<TaskProgress>,
+    /// `None` when the task did not change since the receiver's cursor.
+    pub status: Option<TaskStatus>,
+    /// `None` once the receiver holds it: it never changes.
+    pub definition: Option<Arc<TaskDefinition>>,
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+    pub subtasks: IndexMap<TaskId, TaskUpdate>,
+}
+
+/// Error for incomplete update - some of the required fields are missing
+#[derive(Debug, Clone, PartialEq, Display, Error)]
+#[display("update for task {id} omits its {field}")]
+pub struct IncompleteUpdate {
+    pub id: TaskId,
+    pub field: &'static str,
+}
+
+/// Create the new [`TaskEntry`] from [`TaskUpdate`].
+///
+/// # Errors
+///
+/// If some required fields are missing the error is generated that should
+/// requests the whole tree from the instance again.
+impl TryFrom<TaskUpdate> for TaskEntry {
+    type Error = IncompleteUpdate;
+
+    fn try_from(update: TaskUpdate) -> Result<Self, IncompleteUpdate> {
+        let TaskUpdate {
+            id,
+            started_at,
+            updated_at,
+            progress,
+            status,
+            definition,
+            subtasks,
+        } = update;
+
+        let missing = |field| IncompleteUpdate { id, field };
+
+        let subtasks = subtasks
+            .into_values()
+            .map(|child| Self::try_from(child).map(|entry| (entry.id, entry)))
+            .collect::<Result<IndexMap<TaskId, Self>, IncompleteUpdate>>()?;
+
+        Ok(Self {
+            id,
+            started_at,
+            updated_at,
+            progress: progress.ok_or_else(|| missing("progress"))?,
+            status: status.ok_or_else(|| missing("status"))?,
+            definition: definition.ok_or_else(|| missing("definition"))?,
+            subtasks,
+        })
+    }
+}
+
+impl TaskEntry {
+    /// Newest `updated_at` in this subtree, this task included.
+    pub fn subtree_updated_at(&self) -> SystemTime {
+        self.subtasks
+            .values()
+            .map(Self::subtree_updated_at)
+            .fold(self.updated_at, SystemTime::max)
+    }
+
+    /// Whether this task reached a terminal state more than `ttl` ago. Only
+    /// this task is read: a terminal task implies terminal children.
+    pub fn expired(&self, now: SystemTime, ttl: Duration) -> bool {
+        self.progress.is_terminal()
+            && now
+                .duration_since(self.updated_at)
+                .is_ok_and(|age| age >= ttl)
+    }
+
+    /// Apply an update to current TaskEntry. The present fields will overwrite existing
+    /// fields, otherwise the current value will be used.
+    ///
+    /// # Errors
+    ///
+    /// In case some required fields are missing (when the entry was not seen before) the
+    /// error is raised.
+    pub fn update(&mut self, update: TaskUpdate) -> Result<(), IncompleteUpdate> {
+        if update.updated_at < self.updated_at {
+            return Ok(());
+        }
+
+        self.updated_at = update.updated_at;
+        if let Some(progress) = update.progress {
+            self.progress = progress;
+        }
+        if let Some(status) = update.status {
+            self.status = status;
+        }
+        if let Some(definition) = update.definition {
+            self.definition = definition;
+        }
+
+        for (id, child) in update.subtasks {
+            match self.subtasks.get_mut(&id) {
+                Some(entry) => entry.update(child)?,
+                None => {
+                    self.subtasks.insert(id, Self::try_from(child)?);
+                }
+            }
+        }
+
+        Ok(())
+    }
 }
 
 /// The definition of the task - initial options of the task
@@ -431,6 +626,7 @@ pub struct SchemaShardDefinition {
 #[cfg(test)]
 mod test {
     use super::*;
+    use std::time::{Duration, UNIX_EPOCH};
 
     fn table_copy() -> TableCopyDefinition {
         TableCopyDefinition {
@@ -848,5 +1044,129 @@ mod test {
             .to_string(),
             "10 rows, 2048 bytes, 512 bytes/s"
         );
+    }
+
+    fn at(ms: u64) -> SystemTime {
+        UNIX_EPOCH + Duration::from_millis(ms)
+    }
+
+    fn create_task_update(id: u64, updated_at_ms: u64, subtasks: Vec<TaskUpdate>) -> TaskUpdate {
+        TaskUpdate {
+            id: TaskId::new(id),
+            started_at: at(1),
+            updated_at: at(updated_at_ms),
+            progress: Some(TaskProgress::Running),
+            status: Some(TaskStatus::Other),
+            definition: Some(Arc::new(TaskDefinition::named("my-task"))),
+            subtasks: subtasks.into_iter().map(|node| (node.id, node)).collect(),
+        }
+    }
+
+    fn shallow_update(mut update: TaskUpdate) -> TaskUpdate {
+        update.progress = None;
+        update.status = None;
+        update.definition = None;
+        update
+    }
+
+    fn stored(update: TaskUpdate) -> TaskEntry {
+        TaskEntry::try_from(update).unwrap()
+    }
+
+    #[test]
+    fn test_update_merges_into_the_stored_tree() {
+        let mut entry = stored(create_task_update(
+            1,
+            100,
+            vec![
+                create_task_update(2, 100, Vec::new()),
+                create_task_update(3, 100, Vec::new()),
+            ],
+        ));
+
+        entry
+            .update(shallow_update(create_task_update(
+                1,
+                200,
+                vec![shallow_update(create_task_update(3, 250, Vec::new()))],
+            )))
+            .unwrap();
+
+        assert_eq!(entry.updated_at, at(200));
+        assert_eq!(entry.progress, TaskProgress::Running);
+        assert_eq!(entry.status, TaskStatus::Other);
+        assert_eq!(entry.definition.name, "my-task");
+
+        assert_eq!(entry.subtasks.len(), 2);
+        assert_eq!(entry.subtasks[0].id, TaskId::new(2));
+        assert_eq!(entry.subtasks[0].updated_at, at(100));
+        assert_eq!(entry.subtasks[1].id, TaskId::new(3));
+        assert_eq!(entry.subtasks[1].updated_at, at(250));
+    }
+
+    #[test]
+    fn test_update_older_than_the_entry_is_ignored_whole() {
+        let mut entry = stored(create_task_update(
+            1,
+            300,
+            vec![create_task_update(2, 300, Vec::new())],
+        ));
+
+        entry
+            .update(shallow_update(create_task_update(1, 100, Vec::new())))
+            .unwrap();
+
+        assert_eq!(entry.updated_at, at(300));
+        assert_eq!(entry.progress, TaskProgress::Running);
+        assert_eq!(entry.subtasks.len(), 1);
+        assert_eq!(entry.subtasks[0].id, TaskId::new(2));
+    }
+
+    #[test]
+    fn test_try_from_names_the_task_and_the_missing_field() {
+        let err = TaskEntry::try_from(shallow_update(create_task_update(1, 100, Vec::new())))
+            .unwrap_err();
+        assert_eq!(err.id, TaskId::new(1));
+        assert_eq!(err.field, "progress");
+
+        let deep = create_task_update(
+            1,
+            100,
+            vec![shallow_update(create_task_update(9, 100, Vec::new()))],
+        );
+        assert_eq!(TaskEntry::try_from(deep).unwrap_err().id, TaskId::new(9));
+    }
+
+    #[test]
+    fn test_unknown_progress_decodes_without_failing_the_batch() {
+        let tree: TaskUpdate = serde_json::from_str(
+            r#"{"id":1,"started_at":1,"updated_at":1,
+                "progress":{"state":"teleporting"},"status":{"kind":"other"},
+                "subtasks":{
+                    "2":{"id":2,"started_at":1,"updated_at":2,
+                         "progress":{"state":"finished"},"status":{"kind":"other"}}
+                }}"#,
+        )
+        .unwrap();
+
+        assert_eq!(tree.progress, Some(TaskProgress::Unknown));
+        assert_eq!(
+            tree.subtasks[&TaskId::new(2)].progress,
+            Some(TaskProgress::Finished)
+        );
+    }
+
+    #[test]
+    fn test_progress_error_carries_its_message() {
+        let progress = TaskProgress::error("boom");
+        let json = serde_json::to_string(&progress).unwrap();
+
+        assert_eq!(json, r#"{"state":"error","message":"boom"}"#);
+        assert_eq!(
+            serde_json::from_str::<TaskProgress>(&json).unwrap(),
+            progress
+        );
+        assert!(progress.is_terminal());
+        assert!(progress.is_error());
     }
 }

--- a/pgdog/src/api/task.rs
+++ b/pgdog/src/api/task.rs
@@ -10,9 +10,10 @@ use std::time::{Duration, SystemTime};
 
 use dashmap::DashMap;
 use derive_more::Debug;
+use indexmap::IndexMap;
 use parking_lot::RwLock;
-pub(crate) use pgdog_stats::TaskId;
-use pgdog_stats::{TaskDefinition, TaskStatus};
+use pgdog_stats::{TaskDefinition, TaskStatus, TaskUpdate};
+pub(crate) use pgdog_stats::{TaskId, TaskProgress};
 use tokio::select;
 use tokio::sync::oneshot::{self, Receiver};
 use tokio_util::sync::CancellationToken;
@@ -54,35 +55,11 @@ pub(crate) trait Task: std::fmt::Debug + Send + Sync + Sized {
     ) -> impl Future<Output = Result<Self::Output, Self::Error>> + Send;
 }
 
-/// How far a task got through its lifecycle — a fixed, enumerable set,
-/// independent of the domain-specific status the task reports for itself
-/// (which is tracked separately as [`TaskStatus`]).
-#[derive(Display, Debug, Clone, PartialEq, Eq)]
-pub(crate) enum TaskProgress {
-    #[display("started")]
-    Started,
-    #[display("running")]
-    Running,
-    #[display("finished")]
-    Finished,
-    /// Cancellation has been requested; the task is winding down
-    /// cooperatively and has not yet reached a terminal state.
-    #[display("cancelling")]
-    Cancelling,
-    #[display("cancelled")]
-    Cancelled,
-    #[display("failed: {_0}")]
-    Error(String),
-    #[display("panicked: {_0}")]
-    Panic(String),
-}
-
 /// Snapshot of a task's current state, readable through the registry.
 #[derive(Debug, Clone)]
 pub(crate) struct TaskState {
-    /// What the task is, from [`Task::definition`]: its name and, where it has
-    /// any, the structured detail. Immutable for the life of the task, so every
-    /// snapshot shares it.
+    /// What the task is: its name and, where it has any, the structured
+    /// detail. Immutable for the life of the task, so every snapshot shares it.
     pub(crate) definition: Arc<TaskDefinition>,
     /// Where the task is in its lifecycle (carries the error/panic message
     /// for its terminal failure variants).
@@ -119,21 +96,6 @@ pub(crate) enum TaskError<E> {
     /// died without reporting (e.g. runtime shutdown).
     #[display("task result was never delivered")]
     Abandoned,
-}
-
-impl TaskProgress {
-    /// Whether the task reached a terminal state.
-    fn is_terminal(&self) -> bool {
-        matches!(
-            self,
-            Self::Finished | Self::Cancelled | Self::Error(_) | Self::Panic(_)
-        )
-    }
-
-    /// Whether the task failed.
-    fn is_error(&self) -> bool {
-        matches!(self, Self::Error(_) | Self::Panic(_))
-    }
 }
 
 /// Tasks of one nesting level
@@ -181,6 +143,10 @@ impl TaskEntryState {
             status: TaskStatus::Other,
         }
     }
+
+    fn mark_updated(&mut self) {
+        self.updated_at = SystemTime::now().max(self.updated_at);
+    }
 }
 
 /// Registry entry of a queued task. Holds no `T`: the reported status is a
@@ -227,7 +193,7 @@ impl TaskEntry {
             return;
         }
 
-        let panicked = matches!(progress, TaskProgress::Panic(_));
+        let panicked = matches!(progress, TaskProgress::Panic { .. });
         if progress.is_terminal() && !panicked && self.cancellation_token.is_cancelled() {
             info!(
                 "The task is cancelled, ignore the current progress: {progress} and set it Cancelled"
@@ -242,7 +208,7 @@ impl TaskEntry {
         }
 
         state.progress = progress;
-        state.updated_at = SystemTime::now();
+        state.mark_updated();
     }
 
     pub(crate) fn state(&self) -> TaskState {
@@ -264,6 +230,34 @@ impl TaskEntry {
                 .duration_since(state.updated_at)
                 .is_ok_and(|age| age >= ttl)
     }
+
+    /// Create the [`TaskUpdate`] from the current entry
+    #[allow(dead_code)] // used by ee
+    pub(crate) fn as_update(&self, since: SystemTime) -> Option<TaskUpdate> {
+        let state = self.state();
+        let subtasks: IndexMap<TaskId, TaskUpdate> = self
+            .subtasks
+            .map
+            .iter()
+            .filter_map(|child| child.value().as_update(since))
+            .map(|child| (child.id, child))
+            .collect();
+
+        let changed = state.updated_at >= since;
+        if !changed && subtasks.is_empty() {
+            return None;
+        }
+
+        Some(TaskUpdate {
+            id: self.id,
+            started_at: state.started_at,
+            updated_at: state.updated_at,
+            progress: changed.then_some(state.progress),
+            status: changed.then_some(state.status),
+            definition: (state.started_at >= since).then_some(state.definition),
+            subtasks,
+        })
+    }
 }
 
 struct TerminalOnDrop(Arc<TaskEntry>);
@@ -271,7 +265,7 @@ struct TerminalOnDrop(Arc<TaskEntry>);
 impl Drop for TerminalOnDrop {
     fn drop(&mut self) {
         let progress = if std::thread::panicking() {
-            TaskProgress::Panic("unwound by a panic".into())
+            TaskProgress::panic("unwound by a panic")
         } else {
             TaskProgress::Cancelled
         };
@@ -367,7 +361,7 @@ impl<T: Task> TaskContext<T> {
         }
 
         state.status = status.into();
-        state.updated_at = SystemTime::now();
+        state.mark_updated();
     }
 
     /// Get the task's cancellation token.
@@ -429,7 +423,7 @@ impl<T: Task> TaskContext<T> {
                     Ok(output)
                 }
                 Err(err) => {
-                    ctx.transition(TaskProgress::Error(err.to_string()));
+                    ctx.transition(TaskProgress::error(err.to_string()));
 
                     Err(err)
                 }
@@ -519,7 +513,7 @@ impl TaskStorage {
                     let _ = sender.send(Ok(res));
                 }
                 Ok(Err(err)) => {
-                    ctx.transition(TaskProgress::Error(err.to_string()));
+                    ctx.transition(TaskProgress::error(err.to_string()));
                     let _ = sender.send(Err(TaskError::Failed(err)));
                 }
                 Err(err) if err.is_cancelled() => {
@@ -529,7 +523,7 @@ impl TaskStorage {
                 Err(err) => {
                     let panic = err.to_string();
                     error!("task panicked: {panic}");
-                    ctx.transition(TaskProgress::Panic(panic.clone()));
+                    ctx.transition(TaskProgress::panic(panic.clone()));
                     let _ = sender.send(Err(TaskError::Panicked(panic)));
                 }
             }
@@ -624,6 +618,7 @@ mod tests {
     use std::convert::Infallible;
     use std::fmt::Debug;
     use std::sync::Arc;
+    use std::time::UNIX_EPOCH;
     use tokio::sync::Notify;
     use tokio::task::yield_now;
     use tokio::test;
@@ -1156,7 +1151,7 @@ mod tests {
         assert!(matches!(res, Err(TaskError::Panicked(_))));
 
         let entry = storage.task(task_id).unwrap();
-        assert!(matches!(entry.state().progress, TaskProgress::Panic(_)));
+        assert!(matches!(entry.state().progress, TaskProgress::Panic { .. }));
     }
 
     #[test(start_paused = true)]
@@ -1247,7 +1242,7 @@ mod tests {
         assert_eq!(*state_a.lock(), "failed");
 
         let info = storage.task(task_id).unwrap();
-        assert!(matches!(info.state().progress, TaskProgress::Error(_)));
+        assert!(matches!(info.state().progress, TaskProgress::Error { .. }));
     }
 
     #[test]
@@ -1303,7 +1298,7 @@ mod tests {
         assert_eq!(*state_a.lock(), "started");
 
         let info = storage.task(task_id).unwrap();
-        assert!(matches!(info.state().progress, TaskProgress::Panic(_)));
+        assert!(matches!(info.state().progress, TaskProgress::Panic { .. }));
     }
 
     #[test]
@@ -1328,7 +1323,7 @@ mod tests {
         assert!(matches!(task.await, Err(TaskError::Panicked(_))));
 
         let root = storage.task(id).unwrap();
-        assert!(matches!(root.state().progress, TaskProgress::Panic(_)));
+        assert!(matches!(root.state().progress, TaskProgress::Panic { .. }));
 
         let subtasks = root
             .subtasks()
@@ -1337,7 +1332,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(subtasks.len(), 1);
-        assert!(matches!(subtasks[0], TaskProgress::Panic(_)));
+        assert!(matches!(subtasks[0], TaskProgress::Panic { .. }));
     }
 
     #[test]
@@ -1661,7 +1656,7 @@ mod tests {
         assert!(
             progress
                 .iter()
-                .any(|progress| matches!(progress, TaskProgress::Error(_)))
+                .any(|progress| matches!(progress, TaskProgress::Error { .. }))
         );
     }
 
@@ -1721,5 +1716,69 @@ mod tests {
 
         assert_eq!(waiter.id(), TaskId::new(7));
         assert!(matches!(waiter.await, Err(TaskError::Abandoned)));
+    }
+
+    #[test]
+    async fn test_as_update_skips_sent() {
+        let notify = Arc::new(Notify::new());
+        let state_a = Arc::new(Mutex::new("initial"));
+        let a = mock_successful!(state_a, notify);
+
+        let storage = TaskStorage::default();
+        let task = storage.run(a);
+        let id = task.id();
+
+        settle().await;
+
+        let root = storage.task(id).unwrap();
+        assert!(
+            root.as_update(SystemTime::now() + Duration::from_secs(60))
+                .is_none()
+        );
+
+        notify.notify_one();
+        task.await.unwrap();
+
+        let finished_at = root.state().updated_at;
+        assert!(root.as_update(finished_at).is_some());
+        assert!(
+            root.as_update(finished_at + Duration::from_millis(1))
+                .is_none()
+        );
+    }
+
+    #[test]
+    async fn test_as_update_sends_only_receiver_updates() {
+        let sub_gate = Arc::new(Notify::new());
+        let parent_gate = Arc::new(Notify::new());
+
+        let storage = TaskStorage::default();
+        let task = storage.run(TraverseRoot {
+            sub_gate: sub_gate.clone(),
+            parent_gate: parent_gate.clone(),
+        });
+
+        settle().await;
+
+        let root = storage.task(task.id()).unwrap();
+
+        let full = root.as_update(UNIX_EPOCH).unwrap();
+        assert_eq!(full.id, root.id);
+        assert!(full.definition.is_some());
+        assert!(full.progress.is_some());
+        assert!(full.status.is_some());
+
+        let child = &full.subtasks[0];
+        let grandchild = &child.subtasks[0];
+        assert!(child.id > full.id);
+        assert!(grandchild.id > child.id);
+
+        let thinned = root.as_update(child.started_at).unwrap();
+        assert_eq!(thinned.started_at, root.started_at);
+        assert!(thinned.definition.is_none());
+        assert!(thinned.subtasks[0].definition.is_some());
+
+        sub_gate.notify_one();
+        parent_gate.notify_one();
     }
 }


### PR DESCRIPTION
Move some types from pgdog to pgdog-stats to be able to reuse it on the EE side