### PR TITLE
fix: allow omnisharded reads with a shard directive inside transactions

### DIFF
--- a/integration/rust/tests/integration/cross_shard_omni_check.rs
+++ b/integration/rust/tests/integration/cross_shard_omni_check.rs
@@ -140,7 +140,7 @@ async fn test_cross_shard_omni_check_valid_cases() {
     }
 }
 
-// All of these should throw errors.
+// Reads inside a pinned transaction succeed; writes to omnisharded tables throw.
 #[tokio::test]
 async fn test_cross_shard_omni_check_invalid_cases() {
     let admin = admin_sqlx().await;
@@ -155,8 +155,12 @@ async fn test_cross_shard_omni_check_invalid_cases() {
             .unwrap();
 
     // Test on a table that's NOT schema sharded.
-    // Try a direct-to-shard SET in a transaction using a SELECT to an omnisharded table.
-    // Should fail with "cannot write to an omnisharded table with a shard directive"
+    // A direct-to-shard SET in a transaction, then a SELECT from an omnisharded
+    // table (pg_type). The read is allowed: every shard holds the same rows, and
+    // the transaction routing it to the primary does not make it a write.
+    // A write to an omnisharded table in the same pinned transaction could only
+    // reach shard 0, so it must fail with
+    // "cannot write to an omnisharded table with a shard directive".
     {
         let mut transaction = conn.begin().await.unwrap();
         transaction
@@ -164,7 +168,7 @@ async fn test_cross_shard_omni_check_invalid_cases() {
             .await
             .unwrap();
 
-        let error = transaction
+        let result = transaction
             .fetch_one(
                 "
                     SELECT
@@ -175,6 +179,13 @@ async fn test_cross_shard_omni_check_invalid_cases() {
                     ORDER BY t.oid;",
             )
             .await
+            .unwrap();
+
+        assert_eq!(result.get::<&str, &str>("name"), "int4");
+
+        let error = transaction
+            .execute("INSERT INTO sharded_omni (id, value) VALUES (1, 'omni')")
+            .await
             .err()
             .unwrap();
 
@@ -183,6 +194,6 @@ async fn test_cross_shard_omni_check_invalid_cases() {
                 .to_string()
                 .contains("cannot write to an omnisharded table with a shard directive")
         );
-        transaction.commit().await.unwrap();
+        transaction.rollback().await.unwrap();
     }
 }

--- a/pgdog/src/frontend/client/query_engine/test/test_omnisharded.rs
+++ b/pgdog/src/frontend/client/query_engine/test/test_omnisharded.rs
@@ -7,6 +7,10 @@
 //! omni write can only reach that one shard, which would leave the shards
 //! inconsistent. We block such writes with an error instead.
 //!
+//! Reads are different: any single shard can answer a read of an omnisharded
+//! table, so a read inside a pinned transaction is allowed even though the
+//! conservative read/write strategy routes it to the primary.
+//!
 //! See [`crate::frontend::client::query_engine::route_query`].
 
 use crate::{
@@ -178,10 +182,11 @@ async fn test_omni_write_allowed_as_first_statement_in_transaction() {
 }
 
 /// A SELECT against an omnisharded table inside a direct-to-shard transaction is
-/// also blocked: inside an explicit transaction, reads are routed to the primary
-/// (treated as writes), so they hit the same omni-in-direct-to-shard guard.
+/// allowed: the pinned shard holds the same rows as every other shard. The
+/// transaction routes the read to the primary, but that does not make it a
+/// mutation, so the omni-in-direct-to-shard guard does not apply.
 #[tokio::test]
-async fn test_omni_read_blocked_in_direct_to_shard_transaction() {
+async fn test_omni_read_allowed_in_direct_to_shard_transaction() {
     let mut client = TestClient::new_sharded(Parameters::default()).await;
     reset_tables(&mut client).await;
 
@@ -194,10 +199,16 @@ async fn test_omni_read_blocked_in_direct_to_shard_transaction() {
     client
         .send_simple(Query::new("SELECT * FROM sharded_omni"))
         .await;
-    let err = expect_message!(client.read().await, ErrorResponse);
-    assert_omni_write_with_directive(&err);
-    let rfq = expect_message!(client.read().await, ReadyForQuery);
-    assert_eq!(rfq.status, 'E');
+    let messages = client
+        .read_until('Z')
+        .await
+        .expect("omnisharded read inside a pinned transaction must succeed");
+    let cc = messages
+        .iter()
+        .find(|m| m.code() == 'C')
+        .map(|m| CommandComplete::try_from(m.clone()).unwrap())
+        .expect("SELECT should complete");
+    assert_eq!(cc.command(), "SELECT 0");
 
     client.send_simple(Query::new("ROLLBACK")).await;
     client.read_until('Z').await.unwrap();
@@ -234,11 +245,11 @@ async fn test_omni_write_blocked_after_set_sharding_key() {
     reset_tables(&mut client).await;
 }
 
-/// A SELECT against an omnisharded table after `SET pgdog.sharding_key` is also
-/// blocked, for the same reason as the `SET pgdog.shard` case: in-transaction
-/// reads are routed to the primary and hit the omni-in-direct-to-shard guard.
+/// A SELECT against an omnisharded table after `SET pgdog.sharding_key` is
+/// allowed for the same reason as the `SET pgdog.shard` case: a read pinned to
+/// one shard is still a read.
 #[tokio::test]
-async fn test_omni_read_blocked_after_set_sharding_key() {
+async fn test_omni_read_allowed_after_set_sharding_key() {
     let mut client = new_sharded_client_without_schemas().await;
     reset_tables(&mut client).await;
 
@@ -250,10 +261,16 @@ async fn test_omni_read_blocked_after_set_sharding_key() {
     client
         .send_simple(Query::new("SELECT * FROM sharded_omni"))
         .await;
-    let err = expect_message!(client.read().await, ErrorResponse);
-    assert_omni_write_with_directive(&err);
-    let rfq = expect_message!(client.read().await, ReadyForQuery);
-    assert_eq!(rfq.status, 'E');
+    let messages = client
+        .read_until('Z')
+        .await
+        .expect("omnisharded read after SET pgdog.sharding_key must succeed");
+    let cc = messages
+        .iter()
+        .find(|m| m.code() == 'C')
+        .map(|m| CommandComplete::try_from(m.clone()).unwrap())
+        .expect("SELECT should complete");
+    assert_eq!(cc.command(), "SELECT 0");
 
     client.send_simple(Query::new("ROLLBACK")).await;
     client.read_until('Z').await.unwrap();

--- a/pgdog/src/frontend/router/parser/query/mod.rs
+++ b/pgdog/src/frontend/router/parser/query/mod.rs
@@ -126,6 +126,10 @@ impl QueryParser {
                     !context.sharding_schema.schemas.is_empty() && !context.sharded_tables;
 
                 // Note: this is dependent on route.sharded_schema_only being set first.
+                // Only statements that mutate an omnisharded table need full
+                // coverage; a read pinned to one shard by a directive is fine
+                // (every shard holds the same rows), even inside a read/write
+                // transaction that routes it to the primary.
                 let full_shard_coverage = route.requires_full_shard_coverage();
 
                 let manual_routing = matches!(

--- a/pgdog/src/frontend/router/parser/query/select.rs
+++ b/pgdog/src/frontend/router/parser/query/select.rs
@@ -69,6 +69,7 @@ impl QueryParser {
             return Ok(Command::Query(
                 Route::read(context.shards_calculator.shard().clone())
                     .with_read(!writes)
+                    .with_mutates(mutates)
                     .with_omnisharded(omnisharded)
                     .with_advisory_locks(advisory_locks),
             ));
@@ -137,6 +138,7 @@ impl QueryParser {
             return Ok(Command::Query(
                 Route::read(context.shards_calculator.shard().clone())
                     .with_read(!writes)
+                    .with_mutates(mutates)
                     .with_omnisharded(omnisharded)
                     .with_advisory_locks(advisory_locks),
             ));
@@ -283,6 +285,7 @@ impl QueryParser {
         Ok(Command::Query(
             query
                 .with_read(!writes)
+                .with_mutates(mutates)
                 .with_omnisharded(omnisharded)
                 .with_advisory_locks(advisory_locks),
         ))

--- a/pgdog/src/frontend/router/parser/query/test/setup.rs
+++ b/pgdog/src/frontend/router/parser/query/test/setup.rs
@@ -99,6 +99,13 @@ impl QueryParserTest {
         self
     }
 
+    /// Set the exact transaction state, e.g. `TransactionType::ReadOnly` for
+    /// a `BEGIN READ ONLY` transaction.
+    pub(crate) fn with_transaction(mut self, transaction: TransactionType) -> Self {
+        self.transaction = Some(transaction);
+        self
+    }
+
     /// Set the read/write strategy on the cluster.
     pub(crate) fn with_read_write_strategy(mut self, strategy: ReadWriteStrategy) -> Self {
         self.cluster.set_read_write_strategy(strategy);

--- a/pgdog/src/frontend/router/parser/query/test/test_sharding.rs
+++ b/pgdog/src/frontend/router/parser/query/test/test_sharding.rs
@@ -1,5 +1,6 @@
 use crate::config::config;
 use crate::frontend::Command;
+use crate::frontend::client::TransactionType;
 use crate::frontend::router::parser::{Cache, Shard};
 use std::collections::HashSet;
 use std::ops::Deref;
@@ -389,6 +390,125 @@ fn test_set_key_errors_on_omnisharded_write() {
     assert!(matches!(result, Err(Error::OmniWriteWithDirective)));
 }
 
+/// Inside a read/write transaction the conservative strategy routes every
+/// statement to the primary, but a read of an omnisharded table is still a
+/// read: pinning it to one shard with a directive is safe (every shard holds
+/// the same rows) and must be allowed.
+#[test]
+fn test_omnisharded_read_with_directive_allowed_inside_transaction() {
+    let tables = lookup_rule_tables();
+    let mut test = QueryParserTest::new()
+        .with_sharded_tables(tables)
+        .without_sharded_schemas()
+        .in_transaction(true);
+
+    let command = test
+        .try_execute(vec![
+            Query::new("/* pgdog_shard: 1 */ SELECT id FROM organizations WHERE id = 'org_child'")
+                .into(),
+        ])
+        .expect("omnisharded read with a shard directive inside a transaction");
+
+    match command {
+        Command::Query(route) => {
+            assert_eq!(route.shard(), &Shard::Direct(1), "{:?}", route);
+            assert!(route.is_omnisharded());
+            // Routed to the primary because of the transaction, but not a mutation.
+            assert!(route.is_write());
+            assert!(!route.mutates());
+        }
+        other => panic!("expected Command::Query, got {other:#?}"),
+    }
+}
+
+/// Same as above with the directive supplied via `SET pgdog.sharding_key`.
+#[test]
+fn test_omnisharded_read_with_set_key_allowed_inside_transaction() {
+    let tables = lookup_rule_tables();
+    let mut test = QueryParserTest::new()
+        .with_sharded_tables(tables)
+        .without_sharded_schemas()
+        .with_param("pgdog.sharding_key", "org_child")
+        .in_transaction(true);
+
+    let result = test.try_execute(vec![
+        Query::new("SELECT id FROM organizations WHERE id = 'org_child'").into(),
+    ]);
+    assert!(
+        matches!(result, Ok(Command::Query(_))),
+        "expected the read to route, got {result:#?}"
+    );
+}
+
+/// A `BEGIN READ ONLY` transaction cannot contain mutations at all, and the
+/// conservative strategy does not force its reads onto the primary, so an
+/// omnisharded read with a directive routes like any other read.
+#[test]
+fn test_omnisharded_read_with_directive_allowed_in_read_only_transaction() {
+    let tables = lookup_rule_tables();
+    let mut test = QueryParserTest::new()
+        .with_sharded_tables(tables)
+        .without_sharded_schemas()
+        .with_transaction(TransactionType::ReadOnly);
+
+    let command = test
+        .try_execute(vec![
+            Query::new("/* pgdog_shard: 1 */ SELECT id FROM organizations WHERE id = 'org_child'")
+                .into(),
+        ])
+        .expect("omnisharded read with a shard directive inside a read-only transaction");
+
+    match command {
+        Command::Query(route) => {
+            assert_eq!(route.shard(), &Shard::Direct(1), "{:?}", route);
+            assert!(route.is_read());
+            assert!(!route.mutates());
+        }
+        other => panic!("expected Command::Query, got {other:#?}"),
+    }
+}
+
+/// The guard still protects mutations: an omnisharded UPDATE pinned to one
+/// shard inside a transaction would diverge that shard.
+#[test]
+fn test_omnisharded_write_with_directive_rejected_inside_transaction() {
+    use crate::frontend::router::parser::Error;
+
+    let tables = lookup_rule_tables();
+    let mut test = QueryParserTest::new()
+        .with_sharded_tables(tables)
+        .without_sharded_schemas()
+        .in_transaction(true);
+
+    let result = test.try_execute(vec![
+        Query::new(
+            "/* pgdog_shard: 1 */ UPDATE organizations SET name = 'x' WHERE id = 'org_child'",
+        )
+        .into(),
+    ]);
+    assert!(matches!(result, Err(Error::OmniWriteWithDirective)));
+}
+
+/// A SELECT that takes row locks changes lock state on the shard it runs on,
+/// so it counts as a mutation and is still rejected with a directive.
+#[test]
+fn test_omnisharded_locking_select_with_directive_rejected() {
+    use crate::frontend::router::parser::Error;
+
+    let tables = lookup_rule_tables();
+    let mut test = QueryParserTest::new()
+        .with_sharded_tables(tables)
+        .without_sharded_schemas();
+
+    let result = test.try_execute(vec![
+        Query::new(
+            "/* pgdog_shard: 1 */ SELECT id FROM organizations WHERE id = 'org_child' FOR UPDATE",
+        )
+        .into(),
+    ]);
+    assert!(matches!(result, Err(Error::OmniWriteWithDirective)));
+}
+
 /// A SELECT whose CTE modifies data is a mutation: pinned to one shard by a
 /// directive it would diverge that shard, so it is still rejected. The outer
 /// query reads the CTE by name; that name must not be mistaken for a table.
@@ -437,6 +557,7 @@ fn test_omnisharded_data_modifying_cte_broadcasts() {
         let route = command.route();
         assert_eq!(route.shard(), &Shard::All, "{sql}: {route:?}");
         assert!(route.is_omnisharded(), "{sql}");
+        assert!(route.mutates(), "{sql}");
         assert!(route.is_write(), "{sql}");
     }
 }
@@ -496,6 +617,7 @@ fn test_omnisharded_read_only_cte_stays_single_shard() {
             "{sql}: {route:?}"
         );
         assert!(route.is_omnisharded(), "{sql}: {route:?}");
+        assert!(!route.mutates(), "{sql}");
     }
 }
 

--- a/pgdog/src/frontend/router/parser/route.rs
+++ b/pgdog/src/frontend/router/parser/route.rs
@@ -80,8 +80,23 @@ pub(crate) struct Route {
     /// Computed shard. This is where the query carrying
     /// this route will go no matter what.
     shard: ShardWithPriority,
-    /// Is this query a read, e.g. SELECT.
+    /// Is this query a read, e.g. SELECT. This is the primary/replica
+    /// routing decision: a `SELECT` inside a read/write transaction is
+    /// marked as a write under the conservative read/write strategy so it
+    /// runs on the primary, without becoming a mutation.
     read: bool,
+    /// Does this statement change data or schema. Unlike `read`, this is a
+    /// property of the statement itself and is what decides whether an
+    /// omnisharded statement must reach every shard.
+    ///
+    /// Conservatively `true` for every non-`SELECT` command built with
+    /// [`Route::write`] (DML, DDL, `SET`, `SHOW`, `BEGIN`, ...). For a
+    /// `SELECT` it is a best-effort classification of the statement text:
+    /// data-modifying CTEs, locking clauses (`FOR UPDATE`), the write
+    /// functions in `function.rs` (`nextval`, `setval`) and advisory locks.
+    /// A user-defined function with side effects is not detected and is
+    /// treated as a read.
+    mutates: bool,
     /// `ORDER BY` clause, transformed into something
     /// we can quickly use to sort the result.
     order_by: Vec<OrderBy>,
@@ -168,6 +183,7 @@ impl Route {
     pub(crate) fn write(shard: ShardWithPriority) -> Self {
         Self {
             shard,
+            mutates: true,
             ..Default::default()
         }
     }
@@ -182,6 +198,22 @@ impl Route {
     /// to a primary.
     pub(crate) fn is_write(&self) -> bool {
         !self.is_read()
+    }
+
+    /// Returns true if the statement changes data or schema, independently
+    /// of where it is routed. A read forced onto the primary by a
+    /// read/write transaction is not a mutation.
+    ///
+    /// For `SELECT` this is best-effort: see the `mutates` field docs for
+    /// what is and isn't detected.
+    pub(crate) fn mutates(&self) -> bool {
+        self.mutates
+    }
+
+    /// Set whether the statement changes data or schema.
+    pub(crate) fn with_mutates(mut self, mutates: bool) -> Self {
+        self.mutates = mutates;
+        self
     }
 
     /// Sharding key lookups that missed the cache while routing.
@@ -272,11 +304,16 @@ impl Route {
         self.search_path_driven
     }
 
-    /// Whether an omnisharded write must reach every shard to remain consistent.
+    /// Whether an omnisharded mutation must reach every shard to remain consistent.
+    ///
+    /// Only statements that change data or schema (`mutates`) need full
+    /// coverage. A read of an omnisharded table can be served by any single
+    /// shard, even when a read/write transaction routes it to the primary
+    /// (`is_write()`), because every shard holds the same rows.
     ///
     /// If the database is configured *only* with schema sharding, we don't run any checks.
     pub(crate) fn requires_full_shard_coverage(&self) -> bool {
-        self.is_omnisharded() && self.is_write() && !self.sharded_schema_only
+        self.is_omnisharded() && self.mutates() && !self.sharded_schema_only
     }
 
     /// Return true if this route requires result set manipulation to
@@ -765,5 +802,28 @@ mod test {
         route.set_search_path_driven(true);
         route.sharded_schema_only = true;
         assert!(!route.requires_full_shard_coverage());
+    }
+
+    /// A read routed to the primary (e.g. inside a read/write transaction) is
+    /// still a read: it never needs full shard coverage.
+    #[test]
+    fn test_omnisharded_read_on_primary_needs_no_coverage() {
+        let route = Route::read(ShardWithPriority::new_table_omni(Shard::All))
+            .with_read(false)
+            .with_omnisharded(true);
+        assert!(route.is_write());
+        assert!(!route.mutates());
+        assert!(!route.requires_full_shard_coverage());
+    }
+
+    /// A SELECT that mutates (locking clause, write function) needs coverage
+    /// even though it is built as a read route.
+    #[test]
+    fn test_omnisharded_mutating_select_needs_coverage() {
+        let route = Route::read(ShardWithPriority::new_table_omni(Shard::All))
+            .with_read(false)
+            .with_mutates(true)
+            .with_omnisharded(true);
+        assert!(route.requires_full_shard_coverage());
     }
 }


### PR DESCRIPTION
A plain SELECT from an omnisharded table inside a read/write transaction failed with cannot write to an omnisharded table with a shard directive whenever a directive was present, whether `/* pgdog_shard */`, `/* pgdog_sharding_key */`, or `SET pgdog.shard`. The guard used `Route::is_write()` to decide whether a statement mutates, but under the conservative read/write strategy every statement in a read/write transaction is marked a write so it runs on the primary. Any application that keys its transactions and reads a replicated table inside one hit this on a multi-shard cluster.

Route now carries a statement-intrinsic mutates flag: DML, DDL, data-modifying CTEs, locking clauses, write functions and advisory locks. The omnisharded coverage check uses it; read is unchanged and still drives primary/replica placement. The guard is per statement, so a later omni write in the same pinned transaction is still rejected.

This finishes the fix for #1374. #1384 and #1398 diagnosed the same false positive and relaxed the check when schema sharding is used exclusively, leaving the mixed `sharded_schemas` + `sharded_tables` case for later ("the error will still throw ... I also added a test for that for later"). Scoping the exemption by statement kind instead of by config covers that case: a plain read of a pinned shard is correct whether the table is omnisharded or schema-sharded. The "invalid cases" test in `integration/rust/tests/integration/cross_shard_omni_check.rs`, which asserted the pinned read fails, now checks the read succeeds and that an INSERT into an omnisharded table in the same pinned transaction is still rejected.

Covered by parser and route unit tests plus engine tests against Postgres for reads inside pinned transactions.

