### PR TITLE
added benchmark for insert splits

### DIFF
--- a/benches/perf/sharding/pgdog.toml
+++ b/benches/perf/sharding/pgdog.toml
@@ -36,3 +36,11 @@ host = "localhost"
 role = "replica"
 shard = 2
 database_name = "pgdog3"
+
+[[sharded_tables]]
+database = "pgdog"
+column = "id"
+name = "sharding_bench"
+
+[rewrite]
+split_inserts = "rewrite"

--- a/benches/perf/sharding/script.sql
+++ b/benches/perf/sharding/script.sql
@@ -1,3 +1,6 @@
-\set id random(1, 30)
+\set id random(1, 10000)
+\set id2 random(10000, 20000)
+\set id3 random(20000, 30000)
 
-SELECT * FROM sharding_bench WHERE id = :id;
+
+INSERT INTO sharding_bench (id, value) VALUES (:id, 'test1'), (:id2, 'test3'), (:id3, 'test3');

--- a/benches/perf/sharding/setup.sql
+++ b/benches/perf/sharding/setup.sql
@@ -1,5 +1,5 @@
 DROP TABLE IF EXISTS sharding_bench;
-CREATE TABLE sharding_bench (id BIGINT PRIMARY KEY, value TEXT, created_at TIMESTAMPTZ DEFAULT NOW());
+CREATE TABLE sharding_bench (id BIGINT, value TEXT, created_at TIMESTAMPTZ DEFAULT NOW());
 
 INSERT INTO sharding_bench VALUES (1, 'test1');
 INSERT INTO sharding_bench VALUES (2, 'test2');


### PR DESCRIPTION
### `main`

```
progress: 1.0 s, 8427.5 tps, lat 1.164 ms stddev 0.466, 0 failed
progress: 2.0 s, 9175.5 tps, lat 1.089 ms stddev 0.348, 0 failed
progress: 3.0 s, 8897.5 tps, lat 1.123 ms stddev 0.394, 0 failed
progress: 4.0 s, 8999.0 tps, lat 1.110 ms stddev 0.310, 0 failed
progress: 5.0 s, 9155.5 tps, lat 1.091 ms stddev 0.298, 0 failed
progress: 6.0 s, 8907.0 tps, lat 1.122 ms stddev 0.393, 0 failed
progress: 7.0 s, 8986.5 tps, lat 1.112 ms stddev 0.311, 0 failed
progress: 8.0 s, 9154.5 tps, lat 1.091 ms stddev 0.305, 0 failed
progress: 9.0 s, 8876.5 tps, lat 1.125 ms stddev 0.408, 0 failed
progress: 10.0 s, 9002.0 tps, lat 1.110 ms stddev 0.303, 0 failed
progress: 11.0 s, 9219.0 tps, lat 1.084 ms stddev 0.305, 0 failed
progress: 12.0 s, 8832.0 tps, lat 1.131 ms stddev 0.389, 0 failed
progress: 13.0 s, 9025.5 tps, lat 1.107 ms stddev 0.389, 0 failed
progress: 14.0 s, 9280.9 tps, lat 1.076 ms stddev 0.385, 0 failed
progress: 15.0 s, 9161.9 tps, lat 1.090 ms stddev 0.311, 0 failed
```

### Refactor

```
progress: 1.0 s, 8028.6 tps, lat 1.222 ms stddev 0.523, 0 failed
progress: 2.0 s, 8400.3 tps, lat 1.190 ms stddev 0.338, 0 failed
progress: 3.0 s, 8437.1 tps, lat 1.184 ms stddev 0.472, 0 failed
progress: 4.0 s, 8352.1 tps, lat 1.197 ms stddev 0.407, 0 failed
progress: 5.0 s, 8471.9 tps, lat 1.179 ms stddev 0.327, 0 failed
progress: 6.0 s, 8637.7 tps, lat 1.157 ms stddev 0.318, 0 failed
progress: 7.0 s, 8371.0 tps, lat 1.194 ms stddev 0.406, 0 failed
progress: 8.0 s, 8435.9 tps, lat 1.185 ms stddev 0.333, 0 failed
progress: 9.0 s, 8424.1 tps, lat 1.186 ms stddev 0.490, 0 failed
progress: 10.0 s, 8304.2 tps, lat 1.203 ms stddev 0.420, 0 failed
progress: 11.0 s, 8461.8 tps, lat 1.181 ms stddev 0.328, 0 failed
```