### PR TITLE
feat: restore startup session parameters on DISCARD ALL

### DIFF
--- a/pgdog/src/backend/pool/connection/mirror/mod.rs
+++ b/pgdog/src/backend/pool/connection/mirror/mod.rs
@@ -40,6 +40,8 @@ pub(crate) struct Mirror {
     pub(crate) prepared_statements: PreparedStatements,
     /// Mirror connection parameters.
     pub(crate) params: Parameters,
+    /// Parameters the mirrored client started with.
+    pub(crate) startup_params: Parameters,
     /// Timeouts.
     pub(crate) timeouts: Timeouts,
     /// Stream that absorbs all data.
@@ -57,6 +59,7 @@ impl Mirror {
             id: FrontendPid::new(),
             prepared_statements,
             params: params.clone(),
+            startup_params: params.clone(),
             timeouts: Timeouts::from_config(&config.config.general),
             stream: Stream::dev_null(),
             transaction: None,

--- a/pgdog/src/frontend/client/mod.rs
+++ b/pgdog/src/frontend/client/mod.rs
@@ -58,6 +58,8 @@ pub(crate) struct Client {
     // Client startup parameters. Keeps track of any parameters
     // the client changes at runtime with `SET` as well.
     params: Parameters,
+    // Parameters exactly as they came in the startup message.
+    startup_params: Parameters,
     // Process-global communication primitives used for clients
     // to talk to each other, e.g. to track their own state.
     comms: ClientComms,
@@ -418,6 +420,7 @@ impl Client {
             comms,
             admin,
             streaming: false,
+            startup_params: params.clone(),
             params: params.clone(),
             prepared_statements: PreparedStatements::new(),
             transaction: None,
@@ -466,6 +469,7 @@ impl Client {
                 config().config.general.frontend_query_size_limit_block(),
             ),
             sticky: Sticky::from_params(&params),
+            startup_params: params.clone(),
             params,
             database: "pgdog".to_string(),
             query_log_stdout: false,
@@ -743,6 +747,7 @@ impl MemoryUsage for Client {
             + std::mem::size_of::<Stream>()
             + std::mem::size_of::<BackendKeyData>()
             + self.params.memory_usage()
+            + self.startup_params.memory_usage()
             + std::mem::size_of::<ClientComms>()
             + std::mem::size_of::<bool>() * 5
             + self.prepared_statements.memory_used()

--- a/pgdog/src/frontend/client/query_engine/context.rs
+++ b/pgdog/src/frontend/client/query_engine/context.rs
@@ -17,6 +17,8 @@ pub(crate) struct QueryEngineContext<'a> {
     pub(super) prepared_statements: &'a mut PreparedStatements,
     /// Client session parameters.
     pub(super) params: &'a mut Parameters,
+    /// Parameters from the client's startup message.
+    pub(super) startup_params: &'a Parameters,
     /// Request.
     pub(super) client_request: &'a mut ClientRequest,
     /// How many requests are left to execute in an extended pipeline.
@@ -51,6 +53,7 @@ impl<'a> QueryEngineContext<'a> {
             id: FrontendPid::from(&client.key),
             prepared_statements: &mut client.prepared_statements,
             params: &mut client.params,
+            startup_params: &client.startup_params,
             client_request: &mut client.client_request,
             stream: &mut client.stream,
             transaction: client.transaction,
@@ -80,6 +83,7 @@ impl<'a> QueryEngineContext<'a> {
             id: mirror.id,
             prepared_statements: &mut mirror.prepared_statements,
             params: &mut mirror.params,
+            startup_params: &mirror.startup_params,
             client_request: buffer,
             stream: &mut mirror.stream,
             transaction: mirror.transaction,

--- a/pgdog/src/frontend/client/query_engine/discard.rs
+++ b/pgdog/src/frontend/client/query_engine/discard.rs
@@ -1,3 +1,4 @@
+use crate::frontend::router::parameter_hints::PGDOG_PIN;
 use crate::net::{CommandComplete, Protocol, ReadyForQuery};
 
 use super::*;
@@ -23,6 +24,7 @@ impl QueryEngine {
             self.advisory_locks.clear();
             context.prepared_statements.close_all();
             self.backend.unlisten_all();
+            self.reset_session_params(context).await?;
             self.check_lock();
         }
         let bytes_sent = context
@@ -33,6 +35,32 @@ impl QueryEngine {
             ])
             .await?;
         self.stats.sent(bytes_sent);
+        Ok(())
+    }
+
+    async fn reset_session_params(
+        &mut self,
+        context: &mut QueryEngineContext<'_>,
+    ) -> Result<(), Error> {
+        context.params.restore_startup(context.startup_params);
+        self.manual_lock = context
+            .params
+            .get(PGDOG_PIN)
+            .and_then(|value| value.as_str())
+            .map(|value| matches!(value, "true" | "t"))
+            .unwrap_or_default();
+        self.comms.update_params(context.params);
+
+        // Parameters the client SET while holding this server were sent straight
+        // through, and `link_client` only replays what it knows diverged. Reset the
+        // server so the startup values are re-applied onto a clean session.
+        if self.backend.connected() {
+            self.backend.execute("RESET ALL").await?;
+            self.backend
+                .link_client(context.id, context.params, None)
+                .await?;
+        }
+
         Ok(())
     }
 }

--- a/pgdog/src/frontend/client/query_engine/discard.rs
+++ b/pgdog/src/frontend/client/query_engine/discard.rs
@@ -1,4 +1,4 @@
-use crate::frontend::router::parameter_hints::PGDOG_PIN;
+use crate::frontend::{client::TransactionType, router::parameter_hints::PGDOG_PIN};
 use crate::net::{CommandComplete, Protocol, ReadyForQuery};
 
 use super::*;
@@ -14,6 +14,18 @@ impl QueryEngine {
         extended: bool,
     ) -> Result<(), Error> {
         let _extended = extended;
+        if target == DiscardTarget::All && context.in_transaction() {
+            context.transaction = Some(match context.transaction {
+                Some(TransactionType::ReadOnly | TransactionType::ErrorReadOnly) => {
+                    TransactionType::ErrorReadOnly
+                }
+                _ => TransactionType::ErrorReadWrite,
+            });
+            self.error_response(context, ErrorResponse::discard_all_in_transaction())
+                .await?;
+            return Ok(());
+        }
+
         if target == DiscardTarget::All {
             if self.backend.connected() {
                 self.backend

--- a/pgdog/src/frontend/client/query_engine/discard.rs
+++ b/pgdog/src/frontend/client/query_engine/discard.rs
@@ -12,6 +12,7 @@ impl QueryEngine {
         extended: bool,
     ) -> Result<(), Error> {
         let _extended = extended;
+
         match target {
             DiscardTarget::All if context.in_transaction() => {
                 context.transaction = Some(match context.transaction {
@@ -44,8 +45,9 @@ impl QueryEngine {
                 self.advisory_locks.clear();
                 context.prepared_statements.close_all();
                 self.backend.unlisten_all();
-                self.reset_session_params(context).await?;
+                self.reset_session_params(context);
                 self.check_lock();
+                self.cleanup_backend(context)?;
             }
             DiscardTarget::Plans | DiscardTarget::Sequences | DiscardTarget::Temp => {}
         }
@@ -61,10 +63,7 @@ impl QueryEngine {
         Ok(())
     }
 
-    async fn reset_session_params(
-        &mut self,
-        context: &mut QueryEngineContext<'_>,
-    ) -> Result<(), Error> {
+    fn reset_session_params(&mut self, context: &mut QueryEngineContext<'_>) {
         context.params.restore_startup(context.startup_params);
         self.manual_lock = context
             .params
@@ -73,17 +72,5 @@ impl QueryEngine {
             .map(|value| matches!(value, "true" | "t"))
             .unwrap_or_default();
         self.comms.update_params(context.params);
-
-        // Parameters the client SET while holding this server were sent straight
-        // through, and `link_client` only replays what it knows diverged. Reset the
-        // server so the startup values are re-applied onto a clean session.
-        if self.backend.connected() {
-            self.backend.execute("RESET ALL").await?;
-            self.backend
-                .link_client(context.id, context.params, None)
-                .await?;
-        }
-
-        Ok(())
     }
 }

--- a/pgdog/src/frontend/client/query_engine/test/discard.rs
+++ b/pgdog/src/frontend/client/query_engine/test/discard.rs
@@ -1,9 +1,53 @@
 use crate::{
+    backend::databases::reload_from_existing,
+    config::{config, load_test, set},
     expect_message,
-    net::{CommandComplete, Parameters, ParseComplete, ReadyForQuery},
+    net::{
+        CommandComplete, DataRow, Parameters, ParseComplete, ReadyForQuery, RowDescription,
+        parameter::ParameterValue,
+    },
 };
 
 use super::prelude::*;
+
+/// Run a query that returns command tag.
+async fn run_simple(client: &mut TestClient, query: &str) -> ReadyForQuery {
+    client.send_simple(Query::new(query)).await;
+    expect_message!(client.read().await, CommandComplete);
+    expect_message!(client.read().await, ReadyForQuery)
+}
+
+/// Ask the server what a parameter is actually set to.
+async fn show(client: &mut TestClient, name: &str) -> String {
+    client
+        .send_simple(Query::new(format!("SHOW {}", name)))
+        .await;
+    expect_message!(client.read().await, RowDescription);
+    let row = expect_message!(client.read().await, DataRow);
+    let value = row.get_text(0).expect("SHOW returns a value");
+    client.read_until('Z').await.unwrap();
+    value
+}
+
+/// A pool with a single connection, so a client is guaranteed to get the same
+/// server back after it's released.
+fn load_single_connection_test_pool() {
+    load_test();
+
+    let mut config = (*config()).clone();
+    config.config.general.default_pool_size = 1;
+    config.config.general.min_pool_size = 0;
+    set(config).unwrap();
+    reload_from_existing().unwrap();
+}
+
+fn startup_params(params: &[(&str, &str)]) -> Parameters {
+    let mut startup = Parameters::default();
+    for (name, value) in params {
+        startup.insert(*name, *value);
+    }
+    startup
+}
 
 #[tokio::test]
 async fn test_discard_clears_prepared_statement_cache() {
@@ -61,4 +105,118 @@ async fn test_non_all_discard_keeps_prepared_statement_cache() {
         );
         assert_eq!(global.read().statements().iter().next().unwrap().1.used, 1);
     }
+}
+
+#[tokio::test]
+async fn test_discard_all_restores_startup_parameters() {
+    let mut client =
+        TestClient::new_sharded(startup_params(&[("application_name", "from_startup")])).await;
+
+    run_simple(&mut client, "SET application_name TO 'changed'").await;
+    assert_eq!(
+        client.client().params.get("application_name"),
+        Some(&ParameterValue::String("changed".into())),
+    );
+
+    client.send_simple(Query::new("DISCARD ALL")).await;
+    assert_eq!(
+        expect_message!(client.read().await, CommandComplete).command(),
+        "DISCARD"
+    );
+    assert_eq!(
+        expect_message!(client.read().await, ReadyForQuery).status,
+        'I'
+    );
+
+    assert_eq!(
+        client.client().params.get("application_name"),
+        Some(&ParameterValue::String("from_startup".into())),
+        "DISCARD ALL should restore the startup value, not the one set at runtime",
+    );
+}
+
+#[tokio::test]
+async fn test_discard_all_drops_parameters_missing_from_startup() {
+    let mut client = TestClient::new_sharded(Parameters::default()).await;
+
+    run_simple(&mut client, "SET statement_timeout TO 5000").await;
+    run_simple(&mut client, "SET search_path TO acustomer").await;
+
+    client.send_simple(Query::new("DISCARD ALL")).await;
+    client.read_until('Z').await.unwrap();
+
+    assert_eq!(client.client().params.get("statement_timeout"), None);
+    assert_eq!(client.client().params.get("search_path"), None);
+}
+
+#[tokio::test]
+async fn test_non_all_discard_keeps_parameters() {
+    for query in ["DISCARD PLANS", "DISCARD SEQUENCES", "DISCARD TEMP"] {
+        let mut client =
+            TestClient::new_sharded(startup_params(&[("application_name", "from_startup")])).await;
+
+        run_simple(&mut client, "SET application_name TO 'changed'").await;
+
+        client.send_simple(Query::new(query)).await;
+        client.read_until('Z').await.unwrap();
+
+        assert_eq!(
+            client.client().params.get("application_name"),
+            Some(&ParameterValue::String("changed".into())),
+            "{query} should not reset parameters",
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_discard_all_resets_parameters_on_a_pinned_server() {
+    load_single_connection_test_pool();
+    let mut client = TestClient::new(Parameters::default()).await;
+
+    run_simple(&mut client, "SET pgdog.pin TO true").await;
+    run_simple(&mut client, "SET statement_timeout TO 5000").await;
+
+    assert_eq!(show(&mut client, "statement_timeout").await, "5s");
+    let pinned_backend_pid = client.backend_pid().await;
+
+    client.send_simple(Query::new("DISCARD ALL")).await;
+    client.read_until('Z').await.unwrap();
+
+    assert!(
+        !client.backend_locked(),
+        "DISCARD ALL should release the pin taken with pgdog.pin"
+    );
+    assert_eq!(
+        show(&mut client, "statement_timeout").await,
+        "0",
+        "DISCARD ALL should reset the parameter on the server too"
+    );
+    assert_eq!(
+        client.backend_pid().await,
+        pinned_backend_pid,
+        "single connection test pool should reuse the same backend"
+    );
+}
+
+#[tokio::test]
+async fn test_discard_all_reapplies_startup_parameters_to_the_server() {
+    load_single_connection_test_pool();
+    let mut client = TestClient::new(startup_params(&[(
+        "application_name",
+        "test_discard_startup",
+    )]))
+    .await;
+
+    run_simple(&mut client, "SET pgdog.pin TO true").await;
+    run_simple(&mut client, "SET application_name TO 'changed'").await;
+    assert_eq!(show(&mut client, "application_name").await, "changed");
+
+    client.send_simple(Query::new("DISCARD ALL")).await;
+    client.read_until('Z').await.unwrap();
+
+    assert_eq!(
+        show(&mut client, "application_name").await,
+        "test_discard_startup",
+        "the startup value should be re-applied to the server after the reset"
+    );
 }

--- a/pgdog/src/frontend/client/query_engine/test/discard.rs
+++ b/pgdog/src/frontend/client/query_engine/test/discard.rs
@@ -3,8 +3,8 @@ use crate::{
     config::{config, load_test, set},
     expect_message,
     net::{
-        CommandComplete, DataRow, Parameters, ParseComplete, ReadyForQuery, RowDescription,
-        parameter::ParameterValue,
+        CommandComplete, DataRow, ErrorResponse, Parameters, ParseComplete, ReadyForQuery,
+        RowDescription, parameter::ParameterValue,
     },
 };
 
@@ -166,6 +166,32 @@ async fn test_non_all_discard_keeps_parameters() {
             "{query} should not reset parameters",
         );
     }
+}
+
+#[tokio::test]
+async fn test_discard_all_fails_inside_transaction() {
+    let mut client = TestClient::new_sharded(Parameters::default()).await;
+
+    run_simple(&mut client, "BEGIN").await;
+    client.send_simple(Query::new("DISCARD ALL")).await;
+
+    let error = expect_message!(client.read().await, ErrorResponse);
+    assert_eq!(error.code, "25001");
+    assert_eq!(
+        error.message,
+        "DISCARD ALL cannot run inside a transaction block"
+    );
+    assert_eq!(
+        expect_message!(client.read().await, ReadyForQuery).status,
+        'E'
+    );
+    assert!(
+        client
+            .client()
+            .transaction
+            .is_some_and(|state| state.error()),
+        "the transaction should be aborted"
+    );
 }
 
 #[tokio::test]

--- a/pgdog/src/frontend/regex_parser.rs
+++ b/pgdog/src/frontend/regex_parser.rs
@@ -10,7 +10,7 @@ use crate::util::truncate_utf8;
 static COMMENT_PREFIX: &str = r"(?i)^\s*(?:(?:--[^\n]*\n|/\*[\s\S]*?\*/)\s*)*";
 
 static CMD_BASE: &[&str] = &[
-    "(RE)?SET", "BEGIN", "COMMIT", "ROLLBACK", "LISTEN", "UNLISTEN", "NOTIFY",
+    "(RE)?SET", "BEGIN", "COMMIT", "ROLLBACK", "LISTEN", "UNLISTEN", "NOTIFY", "DISCARD",
 ];
 
 static CMD_ADVISORY: &[&str] = &[
@@ -170,6 +170,18 @@ mod test {
         assert!(matches("NOTIFY test_channel, 'payload'"));
         assert!(matches("/* comment */ NOTIFY test_channel"));
         assert!(matches("-- comment\nNOTIFY test_channel, 'payload'"));
+    }
+
+    #[test]
+    fn test_discard() {
+        assert!(matches("DISCARD ALL"));
+        assert!(matches("discard all"));
+        assert!(matches("   DISCARD ALL"));
+        assert!(matches("DISCARD PLANS"));
+        assert!(matches("DISCARD SEQUENCES"));
+        assert!(matches("DISCARD TEMPORARY"));
+        assert!(matches("/* comment */ DISCARD ALL"));
+        assert!(matches("-- comment\nDISCARD ALL"));
     }
 
     #[test]

--- a/pgdog/src/net/messages/error_response.rs
+++ b/pgdog/src/net/messages/error_response.rs
@@ -300,6 +300,15 @@ impl ErrorResponse {
         }
     }
 
+    pub(crate) fn discard_all_in_transaction() -> Self {
+        Self {
+            severity: "ERROR".into(),
+            code: "25001".into(),
+            message: "DISCARD ALL cannot run inside a transaction block".into(),
+            ..Default::default()
+        }
+    }
+
     pub(crate) fn in_failed_transaction() -> Self {
         Self {
             severity: "ERROR".into(),

--- a/pgdog/src/net/parameter.rs
+++ b/pgdog/src/net/parameter.rs
@@ -263,6 +263,16 @@ impl Parameters {
         self.transaction_local_params.remove(&name);
     }
 
+    /// Restore parameters to the values supplied in the startup message,
+    /// dropping everything changed since with `SET`.
+    pub(crate) fn restore_startup(&mut self, startup: &Parameters) {
+        self.params.clone_from(&startup.params);
+        self.transaction_params.clear();
+        self.transaction_local_params.clear();
+        self.reset_params.clear();
+        self.hash = Self::compute_hash(&self.params);
+    }
+
     /// Reset all tracked parameters.
     pub(crate) fn reset_all(&mut self) {
         let mut keys: Vec<String> = self.params.keys().cloned().collect();

--- a/pgdog/src/net/parameter.rs
+++ b/pgdog/src/net/parameter.rs
@@ -267,8 +267,6 @@ impl Parameters {
     /// dropping everything changed since with `SET`.
     pub(crate) fn restore_startup(&mut self, startup: &Parameters) {
         self.params.clone_from(&startup.params);
-        self.transaction_params.clear();
-        self.transaction_local_params.clear();
         self.reset_params.clear();
         self.hash = Self::compute_hash(&self.params);
     }


### PR DESCRIPTION
## Summary
- `DISCARD ALL` now restores session to the values from the client's startup message.
- Runtime `SET` values are dropped; parameters that were never in the startup packet stay unset and are reset on a held backend.
- `pgdog.pin` taken after connect is released, so the backend is no longer stuck after `DISCARD ALL`.

closes #1475 