### PR TITLE
fix: broadcast omnisharded writes inside CTEs and stop treating CTE names as tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,7 +467,7 @@ Currently, support for certain SQL features in cross-shard queries is limited. H
 | Multi-tuple `INSERT`  | Supported | PgDog generates one statement per tuple and executes them automatically.                     |
 | Sharding key `UPDATE` | Supported | PgDog generates a `SELECT`, `INSERT` and `DELETE` statements and execute them automatically. |
 | Subqueries            | No        | The same subquery is executed on all shards.                                                 |
-| CTEs                  | No        | The same CTE is executed on all shards.                                                      |
+| CTEs                  | No        | The same CTE is executed on all shards. Data-modifying CTEs on omnisharded tables reach every shard. |
 
 #### Using `COPY`
 

--- a/pgdog/src/frontend/client/query_engine/test/test_omnisharded.rs
+++ b/pgdog/src/frontend/client/query_engine/test/test_omnisharded.rs
@@ -13,7 +13,7 @@ use crate::{
     backend::databases::reload_from_existing,
     config::{config, load_test_sharded, set},
     expect_message,
-    net::{CommandComplete, ErrorResponse, Parameters, Query, ReadyForQuery},
+    net::{CommandComplete, DataRow, ErrorResponse, Parameters, Query, ReadyForQuery},
 };
 
 use super::prelude::*;
@@ -257,6 +257,78 @@ async fn test_omni_read_blocked_after_set_sharding_key() {
 
     client.send_simple(Query::new("ROLLBACK")).await;
     client.read_until('Z').await.unwrap();
+
+    reset_tables(&mut client).await;
+}
+
+/// Count rows with `id` on one specific shard.
+async fn count_on_shard(client: &mut TestClient, shard: usize, id: i64) -> i64 {
+    client
+        .send_simple(Query::new(format!(
+            "/* pgdog_shard: {shard} */ SELECT count(*) FROM sharded_omni WHERE id = {id}"
+        )))
+        .await;
+    let messages = client.read_until('Z').await.unwrap();
+    let row = messages
+        .iter()
+        .find(|m| m.code() == 'D')
+        .map(|m| DataRow::try_from(m.clone()).unwrap())
+        .expect("count(*) returns a row");
+    row.get_int(0, true).unwrap()
+}
+
+/// A write to an omnisharded table hidden inside a CTE of a SELECT is
+/// broadcast like a plain omnisharded INSERT: the row lands on every shard,
+/// and the client sees the `RETURNING` rows from one shard only. With a shard
+/// directive the same statement is rejected, since it could only reach the
+/// directed shard.
+#[tokio::test]
+async fn test_omni_write_in_cte_reaches_every_shard() {
+    let mut client = TestClient::new_sharded(Parameters::default()).await;
+    reset_tables(&mut client).await;
+    let id = client.random_id_for_shard(1);
+
+    let cte = format!(
+        "WITH ins AS (INSERT INTO sharded_omni (id, value) VALUES ({id}, 'cte') RETURNING id) \
+         SELECT id FROM ins"
+    );
+
+    client.send_simple(Query::new(cte.clone())).await;
+    let messages = client
+        .read_until('Z')
+        .await
+        .expect("omnisharded write inside a CTE must succeed");
+    let rows: Vec<_> = messages
+        .iter()
+        .filter(|m| m.code() == 'D')
+        .map(|m| DataRow::try_from(m.clone()).unwrap())
+        .collect();
+    assert_eq!(
+        rows.len(),
+        1,
+        "RETURNING rows must be deduplicated to one shard"
+    );
+    assert_eq!(rows[0].get_int(0, true), Some(id));
+
+    assert_eq!(
+        count_on_shard(&mut client, 0, id).await,
+        1,
+        "row missing on shard 0"
+    );
+    assert_eq!(
+        count_on_shard(&mut client, 1, id).await,
+        1,
+        "row missing on shard 1"
+    );
+
+    // The same write pinned to one shard is rejected.
+    client
+        .send_simple(Query::new(format!("/* pgdog_shard: 1 */ {cte}")))
+        .await;
+    let err = expect_message!(client.read().await, ErrorResponse);
+    assert_omni_write_with_directive(&err);
+    let rfq = expect_message!(client.read().await, ReadyForQuery);
+    assert_eq!(rfq.status, 'I');
 
     reset_tables(&mut client).await;
 }

--- a/pgdog/src/frontend/router/parser/query/select.rs
+++ b/pgdog/src/frontend/router/parser/query/select.rs
@@ -21,20 +21,23 @@ impl QueryParser {
         context: &mut QueryParserContext,
     ) -> Result<Command, Error> {
         let mut cross_shard = false;
-        // Write overwrite because of conservative read/write split.
-        let mut writes = self.write_override;
+        // Does the statement itself change data: data-modifying CTEs,
+        // locking clauses, write functions. This decides omnisharded
+        // coverage; the primary/replica decision (`writes`) additionally
+        // honours the conservative read/write split's transaction override.
+        let mut mutates = false;
         walk::walk(stmt.into(), |node| match node {
             Node::CommonTableExpr(expr) => match expr.ctequery() {
                 Node::SelectStmt(_) => (),
-                _ => writes = true,
+                _ => mutates = true,
             },
-            Node::LockingClause(_) => writes = true,
+            Node::LockingClause(_) => mutates = true,
             Node::FuncCall(f) => {
                 if let Some(f) =
                     Function::from_strings(f.funcname().into_iter().filter_map(Node::as_str))
                 {
                     cross_shard = cross_shard || f.behavior().cross_shard;
-                    writes = writes || f.behavior().writes;
+                    mutates = mutates || f.behavior().writes;
                 }
             }
             _ => (),
@@ -57,7 +60,9 @@ impl QueryParser {
             (parser.extract_advisory_locks(), parser.is_all_omnisharded())
         };
 
-        let writes = writes || !advisory_locks.is_empty();
+        mutates |= !advisory_locks.is_empty();
+        // Write override because of conservative read/write split.
+        let writes = self.write_override || mutates;
 
         // Early return for any direct-to-shard queries.
         if context.shards_calculator.shard().is_direct() {
@@ -107,15 +112,27 @@ impl QueryParser {
 
         // SELECT NOW(), SELECT 1
         if shards.is_empty() && stmt.from_clause().is_empty() {
-            let shard = Shard::Direct(round_robin::next(context.shards));
+            if omnisharded && mutates {
+                // e.g. `WITH ins AS (INSERT INTO omni ... RETURNING id) SELECT 1`.
+                // The write must reach every shard to keep them identical.
+                if let Some(recorder) = self.recorder_mut() {
+                    recorder.record_entry(None, "SELECT omnishard write broadcasted");
+                }
 
-            if let Some(recorder) = self.recorder_mut() {
-                recorder.record_entry(Some(shard.clone()), "SELECT omnishard no table".to_string());
+                context
+                    .shards_calculator
+                    .push(ShardWithPriority::new_table_omni(Shard::All));
+            } else {
+                let shard = Shard::Direct(round_robin::next(context.shards));
+
+                if let Some(recorder) = self.recorder_mut() {
+                    recorder.record_entry(Some(shard.clone()), "SELECT omnishard no table");
+                }
+
+                context
+                    .shards_calculator
+                    .push(ShardWithPriority::new_rr_no_table(shard));
             }
-
-            context
-                .shards_calculator
-                .push(ShardWithPriority::new_rr_no_table(shard));
 
             return Ok(Command::Query(
                 Route::read(context.shards_calculator.shard().clone())
@@ -195,43 +212,58 @@ impl QueryParser {
                     context.router_context.schema.is_loaded()
                 );
 
-                // Omnisharded by default.
-                let sticky = tables.iter().any(|table| {
-                    context
-                        .sharding_schema
-                        .tables()
-                        .is_omnisharded_sticky(table.name)
-                        == Some(true)
-                });
-
-                let (rr_index, explain) = if sticky
-                    || context
-                        .sharding_schema
-                        .tables()
-                        .is_omnisharded_sticky_default()
-                {
-                    (
-                        context.router_context.sticky.omni_index % context.shards,
-                        "sticky",
-                    )
-                } else {
-                    (round_robin::next(context.shards), "round robin")
-                };
-
-                let shard = Shard::Direct(rr_index);
-
-                // Routed to a single shard via the omnisharded-by-default path
-                // (non-sharded tables, including system catalogs).
+                // Omnisharded by default (non-sharded tables, including
+                // system catalogs).
                 omnisharded = true;
 
-                if let Some(recorder) = self.recorder_mut() {
-                    recorder
-                        .record_entry(Some(shard.clone()), format!("SELECT omnishard {}", explain));
-                }
+                if mutates {
+                    // A write through an omnisharded table, e.g. a
+                    // data-modifying CTE, must reach every shard to keep
+                    // them identical, like an omnisharded INSERT or UPDATE.
+                    if let Some(recorder) = self.recorder_mut() {
+                        recorder.record_entry(None, "SELECT omnishard write broadcasted");
+                    }
 
-                context
-                    .shards_calculator
-                    .push(ShardWithPriority::new_rr_omni(shard));
+                    context
+                        .shards_calculator
+                        .push(ShardWithPriority::new_table_omni(Shard::All));
+                } else {
+                    // Any single shard can answer a read.
+                    let sticky = tables.iter().any(|table| {
+                        context
+                            .sharding_schema
+                            .tables()
+                            .is_omnisharded_sticky(table.name)
+                            == Some(true)
+                    });
+
+                    let (rr_index, explain) = if sticky
+                        || context
+                            .sharding_schema
+                            .tables()
+                            .is_omnisharded_sticky_default()
+                    {
+                        (
+                            context.router_context.sticky.omni_index % context.shards,
+                            "sticky",
+                        )
+                    } else {
+                        (round_robin::next(context.shards), "round robin")
+                    };
+
+                    let shard = Shard::Direct(rr_index);
+
+                    if let Some(recorder) = self.recorder_mut() {
+                        recorder.record_entry(
+                            Some(shard.clone()),
+                            format!("SELECT omnishard {}", explain),
+                        );
+                    }
+
+                    context
+                        .shards_calculator
+                        .push(ShardWithPriority::new_rr_omni(shard));
+                }
             }
         }
 

--- a/pgdog/src/frontend/router/parser/query/test/test_sharding.rs
+++ b/pgdog/src/frontend/router/parser/query/test/test_sharding.rs
@@ -389,6 +389,94 @@ fn test_set_key_errors_on_omnisharded_write() {
     assert!(matches!(result, Err(Error::OmniWriteWithDirective)));
 }
 
+/// A SELECT whose CTE modifies data is a mutation: pinned to one shard by a
+/// directive it would diverge that shard, so it is still rejected. The outer
+/// query reads the CTE by name; that name must not be mistaken for a table.
+#[test]
+fn test_omnisharded_data_modifying_cte_with_directive_rejected() {
+    use crate::frontend::router::parser::Error;
+
+    let tables = lookup_rule_tables();
+    let mut test = QueryParserTest::new()
+        .with_sharded_tables(tables)
+        .without_sharded_schemas();
+
+    for sql in [
+        "/* pgdog_shard: 1 */ WITH ins AS (INSERT INTO organizations (id, name) VALUES ('org_new', 'x') RETURNING id) SELECT id FROM ins",
+        "/* pgdog_shard: 1 */ WITH ins AS (INSERT INTO organizations (id, name) VALUES ('org_new', 'x') RETURNING id) SELECT id FROM organizations WHERE id = 'org_child'",
+        "/* pgdog_shard: 1 */ WITH ins AS (INSERT INTO organizations (id, name) VALUES ('org_new', 'x') RETURNING id) SELECT 1",
+    ] {
+        let result = test.try_execute(vec![Query::new(sql).into()]);
+        assert!(
+            matches!(result, Err(Error::OmniWriteWithDirective)),
+            "{sql}: expected OmniWriteWithDirective, got {result:#?}"
+        );
+    }
+}
+
+/// Without a directive, a write through an omnisharded table inside a CTE is
+/// broadcast to every shard, like a plain omnisharded INSERT. Sending it to
+/// one round-robin shard would silently diverge the table.
+#[test]
+fn test_omnisharded_data_modifying_cte_broadcasts() {
+    let tables = lookup_rule_tables();
+    let mut test = QueryParserTest::new()
+        .with_sharded_tables(tables)
+        .without_sharded_schemas();
+
+    for sql in [
+        "WITH ins AS (INSERT INTO organizations (id, name) VALUES ('org_new', 'x') RETURNING id) SELECT id FROM ins",
+        "WITH ins AS (INSERT INTO organizations (id, name) VALUES ('org_new', 'x') RETURNING id) SELECT id FROM organizations",
+        "WITH ins AS (INSERT INTO organizations (id, name) VALUES ('org_new', 'x') RETURNING id) SELECT 1",
+        "WITH del AS (DELETE FROM organizations WHERE id = 'org_new' RETURNING id) SELECT count(*) FROM del",
+    ] {
+        let command = test
+            .try_execute(vec![Query::new(sql).into()])
+            .unwrap_or_else(|err| panic!("{sql}: {err:?}"));
+        match command {
+            Command::Query(route) => {
+                assert_eq!(route.shard(), &Shard::All, "{sql}: {route:?}");
+                assert!(route.is_omnisharded(), "{sql}");
+                assert!(route.is_write(), "{sql}");
+            }
+            other => panic!("{sql}: expected Command::Query, got {other:#?}"),
+        }
+    }
+}
+
+/// A read-only CTE over an omnisharded table is still a read: one shard can
+/// answer it, and the CTE name is not treated as an unknown table.
+#[test]
+fn test_omnisharded_read_only_cte_stays_single_shard() {
+    let tables = lookup_rule_tables();
+    let mut test = QueryParserTest::new()
+        .with_sharded_tables(tables)
+        .without_sharded_schemas();
+
+    for sql in [
+        "WITH c AS (SELECT id FROM organizations) SELECT id FROM c",
+        "WITH RECURSIVE tree AS (SELECT id FROM organizations WHERE parent_organization_id IS NULL \
+         UNION ALL SELECT o.id FROM organizations o JOIN tree t ON o.parent_organization_id = t.id) \
+         SELECT id FROM tree",
+        // A CTE shadowing the table name: the qualified reference is still the table.
+        "WITH organizations AS (SELECT 1 AS id) SELECT o.id FROM public.organizations o",
+    ] {
+        let command = test
+            .try_execute(vec![Query::new(sql).into()])
+            .unwrap_or_else(|err| panic!("{sql}: {err:?}"));
+        match command {
+            Command::Query(route) => {
+                assert!(
+                    matches!(route.shard(), Shard::Direct(_)),
+                    "{sql}: {route:?}"
+                );
+                assert!(route.is_omnisharded(), "{sql}: {route:?}");
+            }
+            other => panic!("{sql}: expected Command::Query, got {other:#?}"),
+        }
+    }
+}
+
 /// Translations resolved for a statement route it without consulting
 /// the lookup cache: the second routing pass after resolving lookups
 /// can't miss, even if the cache already evicted the entry.

--- a/pgdog/src/frontend/router/parser/query/test/test_sharding.rs
+++ b/pgdog/src/frontend/router/parser/query/test/test_sharding.rs
@@ -430,17 +430,42 @@ fn test_omnisharded_data_modifying_cte_broadcasts() {
         "WITH ins AS (INSERT INTO organizations (id, name) VALUES ('org_new', 'x') RETURNING id) SELECT 1",
         "WITH del AS (DELETE FROM organizations WHERE id = 'org_new' RETURNING id) SELECT count(*) FROM del",
     ] {
-        let command = test
-            .try_execute(vec![Query::new(sql).into()])
-            .unwrap_or_else(|err| panic!("{sql}: {err:?}"));
-        match command {
-            Command::Query(route) => {
-                assert_eq!(route.shard(), &Shard::All, "{sql}: {route:?}");
-                assert!(route.is_omnisharded(), "{sql}");
-                assert!(route.is_write(), "{sql}");
-            }
-            other => panic!("{sql}: expected Command::Query, got {other:#?}"),
-        }
+        let result = test.try_execute(vec![Query::new(sql).into()]);
+        assert!(result.is_ok(), "{sql}: {result:?}");
+        let command = result.unwrap();
+        assert!(matches!(command, Command::Query(_)), "{sql}: {command:#?}");
+        let route = command.route();
+        assert_eq!(route.shard(), &Shard::All, "{sql}: {route:?}");
+        assert!(route.is_omnisharded(), "{sql}");
+        assert!(route.is_write(), "{sql}");
+    }
+}
+
+/// The explain trace records why the CTE write was broadcast, for both the
+/// `FROM` and the no-`FROM` shapes.
+#[test]
+fn test_omnisharded_data_modifying_cte_explain_broadcast() {
+    let tables = lookup_rule_tables();
+    // `with_expanded_explain` rebuilds the cluster, so it goes first.
+    let mut test = QueryParserTest::new()
+        .with_expanded_explain()
+        .with_sharded_tables(tables)
+        .without_sharded_schemas();
+
+    for sql in [
+        "EXPLAIN WITH ins AS (INSERT INTO organizations (id, name) VALUES ('org_new', 'x') RETURNING id) SELECT id FROM ins",
+        "EXPLAIN WITH ins AS (INSERT INTO organizations (id, name) VALUES ('org_new', 'x') RETURNING id) SELECT 1",
+    ] {
+        let command = test.execute(vec![Query::new(sql).into()]);
+        let route = command.route();
+        assert_eq!(route.shard(), &Shard::All, "{sql}: {route:?}");
+        let lines = route.explain().unwrap().render_lines();
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("SELECT omnishard write broadcasted")),
+            "{sql}: {lines:#?}"
+        );
     }
 }
 
@@ -461,19 +486,16 @@ fn test_omnisharded_read_only_cte_stays_single_shard() {
         // A CTE shadowing the table name: the qualified reference is still the table.
         "WITH organizations AS (SELECT 1 AS id) SELECT o.id FROM public.organizations o",
     ] {
-        let command = test
-            .try_execute(vec![Query::new(sql).into()])
-            .unwrap_or_else(|err| panic!("{sql}: {err:?}"));
-        match command {
-            Command::Query(route) => {
-                assert!(
-                    matches!(route.shard(), Shard::Direct(_)),
-                    "{sql}: {route:?}"
-                );
-                assert!(route.is_omnisharded(), "{sql}: {route:?}");
-            }
-            other => panic!("{sql}: expected Command::Query, got {other:#?}"),
-        }
+        let result = test.try_execute(vec![Query::new(sql).into()]);
+        assert!(result.is_ok(), "{sql}: {result:?}");
+        let command = result.unwrap();
+        assert!(matches!(command, Command::Query(_)), "{sql}: {command:#?}");
+        let route = command.route();
+        assert!(
+            matches!(route.shard(), Shard::Direct(_)),
+            "{sql}: {route:?}"
+        );
+        assert!(route.is_omnisharded(), "{sql}: {route:?}");
     }
 }
 

--- a/pgdog/src/frontend/router/parser/statement.rs
+++ b/pgdog/src/frontend/router/parser/statement.rs
@@ -214,6 +214,9 @@ impl AdvisoryLocks {
 struct Walk<'a> {
     tables: Vec<Table<'a>>,
     advisory_locks: HashSet<AdvisoryLock>,
+    /// Names introduced by `WITH` clauses. An unqualified reference to one
+    /// of these is the CTE, not a table.
+    cte_names: HashSet<&'a str>,
 }
 use crate::{
     backend::{Schema, ShardingSchema},
@@ -556,6 +559,18 @@ impl<'a, 'b: 'a, 'c> StatementParser<'a, 'b, 'c> {
     fn run_walk(&self) -> Walk<'a> {
         let mut walk = Walk::default();
         self.walk_stmt(self.stmt, &mut walk);
+
+        // A CTE name shadows an unqualified table of the same name for the
+        // rest of the statement, so `FROM cte` is not a table reference.
+        // Schema-qualified names always refer to the real table. CTE names
+        // are collected across the whole statement rather than per scope;
+        // a nested `WITH` reusing an outer table's name is not distinguished.
+        if !walk.cte_names.is_empty() {
+            let cte_names = &walk.cte_names;
+            walk.tables
+                .retain(|table| table.schema.is_some() || !cte_names.contains(table.name));
+        }
+
         walk
     }
 
@@ -585,6 +600,13 @@ impl<'a, 'b: 'a, 'c> StatementParser<'a, 'b, 'c> {
 
             Node::RangeVar(r) => {
                 walk.tables.push(Table::from(r));
+                Recurse::yes()
+            }
+
+            Node::CommonTableExpr(cte) => {
+                if let Some(name) = cte.ctename() {
+                    walk.cte_names.insert(name);
+                }
                 Recurse::yes()
             }
 


### PR DESCRIPTION
Two routing bugs for writes to omnisharded tables inside CTEs. A write hidden in a CTE, such as `WITH ins AS (INSERT INTO omni ... RETURNING id) SELECT id FROM ins`, was sent to a single round-robin shard even without a directive, silently diverging the table. And the statement walker counted CTE names as tables, so an unqualified reference to a CTE made the statement non-omnisharded and bypassed the omni-write-with-directive guard entirely.

Mutating omni selects now broadcast like an omni INSERT, and CTE names are excluded from table extraction. Schema-qualified names still refer to the real table.

Covered by parser unit tests plus an engine test against Postgres that verifies a CTE write lands on every shard and returns a single RETURNING row.
