### PR TITLE
feat: add rewrite handler for pgdog.nextval() function

### DIFF
--- a/pgdog/src/frontend/client/query_engine/mod.rs
+++ b/pgdog/src/frontend/client/query_engine/mod.rs
@@ -151,7 +151,7 @@ impl QueryEngine {
         }
 
         // Rewrite statement if necessary.
-        let rewrite_result = match self.parse_and_rewrite(context) {
+        let rewrite_result = match self.parse_and_rewrite(context).await {
             Ok(rewrite_result) => rewrite_result,
             Err(e) => {
                 self.error_response(context, ErrorResponse::syntax(e.to_string()))

--- a/pgdog/src/frontend/client/query_engine/multi_step/test/insert.rs
+++ b/pgdog/src/frontend/client/query_engine/multi_step/test/insert.rs
@@ -23,7 +23,7 @@ async fn test_same_shard_insert_uses_direct_route() {
     ]);
 
     let mut context = QueryEngineContext::new(&mut client.client);
-    let rewrite_result = client.engine.parse_and_rewrite(&mut context).unwrap();
+    let rewrite_result = client.engine.parse_and_rewrite(&mut context).await.unwrap();
     client
         .engine
         .route_query(&mut context, rewrite_result.as_ref())
@@ -58,7 +58,7 @@ async fn test_cross_shard_insert_uses_all_shards() {
     ]);
 
     let mut context = QueryEngineContext::new(&mut client.client);
-    let rewrite_result = client.engine.parse_and_rewrite(&mut context).unwrap();
+    let rewrite_result = client.engine.parse_and_rewrite(&mut context).await.unwrap();
     client
         .engine
         .route_query(&mut context, rewrite_result.as_ref())

--- a/pgdog/src/frontend/client/query_engine/multi_step/test/update.rs
+++ b/pgdog/src/frontend/client/query_engine/multi_step/test/update.rs
@@ -70,7 +70,7 @@ async fn same_shard_check(request: ClientRequest) -> Result<(), Error> {
     client.client().client_request.extend(request.messages);
 
     let mut context = QueryEngineContext::new(&mut client.client);
-    let rewrite_result = client.engine.parse_and_rewrite(&mut context)?;
+    let rewrite_result = client.engine.parse_and_rewrite(&mut context).await?;
     client
         .engine
         .route_query(&mut context, rewrite_result.as_ref())
@@ -186,7 +186,7 @@ async fn test_row_same_shard_no_transaction() {
 
     let mut context = QueryEngineContext::new(&mut client.client);
 
-    let rewrite_result = client.engine.parse_and_rewrite(&mut context).unwrap();
+    let rewrite_result = client.engine.parse_and_rewrite(&mut context).await.unwrap();
 
     assert!(
         context

--- a/pgdog/src/frontend/client/query_engine/rewrite.rs
+++ b/pgdog/src/frontend/client/query_engine/rewrite.rs
@@ -20,7 +20,7 @@ impl QueryEngine {
     }
 
     /// Parse client request and rewrite it, if necessary.
-    pub(super) fn parse_and_rewrite(
+    pub(super) async fn parse_and_rewrite(
         &mut self,
         context: &mut QueryEngineContext<'_>,
     ) -> Result<Option<RewriteResult>, Error> {
@@ -40,7 +40,7 @@ impl QueryEngine {
             let ast_ctx = AstContext::from_cluster(cluster, context.params);
             let ast = Cache::get().query(&query, &ast_ctx, context.prepared_statements)?;
 
-            let rewrite_result = ast.rewrite_plan.apply(context.client_request)?;
+            let rewrite_result = ast.rewrite_plan.apply(context.client_request).await?;
             context.client_request.ast = Some(ast);
             Ok(Some(rewrite_result))
         } else {

--- a/pgdog/src/frontend/client/query_engine/route_query.rs
+++ b/pgdog/src/frontend/client/query_engine/route_query.rs
@@ -149,9 +149,7 @@ impl QueryEngine {
 
                 // Apply post-parser rewrites, e.g. offset/limit.
                 if let Some(rewrite_result) = rewrite_result {
-                    rewrite_result
-                        .apply_after_parser(context.client_request)
-                        .await?;
+                    rewrite_result.apply_after_parser(context.client_request)?;
                 }
 
                 // Only validate shard placement for requests that actually execute

--- a/pgdog/src/frontend/client/query_engine/route_query.rs
+++ b/pgdog/src/frontend/client/query_engine/route_query.rs
@@ -149,7 +149,9 @@ impl QueryEngine {
 
                 // Apply post-parser rewrites, e.g. offset/limit.
                 if let Some(rewrite_result) = rewrite_result {
-                    rewrite_result.apply_after_parser(context.client_request)?;
+                    rewrite_result
+                        .apply_after_parser(context.client_request)
+                        .await?;
                 }
 
                 // Only validate shard placement for requests that actually execute

--- a/pgdog/src/frontend/client/query_engine/test/rewrite_insert_split.rs
+++ b/pgdog/src/frontend/client/query_engine/test/rewrite_insert_split.rs
@@ -13,7 +13,7 @@ async fn run_test(messages: Vec<ProtocolMessage>) -> Vec<ClientRequest> {
     let mut context = QueryEngineContext::new(&mut client);
 
     engine.rewrite_extended(&mut context).unwrap();
-    let rewrite_result = engine.parse_and_rewrite(&mut context).unwrap();
+    let rewrite_result = engine.parse_and_rewrite(&mut context).await.unwrap();
 
     assert!(
         matches!(rewrite_result, Some(RewriteResult::InsertSplit(_))),
@@ -147,7 +147,7 @@ async fn test_insert_split_not_sharded() {
     ]);
     let mut engine = QueryEngine::from_client(&client).unwrap();
     let mut context = QueryEngineContext::new(&mut client);
-    let rewrite_result = engine.parse_and_rewrite(&mut context).unwrap();
+    let rewrite_result = engine.parse_and_rewrite(&mut context).await.unwrap();
 
     assert!(rewrite_result.is_none());
 }

--- a/pgdog/src/frontend/client/query_engine/test/rewrite_offset.rs
+++ b/pgdog/src/frontend/client/query_engine/test/rewrite_offset.rs
@@ -149,7 +149,6 @@ async fn test_offset_with_unique_id_simple() {
         .as_ref()
         .unwrap()
         .apply_after_parser(context.client_request)
-        .await
         .unwrap();
 
     let final_sql = match &context.client_request.messages[0] {
@@ -217,7 +216,6 @@ async fn test_offset_with_unique_id_extended() {
         .as_ref()
         .unwrap()
         .apply_after_parser(context.client_request)
-        .await
         .unwrap();
 
     // SQL unchanged (all limit/offset are params).

--- a/pgdog/src/frontend/client/query_engine/test/rewrite_offset.rs
+++ b/pgdog/src/frontend/client/query_engine/test/rewrite_offset.rs
@@ -15,7 +15,7 @@ async fn run_test(messages: Vec<ProtocolMessage>) -> Option<OffsetPlan> {
     let mut engine = QueryEngine::from_client(&client).unwrap();
     let mut context = QueryEngineContext::new(&mut client);
 
-    let rewrite_result = engine.parse_and_rewrite(&mut context).unwrap();
+    let rewrite_result = engine.parse_and_rewrite(&mut context).await.unwrap();
 
     match rewrite_result {
         Some(RewriteResult::InPlace { offset }) => offset,
@@ -102,7 +102,7 @@ async fn test_offset_limit_not_sharded() {
     let mut engine = QueryEngine::from_client(&client).unwrap();
     let mut context = QueryEngineContext::new(&mut client);
 
-    let rewrite_result = engine.parse_and_rewrite(&mut context).unwrap();
+    let rewrite_result = engine.parse_and_rewrite(&mut context).await.unwrap();
 
     assert!(rewrite_result.is_none());
 }
@@ -127,7 +127,7 @@ async fn test_offset_with_unique_id_simple() {
     let mut engine = QueryEngine::from_client(&client).unwrap();
     let mut context = QueryEngineContext::new(&mut client);
 
-    let rewrite_result = engine.parse_and_rewrite(&mut context).unwrap();
+    let rewrite_result = engine.parse_and_rewrite(&mut context).await.unwrap();
 
     // After parse_and_rewrite, the Query message should have unique_id replaced.
     let rewritten_sql = match &context.client_request.messages[0] {
@@ -149,6 +149,7 @@ async fn test_offset_with_unique_id_simple() {
         .as_ref()
         .unwrap()
         .apply_after_parser(context.client_request)
+        .await
         .unwrap();
 
     let final_sql = match &context.client_request.messages[0] {
@@ -198,7 +199,7 @@ async fn test_offset_with_unique_id_extended() {
     let mut engine = QueryEngine::from_client(&client).unwrap();
     let mut context = QueryEngineContext::new(&mut client);
 
-    let rewrite_result = engine.parse_and_rewrite(&mut context).unwrap();
+    let rewrite_result = engine.parse_and_rewrite(&mut context).await.unwrap();
 
     // After parse_and_rewrite, Parse should have unique_id rewritten to $4::bigint.
     let rewritten_sql = match &context.client_request.messages[0] {
@@ -216,6 +217,7 @@ async fn test_offset_with_unique_id_extended() {
         .as_ref()
         .unwrap()
         .apply_after_parser(context.client_request)
+        .await
         .unwrap();
 
     // SQL unchanged (all limit/offset are params).

--- a/pgdog/src/frontend/client/query_engine/test/rewrite_simple_prepared.rs
+++ b/pgdog/src/frontend/client/query_engine/test/rewrite_simple_prepared.rs
@@ -10,7 +10,13 @@ async fn run_test(client: &mut Client, messages: &[ProtocolMessage]) -> Vec<Prot
     let mut engine = QueryEngine::from_client(client).unwrap();
     let mut context = QueryEngineContext::new(client);
 
-    assert!(engine.parse_and_rewrite(&mut context).unwrap().is_some());
+    assert!(
+        engine
+            .parse_and_rewrite(&mut context)
+            .await
+            .unwrap()
+            .is_some()
+    );
 
     client.client_request.messages.clone()
 }

--- a/pgdog/src/frontend/router/parser/rewrite/ee/error.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/ee/error.rs
@@ -1,0 +1,7 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub(crate) enum Error {
+    #[error("requires enterprise edition")]
+    EERequired,
+}

--- a/pgdog/src/frontend/router/parser/rewrite/ee/mod.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/ee/mod.rs
@@ -1,0 +1,4 @@
+pub(crate) mod error;
+pub(crate) mod nextval;
+pub(crate) use error::Error;
+pub(crate) use nextval::*;

--- a/pgdog/src/frontend/router/parser/rewrite/ee/nextval.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/ee/nextval.rs
@@ -1,0 +1,5 @@
+use super::Error;
+
+pub(crate) async fn nextval(_name: &str) -> Result<i64, Error> {
+    Err(Error::EERequired)
+}

--- a/pgdog/src/frontend/router/parser/rewrite/mod.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/mod.rs
@@ -1,2 +1,3 @@
+pub(crate) mod ee;
 pub(crate) mod statement;
 pub(crate) use statement::{StatementRewrite, StatementRewriteContext};

--- a/pgdog/src/frontend/router/parser/rewrite/statement/error.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/error.rs
@@ -2,6 +2,9 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub(crate) enum Error {
+    #[error(transparent)]
+    Enterprise(#[from] super::super::ee::Error),
+
     #[error("unique_id generation failed: {0}")]
     UniqueId(#[from] crate::unique_id::Error),
 

--- a/pgdog/src/frontend/router/parser/rewrite/statement/mod.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/mod.rs
@@ -21,6 +21,7 @@ pub(crate) mod update;
 
 pub(crate) use error::Error;
 pub(crate) use insert::InsertSplit;
+use plan::GeneratedId;
 pub(crate) use plan::RewritePlan;
 pub(crate) use simple_prepared::PrepareExecute;
 pub(crate) use update::*;
@@ -151,6 +152,10 @@ impl<'a> StatementRewrite<'a> {
                 match Self::rewrite_unique_id(node.as_ref(), mem, self.extended, &mut next_param) {
                     Ok(Some(replacement)) => {
                         plan.unique_ids += 1;
+                        if self.extended {
+                            plan.generated_ids
+                                .push(((next_param - 1) as u16, GeneratedId::UniqueId));
+                        }
                         self.rewritten = true;
                         node.replace(replacement);
                         None
@@ -159,15 +164,22 @@ impl<'a> StatementRewrite<'a> {
                         err = Some(e);
                         None
                     }
-                    Ok(None) => Some(node),
+                    Ok(None) => {
+                        if let Some(replacement) =
+                            self.rewrite_nextval(node.as_ref(), mem, &mut next_param, &mut plan)
+                        {
+                            node.replace(replacement);
+                            None
+                        } else {
+                            Some(node)
+                        }
+                    }
                 }
             }),
         );
         if let Some(err) = err {
             return Err(err);
         }
-
-        self.rewrite_nextval(stmt.stmt_mut(), mem, &mut next_param, &mut plan);
 
         if let NodeMut::SelectStmt(mut select) = stmt.stmt_mut() {
             self.rewrite_aggregates(&mut select, mem, &mut plan, self.db_schema)?;

--- a/pgdog/src/frontend/router/parser/rewrite/statement/mod.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod aggregate;
 pub(crate) mod auto_id;
 pub(crate) mod error;
 pub(crate) mod insert;
+pub(crate) mod nextval;
 pub(crate) mod offset;
 pub(crate) mod plan;
 pub(crate) mod simple_prepared;
@@ -165,6 +166,8 @@ impl<'a> StatementRewrite<'a> {
         if let Some(err) = err {
             return Err(err);
         }
+
+        self.rewrite_nextval(stmt.stmt_mut(), mem, &mut next_param, &mut plan);
 
         if let NodeMut::SelectStmt(mut select) = stmt.stmt_mut() {
             self.rewrite_aggregates(&mut select, mem, &mut plan, self.db_schema)?;

--- a/pgdog/src/frontend/router/parser/rewrite/statement/nextval.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/nextval.rs
@@ -1,11 +1,10 @@
 use std::collections::HashMap;
 
-use pg_raw_parse::{ConstValue, Node, NodeMut, make, transform, walk};
+use pg_raw_parse::{ConstValue, Node, make, transform, walk};
 
 use crate::frontend::router::parser::rewrite::ee;
-use crate::net::Bind;
-use crate::net::messages::bind::{Format, Parameter};
 
+use super::plan::GeneratedId;
 use super::{Error, RewritePlan, StatementRewrite};
 
 impl RewritePlan {
@@ -78,65 +77,35 @@ impl RewritePlan {
         });
         Ok(Some(pg_raw_parse::deparse_stmts(&*rewritten)?))
     }
-
-    /// Fetch one value per call and append it after the client and unique-ID
-    /// parameters, following the order recorded in the plan.
-    pub(super) async fn apply_nextval(
-        &self,
-        bind: &mut Bind,
-        mut nextval: impl AsyncFnMut(&str) -> Result<i64, ee::Error>,
-    ) -> Result<(), Error> {
-        let format = bind.default_param_format();
-        for (_, name) in &self.global_sequences {
-            let value = nextval(name).await?;
-            let parameter = match format {
-                Format::Binary => Parameter::new(&value.to_be_bytes()),
-                Format::Text => Parameter::new(itoa::Buffer::new().format(value).as_bytes()),
-            };
-            bind.push_param(parameter, format);
-        }
-        Ok(())
-    }
 }
 
 impl StatementRewrite<'_> {
-    /// Record sequence calls in encounter order, allocating one-based parameter
-    /// indexes after client parameters and generated unique IDs. Simple protocol
-    /// retains the statement for asynchronous rewriting without placeholders.
+    /// Record a sequence call and return its replacement in extended protocol.
+    /// Simple protocol retains the call for asynchronous rewriting.
     pub(super) fn rewrite_nextval<'mem>(
         &mut self,
-        node: NodeMut<'mem, '_>,
+        node: Node<'_>,
         mem: make::MemoryToken<'mem>,
         next_param: &mut i32,
         plan: &mut RewritePlan,
-    ) {
-        transform::transform_node(
-            node,
-            &mut transform::TransformClosure::new(|node| {
-                let Some(sequence) = sequence_name(node.as_ref()) else {
-                    return Some(node);
-                };
-                let param = *next_param;
-                *next_param += 1;
-                plan.global_sequences.push((param as u16, sequence));
-                if self.extended {
-                    node.replace(
-                        mem.make_type_cast(
-                            mem.make_param_ref(param).uncast(),
-                            mem.make_list(&[
-                                mem.make_string(Some("pg_catalog")),
-                                mem.make_string(Some("int8")),
-                            ]),
-                        )
-                        .uncast(),
-                    );
-                }
-                // Retain the SQL even when a simple-protocol nextval call is
-                // the only rewrite, so it can be resolved asynchronously.
-                self.rewritten = true;
-                None
-            }),
-        );
+    ) -> Option<make::Unique<'mem, Node<'mem>>> {
+        let sequence = sequence_name(node)?;
+        let param = *next_param;
+        *next_param += 1;
+        plan.generated_ids
+            .push((param as u16, GeneratedId::Sequence(sequence)));
+        // Retain simple-protocol SQL even when nextval is the only rewrite.
+        self.rewritten = true;
+        self.extended.then(|| {
+            mem.make_type_cast(
+                mem.make_param_ref(param).uncast(),
+                mem.make_list(&[
+                    mem.make_string(Some("pg_catalog")),
+                    mem.make_string(Some("int8")),
+                ]),
+            )
+            .uncast()
+        })
     }
 }
 
@@ -186,7 +155,8 @@ mod tests {
     use crate::frontend::ClientRequest;
     use crate::frontend::PreparedStatements;
     use crate::frontend::router::parser::StatementRewriteContext;
-    use crate::net::{Parse, ProtocolMessage, Query};
+    use crate::net::messages::bind::{Format, Parameter};
+    use crate::net::{Bind, Parse, ProtocolMessage, Query};
     use pgdog_config::Rewrite;
 
     use super::*;
@@ -230,16 +200,17 @@ mod tests {
         );
         assert_eq!(
             sql,
-            "SELECT $3::bigint, $1, $2::bigint, $4::bigint, $5::bigint"
+            "SELECT $2::bigint, $1, $3::bigint, $4::bigint, $5::bigint"
         );
         assert_eq!(plan.params, 1);
         assert_eq!(plan.unique_ids, 1);
         assert_eq!(
-            plan.global_sequences,
+            plan.generated_ids,
             vec![
-                (3, "sequence.name".to_owned()),
-                (4, "other.seq".to_owned()),
-                (5, "sequence.name".to_owned()),
+                (2, GeneratedId::Sequence("sequence.name".to_owned())),
+                (3, GeneratedId::UniqueId),
+                (4, GeneratedId::Sequence("other.seq".to_owned())),
+                (5, GeneratedId::Sequence("sequence.name".to_owned())),
             ]
         );
         assert_eq!(plan.stmt.as_deref(), Some(sql.as_str()));
@@ -252,10 +223,10 @@ mod tests {
         let (sql, plan) = rewrite(original, false);
         assert_eq!(sql, original);
         assert_eq!(
-            plan.global_sequences,
+            plan.generated_ids,
             vec![
-                (1, "sequence.name".to_owned()),
-                (2, "sequence.name".to_owned()),
+                (1, GeneratedId::Sequence("sequence.name".to_owned())),
+                (2, GeneratedId::Sequence("sequence.name".to_owned())),
             ]
         );
         assert_eq!(plan.unique_ids, 0);
@@ -273,10 +244,13 @@ mod tests {
         );
         assert_eq!(sql, "INSERT INTO t (id) VALUES ($1::bigint), ($2::bigint)");
         assert_eq!(
-            plan.global_sequences,
+            plan.generated_ids,
             vec![
-                (1, "\"My Schema\".\"My Sequence\"".to_owned()),
-                (2, "other.seq".to_owned()),
+                (
+                    1,
+                    GeneratedId::Sequence("\"My Schema\".\"My Sequence\"".to_owned())
+                ),
+                (2, GeneratedId::Sequence("other.seq".to_owned())),
             ]
         );
     }
@@ -394,8 +368,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_nextval_bind_values_and_formats() {
+        let _guard = crate::test_utils::set_env_var("NODE_ID", "pgdog-1");
         let (_, plan) = rewrite(
-            "SELECT $1, $2, pgdog.nextval('a'), pgdog.nextval('b'), pgdog.nextval('a')",
+            "SELECT $1, $2, pgdog.nextval('a'), pgdog.unique_id(), \
+             pgdog.nextval('b'), pgdog.unique_id(), pgdog.nextval('a')",
             true,
         );
         for codes in [
@@ -410,7 +386,7 @@ mod tests {
             let mut bind = Bind::new_params_codes("stmt", &original_params, &codes);
             let mut calls = Vec::new();
             let mut value = -2i64;
-            plan.apply_nextval(&mut bind, async |name: &str| {
+            plan.apply_generated_ids(&mut bind, async |name: &str| {
                 calls.push(name.to_owned());
                 value += 1;
                 Ok(value)
@@ -420,8 +396,8 @@ mod tests {
 
             assert_eq!(calls, ["a", "b", "a"]);
             assert_eq!(&bind.params_raw()[..2], &original_params);
-            assert_eq!(bind.params_raw().len(), 5);
-            for (index, value) in [(2, -1), (3, 0), (4, 1)] {
+            assert_eq!(bind.params_raw().len(), 7);
+            for (index, value) in [(2, -1), (4, 0), (6, 1)] {
                 let param = bind.parameter(index).expect("format").expect("parameter");
                 assert_eq!(param.bigint(), Some(value));
                 assert_eq!(
@@ -433,6 +409,20 @@ mod tests {
                     }
                 );
             }
+            let first_id = bind
+                .parameter(3)
+                .expect("format")
+                .expect("parameter")
+                .bigint()
+                .expect("bigint");
+            let second_id = bind
+                .parameter(5)
+                .expect("format")
+                .expect("parameter")
+                .bigint()
+                .expect("bigint");
+            assert!(first_id > 0);
+            assert!(second_id > first_id);
             if codes.len() <= 1 {
                 assert_eq!(bind.format_codes_raw(), codes);
             } else {
@@ -441,6 +431,8 @@ mod tests {
                     [
                         Format::Text,
                         Format::Binary,
+                        Format::Text,
+                        Format::Text,
                         Format::Text,
                         Format::Text,
                         Format::Text
@@ -460,7 +452,7 @@ mod tests {
         };
         for expected in [2, 4] {
             let mut bind = Bind::default();
-            plan.apply_nextval(&mut bind, &mut nextval)
+            plan.apply_generated_ids(&mut bind, &mut nextval)
                 .await
                 .expect("values");
             assert_eq!(
@@ -553,7 +545,7 @@ mod tests {
                 "{call}"
             );
             let (_, plan) = rewrite(&format!("SELECT {call}"), true);
-            assert!(plan.global_sequences.is_empty(), "{call}");
+            assert!(plan.generated_ids.is_empty(), "{call}");
             assert!(plan.is_empty(), "{call}");
         }
     }

--- a/pgdog/src/frontend/router/parser/rewrite/statement/nextval.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/nextval.rs
@@ -1,0 +1,560 @@
+use std::collections::HashMap;
+
+use pg_raw_parse::{ConstValue, Node, NodeMut, make, transform, walk};
+
+use crate::frontend::router::parser::rewrite::ee;
+use crate::net::Bind;
+use crate::net::messages::bind::{Format, Parameter};
+
+use super::{Error, RewritePlan, StatementRewrite};
+
+impl RewritePlan {
+    /// Replace simple-protocol sequence calls in the current statement with
+    /// freshly fetched bigint literals. The cached plan remains unchanged.
+    /// Returns `None` when the plan has no statement.
+    pub(crate) async fn rewrite_nextval_simple(&self) -> Result<Option<String>, Error> {
+        self.rewrite_nextval_simple_with(ee::nextval).await
+    }
+
+    async fn rewrite_nextval_simple_with(
+        &self,
+        mut nextval: impl AsyncFnMut(&str) -> Result<i64, ee::Error>,
+    ) -> Result<Option<String>, Error> {
+        let Some(stmt) = &self.stmt else {
+            return Ok(None);
+        };
+
+        // Reparse the current SQL to find calls after any earlier rewrites.
+        let ast = pg_raw_parse::parse(stmt)?;
+        let mut calls = Vec::new();
+        for stmt in ast.stmts() {
+            walk::walk(stmt, |node| {
+                if let Node::FuncCall(func) = node
+                    && let Some(name) = sequence_name(node)
+                {
+                    calls.push((func.location, name));
+                }
+            });
+        }
+        if calls.is_empty() {
+            return Ok(Some(stmt.clone()));
+        }
+        calls.sort_unstable_by_key(|(location, _)| *location);
+
+        // AST mutation callbacks are synchronous; resolve values before
+        // entering the parser's memory context to replace the calls.
+        let mut values = HashMap::with_capacity(calls.len());
+        for (location, name) in calls {
+            values.insert(location, nextval(&name).await?);
+        }
+        let rewritten = make::owned(|mem| {
+            let mut copy = mem.make_unique(&**ast);
+            for mut stmt in copy.as_mut() {
+                transform::transform_node(
+                    stmt.stmt_mut(),
+                    &mut transform::TransformClosure::new(|node| {
+                        if let Node::FuncCall(func) = node.as_ref()
+                            && let Some(value) = values.get(&func.location)
+                        {
+                            node.replace(
+                                mem.make_type_cast(
+                                    mem.make_a_const(ConstValue::Float(&value.to_string()))
+                                        .uncast(),
+                                    mem.make_list(&[
+                                        mem.make_string(Some("pg_catalog")),
+                                        mem.make_string(Some("int8")),
+                                    ]),
+                                )
+                                .uncast(),
+                            );
+                            None
+                        } else {
+                            Some(node)
+                        }
+                    }),
+                );
+            }
+            copy
+        });
+        Ok(Some(pg_raw_parse::deparse_stmts(&*rewritten)?))
+    }
+
+    /// Fetch one value per call and append it after the client and unique-ID
+    /// parameters, following the order recorded in the plan.
+    pub(super) async fn apply_nextval(
+        &self,
+        bind: &mut Bind,
+        mut nextval: impl AsyncFnMut(&str) -> Result<i64, ee::Error>,
+    ) -> Result<(), Error> {
+        let format = bind.default_param_format();
+        for (_, name) in &self.global_sequences {
+            let value = nextval(name).await?;
+            let parameter = match format {
+                Format::Binary => Parameter::new(&value.to_be_bytes()),
+                Format::Text => Parameter::new(itoa::Buffer::new().format(value).as_bytes()),
+            };
+            bind.push_param(parameter, format);
+        }
+        Ok(())
+    }
+}
+
+impl StatementRewrite<'_> {
+    /// Record sequence calls in encounter order, allocating one-based parameter
+    /// indexes after client parameters and generated unique IDs. Simple protocol
+    /// retains the statement for asynchronous rewriting without placeholders.
+    pub(super) fn rewrite_nextval<'mem>(
+        &mut self,
+        node: NodeMut<'mem, '_>,
+        mem: make::MemoryToken<'mem>,
+        next_param: &mut i32,
+        plan: &mut RewritePlan,
+    ) {
+        transform::transform_node(
+            node,
+            &mut transform::TransformClosure::new(|node| {
+                let Some(sequence) = sequence_name(node.as_ref()) else {
+                    return Some(node);
+                };
+                let param = *next_param;
+                *next_param += 1;
+                plan.global_sequences.push((param as u16, sequence));
+                if self.extended {
+                    node.replace(
+                        mem.make_type_cast(
+                            mem.make_param_ref(param).uncast(),
+                            mem.make_list(&[
+                                mem.make_string(Some("pg_catalog")),
+                                mem.make_string(Some("int8")),
+                            ]),
+                        )
+                        .uncast(),
+                    );
+                }
+                // Retain the SQL even when a simple-protocol nextval call is
+                // the only rewrite, so it can be resolved asynchronously.
+                self.rewritten = true;
+                None
+            }),
+        );
+    }
+}
+
+/// Extract the literal sequence name from a pgdog.nextval() call.
+fn sequence_name(node: Node<'_>) -> Option<String> {
+    let Node::FuncCall(func) = node else {
+        return None;
+    };
+    if !func
+        .funcname()
+        .iter()
+        .map(Node::as_str)
+        .eq([Some("pgdog"), Some("nextval")])
+    {
+        return None;
+    }
+
+    let mut args = func.args().iter();
+    let mut arg = args.next()?;
+    if args.next().is_some() {
+        return None;
+    }
+
+    if let Node::TypeCast(cast) = arg {
+        let type_name = cast.type_name()?;
+        let names = type_name.names();
+        if !names.iter().map(|name| name.sval()).eq([Some("regclass")])
+            && !names
+                .iter()
+                .map(|name| name.sval())
+                .eq([Some("pg_catalog"), Some("regclass")])
+        {
+            return None;
+        }
+        arg = cast.arg();
+    }
+
+    let Node::A_Const(value) = arg else {
+        return None;
+    };
+    value.val()?.string_value().map(str::to_owned)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::backend::{ShardingSchema, schema::Schema};
+    use crate::frontend::ClientRequest;
+    use crate::frontend::PreparedStatements;
+    use crate::frontend::router::parser::StatementRewriteContext;
+    use crate::net::{Parse, ProtocolMessage, Query};
+    use pgdog_config::Rewrite;
+
+    use super::*;
+
+    fn rewrite(sql: &str, extended: bool) -> (String, RewritePlan) {
+        let schema = ShardingSchema {
+            rewrite: Rewrite {
+                enabled: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let db_schema = Schema::default();
+        let mut prepared_statements = PreparedStatements::default();
+        let mut rewriter = StatementRewrite::new(StatementRewriteContext {
+            extended,
+            prepared: false,
+            prepared_statements: &mut prepared_statements,
+            schema: &schema,
+            db_schema: &db_schema,
+            user: "test",
+            search_path: None,
+        });
+        let mut plan = RewritePlan::default();
+        let ast = make::owned(|mem| {
+            let mut ast = mem.parse(sql).expect("valid SQL");
+            plan = rewriter
+                .maybe_rewrite(ast.as_mut().into_iter().next().expect("statement"), mem)
+                .expect("rewrite succeeds");
+            ast
+        });
+        (pg_raw_parse::deparse_stmts(&*ast).expect("valid AST"), plan)
+    }
+
+    #[test]
+    fn test_nextval_extended_parameter_indexes() {
+        let (sql, plan) = rewrite(
+            "SELECT pgdog.nextval('sequence.name'), $1, pgdog.unique_id(), \
+             pgdog.nextval('other.seq'::regclass), pgdog.nextval('sequence.name')",
+            true,
+        );
+        assert_eq!(
+            sql,
+            "SELECT $3::bigint, $1, $2::bigint, $4::bigint, $5::bigint"
+        );
+        assert_eq!(plan.params, 1);
+        assert_eq!(plan.unique_ids, 1);
+        assert_eq!(
+            plan.global_sequences,
+            vec![
+                (3, "sequence.name".to_owned()),
+                (4, "other.seq".to_owned()),
+                (5, "sequence.name".to_owned()),
+            ]
+        );
+        assert_eq!(plan.stmt.as_deref(), Some(sql.as_str()));
+    }
+
+    #[test]
+    fn test_nextval_simple_records_calls_without_placeholders() {
+        let original = "SELECT pgdog.nextval('sequence.name'), \
+                        pgdog.nextval('sequence.name'::regclass)";
+        let (sql, plan) = rewrite(original, false);
+        assert_eq!(sql, original);
+        assert_eq!(
+            plan.global_sequences,
+            vec![
+                (1, "sequence.name".to_owned()),
+                (2, "sequence.name".to_owned()),
+            ]
+        );
+        assert_eq!(plan.unique_ids, 0);
+        assert_eq!(plan.stmt.as_deref(), Some(original));
+        assert!(!plan.is_empty());
+    }
+
+    #[test]
+    fn test_nextval_insert_preserves_quoted_sequence_name() {
+        let (sql, plan) = rewrite(
+            "INSERT INTO t (id) VALUES \
+             (pgdog.nextval('\"My Schema\".\"My Sequence\"'::pg_catalog.regclass)), \
+             (pgdog.nextval('other.seq'))",
+            true,
+        );
+        assert_eq!(sql, "INSERT INTO t (id) VALUES ($1::bigint), ($2::bigint)");
+        assert_eq!(
+            plan.global_sequences,
+            vec![
+                (1, "\"My Schema\".\"My Sequence\"".to_owned()),
+                (2, "other.seq".to_owned()),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_nextval_simple_rewrites_current_statement() {
+        let (_, mut plan) = rewrite("SELECT pgdog.nextval('old')", false);
+        // The current statement has different locations, names, and call count
+        // than the original SQL.
+        plan.stmt = Some(
+            "SELECT 123::bigint, pgdog.nextval('a'::regclass), \
+             (SELECT pgdog.nextval('b')), pgdog.nextval('a'::pg_catalog.regclass), \
+             nextval('local'), 'pgdog.nextval(''literal'')'"
+                .to_owned(),
+        );
+        let before = plan.stmt.clone();
+        let mut names = Vec::new();
+        let mut values = [i64::MIN, 0, i64::MAX].into_iter();
+        let sql = plan
+            .rewrite_nextval_simple_with(async |name: &str| {
+                names.push(name.to_owned());
+                Ok(values.next().expect("one value per call"))
+            })
+            .await
+            .expect("rewrite succeeds")
+            .expect("statement");
+        assert_eq!(names, ["a", "b", "a"]);
+        assert_eq!(
+            sql,
+            "SELECT 123::bigint, (-9223372036854775808)::bigint, \
+                         (SELECT (0)::bigint), (9223372036854775807)::bigint, \
+                         nextval('local'), 'pgdog.nextval(''literal'')'"
+        );
+        assert_eq!(plan.stmt, before);
+        pg_raw_parse::parse(&sql).expect("rewritten SQL parses");
+    }
+
+    #[tokio::test]
+    async fn test_nextval_simple_fetches_fresh_values() {
+        let (_, plan) = rewrite(
+            "INSERT INTO t (id) VALUES (pgdog.nextval('a')), (pgdog.nextval('a'))",
+            false,
+        );
+        let mut value = 0i64;
+        let mut nextval = async |_: &str| {
+            value += 1;
+            Ok(value)
+        };
+        for (first, second) in [(1, 2), (3, 4)] {
+            let sql = plan
+                .rewrite_nextval_simple_with(&mut nextval)
+                .await
+                .expect("rewrite succeeds")
+                .expect("statement");
+            assert_eq!(
+                sql,
+                format!("INSERT INTO t (id) VALUES (({first})::bigint), (({second})::bigint)")
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_nextval_simple_error_preserves_statement() {
+        let (_, plan) = rewrite("SELECT pgdog.nextval('a'), pgdog.nextval('b')", false);
+        let before = plan.stmt.clone();
+        let mut calls = 0;
+        let error = plan
+            .rewrite_nextval_simple_with(async |_: &str| {
+                calls += 1;
+                if calls == 1 {
+                    Ok(42)
+                } else {
+                    Err(ee::Error::EERequired)
+                }
+            })
+            .await
+            .expect_err("second fetch fails");
+        assert!(matches!(error, Error::Enterprise(ee::Error::EERequired)));
+        assert_eq!(plan.stmt, before);
+        assert!(matches!(
+            plan.rewrite_nextval_simple().await,
+            Err(Error::Enterprise(ee::Error::EERequired))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_nextval_simple_without_calls() {
+        assert_eq!(
+            RewritePlan::default()
+                .rewrite_nextval_simple()
+                .await
+                .expect("no SQL"),
+            None
+        );
+        let sql = "SELECT  $1::bigint, nextval('local') /* keep formatting */";
+        let plan = RewritePlan {
+            stmt: Some(sql.to_owned()),
+            ..Default::default()
+        };
+        assert_eq!(
+            plan.rewrite_nextval_simple()
+                .await
+                .expect("no global calls"),
+            Some(sql.to_owned())
+        );
+        let invalid = RewritePlan {
+            stmt: Some("SELECT (".to_owned()),
+            ..Default::default()
+        };
+        assert!(matches!(
+            invalid.rewrite_nextval_simple().await,
+            Err(Error::Parser(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_nextval_bind_values_and_formats() {
+        let (_, plan) = rewrite(
+            "SELECT $1, $2, pgdog.nextval('a'), pgdog.nextval('b'), pgdog.nextval('a')",
+            true,
+        );
+        for codes in [
+            vec![],
+            vec![Format::Binary],
+            vec![Format::Text, Format::Binary],
+        ] {
+            let original_params = [
+                Parameter::new(b"client"),
+                Parameter::new(&7i64.to_be_bytes()),
+            ];
+            let mut bind = Bind::new_params_codes("stmt", &original_params, &codes);
+            let mut calls = Vec::new();
+            let mut value = -2i64;
+            plan.apply_nextval(&mut bind, async |name: &str| {
+                calls.push(name.to_owned());
+                value += 1;
+                Ok(value)
+            })
+            .await
+            .expect("sequence values appended");
+
+            assert_eq!(calls, ["a", "b", "a"]);
+            assert_eq!(&bind.params_raw()[..2], &original_params);
+            assert_eq!(bind.params_raw().len(), 5);
+            for (index, value) in [(2, -1), (3, 0), (4, 1)] {
+                let param = bind.parameter(index).expect("format").expect("parameter");
+                assert_eq!(param.bigint(), Some(value));
+                assert_eq!(
+                    param.format(),
+                    if codes.len() == 1 {
+                        Format::Binary
+                    } else {
+                        Format::Text
+                    }
+                );
+            }
+            if codes.len() <= 1 {
+                assert_eq!(bind.format_codes_raw(), codes);
+            } else {
+                assert_eq!(
+                    bind.format_codes_raw(),
+                    [
+                        Format::Text,
+                        Format::Binary,
+                        Format::Text,
+                        Format::Text,
+                        Format::Text
+                    ]
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_nextval_bind_reexecution_fetches_new_values() {
+        let (_, plan) = rewrite("SELECT pgdog.nextval('a'), pgdog.nextval('a')", true);
+        let mut value = 0i64;
+        let mut nextval = async |_: &str| {
+            value += 1;
+            Ok(value)
+        };
+        for expected in [2, 4] {
+            let mut bind = Bind::default();
+            plan.apply_nextval(&mut bind, &mut nextval)
+                .await
+                .expect("values");
+            assert_eq!(
+                bind.parameter(1)
+                    .expect("format")
+                    .expect("parameter")
+                    .bigint(),
+                Some(expected)
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_nextval_apply_propagates_enterprise_error() {
+        let (_, plan) = rewrite("SELECT pgdog.nextval('a')", true);
+        let mut request = ClientRequest::from(vec![ProtocolMessage::Bind(Bind::default())]);
+        let error = plan
+            .apply(&mut request)
+            .await
+            .expect_err("EE hook rejects sequence");
+        assert!(matches!(error, Error::Enterprise(ee::Error::EERequired)));
+    }
+
+    #[tokio::test]
+    async fn test_nextval_apply_fetches_for_query_but_not_parse() {
+        let original = "SELECT pgdog.nextval('a')";
+        let (_, extended_plan) = rewrite(original, true);
+        let mut request =
+            ClientRequest::from(vec![ProtocolMessage::Parse(Parse::new_anonymous(original))]);
+        extended_plan
+            .apply(&mut request)
+            .await
+            .expect("prepare does not fetch");
+
+        let (_, simple_plan) = rewrite(original, false);
+        let mut request = ClientRequest::from(vec![ProtocolMessage::Query(Query::new(original))]);
+        let error = simple_plan
+            .apply(&mut request)
+            .await
+            .expect_err("simple query calls the EE hook");
+        assert!(matches!(error, Error::Enterprise(ee::Error::EERequired)));
+        let ProtocolMessage::Query(query) = &request.messages[0] else {
+            panic!("expected Query");
+        };
+        assert_eq!(query.query(), original);
+    }
+
+    #[test]
+    fn test_nextval_sequence_name() {
+        for argument in [
+            "'sequence.name'",
+            "'sequence.name'::regclass",
+            "'sequence.name'::pg_catalog.regclass",
+            "CAST('sequence.name' AS regclass)",
+        ] {
+            let ast = pg_raw_parse::parse(&format!("SELECT pgdog.nextval({argument})"))
+                .expect("valid SQL");
+            let Node::SelectStmt(select) = ast.stmts().next().expect("statement") else {
+                panic!("expected SELECT");
+            };
+            assert_eq!(
+                sequence_name(select.target_list().first().expect("target").val()),
+                Some("sequence.name".to_owned()),
+                "{argument}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_nextval_unsupported_calls() {
+        for call in [
+            "nextval('seq')",
+            "other.nextval('seq')",
+            "pgdog.other('seq')",
+            "pgdog.nextval()",
+            "pgdog.nextval('seq', 'other')",
+            "pgdog.nextval($1)",
+            "pgdog.nextval(123)",
+            "pgdog.nextval(NULL)",
+            "pgdog.nextval('seq'::text)",
+            "pgdog.nextval('seq'::other.regclass)",
+        ] {
+            let ast = pg_raw_parse::parse(&format!("SELECT {call}")).expect("valid SQL");
+            let Node::SelectStmt(select) = ast.stmts().next().expect("statement") else {
+                panic!("expected SELECT");
+            };
+            assert_eq!(
+                sequence_name(select.target_list().first().expect("target").val()),
+                None,
+                "{call}"
+            );
+            let (_, plan) = rewrite(&format!("SELECT {call}"), true);
+            assert!(plan.global_sequences.is_empty(), "{call}");
+            assert!(plan.is_empty(), "{call}");
+        }
+    }
+}

--- a/pgdog/src/frontend/router/parser/rewrite/statement/plan.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/plan.rs
@@ -3,6 +3,7 @@ use crate::net::messages::bind::{Format, Parameter};
 use crate::net::{Bind, Parse, ProtocolMessage, Query};
 use crate::unique_id::UniqueId;
 
+use super::super::ee;
 use super::insert::build_split_requests;
 use super::offset::OffsetPlan;
 use super::{
@@ -26,6 +27,10 @@ pub(crate) struct RewritePlan {
 
     /// Number of auto-injected primary key columns with pgdog.unique_id().
     pub(crate) auto_id_injected: u16,
+
+    /// One-based Bind parameter indexes and sequence names in allocation order.
+    /// Simple protocol uses the list to detect calls; it does not use the indexes.
+    pub(crate) global_sequences: Vec<(u16, String)>,
 
     /// Rewritten SQL statement.
     pub(crate) stmt: Option<String>,
@@ -58,7 +63,10 @@ pub(crate) enum RewriteResult {
 }
 
 impl RewriteResult {
-    pub(crate) fn apply_after_parser(&self, request: &mut ClientRequest) -> Result<(), Error> {
+    pub(crate) async fn apply_after_parser(
+        &self,
+        request: &mut ClientRequest,
+    ) -> Result<(), Error> {
         match self {
             Self::InPlace {
                 offset: Some(offset),
@@ -75,6 +83,7 @@ impl RewritePlan {
     pub(crate) fn is_empty(&self) -> bool {
         self.unique_ids == 0
             && self.auto_id_injected == 0
+            && self.global_sequences.is_empty()
             && self.stmt.is_none()
             && self.prepare_rewrites.is_empty()
             && self.insert_split.is_empty()
@@ -83,8 +92,8 @@ impl RewritePlan {
             && self.offset.is_none()
     }
 
-    /// Apply the rewrite plan to a Bind message by appending generated unique IDs.
-    pub(crate) fn apply_bind(&self, bind: &mut Bind) -> Result<(), Error> {
+    /// Append generated unique IDs and sequence values to a Bind message.
+    async fn apply_bind(&self, bind: &mut Bind) -> Result<(), Error> {
         let format = bind.default_param_format();
 
         for _ in 0..self.unique_ids {
@@ -97,11 +106,11 @@ impl RewritePlan {
             bind.push_param(param, format);
         }
 
-        Ok(())
+        self.apply_nextval(bind, ee::nextval).await
     }
 
     /// Apply the rewrite plan to a Parse message by updating the SQL.
-    pub(crate) fn apply_parse(&self, parse: &mut Parse) {
+    fn apply_parse(&self, parse: &mut Parse) {
         if let Some(ref stmt) = self.stmt {
             parse.set_query(stmt);
             if !parse.anonymous() {
@@ -111,14 +120,20 @@ impl RewritePlan {
     }
 
     /// Apply the rewrite plan to a Query message by updating the SQL.
-    pub(crate) fn apply_query(&self, query: &mut Query) {
-        if let Some(ref stmt) = self.stmt {
+    async fn apply_query(&self, query: &mut Query) -> Result<(), Error> {
+        if !self.global_sequences.is_empty() {
+            if let Some(stmt) = self.rewrite_nextval_simple().await? {
+                query.set_query(&stmt);
+            }
+        } else if let Some(ref stmt) = self.stmt {
             query.set_query(stmt);
         }
+
+        Ok(())
     }
 
     /// Apply the rewrite plan to a ClientRequest.
-    pub(crate) fn apply(&self, request: &mut ClientRequest) -> Result<RewriteResult, Error> {
+    pub(crate) async fn apply(&self, request: &mut ClientRequest) -> Result<RewriteResult, Error> {
         // Prepend any required Prepare messages for EXECUTE statements.
         if !self.prepare_rewrites.is_empty() {
             self.prepare_rewrites
@@ -139,8 +154,8 @@ impl RewritePlan {
         for message in request.messages.iter_mut() {
             match message {
                 ProtocolMessage::Parse(parse) => self.apply_parse(parse),
-                ProtocolMessage::Query(query) => self.apply_query(query),
-                ProtocolMessage::Bind(bind) => self.apply_bind(bind)?,
+                ProtocolMessage::Query(query) => self.apply_query(query).await?,
+                ProtocolMessage::Bind(bind) => self.apply_bind(bind).await?,
                 _ => {}
             }
         }
@@ -173,24 +188,38 @@ mod tests {
     use crate::test_utils::set_env_var;
     use std::collections::HashSet;
 
-    #[test]
-    fn test_apply_bind_no_unique_ids() {
+    #[tokio::test]
+    async fn test_apply_query_without_recorded_sequences_skips_nextval() {
+        let stmt = "SELECT pgdog.nextval('seq')";
+        let plan = RewritePlan {
+            stmt: Some(stmt.to_owned()),
+            ..Default::default()
+        };
+        let mut query = Query::new("SELECT 1");
+        plan.apply_query(&mut query)
+            .await
+            .expect("no recorded sequences");
+        assert_eq!(query.query(), stmt);
+    }
+
+    #[tokio::test]
+    async fn test_apply_bind_no_unique_ids() {
         let _guard = set_env_var("NODE_ID", "pgdog-1");
         let plan = RewritePlan::default();
         let mut bind = Bind::default();
-        plan.apply_bind(&mut bind).unwrap();
+        plan.apply_bind(&mut bind).await.unwrap();
         assert_eq!(bind.params_raw().len(), 0);
     }
 
-    #[test]
-    fn test_apply_bind_text_format() {
+    #[tokio::test]
+    async fn test_apply_bind_text_format() {
         let _guard = set_env_var("NODE_ID", "pgdog-1");
         let plan = RewritePlan {
             unique_ids: 1,
             ..Default::default()
         };
         let mut bind = Bind::default();
-        plan.apply_bind(&mut bind).unwrap();
+        plan.apply_bind(&mut bind).await.unwrap();
         assert_eq!(bind.params_raw().len(), 1);
 
         // Default format is Text, so data should be a string
@@ -202,8 +231,8 @@ mod tests {
         assert_eq!(bind.format_codes_raw().len(), 0);
     }
 
-    #[test]
-    fn test_apply_bind_binary_format_uniform() {
+    #[tokio::test]
+    async fn test_apply_bind_binary_format_uniform() {
         let _guard = set_env_var("NODE_ID", "pgdog-1");
         let plan = RewritePlan {
             params: 1,
@@ -213,7 +242,7 @@ mod tests {
         // Create bind with uniform binary format (1 code applies to all)
         let mut bind =
             Bind::new_params_codes("test", &[Parameter::new(b"existing")], &[Format::Binary]);
-        plan.apply_bind(&mut bind).unwrap();
+        plan.apply_bind(&mut bind).await.unwrap();
         assert_eq!(bind.params_raw().len(), 2);
 
         // Should use binary format: 8 bytes big-endian
@@ -227,8 +256,8 @@ mod tests {
         assert_eq!(bind.format_codes_raw()[0], Format::Binary);
     }
 
-    #[test]
-    fn test_apply_bind_binary_format_one_to_one() {
+    #[tokio::test]
+    async fn test_apply_bind_binary_format_one_to_one() {
         let _guard = set_env_var("NODE_ID", "pgdog-1");
         let plan = RewritePlan {
             params: 2,
@@ -241,7 +270,7 @@ mod tests {
             &[Parameter::new(b"a"), Parameter::new(b"b")],
             &[Format::Binary, Format::Binary],
         );
-        plan.apply_bind(&mut bind).unwrap();
+        plan.apply_bind(&mut bind).await.unwrap();
         assert_eq!(bind.params_raw().len(), 3);
 
         // New param should be text (default for one-to-one)
@@ -254,15 +283,15 @@ mod tests {
         assert_eq!(bind.format_codes_raw()[2], Format::Text);
     }
 
-    #[test]
-    fn test_apply_bind_multiple_unique_ids() {
+    #[tokio::test]
+    async fn test_apply_bind_multiple_unique_ids() {
         let _guard = set_env_var("NODE_ID", "pgdog-1");
         let plan = RewritePlan {
             unique_ids: 3,
             ..Default::default()
         };
         let mut bind = Bind::default();
-        plan.apply_bind(&mut bind).unwrap();
+        plan.apply_bind(&mut bind).await.unwrap();
         assert_eq!(bind.params_raw().len(), 3);
 
         let mut ids = HashSet::new();
@@ -274,8 +303,8 @@ mod tests {
         assert_eq!(ids.len(), 3, "all IDs should be unique");
     }
 
-    #[test]
-    fn test_apply_bind_appends_to_existing_params() {
+    #[tokio::test]
+    async fn test_apply_bind_appends_to_existing_params() {
         let _guard = set_env_var("NODE_ID", "pgdog-1");
         let plan = RewritePlan {
             params: 2,
@@ -286,7 +315,7 @@ mod tests {
             "test",
             &[Parameter::new(b"existing1"), Parameter::new(b"existing2")],
         );
-        plan.apply_bind(&mut bind).unwrap();
+        plan.apply_bind(&mut bind).await.unwrap();
         assert_eq!(bind.params_raw().len(), 4);
 
         assert_eq!(bind.params_raw()[0].data.as_ref(), b"existing1");

--- a/pgdog/src/frontend/router/parser/rewrite/statement/plan.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/plan.rs
@@ -63,10 +63,7 @@ pub(crate) enum RewriteResult {
 }
 
 impl RewriteResult {
-    pub(crate) async fn apply_after_parser(
-        &self,
-        request: &mut ClientRequest,
-    ) -> Result<(), Error> {
+    pub(crate) fn apply_after_parser(&self, request: &mut ClientRequest) -> Result<(), Error> {
         match self {
             Self::InPlace {
                 offset: Some(offset),

--- a/pgdog/src/frontend/router/parser/rewrite/statement/plan.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/plan.rs
@@ -10,6 +10,12 @@ use super::{
     Error, InsertSplit, PrepareExecute, ShardingKeyUpdate, aggregate::AggregateRewritePlan,
 };
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum GeneratedId {
+    UniqueId,
+    Sequence(String),
+}
+
 /// Statement rewrite plan.
 ///
 /// Executed in order of fields in this struct.
@@ -22,15 +28,15 @@ pub(crate) struct RewritePlan {
     /// substitute values we are rewriting.
     pub(crate) params: u16,
 
-    /// Number of unique IDs to append to the Bind message.
+    /// Number of unique IDs, also used by SQL PREPARE/EXECUTE rewriting.
     pub(crate) unique_ids: u16,
 
     /// Number of auto-injected primary key columns with pgdog.unique_id().
     pub(crate) auto_id_injected: u16,
 
-    /// One-based Bind parameter indexes and sequence names in allocation order.
-    /// Simple protocol uses the list to detect calls; it does not use the indexes.
-    pub(crate) global_sequences: Vec<(u16, String)>,
+    /// One-based parameter indexes and ID sources in allocation order.
+    /// Simple protocol records sequence calls here without using the indexes.
+    pub(crate) generated_ids: Vec<(u16, GeneratedId)>,
 
     /// Rewritten SQL statement.
     pub(crate) stmt: Option<String>,
@@ -80,7 +86,7 @@ impl RewritePlan {
     pub(crate) fn is_empty(&self) -> bool {
         self.unique_ids == 0
             && self.auto_id_injected == 0
-            && self.global_sequences.is_empty()
+            && self.generated_ids.is_empty()
             && self.stmt.is_none()
             && self.prepare_rewrites.is_empty()
             && self.insert_split.is_empty()
@@ -91,11 +97,21 @@ impl RewritePlan {
 
     /// Append generated unique IDs and sequence values to a Bind message.
     async fn apply_bind(&self, bind: &mut Bind) -> Result<(), Error> {
-        let format = bind.default_param_format();
+        self.apply_generated_ids(bind, ee::nextval).await
+    }
 
-        for _ in 0..self.unique_ids {
-            let generator = UniqueId::generator()?;
-            let id = generator.next_id();
+    /// Append values in the same order their placeholders were allocated.
+    pub(super) async fn apply_generated_ids(
+        &self,
+        bind: &mut Bind,
+        mut nextval: impl AsyncFnMut(&str) -> Result<i64, ee::Error>,
+    ) -> Result<(), Error> {
+        let format = bind.default_param_format();
+        for (_, source) in &self.generated_ids {
+            let id = match source {
+                GeneratedId::UniqueId => UniqueId::generator()?.next_id(),
+                GeneratedId::Sequence(name) => nextval(name).await?,
+            };
             let param = match format {
                 Format::Binary => Parameter::new(&id.to_be_bytes()),
                 Format::Text => Parameter::new(itoa::Buffer::new().format(id).as_bytes()),
@@ -103,7 +119,7 @@ impl RewritePlan {
             bind.push_param(param, format);
         }
 
-        self.apply_nextval(bind, ee::nextval).await
+        Ok(())
     }
 
     /// Apply the rewrite plan to a Parse message by updating the SQL.
@@ -118,7 +134,11 @@ impl RewritePlan {
 
     /// Apply the rewrite plan to a Query message by updating the SQL.
     async fn apply_query(&self, query: &mut Query) -> Result<(), Error> {
-        if !self.global_sequences.is_empty() {
+        if self
+            .generated_ids
+            .iter()
+            .any(|(_, source)| matches!(source, GeneratedId::Sequence(_)))
+        {
             if let Some(stmt) = self.rewrite_nextval_simple().await? {
                 query.set_query(&stmt);
             }
@@ -213,6 +233,7 @@ mod tests {
         let _guard = set_env_var("NODE_ID", "pgdog-1");
         let plan = RewritePlan {
             unique_ids: 1,
+            generated_ids: vec![(1, GeneratedId::UniqueId)],
             ..Default::default()
         };
         let mut bind = Bind::default();
@@ -234,6 +255,7 @@ mod tests {
         let plan = RewritePlan {
             params: 1,
             unique_ids: 1,
+            generated_ids: vec![(2, GeneratedId::UniqueId)],
             ..Default::default()
         };
         // Create bind with uniform binary format (1 code applies to all)
@@ -259,6 +281,7 @@ mod tests {
         let plan = RewritePlan {
             params: 2,
             unique_ids: 1,
+            generated_ids: vec![(3, GeneratedId::UniqueId)],
             ..Default::default()
         };
         // Create bind with one-to-one format codes
@@ -285,6 +308,11 @@ mod tests {
         let _guard = set_env_var("NODE_ID", "pgdog-1");
         let plan = RewritePlan {
             unique_ids: 3,
+            generated_ids: vec![
+                (1, GeneratedId::UniqueId),
+                (2, GeneratedId::UniqueId),
+                (3, GeneratedId::UniqueId),
+            ],
             ..Default::default()
         };
         let mut bind = Bind::default();
@@ -306,6 +334,7 @@ mod tests {
         let plan = RewritePlan {
             params: 2,
             unique_ids: 2,
+            generated_ids: vec![(3, GeneratedId::UniqueId), (4, GeneratedId::UniqueId)],
             ..Default::default()
         };
         let mut bind = Bind::new_params(


### PR DESCRIPTION
Add the ability to parse and rewrite `pgdog.nextval(sequence_name)` into calls to `ee::nextval`. They will be fetched from the control plane in the enterprise edition.

**Example**

```sql
SELECT pgdog.nextval('public.some_sequence_name');
```

**TODO**

For single-node pgdog deployments, we should probably use a local sequence and store it in the write-ahead log. Currently, it requires the control plane, making this an EE-only feature.