### PR TITLE
fix(pool): fence stale automatic-primary checkouts

### DIFF
--- a/pgdog/src/backend/error.rs
+++ b/pgdog/src/backend/error.rs
@@ -30,6 +30,12 @@ pub(crate) enum Error {
     #[error("server connection is not synchronized")]
     NotInSync,
 
+    #[error("automatic primary check timed out")]
+    AutomaticPrimaryCheckTimeout,
+
+    #[error("automatic primary check returned an invalid response")]
+    AutomaticPrimaryCheckInvalidResponse,
+
     #[error("server not connected")]
     NotConnected,
 

--- a/pgdog/src/backend/pool/lb/mod.rs
+++ b/pgdog/src/backend/pool/lb/mod.rs
@@ -8,6 +8,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 
+use parking_lot::Mutex;
 use rand::seq::SliceRandom;
 use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
@@ -80,6 +81,18 @@ impl Target {
     pub(super) fn health(&self) -> &TargetHealth {
         &self.pool.inner().health
     }
+
+    fn is_qualified_primary(&self) -> bool {
+        if self.role() != Role::Primary {
+            return false;
+        }
+        if self.pool.addr().configured_role != Role::Auto {
+            return true;
+        }
+
+        let stats = self.pool.lsn_stats();
+        stats.valid() && !stats.replica
+    }
 }
 
 /// Load balancer.
@@ -97,6 +110,8 @@ pub(crate) struct LoadBalancer {
     pub(super) maintenance: CancellationToken,
     /// Pool elected as primary by automatic role detection.
     pub(super) elected_primary: Arc<watch::Sender<Option<Pool>>>,
+    /// Automatic-role election lock.
+    election: Arc<Mutex<()>>,
     /// Read/write split.
     pub(super) rw_split: ReadWriteSplit,
 }
@@ -148,6 +163,7 @@ impl LoadBalancer {
             lb_strategy,
             maintenance: CancellationToken::new(),
             elected_primary: Arc::new(watch::Sender::new(None)),
+            election: Arc::new(Mutex::new(())),
             rw_split,
         }
     }
@@ -171,12 +187,16 @@ impl LoadBalancer {
     /// Detect database roles from pg_is_in_recovery() and
     /// return new primary (if any), and replicas.
     pub(crate) fn redetect_roles(&self) -> bool {
-        let mut promoted = false;
+        let _election = self.election.lock();
+        let previous_primary = self
+            .primary_target()
+            .filter(|target| target.pool.addr().configured_role == Role::Auto)
+            .map(|target| target.pool.id());
 
         let mut targets = self
             .targets
-            .clone()
-            .into_iter()
+            .iter()
+            .filter(|target| target.pool.addr().configured_role == Role::Auto)
             .map(|target| (target.pool.lsn_stats(), target))
             .collect::<Vec<_>>();
 
@@ -193,13 +213,15 @@ impl LoadBalancer {
         let primary = targets
             .iter()
             .position(|target| !target.0.replica && target.0.valid());
+        let current_primary = primary.map(|index| targets[index].1.pool.id());
+        let primary_changed = previous_primary != current_primary;
 
         self.elected_primary.send_replace(None);
 
         if let Some(primary) = primary {
-            promoted = targets[primary].1.set_role(Role::Primary);
+            targets[primary].1.set_role(Role::Primary);
 
-            if promoted {
+            if primary_changed {
                 warn!("new primary chosen: {}", targets[primary].1.pool.addr());
             }
 
@@ -211,16 +233,18 @@ impl LoadBalancer {
                 .for_each(|(_, target)| {
                     target.1.set_role(Role::Replica);
                 });
-        } else if targets.iter().all(|target| target.0.valid()) {
-            // All targets are replicas until we get a primary.
+        } else {
             targets.iter().for_each(|target| {
                 target.1.set_role(Role::Replica);
             });
         }
 
-        self.elected_primary.send_replace(self.primary().cloned());
+        self.elected_primary.send_replace(
+            self.qualified_primary_target()
+                .map(|target| target.pool.clone()),
+        );
 
-        promoted
+        primary_changed
     }
 
     /// Launch replica pools and start the monitor.
@@ -324,15 +348,25 @@ impl LoadBalancer {
         result
     }
 
-    /// Wait until automatic role detection elects a primary.
-    ///
-    /// Fails with [`Error::CheckoutTimeout`] if no election happens in time.
+    fn qualified_primary_target(&self) -> Option<&Target> {
+        self.targets
+            .iter()
+            .rev()
+            .find(|target| target.is_qualified_primary())
+    }
+
+    /// Wait until automatic role detection elects a qualified primary.
     async fn wait_primary(&self) -> Result<Pool, Error> {
         let mut receiver = self.elected_primary.subscribe();
 
-        safe_timeout(self.checkout_timeout, receiver.wait_for(|p| p.is_some()))
+        receiver
+            .wait_for(|primary| {
+                primary.as_ref().is_some_and(|pool| {
+                    let stats = pool.lsn_stats();
+                    stats.valid() && !stats.replica
+                })
+            })
             .await
-            .map_err(|_| Error::CheckoutTimeout)?
             .ok()
             .and_then(|elected| elected.as_ref().cloned())
             .ok_or(Error::NoPrimary)
@@ -343,8 +377,14 @@ impl LoadBalancer {
     /// In automatic mode, the caller waits for an election. Static
     /// replica-only configurations fail immediately with [`Error::NoPrimary`].
     pub(super) async fn get_primary(&self, request: &Request) -> Result<Guard, Error> {
-        if let Some(pool) = self.primary() {
-            return pool.get(request).await;
+        safe_timeout(self.checkout_timeout, self.get_primary_internal(request))
+            .await
+            .map_err(|_| Error::CheckoutTimeout)?
+    }
+
+    async fn get_primary_internal(&self, request: &Request) -> Result<Guard, Error> {
+        if let Some(target) = self.qualified_primary_target() {
+            return target.pool.get(request).await;
         }
 
         if !self.role_detection_enabled() {

--- a/pgdog/src/backend/pool/lb/mod.rs
+++ b/pgdog/src/backend/pool/lb/mod.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 
 use super::{Error, Guard, Oids, Pool, PoolConfig, PoolRole, Request};
-use crate::util::safe_timeout;
+use crate::{state::State, util::safe_timeout};
 
 pub(crate) mod ban;
 pub(crate) mod monitor;
@@ -92,6 +92,10 @@ impl Target {
 
         let stats = self.pool.lsn_stats();
         stats.valid() && !stats.replica
+    }
+
+    fn is_automatic_primary(&self) -> bool {
+        self.role() == Role::Primary && self.pool.addr().configured_role == Role::Auto
     }
 }
 
@@ -240,7 +244,7 @@ impl LoadBalancer {
         }
 
         self.elected_primary.send_replace(
-            self.qualified_primary_target()
+            self.qualified_primary_target(&[])
                 .map(|target| target.pool.clone()),
         );
 
@@ -348,11 +352,10 @@ impl LoadBalancer {
         result
     }
 
-    fn qualified_primary_target(&self) -> Option<&Target> {
-        self.targets
-            .iter()
-            .rev()
-            .find(|target| target.is_qualified_primary())
+    fn qualified_primary_target(&self, excluded_pools: &[u64]) -> Option<&Target> {
+        self.targets.iter().rev().find(|target| {
+            !excluded_pools.contains(&target.pool.id()) && target.is_qualified_primary()
+        })
     }
 
     /// Wait until automatic role detection elects a qualified primary.
@@ -383,15 +386,102 @@ impl LoadBalancer {
     }
 
     async fn get_primary_internal(&self, request: &Request) -> Result<Guard, Error> {
-        if let Some(target) = self.qualified_primary_target() {
-            return target.pool.get(request).await;
+        use smallvec::SmallVec;
+
+        if self.qualified_primary_target(&[]).is_none() {
+            if !self.role_detection_enabled() {
+                return Err(Error::NoPrimary);
+            }
+            self.wait_primary().await?;
         }
 
-        if !self.role_detection_enabled() {
+        let mut attempted: SmallVec<[u64; 8]> = SmallVec::new();
+
+        while attempted.len() < self.targets.len() {
+            let target = self
+                .qualified_primary_target(&attempted)
+                .ok_or(Error::NoPrimary)?;
+            attempted.push(target.pool.id());
+
+            match self.checkout_target(target, request, true).await {
+                Err(Error::NoPrimary) => continue,
+                result => return result,
+            }
+        }
+
+        Err(Error::NoPrimary)
+    }
+
+    async fn checkout_target(
+        &self,
+        target: &Target,
+        request: &Request,
+        primary_required: bool,
+    ) -> Result<Guard, Error> {
+        let automatic_primary_before = target.is_automatic_primary();
+        if (primary_required || automatic_primary_before) && !target.is_qualified_primary() {
             return Err(Error::NoPrimary);
         }
 
-        self.wait_primary().await?.get(request).await
+        let guard = target.pool.get(request).await?;
+        if primary_required || automatic_primary_before || target.is_automatic_primary() {
+            self.check_automatic_primary_guard(target, guard).await
+        } else {
+            Ok(guard)
+        }
+    }
+
+    async fn check_automatic_primary_guard(
+        &self,
+        target: &Target,
+        guard: Guard,
+    ) -> Result<Guard, Error> {
+        let mut guard = guard;
+        if !target.is_qualified_primary() {
+            guard.stats_mut().state(State::ForceClose);
+            return Err(Error::NoPrimary);
+        }
+
+        if target.pool.addr().configured_role == Role::Auto {
+            match guard
+                .check_automatic_primary_backend(target.pool.config().lsn_check_timeout)
+                .await
+            {
+                Ok(true) => {}
+                Ok(false) => {
+                    warn!(
+                        "automatic primary checkout rejected: backend {} is in recovery [{}]",
+                        guard.id(),
+                        guard.addr(),
+                    );
+                    self.reject_automatic_primary(target, &mut guard);
+                    return Err(Error::NoPrimary);
+                }
+                Err(err) => {
+                    self.reject_automatic_primary(target, &mut guard);
+                    return Err(
+                        if matches!(err, crate::backend::Error::AutomaticPrimaryCheckTimeout) {
+                            Error::CheckoutTimeout
+                        } else {
+                            Error::ServerError
+                        },
+                    );
+                }
+            }
+        }
+
+        if !target.is_qualified_primary() {
+            guard.stats_mut().state(State::ForceClose);
+            return Err(Error::NoPrimary);
+        }
+
+        Ok(guard)
+    }
+
+    fn reject_automatic_primary(&self, target: &Target, guard: &mut Guard) {
+        guard.stats_mut().state(State::ForceClose);
+        target.pool.revoke_automatic_primary_evidence();
+        self.redetect_roles();
     }
 
     async fn get_internal(&self, request: &Request) -> Result<Guard, Error> {
@@ -476,14 +566,26 @@ impl LoadBalancer {
         // Only ban a candidate pool if there are more than one
         // and we have alternates.
         let bannable = candidates.len() > 1;
+        let mut automatic_primary_rejected = false;
+        let mut automatic_primary_error = None;
 
         for target in &candidates {
             if target.ban.banned() {
                 continue;
             }
-            match target.pool.get(request).await {
+            let automatic_primary = target.is_automatic_primary();
+            match self.checkout_target(target, request, false).await {
                 Ok(conn) => return Ok(conn),
-                Err(Error::Offline) => {
+                Err(Error::Offline) => continue,
+                Err(Error::NoPrimary) => {
+                    automatic_primary_rejected = true;
+                    continue;
+                }
+                Err(err)
+                    if matches!(err, Error::CheckoutTimeout | Error::ServerError)
+                        && automatic_primary =>
+                {
+                    automatic_primary_error.get_or_insert(err);
                     continue;
                 }
                 Err(err) => {
@@ -498,7 +600,13 @@ impl LoadBalancer {
             .iter()
             .for_each(|target| target.ban.unban(true, UnbanReason::AllTargetsBanned));
 
-        Err(Error::AllReplicasDown)
+        Err(if automatic_primary_rejected {
+            Error::NoPrimary
+        } else if let Some(err) = automatic_primary_error {
+            err
+        } else {
+            Error::AllReplicasDown
+        })
     }
 
     /// Shutdown replica pools.

--- a/pgdog/src/backend/pool/lb/test.rs
+++ b/pgdog/src/backend/pool/lb/test.rs
@@ -72,7 +72,7 @@ fn set_lsn_stats(target: &Target, replica: bool, lsn: i64) {
         ..Default::default()
     }
     .into();
-    *target.pool.inner().lsn_stats.write() = stats;
+    target.pool.publish_lsn_stats(stats);
 }
 
 impl LoadBalancer {
@@ -1638,6 +1638,82 @@ async fn test_static_replica_only_does_not_wait_for_primary() {
         Err(Error::NoPrimary)
     ));
     assert!(started.elapsed() < Duration::from_millis(100));
+}
+
+#[test]
+fn test_automatic_primary_requires_valid_writer_evidence() {
+    let lb = LoadBalancer::new(
+        &None,
+        &[create_auto_test_pool_config("127.0.0.1", 5432)],
+        LoadBalancingStrategy::Random,
+        ReadWriteSplit::IncludePrimary,
+        Default::default(),
+    );
+    let target = &lb.targets[0];
+
+    target.set_role(Role::Primary);
+    assert!(!target.is_qualified_primary());
+
+    set_lsn_stats(target, false, 100);
+    assert!(target.is_qualified_primary());
+
+    target.pool.revoke_automatic_primary_evidence();
+    assert!(!target.is_qualified_primary());
+}
+
+#[test]
+fn test_redetect_roles_demotes_primary_after_evidence_revocation() {
+    let lb = LoadBalancer::new(
+        &None,
+        &[create_auto_test_pool_config("127.0.0.1", 5432)],
+        LoadBalancingStrategy::Random,
+        ReadWriteSplit::IncludePrimary,
+        Default::default(),
+    );
+    let target = &lb.targets[0];
+
+    set_lsn_stats(target, false, 100);
+    assert!(lb.redetect_roles());
+    assert_eq!(target.role(), Role::Primary);
+
+    target.pool.revoke_automatic_primary_evidence();
+    assert!(lb.redetect_roles());
+    assert_eq!(target.role(), Role::Replica);
+}
+
+#[test]
+fn test_concurrent_role_detection_keeps_one_qualified_primary() {
+    let lb = LoadBalancer::new(
+        &None,
+        &[
+            create_auto_test_pool_config("127.0.0.1", 5432),
+            create_auto_test_pool_config("localhost", 5432),
+        ],
+        LoadBalancingStrategy::Random,
+        ReadWriteSplit::IncludePrimary,
+        Default::default(),
+    );
+    set_lsn_stats(&lb.targets[0], false, 100);
+    set_lsn_stats(&lb.targets[1], false, 200);
+
+    std::thread::scope(|scope| {
+        for _ in 0..8 {
+            let lb = lb.clone();
+            scope.spawn(move || {
+                for _ in 0..100 {
+                    lb.redetect_roles();
+                }
+            });
+        }
+    });
+
+    let primaries = lb
+        .targets
+        .iter()
+        .filter(|target| target.is_qualified_primary())
+        .collect::<Vec<_>>();
+    assert_eq!(primaries.len(), 1);
+    assert_eq!(primaries[0].pool.id(), lb.targets[1].pool.id());
 }
 
 #[tokio::test]

--- a/pgdog/src/backend/pool/lb/test.rs
+++ b/pgdog/src/backend/pool/lb/test.rs
@@ -3,8 +3,11 @@ use std::time::Duration;
 use tokio::task::yield_now;
 use tokio::time::{Instant, sleep, timeout};
 
-use crate::backend::pool::{Address, Config, Error, PoolConfig, Request};
 use crate::backend::replication::publisher::Lsn;
+use crate::backend::{
+    Server,
+    pool::{Address, Config, Error, Pool, PoolConfig, Request},
+};
 use crate::config::{LoadBalancingStrategy, Role};
 use itertools::*;
 use pgdog_stats::{LsnStats as StatsLsnStats, ReplicaLag};
@@ -73,6 +76,15 @@ fn set_lsn_stats(target: &Target, replica: bool, lsn: i64) {
     }
     .into();
     target.pool.publish_lsn_stats(stats);
+}
+
+fn install_idle_server(pool: &Pool, mut server: Server) {
+    server.stats_mut().healthcheck();
+    let mut inner = pool.lock();
+    inner.online = true;
+    inner
+        .put(Box::new(server), Instant::now())
+        .expect("test server should check in");
 }
 
 impl LoadBalancer {
@@ -1714,6 +1726,127 @@ fn test_concurrent_role_detection_keeps_one_qualified_primary() {
         .collect::<Vec<_>>();
     assert_eq!(primaries.len(), 1);
     assert_eq!(primaries[0].pool.id(), lb.targets[1].pool.id());
+}
+
+#[tokio::test]
+async fn test_primary_checkout_retries_after_standby_automatic_backend() {
+    let configs = [
+        create_auto_test_pool_config("127.0.0.1", 5432),
+        create_auto_test_pool_config("localhost", 5432),
+    ];
+    let lb = LoadBalancer::new(
+        &None,
+        &configs,
+        LoadBalancingStrategy::RoundRobin,
+        ReadWriteSplit::IncludePrimary,
+        Default::default(),
+    );
+    set_lsn_stats(&lb.targets[0], false, 100);
+    set_lsn_stats(&lb.targets[1], false, 200);
+    assert!(lb.redetect_roles());
+
+    let stale = crate::backend::server::test::automatic_role_server(Some("t")).await;
+    let writer = crate::backend::server::test::automatic_role_server(Some("f")).await;
+    let writer_id = writer.id();
+    install_idle_server(&lb.targets[1].pool, stale);
+    install_idle_server(&lb.targets[0].pool, writer);
+
+    let guard = lb.get_primary(&Request::default()).await.unwrap();
+    assert_eq!(guard.id(), writer_id);
+    assert_eq!(lb.targets[1].role(), Role::Replica);
+    assert!(!lb.targets[1].pool.lsn_stats().valid());
+    assert_eq!(lb.targets[1].pool.lock().force_close, 1);
+}
+
+#[tokio::test]
+async fn test_read_checkout_falls_through_after_standby_automatic_primary() {
+    let mut primary = create_auto_test_pool_config("primary", 5432);
+    primary.config.lsn_check_timeout = Duration::from_millis(50);
+    let replica = create_test_pool_config("replica", 5432);
+    let lb = LoadBalancer::new(
+        &None,
+        &[primary, replica],
+        LoadBalancingStrategy::RoundRobin,
+        ReadWriteSplit::IncludePrimary,
+        Default::default(),
+    );
+    set_lsn_stats(&lb.targets[0], false, 100);
+    assert!(lb.redetect_roles());
+
+    install_idle_server(
+        &lb.targets[0].pool,
+        crate::backend::server::test::automatic_role_server(Some("t")).await,
+    );
+    let replica_server = crate::backend::server::test::live_server().await;
+    let replica_id = replica_server.id();
+    install_idle_server(&lb.targets[1].pool, replica_server);
+
+    let guard = lb.get(&Request::default()).await.unwrap();
+    assert_eq!(guard.id(), replica_id);
+    assert_eq!(lb.targets[0].role(), Role::Replica);
+}
+
+async fn assert_automatic_primary_probe_error(server: Server, expected: Error) {
+    let mut config = create_auto_test_pool_config("127.0.0.1", 5432);
+    config.config.lsn_check_timeout = Duration::from_millis(10);
+    let lb = LoadBalancer::new(
+        &None,
+        &[config],
+        LoadBalancingStrategy::Random,
+        ReadWriteSplit::IncludePrimary,
+        Default::default(),
+    );
+    set_lsn_stats(&lb.targets[0], false, 100);
+    assert!(lb.redetect_roles());
+    install_idle_server(&lb.targets[0].pool, server);
+
+    assert_eq!(
+        lb.get_primary(&Request::default()).await.unwrap_err(),
+        expected
+    );
+    assert!(!lb.targets[0].pool.lsn_stats().valid());
+    assert_eq!(lb.targets[0].role(), Role::Replica);
+    assert_eq!(lb.targets[0].pool.lock().force_close, 1);
+}
+
+#[tokio::test]
+async fn test_automatic_primary_probe_errors_are_distinct_and_fail_closed() {
+    assert_automatic_primary_probe_error(
+        crate::backend::server::test::automatic_role_error_server().await,
+        Error::ServerError,
+    )
+    .await;
+    assert_automatic_primary_probe_error(
+        crate::backend::server::test::automatic_role_server(None).await,
+        Error::CheckoutTimeout,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_static_primary_checkout_does_not_probe_backend_role() {
+    let mut config = create_test_pool_config("127.0.0.1", 5432);
+    config.address.configured_role = Role::Primary;
+    let primary = Pool::new(&config);
+    let server = crate::backend::server::test::live_server().await;
+    let server_id = server.id();
+    install_idle_server(&primary, server);
+    let lb = LoadBalancer::new(
+        &Some(primary),
+        &[],
+        LoadBalancingStrategy::Random,
+        ReadWriteSplit::IncludePrimary,
+        Default::default(),
+    );
+
+    let result = timeout(
+        Duration::from_millis(50),
+        lb.get_primary(&Request::default()),
+    )
+    .await
+    .expect("static primary checkout must not issue a role probe")
+    .unwrap();
+    assert_eq!(result.id(), server_id);
 }
 
 #[tokio::test]

--- a/pgdog/src/backend/pool/lsn_monitor.rs
+++ b/pgdog/src/backend/pool/lsn_monitor.rs
@@ -97,16 +97,18 @@ impl LsnStats {
 }
 
 impl LsnStats {
-    fn from_row(value: DataRow, aurora: bool) -> Self {
-        StatsLsnStats {
-            replica: value.get(0, Format::Text).unwrap_or_default(),
-            lsn: value.get(1, Format::Text).unwrap_or_default(),
-            offset_bytes: value.get(2, Format::Text).unwrap_or_default(),
-            timestamp: value.get(3, Format::Text).unwrap_or_default(),
-            fetched: SystemTime::now(),
-            aurora,
-        }
-        .into()
+    fn from_row(value: DataRow, aurora: bool) -> Option<Self> {
+        Some(
+            StatsLsnStats {
+                replica: value.get(0, Format::Text)?,
+                lsn: value.get(1, Format::Text)?,
+                offset_bytes: value.get(2, Format::Text)?,
+                timestamp: value.get(3, Format::Text)?,
+                fetched: SystemTime::now(),
+                aurora,
+            }
+            .into(),
+        )
     }
 }
 
@@ -126,12 +128,24 @@ impl LsnMonitor {
 
     async fn run_query(&self, conn: &mut Server, query: &str) -> Option<DataRow> {
         match safe_timeout(self.pool.config().lsn_check_timeout, conn.fetch_all(query)).await {
-            Ok(Ok(rows)) => rows.into_iter().next(),
+            Ok(Ok(rows)) => match rows.into_iter().next() {
+                Some(row) => Some(row),
+                None => {
+                    self.revoke_automatic_primary_evidence();
+                    error!(
+                        "lsn monitor query returned zero rows [{}]",
+                        self.pool.addr()
+                    );
+                    None
+                }
+            },
             Ok(Err(err)) => {
+                self.revoke_automatic_primary_evidence();
                 error!("lsn monitor query error: {} [{}]", err, self.pool.addr());
                 None
             }
             Err(_) => {
+                self.revoke_automatic_primary_evidence();
                 error!("lsn monitor query timeout [{}]", self.pool.addr());
                 None
             }
@@ -145,12 +159,21 @@ impl LsnMonitor {
         )
         .await
         {
-            Ok(Ok(_)) => {
+            Ok(Ok(rows)) if !rows.is_empty() => {
                 debug!("aurora detected [{}]", self.pool.addr());
                 Some(true)
             }
+            Ok(Ok(_)) => {
+                self.revoke_automatic_primary_evidence();
+                error!(
+                    "lsn monitor aurora detection returned zero rows [{}]",
+                    self.pool.addr()
+                );
+                None
+            }
             Ok(Err(crate::backend::Error::ExecutionError(_))) => Some(false),
             Ok(Err(err)) => {
+                self.revoke_automatic_primary_evidence();
                 error!(
                     "lsn monitor aurora detection error: {} [{}]",
                     err,
@@ -159,6 +182,7 @@ impl LsnMonitor {
                 None
             }
             Err(_) => {
+                self.revoke_automatic_primary_evidence();
                 error!(
                     "lsn monitor aurora detection timeout [{}]",
                     self.pool.addr()
@@ -198,8 +222,12 @@ impl LsnMonitor {
     async fn run_check(&self, mut aurora_detected: Option<bool>) -> Result<Option<bool>, Error> {
         let mut conn = match self.get_connection().await {
             Ok(conn) => conn,
-            Err(Error::Offline) => return Err(Error::Offline),
+            Err(Error::Offline) => {
+                self.revoke_automatic_primary_evidence();
+                return Err(Error::Offline);
+            }
             Err(err) => {
+                self.revoke_automatic_primary_evidence();
                 error!("lsn monitor checkout error: {} [{}]", err, self.pool.addr());
                 return Err(err);
             }
@@ -218,20 +246,27 @@ impl LsnMonitor {
 
         if let Some(row) = self.run_query(&mut conn, query).await {
             drop(conn);
-            let stats = LsnStats::from_row(row, aurora);
-            {
-                let mut guard = self.pool.inner().lsn_stats.write();
-                // Notify that the role changed and the shard monitor
-                // should immediately resynchronize.
-                if stats.replica != guard.replica {
-                    self.pool.inner().lsn_role_change.notify_one();
-                }
-                (*guard) = stats;
-            }
-            trace!("lsn monitor stats updated [{}]", self.pool.addr());
+            self.update_stats(row, aurora);
         }
 
         Ok(aurora_detected)
+    }
+
+    fn update_stats(&self, row: DataRow, aurora: bool) {
+        if let Some(stats) = LsnStats::from_row(row, aurora) {
+            self.pool.publish_lsn_stats(stats);
+            trace!("lsn monitor stats updated [{}]", self.pool.addr());
+        } else {
+            self.revoke_automatic_primary_evidence();
+            error!(
+                "lsn monitor returned malformed stats row [{}]",
+                self.pool.addr()
+            );
+        }
+    }
+
+    fn revoke_automatic_primary_evidence(&self) {
+        self.pool.revoke_automatic_primary_evidence();
     }
 
     async fn get_connection(&self) -> Result<LsnConnection, Error> {
@@ -273,10 +308,16 @@ impl DerefMut for LsnConnection {
 
 #[cfg(test)]
 mod test {
+    use std::time::{Duration, SystemTime};
+
     use super::*;
+    use crate::{
+        backend::pool::{Address, Config, PoolConfig, lb::LoadBalancer},
+        config::{LoadBalancingStrategy, ReadWriteSplit, Role},
+    };
 
     use pgdog_postgres_types::TimestampTz;
-    use pgdog_stats::Lsn;
+    use pgdog_stats::{Lsn, LsnStats as StatsLsnStats};
     use tokio::time::timeout;
 
     // A launched pool against the local Postgres. The default `lsn_check_delay`
@@ -287,6 +328,151 @@ mod test {
         let pool = Pool::new_test();
         pool.launch();
         LsnMonitor { pool }
+    }
+
+    fn lsn_row(role: &str) -> DataRow {
+        let mut row = DataRow::new();
+        row.add(role)
+            .add("0/64")
+            .add(100_i64)
+            .add("2026-07-01 13:33:10.000000+00");
+        row
+    }
+
+    fn automatic_primary_monitor() -> (LoadBalancer, LsnMonitor) {
+        let mut config = PoolConfig {
+            address: Address::new_test(),
+            config: Config::default(),
+        };
+        config.address.configured_role = Role::Auto;
+        config.config.inner.role_detection = true;
+        config.config.inner.lsn_check_timeout = Duration::from_millis(10);
+        let lb = LoadBalancer::new(
+            &None,
+            &[config],
+            LoadBalancingStrategy::Random,
+            ReadWriteSplit::IncludePrimary,
+            Default::default(),
+        );
+        let monitor = LsnMonitor {
+            pool: lb.targets[0].pool.clone(),
+        };
+        publish_writer_and_elect(&lb, &monitor);
+        (lb, monitor)
+    }
+
+    fn publish_writer_and_elect(lb: &LoadBalancer, monitor: &LsnMonitor) {
+        monitor.pool.publish_lsn_stats(
+            StatsLsnStats {
+                replica: false,
+                lsn: Lsn::from_i64(100),
+                offset_bytes: 100,
+                fetched: SystemTime::now(),
+                ..Default::default()
+            }
+            .into(),
+        );
+        assert!(lb.redetect_roles());
+        assert_eq!(lb.targets[0].role(), Role::Primary);
+    }
+
+    fn assert_writer_evidence_revoked(lb: &LoadBalancer, monitor: &LsnMonitor) {
+        assert!(!monitor.pool.lsn_stats().valid());
+        assert!(lb.redetect_roles());
+        assert_eq!(lb.targets[0].role(), Role::Replica);
+    }
+
+    #[tokio::test]
+    async fn test_malformed_row_revokes_writer_evidence() {
+        let (lb, monitor) = automatic_primary_monitor();
+        let notified = monitor.pool.inner().lsn_role_change.notified();
+        tokio::pin!(notified);
+        notified.as_mut().enable();
+
+        monitor.update_stats(lsn_row("invalid"), false);
+
+        assert!(timeout(Duration::from_millis(10), notified).await.is_ok());
+        assert_writer_evidence_revoked(&lb, &monitor);
+    }
+
+    #[tokio::test]
+    async fn test_lsn_query_failures_revoke_writer_evidence() {
+        let (lb, monitor) = automatic_primary_monitor();
+        let servers = [
+            crate::backend::server::test::automatic_role_error_server().await,
+            crate::backend::server::test::automatic_role_empty_server().await,
+            crate::backend::server::test::automatic_role_server(None).await,
+        ];
+
+        for mut server in servers {
+            assert!(monitor.run_query(&mut server, LSN_QUERY).await.is_none());
+            assert_writer_evidence_revoked(&lb, &monitor);
+            publish_writer_and_elect(&lb, &monitor);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_aurora_detection_failures_revoke_writer_evidence() {
+        let (lb, monitor) = automatic_primary_monitor();
+        let servers = [
+            crate::backend::server::test::automatic_role_disconnect_server().await,
+            crate::backend::server::test::automatic_role_empty_server().await,
+            crate::backend::server::test::automatic_role_server(None).await,
+        ];
+
+        for mut server in servers {
+            assert_eq!(monitor.detect_aurora(&mut server).await, None);
+            assert_writer_evidence_revoked(&lb, &monitor);
+            publish_writer_and_elect(&lb, &monitor);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_offline_monitor_checkout_revokes_writer_evidence() {
+        let (lb, monitor) = automatic_primary_monitor();
+
+        assert_eq!(monitor.run_check(None).await, Err(Error::Offline));
+        assert_writer_evidence_revoked(&lb, &monitor);
+    }
+
+    #[tokio::test]
+    async fn test_evidence_revocation_notifies_only_on_valid_to_invalid_transition() {
+        let (_lb, monitor) = automatic_primary_monitor();
+        assert!(
+            timeout(
+                Duration::from_millis(10),
+                monitor.pool.inner().lsn_role_change.notified()
+            )
+            .await
+            .is_ok()
+        );
+        let first = monitor.pool.inner().lsn_role_change.notified();
+        tokio::pin!(first);
+        first.as_mut().enable();
+
+        monitor.pool.revoke_automatic_primary_evidence();
+        assert!(timeout(Duration::from_millis(10), first).await.is_ok());
+
+        let second = monitor.pool.inner().lsn_role_change.notified();
+        tokio::pin!(second);
+        second.as_mut().enable();
+        monitor.pool.revoke_automatic_primary_evidence();
+        assert!(timeout(Duration::from_millis(10), second).await.is_err());
+    }
+
+    #[test]
+    fn test_lsn_stats_from_row_requires_all_fields() {
+        let stats = LsnStats::from_row(lsn_row("f"), false).unwrap();
+        assert!(!stats.replica);
+        assert_eq!(stats.lsn, Lsn::from_i64(100));
+        assert_eq!(stats.offset_bytes, 100);
+
+        assert!(LsnStats::from_row(lsn_row("invalid"), false).is_none());
+        assert!(LsnStats::from_row(DataRow::new(), false).is_none());
+
+        let mut null_role = lsn_row("f");
+        null_role.insert(0, "", true);
+        assert!(LsnStats::from_row(null_role, false).is_none());
     }
 
     #[tokio::test]

--- a/pgdog/src/backend/pool/lsn_monitor.rs
+++ b/pgdog/src/backend/pool/lsn_monitor.rs
@@ -345,8 +345,8 @@ mod test {
             config: Config::default(),
         };
         config.address.configured_role = Role::Auto;
-        config.config.inner.role_detection = true;
-        config.config.inner.lsn_check_timeout = Duration::from_millis(10);
+        config.config.role_detection = true;
+        config.config.lsn_check_timeout = Duration::from_millis(10);
         let lb = LoadBalancer::new(
             &None,
             &[config],

--- a/pgdog/src/backend/pool/pool_impl.rs
+++ b/pgdog/src/backend/pool/pool_impl.rs
@@ -104,6 +104,41 @@ impl Pool {
         self.inner.health.healthy()
     }
 
+    pub(super) fn revoke_automatic_primary_evidence(&self) {
+        if !self.config().role_detection {
+            return;
+        }
+
+        let was_valid = {
+            let mut stats = self.inner.lsn_stats.write();
+            let was_valid = stats.valid();
+            if was_valid {
+                *stats = Default::default();
+            }
+            was_valid
+        };
+
+        if was_valid {
+            self.inner.lsn_role_change.notify_one();
+        }
+    }
+
+    pub(super) fn publish_lsn_stats(&self, stats: LsnStats) {
+        let notify = {
+            let mut current = self.inner.lsn_stats.write();
+            let current_valid = current.valid();
+            let stats_valid = stats.valid();
+            let notify = current_valid != stats_valid
+                || (current_valid && stats_valid && current.replica != stats.replica);
+            *current = stats;
+            notify
+        };
+
+        if notify {
+            self.inner.lsn_role_change.notify_one();
+        }
+    }
+
     /// Launch the maintenance loop, bringing the pool online.
     pub(crate) fn launch(&self) {
         let mut guard = self.lock();

--- a/pgdog/src/backend/pool/shard/monitor.rs
+++ b/pgdog/src/backend/pool/shard/monitor.rs
@@ -113,20 +113,19 @@ fn update_replica_lag(pools: &[Pool]) {
     let primary = pools
         .iter()
         .map(|pool| (pool, pool.lsn_stats()))
-        .find(|(_, stats)| !stats.replica);
+        .find(|(_, stats)| stats.valid() && !stats.replica);
 
-    // There is a primary. If not, replica lag cannot be calculated.
-    if let Some((primary_pool, primary_stats)) = primary {
-        for replica_pool in pools {
-            let replica_stats = replica_pool.lsn_stats();
-            if !replica_stats.replica {
-                continue;
+    for pool in pools {
+        let stats = pool.lsn_stats();
+        let lag = match &primary {
+            Some((primary_pool, primary_stats))
+                if pool.id() != primary_pool.id() && stats.valid() && stats.replica =>
+            {
+                calculate_replica_lag(primary_stats, &stats)
             }
-
-            let lag = calculate_replica_lag(&primary_stats, &replica_stats);
-            replica_pool.lock().replica_lag = lag;
-        }
-        primary_pool.lock().replica_lag = ReplicaLag::default();
+            _ => ReplicaLag::default(),
+        };
+        pool.lock().replica_lag = lag;
     }
 }
 
@@ -248,7 +247,7 @@ mod test {
     }
 
     #[test]
-    fn test_update_replica_lag_assigns_primary_minus_replica_to_replica_pool() {
+    fn test_update_replica_lag_clears_lag_from_invalid_evidence() {
         let primary = Pool::new(&PoolConfig {
             address: Address::new_test(),
             config: Config::default(),
@@ -264,15 +263,23 @@ mod test {
         set_pool_lsn_stats(&primary, false, 200, "2026-07-01 13:33:10.000000+00");
         set_pool_lsn_stats(&replica, true, 100, "2026-07-01 13:33:00.000000+00");
 
-        update_replica_lag(&[replica.clone(), primary.clone()]);
+        update_replica_lag(&[primary.clone(), replica.clone()]);
+        assert_eq!(replica.replica_lag().bytes, 100);
+        assert_eq!(replica.replica_lag().duration.as_secs(), 10);
 
-        let replica_lag = replica.replica_lag();
-        assert_eq!(replica_lag.bytes, 100);
-        assert_eq!(replica_lag.duration.as_secs(), 10);
+        *primary.inner().lsn_stats.write() = LsnStats::default();
+        update_replica_lag(&[primary.clone(), replica.clone()]);
+        assert_eq!(replica.replica_lag().bytes, 0);
+        assert_eq!(replica.replica_lag().duration, Duration::default());
 
-        let primary_lag = primary.replica_lag();
-        assert_eq!(primary_lag.bytes, 0);
-        assert_eq!(primary_lag.duration, Duration::default());
+        set_pool_lsn_stats(&primary, false, 200, "2026-07-01 13:33:10.000000+00");
+        update_replica_lag(&[primary.clone(), replica.clone()]);
+        assert_eq!(replica.replica_lag().bytes, 100);
+
+        *replica.inner().lsn_stats.write() = LsnStats::default();
+        update_replica_lag(&[primary, replica.clone()]);
+        assert_eq!(replica.replica_lag().bytes, 0);
+        assert_eq!(replica.replica_lag().duration, Duration::default());
     }
 
     // The shard monitor reacts to an `lsn_role_change` notification by
@@ -282,7 +289,10 @@ mod test {
     async fn test_monitor_updates_roles_on_failover() {
         crate::logger();
 
-        let primary = Some(&pool_config(Address::new_test()));
+        let primary = Some(&pool_config(Address {
+            configured_role: Role::Auto,
+            ..Address::new_test()
+        }));
         let replicas = [pool_config(Address {
             configured_role: Role::Auto,
             ..Address::new_test()

--- a/pgdog/src/backend/pool/shard/role_detector.rs
+++ b/pgdog/src/backend/pool/shard/role_detector.rs
@@ -102,7 +102,7 @@ mod test {
     }
 
     #[test]
-    fn test_changed_returns_false_when_lsn_stats_invalid() {
+    fn test_changed_revokes_primary_when_lsn_stats_invalid() {
         let primary = Some(create_test_pool_config("127.0.0.1", 5432, true));
         let replicas = [create_test_pool_config("localhost", 5432, true)];
         let shard = create_test_shard(primary.as_ref(), &replicas);
@@ -110,6 +110,7 @@ mod test {
         let mut detector = RoleDetector::new(&shard);
 
         assert!(detector.enabled());
+        assert!(detector.changed());
         assert!(!detector.changed());
     }
 

--- a/pgdog/src/backend/pool/shard/role_detector.rs
+++ b/pgdog/src/backend/pool/shard/role_detector.rs
@@ -2,17 +2,20 @@ use super::Shard;
 
 pub(super) struct RoleDetector {
     enabled: bool,
+    primary_id: Option<u64>,
     shard: Shard,
 }
 
 impl RoleDetector {
     /// Create new role change detector.
     pub(super) fn new(shard: &Shard) -> Self {
+        let primary_id = shard.lb.primary().map(|pool| pool.id());
         Self {
             enabled: shard
                 .pools()
                 .iter()
                 .all(|pool| pool.config().role_detection),
+            primary_id,
             shard: shard.clone(),
         }
     }
@@ -20,11 +23,14 @@ impl RoleDetector {
     /// Detect role change in the shard.
     pub(super) fn changed(&mut self) -> bool {
         if self.enabled() {
-            let changed = self.shard.redetect_roles();
+            let lb_changed = self.shard.redetect_roles();
+            let primary_id = self.shard.lb.primary().map(|pool| pool.id());
+            let changed = lb_changed || primary_id != self.primary_id;
             if changed {
                 // Re-initialize pub/sub channel.
                 self.shard.init_pub_sub();
             }
+            self.primary_id = primary_id;
             changed
         } else {
             false
@@ -130,7 +136,7 @@ mod test {
     }
 
     #[test]
-    fn test_changed_returns_true_on_failover() {
+    fn test_changed_returns_true_after_external_failover_detection() {
         let primary = Some(create_test_pool_config("127.0.0.1", 5432, true));
         let replicas = [create_test_pool_config("localhost", 5432, true)];
         let shard = create_test_shard(primary.as_ref(), &replicas);
@@ -146,6 +152,7 @@ mod test {
         set_lsn_stats(&shard, 0, false, 300);
         set_lsn_stats(&shard, 1, true, 200);
 
+        assert!(shard.redetect_roles());
         assert!(detector.changed());
     }
 

--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -1392,6 +1392,84 @@ pub(crate) mod test {
         }
     }
 
+    pub(crate) async fn automatic_role_server(value: Option<&'static str>) -> Server {
+        automatic_role_server_response(value.map(AutomaticRoleResponse::Value)).await
+    }
+
+    pub(crate) async fn automatic_role_error_server() -> Server {
+        automatic_role_server_response(Some(AutomaticRoleResponse::Error)).await
+    }
+
+    pub(crate) async fn automatic_role_empty_server() -> Server {
+        automatic_role_server_response(Some(AutomaticRoleResponse::Empty)).await
+    }
+
+    pub(crate) async fn automatic_role_disconnect_server() -> Server {
+        automatic_role_server_response(Some(AutomaticRoleResponse::Disconnect)).await
+    }
+
+    enum AutomaticRoleResponse {
+        Value(&'static str),
+        Error,
+        Empty,
+        Disconnect,
+    }
+
+    async fn automatic_role_server_response(response: Option<AutomaticRoleResponse>) -> Server {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let connect = tokio::net::TcpStream::connect(listener.local_addr().unwrap());
+        let (client, accepted) = tokio::join!(connect, listener.accept());
+        let mut socket = accepted.unwrap().0;
+        tokio::spawn(async move {
+            let code = socket.read_u8().await.unwrap();
+            let len = socket.read_i32().await.unwrap();
+            assert_eq!(code, b'Q');
+            let mut payload = vec![0; len as usize - 4];
+            socket.read_exact(&mut payload).await.unwrap();
+
+            let Some(response) = response else {
+                std::future::pending::<()>().await;
+                return;
+            };
+
+            let mut bytes = BytesMut::new();
+            match response {
+                AutomaticRoleResponse::Value(value) => {
+                    let mut row = DataRow::new();
+                    row.add(value);
+                    bytes.extend_from_slice(
+                        &RowDescription::new(&[Field::bool("pg_is_in_recovery")]).to_bytes(),
+                    );
+                    bytes.extend_from_slice(&row.to_bytes());
+                    bytes.extend_from_slice(&CommandComplete::new("SELECT 1").to_bytes());
+                }
+                AutomaticRoleResponse::Error => {
+                    bytes.extend_from_slice(
+                        &ErrorResponse {
+                            code: "XX000".into(),
+                            message: "backend role query failed".into(),
+                            ..Default::default()
+                        }
+                        .to_bytes(),
+                    );
+                }
+                AutomaticRoleResponse::Empty => {
+                    bytes.extend_from_slice(
+                        &RowDescription::new(&[Field::bool("pg_is_in_recovery")]).to_bytes(),
+                    );
+                    bytes.extend_from_slice(&CommandComplete::new("SELECT 0").to_bytes());
+                }
+                AutomaticRoleResponse::Disconnect => return,
+            }
+            bytes.extend_from_slice(&ReadyForQuery::idle().to_bytes());
+            socket.write_all(&bytes).await.unwrap();
+        });
+
+        let mut server = Server::default();
+        server.stream = Some(Stream::plain(client.unwrap(), 4096));
+        server
+    }
+
     pub(crate) async fn test_server() -> Server {
         Server::connect(
             &Address::new_test(),

--- a/pgdog/src/backend/server.rs
+++ b/pgdog/src/backend/server.rs
@@ -32,6 +32,7 @@ use crate::{
         },
     },
     stats::memory::MemoryUsage,
+    util::safe_timeout,
 };
 use crate::{
     config::{PoolerMode, TlsVerifyMode, config},
@@ -882,6 +883,30 @@ impl Server {
         &self.params
     }
 
+    pub(super) async fn check_automatic_primary_backend(
+        &mut self,
+        timeout: Duration,
+    ) -> Result<bool, Error> {
+        let replica: bool = safe_timeout(
+            timeout,
+            self.fetch_all::<DataRow>("SELECT pg_is_in_recovery()"),
+        )
+        .await
+        .unwrap_or(Err(Error::AutomaticPrimaryCheckTimeout))
+        .and_then(|rows| {
+            rows.into_iter()
+                .next()
+                .ok_or(Error::AutomaticPrimaryCheckInvalidResponse)
+        })
+        .and_then(|row| {
+            row.get(0, Format::Text)
+                .ok_or(Error::AutomaticPrimaryCheckInvalidResponse)
+        })
+        .inspect_err(|_| self.stats.state(State::ForceClose))?;
+
+        Ok(!replica)
+    }
+
     /// Execute a batch of queries and return all results.
     pub(crate) async fn execute_batch(
         &mut self,
@@ -1408,6 +1433,21 @@ pub(crate) mod test {
         automatic_role_server_response(Some(AutomaticRoleResponse::Disconnect)).await
     }
 
+    pub(crate) async fn live_server() -> Server {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let connect = tokio::net::TcpStream::connect(listener.local_addr().unwrap());
+        let (client, accepted) = tokio::join!(connect, listener.accept());
+        let socket = accepted.unwrap().0;
+        tokio::spawn(async move {
+            let _socket = socket;
+            std::future::pending::<()>().await;
+        });
+
+        let mut server = Server::default();
+        server.stream = Some(Stream::plain(client.unwrap(), 4096));
+        server
+    }
+
     enum AutomaticRoleResponse {
         Value(&'static str),
         Error,
@@ -1468,6 +1508,41 @@ pub(crate) mod test {
         let mut server = Server::default();
         server.stream = Some(Stream::plain(client.unwrap(), 4096));
         server
+    }
+
+    async fn assert_automatic_primary_check_fails_closed(mut server: Server) {
+        let result = server
+            .check_automatic_primary_backend(Duration::from_millis(25))
+            .await;
+        assert!(result.is_err());
+        assert_eq!(server.stats().get_state(), State::ForceClose);
+    }
+
+    #[tokio::test]
+    async fn test_automatic_primary_backend_check() {
+        let timeout = Duration::from_millis(50);
+        let mut writer = automatic_role_server(Some("f")).await;
+        let mut standby = automatic_role_server(Some("t")).await;
+
+        assert!(
+            writer
+                .check_automatic_primary_backend(timeout)
+                .await
+                .unwrap()
+        );
+        assert!(
+            !standby
+                .check_automatic_primary_backend(timeout)
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_automatic_primary_backend_check_fails_closed() {
+        assert_automatic_primary_check_fails_closed(automatic_role_error_server().await).await;
+        assert_automatic_primary_check_fails_closed(automatic_role_empty_server().await).await;
+        assert_automatic_primary_check_fails_closed(automatic_role_server(None).await).await;
     }
 
     pub(crate) async fn test_server() -> Server {


### PR DESCRIPTION
**This is an AI-assisted PR**. Consider this an early draft for now and feel free to recommend significant changes.

I ran into an issue where PgDog was not routing queries to my `role=auto` instances after an AWS-induced RDS Aurora failover event. The failover was caused by excessive load on CPU & drained freeable memory. After the event, I've seen a lot of `SQLSTATE 25006`s - indicative of PgDog routing writer queries to what it is now a read replica. I believe PgDog should be adjusted to keep track of the latest & best evidence as to who's the primary.

With the fix applied, I was able to avoid these errors in reproduction scenarios, using an automated testing harness. I only tested this patch with the settings I use: `role=auto`, `pooler_mode=session`, `query_parser=off`, and having two app-side connection pools using the `pgdog.role=replica/primary` option.

I will follow up with timing measurements. This patch series successfully avoids 25006 errors, but I haven't yet measured the unavailability window from the client perspective.

---

## Summary

During a managed PostgreSQL failover, PgDog can retain an automatic target's old `Primary` role after the backend that supplied that evidence disappears. When the database returns as a reader, a fresh session-pool checkout can then bind to that reader. The client receives `SQLSTATE 25006` (`cannot execute ... in a read-only transaction`), and session pooling can keep returning the same bad backend until the frontend session is replaced.

This change makes automatic-primary selection require valid, non-replica role evidence and adds an independent checkout-time `pg_is_in_recovery()` fence before handing a backend to a write client. A backend found to be in recovery is closed, its automatic-role evidence is cleared, and selection retries another qualified target.

## PgDog version

Reproduced on the incident-era PgDog revision (`eff27d42`) and on upstream commit `5e8b8858`. The proposed change is based on `v0.1.54` (`7b40c0c2`), whose additional commit changes only version metadata.

## Description

The failure requires a narrow sequence:

1. PgDog is using `role = auto` with session pooling and has identified a backend as the automatic primary.
2. A managed PostgreSQL failover causes the old writer's connections to close while monitoring and topology information are changing.
3. The old database instance returns or remains reachable as a standby during a short stale-role window.
4. PgDog still has the target labelled `Primary`, or reuses that target before fresh writer evidence is available.
5. New client sessions are checked out against that target and are pinned by session pooling.

The resulting error is produced after a query reaches the wrong backend. A query-level retry therefore does not guarantee a fresh backend when session pooling has pinned the stale binding.

The failure is easiest to observe with sustained concurrent client traffic, short requests that identify the backend role, and a failover triggered while the clients are reconnecting. The application authentication method is not the root cause. The tested setup used IAM backend authentication and `query_parser = "off"`, but the relevant conditions are automatic role selection, session-pool rebinding, and a stale reader/writer topology window.

## How it was observed

The test used one synchronized failover event for all matrix arms. Each arm ran the same client workload and recorded, for every checkout:

- the PgDog/frontend connection identity;
- the backend address and process identity;
- `pg_is_in_recovery()` / writer-versus-reader role;
- query errors, including genuine `25006` responses; and
- whether the client later rebound to a healthy writer.

The failover was considered relevant only when direct database role checks and the client observations bracketed the same topology change. This distinguishes a stale-reader rebind from a separate case where an already-held backend is demoted after a query has already been sent.

The compact matrix compared five arms on the same failover event:

| Arm | Purpose |
| --- | --- |
| Incident-era vanilla | Positive control matching the affected PgDog behavior |
| Upstream socket-liveness fix (#1318) | Tests whether detecting closed idle sockets is sufficient |
| Upstream #1323 (`b050a570`) bundled change | Starts unelected `Auto` targets as replicas and waits for a primary on write checkout; this arm does not isolate those two behaviors |
| Current upstream baseline at the time of testing (5e8b8858). | Current baseline |
| Proposed port | Qualified-primary evidence plus checkout-time backend fencing |

The final slim series was then run in five synchronized events of the same matrix. The counts below are totals across those completed events; the proposed arm had 60 paired clients per event. The socket-liveness comparator (#1318) was also present in the matrix, but its partial-run total is omitted from this concise summary.

| Arm | Stale reader binds | Genuine `25006` | Clients proven wedged within the observation window | Writer binds |
| --- | ---: | ---: | ---: | ---: |
| Incident-era vanilla | 31 | 334 | 12 | — |
| Upstream #1323 (`b050a570`) bundled change | 2 | 55 | 2 | — |
| Current upstream | 1 | 28 | 1 | — |
| Proposed two-commit series | 0 | 0 | 0 | 300/300 |

These are strict observation-window totals and descriptive developmental evidence, not a general safety proof or a formal treatment-efficacy claim. The formal recovery deadline right-censored the completed event outcomes. The preceding ten-event broad prototype showed the same directional contrast, but those results are retained as developmental evidence only.

## Root cause

Automatic role detection and checkout treated cached role state as sufficient to select a writer. Monitoring could lose, clear, or fail to refresh the LSN/recovery evidence without revoking the target's cached `Primary` role. A later checkout therefore had no independent guard against receiving a backend that was now in recovery.

The important distinction is between:

- a backend that was already handed to a client and is later demoted; and
- a new checkout that can still be prevented from binding to a known standby.

This PR addresses the second, incident-relevant path. It does not claim to migrate an in-flight PostgreSQL session or replay an ambiguous query.

## Fix

The series is intentionally split into two reviewable commits:

1. Automatic-primary role selection now requires valid, non-replica role evidence. Unavailable, timed-out, malformed, or failed monitoring evidence revokes stale automatic-primary qualification.
2. Before an automatic-primary backend is returned, PgDog checks `pg_is_in_recovery()` within the existing checkout timeout. A standby is force-closed, its cached automatic-role evidence is cleared, and PgDog retries another qualified primary. Probe failures fail closed rather than handing the client an unverified writer.

The checkout probe is the correctness barrier. Evidence revocation prevents the load balancer from repeatedly selecting the same stale target while the topology converges.

## Testing

Local validation on the final slim series:

- formatting and diff checks: passed;
- workspace check: passed;
- all-workspace, all-target Clippy with warnings denied: passed;
- seven focused automatic-role/evidence/checkout regressions: passed (the broader 19-test focused set also passed);
- full disposable-PostgreSQL suite: 2,384 passed, 7 skipped;
- release build and IAM/session/parser-off configuration check: passed;
- offline listener, OpenMetrics, and clean-shutdown smoke test: passed.

Synchronized failover rerun: five completed events in the same five-arm matrix; the partial, non-claimable results are summarized above. Raw artifacts and provenance are retained by the submitter and are available to reproduce the summary if maintainers want the full diagnostic detail.

## Configuration

No new configuration is required. The behavior applies to automatic-role targets. Static `primary` and `replica` configurations retain their existing semantics.

## Scope and limitations

This series targets fresh stale-reader checkouts after a topology change. It does not make arbitrary in-flight PostgreSQL operations replayable, and it does not transfer transaction state, cursors, temporary objects, prepared statements, or advisory locks between servers. A query whose outcome is ambiguous when a backend connection dies still requires the client/application's existing error-handling policy.

The checkout probe adds a bounded round trip for automatic-primary checkouts. That is an intentional availability/correctness tradeoff during failover: PgDog may return a checkout error while writer identity cannot be verified, rather than risk sending a write to a standby.