### PR TITLE
Release LISTEN subscriptions and advisory locks on DISCARD ALL

### DIFF
--- a/pgdog/src/backend/pool/connection/mod.rs
+++ b/pgdog/src/backend/pool/connection/mod.rs
@@ -17,7 +17,7 @@ use crate::{
         ClientRequest, Router,
         router::{CopyRow, Route, parser::Shard},
     },
-    net::{Bind, Message, ParameterStatus, Protocol, ProtocolMessage},
+    net::{Bind, Message, ParameterStatus, Protocol, ProtocolMessage, Query},
     state::State,
 };
 
@@ -425,6 +425,14 @@ impl Connection {
 
             _ => Ok(()),
         }
+    }
+
+    /// Execute an internal query on all connected servers.
+    pub(crate) async fn execute(
+        &mut self,
+        query: impl Into<Query> + Clone,
+    ) -> Result<Vec<Message>, Error> {
+        self.binding.execute(query).await
     }
 
     /// We are done and can disconnect from this server.

--- a/pgdog/src/backend/pool/connection/mod.rs
+++ b/pgdog/src/backend/pool/connection/mod.rs
@@ -256,6 +256,11 @@ impl Connection {
         self.pub_sub.unlisten(channel);
     }
 
+    /// Stop listening on all channels.
+    pub(crate) fn unlisten_all(&mut self) {
+        self.pub_sub.unlisten_all();
+    }
+
     /// Notify a channel.
     pub(crate) async fn notify(
         &mut self,

--- a/pgdog/src/backend/pub_sub/client.rs
+++ b/pgdog/src/backend/pub_sub/client.rs
@@ -73,6 +73,13 @@ impl PubSubClient {
             notify.notify_one();
         }
     }
+
+    /// Stop listening on all channels.
+    pub(crate) fn unlisten_all(&mut self) {
+        for (_, notify) in self.unlisten.drain() {
+            notify.notify_one();
+        }
+    }
 }
 
 #[cfg(test)]
@@ -165,5 +172,26 @@ mod test {
                 .is_err()
         );
         assert_snapshot(channel.stats(), 0, 0, 0);
+    }
+
+    #[tokio::test]
+    async fn unlisten_all_stops_forwarding_notifications() {
+        let events = TestChannel::new();
+        let updates = TestChannel::new();
+        let mut client = PubSubClient::new();
+
+        client.listen("events", events.listener());
+        client.listen("updates", updates.listener());
+        assert_eq!(client.unlisten.len(), 2);
+
+        client.unlisten_all();
+        assert!(client.unlisten.is_empty());
+        wait_for_listener_count(&events, 0).await;
+        wait_for_listener_count(&updates, 0).await;
+
+        assert!(events.send(notification("events", "payload")).is_err());
+        assert!(updates.send(notification("updates", "payload")).is_err());
+        assert_snapshot(events.stats(), 0, 0, 0);
+        assert_snapshot(updates.stats(), 0, 0, 0);
     }
 }

--- a/pgdog/src/frontend/client/query_engine/advisory_lock.rs
+++ b/pgdog/src/frontend/client/query_engine/advisory_lock.rs
@@ -30,6 +30,10 @@ impl AdvisoryLocks {
         !self.locks.is_empty()
     }
 
+    pub(crate) fn clear(&mut self) {
+        self.locks.clear();
+    }
+
     #[cfg(test)]
     pub(crate) fn contains(&self, id: i64) -> bool {
         self.locks.contains(&id)

--- a/pgdog/src/frontend/client/query_engine/discard.rs
+++ b/pgdog/src/frontend/client/query_engine/discard.rs
@@ -15,6 +15,7 @@ impl QueryEngine {
         let _extended = extended;
         if target == DiscardTarget::All {
             context.prepared_statements.close_all();
+            self.backend.unlisten_all();
         }
         let bytes_sent = context
             .stream

--- a/pgdog/src/frontend/client/query_engine/discard.rs
+++ b/pgdog/src/frontend/client/query_engine/discard.rs
@@ -14,8 +14,16 @@ impl QueryEngine {
     ) -> Result<(), Error> {
         let _extended = extended;
         if target == DiscardTarget::All {
+            if self.backend.connected() {
+                self.backend
+                    .execute("SELECT pg_advisory_unlock_all()")
+                    .await?;
+            }
+
+            self.advisory_locks.clear();
             context.prepared_statements.close_all();
             self.backend.unlisten_all();
+            self.check_lock();
         }
         let bytes_sent = context
             .stream

--- a/pgdog/src/frontend/client/query_engine/test/advisory_lock.rs
+++ b/pgdog/src/frontend/client/query_engine/test/advisory_lock.rs
@@ -147,6 +147,49 @@ async fn test_unlock_all_clears_session_locks() {
 }
 
 #[tokio::test]
+async fn test_discard_all_clears_session_locks() {
+    let mut client = TestClient::new_sharded(Parameters::default()).await;
+
+    client
+        .send_simple(Query::new("SELECT pg_advisory_lock(1)"))
+        .await;
+    client.read_until('Z').await.unwrap();
+
+    assert!(client.engine.advisory_locks().contains(1));
+    assert!(client.backend_locked());
+
+    client.send_simple(Query::new("DISCARD ALL")).await;
+    client.read_until('Z').await.unwrap();
+
+    assert_eq!(client.engine.advisory_locks().len(), 0);
+    assert!(
+        !client.backend_locked(),
+        "backend must be released after DISCARD ALL"
+    );
+}
+
+#[tokio::test]
+async fn test_non_all_discard_keeps_session_locks() {
+    let mut client = TestClient::new_sharded(Parameters::default()).await;
+
+    client
+        .send_simple(Query::new("SELECT pg_advisory_lock(1)"))
+        .await;
+    client.read_until('Z').await.unwrap();
+
+    for query in ["DISCARD PLANS", "DISCARD SEQUENCES", "DISCARD TEMP"] {
+        client.send_simple(Query::new(query)).await;
+        client.read_until('Z').await.unwrap();
+
+        assert!(
+            client.engine.advisory_locks().contains(1),
+            "{query} must not release advisory locks",
+        );
+        assert!(client.backend_locked());
+    }
+}
+
+#[tokio::test]
 async fn test_xact_lock_does_not_pin_backend_and_releases_on_commit() {
     // pg_advisory_xact_lock isn't tracked.
     let mut client = TestClient::new_sharded(Parameters::default()).await;


### PR DESCRIPTION

- Stop all LISTEN subscriptions on DISCARD ALL.
- Release advisory locks on PostgreSQL and clear PgDog’s lock tracking.
- Unpin the backend after advisory locks are released.
