### PR TITLE
fix: separate DISCARD variants and prepared statement cleanup

### DIFF
--- a/pgdog/src/frontend/client/query_engine/discard.rs
+++ b/pgdog/src/frontend/client/query_engine/discard.rs
@@ -9,10 +9,13 @@ impl QueryEngine {
     pub(super) async fn discard(
         &mut self,
         context: &mut QueryEngineContext<'_>,
+        target: DiscardTarget,
         extended: bool,
     ) -> Result<(), Error> {
         let _extended = extended;
-        context.prepared_statements.close_all();
+        if target == DiscardTarget::All {
+            context.prepared_statements.close_all();
+        }
         let bytes_sent = context
             .stream
             .send_many(&[

--- a/pgdog/src/frontend/client/query_engine/mod.rs
+++ b/pgdog/src/frontend/client/query_engine/mod.rs
@@ -2,7 +2,8 @@ use crate::{
     backend::pool::{Connection, Request},
     config::config,
     frontend::{
-        BufferedQuery, Client, ClientComms, Command, Error, Router, RouterContext, Stats,
+        BufferedQuery, Client, ClientComms, Command, DiscardTarget, Error, Router, RouterContext,
+        Stats,
         client::query_engine::{hooks::QueryEngineHooks, route_query::ClusterCheck},
         router::{Route, parser::Shard},
     },
@@ -275,7 +276,9 @@ impl QueryEngine {
             }
             Command::Copy(_) => self.execute(context, rewrite_result).await?,
             Command::Deallocate => self.deallocate(context).await?,
-            Command::Discard { extended } => self.discard(context, *extended).await?,
+            Command::Discard { target, extended } => {
+                self.discard(context, *target, *extended).await?
+            }
             Command::Split(queries) => return Ok(Self::build_simple_split(queries)),
         }
 

--- a/pgdog/src/frontend/client/query_engine/test/discard.rs
+++ b/pgdog/src/frontend/client/query_engine/test/discard.rs
@@ -30,3 +30,35 @@ async fn test_discard_clears_prepared_statement_cache() {
     assert_eq!(client.client().prepared_statements.num_statements(), 0);
     assert_eq!(global.read().statements().iter().next().unwrap().1.used, 0);
 }
+
+#[tokio::test]
+async fn test_non_all_discard_keeps_prepared_statement_cache() {
+    for query in ["DISCARD PLANS", "DISCARD SEQUENCES", "DISCARD TEMP"] {
+        let mut client = TestClient::new_replicas(Parameters::default())
+            .await
+            .with_full_prepared_statements();
+
+        client.send(Parse::named("test_stmt", "SELECT $1")).await;
+        client.send(Sync).await;
+        client.try_process().await.unwrap();
+
+        expect_message!(client.read().await, ParseComplete);
+        expect_message!(client.read().await, ReadyForQuery);
+
+        let global = client.client().prepared_statements.global.clone();
+        assert_eq!(client.client().prepared_statements.num_statements(), 1);
+        assert_eq!(global.read().statements().iter().next().unwrap().1.used, 1);
+
+        client.send_simple(Query::new(query)).await;
+
+        expect_message!(client.read().await, CommandComplete);
+        expect_message!(client.read().await, ReadyForQuery);
+
+        assert_eq!(
+            client.client().prepared_statements.num_statements(),
+            1,
+            "{query} should not clear prepared statements",
+        );
+        assert_eq!(global.read().statements().iter().next().unwrap().1.used, 1);
+    }
+}

--- a/pgdog/src/frontend/mod.rs
+++ b/pgdog/src/frontend/mod.rs
@@ -20,6 +20,6 @@ pub(crate) use connected_client::ConnectedClient;
 pub(crate) use error::Error;
 pub(crate) use prepared_statements::PreparedStatements;
 pub(crate) use regex_parser::RegexParser;
-pub(crate) use router::{Command, RewritePlan, Router, SetParam};
+pub(crate) use router::{Command, DiscardTarget, RewritePlan, Router, SetParam};
 pub(crate) use router::{RouterContext, SearchPath};
 pub(crate) use stats::Stats;

--- a/pgdog/src/frontend/router/mod.rs
+++ b/pgdog/src/frontend/router/mod.rs
@@ -12,7 +12,7 @@ pub(crate) mod sharding;
 
 pub(crate) use copy::CopyRow;
 pub(crate) use error::Error;
-pub(crate) use parser::{Ast, Command, QueryParser, RewritePlan, Route, SetParam};
+pub(crate) use parser::{Ast, Command, DiscardTarget, QueryParser, RewritePlan, Route, SetParam};
 
 use super::ClientRequest;
 pub(crate) use context::RouterContext;

--- a/pgdog/src/frontend/router/parser/command.rs
+++ b/pgdog/src/frontend/router/parser/command.rs
@@ -12,6 +12,14 @@ pub(crate) struct SetParam {
     pub(crate) local: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DiscardTarget {
+    All,
+    Plans,
+    Sequences,
+    Temp,
+}
+
 /// Query parser result.
 #[derive(Debug, Clone)]
 pub(crate) enum Command {
@@ -42,6 +50,7 @@ pub(crate) enum Command {
     },
     Deallocate,
     Discard {
+        target: DiscardTarget,
         extended: bool,
     },
     Listen {

--- a/pgdog/src/frontend/router/parser/error.rs
+++ b/pgdog/src/frontend/router/parser/error.rs
@@ -90,4 +90,7 @@ pub(crate) enum Error {
 
     #[error("execute requires prepared statements to be set to full")]
     ExecuteRequiresFull,
+
+    #[error("unknown DISCARD target: {0}")]
+    UnknownDiscardTarget(u32),
 }

--- a/pgdog/src/frontend/router/parser/mod.rs
+++ b/pgdog/src/frontend/router/parser/mod.rs
@@ -34,7 +34,7 @@ pub(crate) use aggregate::{Aggregate, AggregateFunction, AggregateTarget};
 pub(crate) use binary::BinaryStream;
 pub(crate) use cache::{Ast, AstContext, Cache};
 pub(crate) use column::Column;
-pub(crate) use command::{Command, SetParam};
+pub(crate) use command::{Command, DiscardTarget, SetParam};
 pub(crate) use comment::parse_edge_comment;
 pub(crate) use context::QueryParserContext;
 pub(crate) use copy::{CopyFormat, CopyParser};

--- a/pgdog/src/frontend/router/parser/query/mod.rs
+++ b/pgdog/src/frontend/router/parser/query/mod.rs
@@ -440,8 +440,17 @@ impl QueryParser {
 
             Node::ExplainStmt(stmt) => self.explain(statement, stmt, context),
 
-            Node::DiscardStmt { .. } => {
+            Node::DiscardStmt(stmt) => {
+                let target = match stmt.target {
+                    nodes::DiscardMode::DISCARD_ALL => DiscardTarget::All,
+                    nodes::DiscardMode::DISCARD_PLANS => DiscardTarget::Plans,
+                    nodes::DiscardMode::DISCARD_SEQUENCES => DiscardTarget::Sequences,
+                    nodes::DiscardMode::DISCARD_TEMP => DiscardTarget::Temp,
+                    target => return Err(Error::UnknownDiscardTarget(target)),
+                };
+
                 return Ok(Command::Discard {
+                    target,
                     extended: !context.query()?.simple(),
                 });
             }

--- a/pgdog/src/frontend/router/parser/query/test/test_session_control.rs
+++ b/pgdog/src/frontend/router/parser/query/test/test_session_control.rs
@@ -1,6 +1,9 @@
 use pgdog_config::QueryParserLevel;
 
-use crate::{config::config, frontend::Command};
+use crate::{
+    config::config,
+    frontend::{Command, DiscardTarget},
+};
 
 use super::setup::*;
 
@@ -38,6 +41,27 @@ fn test_reset_all() {
         matches!(command, Command::ResetAll),
         "expected Command::ResetAll, got {command:#?}",
     );
+}
+
+#[test]
+fn test_discard_variants() {
+    let mut config = (*config()).clone();
+    config.config.general.query_parser = QueryParserLevel::On;
+
+    for (query, expected) in [
+        ("DISCARD ALL", DiscardTarget::All),
+        ("DISCARD PLANS", DiscardTarget::Plans),
+        ("DISCARD SEQUENCES", DiscardTarget::Sequences),
+        ("DISCARD TEMP", DiscardTarget::Temp),
+        ("DISCARD TEMPORARY", DiscardTarget::Temp),
+    ] {
+        let mut test = QueryParserTest::new_single_primary(&config);
+        let command = test.execute(vec![Query::new(query).into()]);
+        assert!(
+            matches!(command, Command::Discard { target, .. } if target == expected),
+            "expected {expected:?} for {query}, got {command:#?}",
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
- Preserve the specific PostgreSQL DISCARD target during parsing.
- Clear client prepared statements only for DISCARD ALL.
- closes #1477  