### PR TITLE
fix: insert splits + nextval

### DIFF
--- a/pgdog/src/frontend/router/parser/rewrite/statement/auto_id.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/auto_id.rs
@@ -226,6 +226,9 @@ fn is_bigint_type(data_type: &str) -> bool {
 }
 
 #[cfg(test)]
+mod split_tests;
+
+#[cfg(test)]
 mod tests {
     use super::super::nextval::SequenceCall;
     use super::super::plan::GeneratedId;
@@ -243,7 +246,7 @@ mod tests {
     use crate::frontend::router::parser::StatementRewriteContext;
     use crate::test_utils::set_env_var;
 
-    fn make_schema_with_bigint_pk() -> Schema {
+    pub(super) fn make_schema_with_bigint_pk() -> Schema {
         let mut columns = IndexMap::new();
         columns.insert(
             "id".to_string(),

--- a/pgdog/src/frontend/router/parser/rewrite/statement/auto_id/split_tests.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/auto_id/split_tests.rs
@@ -1,0 +1,199 @@
+use super::super::nextval::SequenceCall;
+use super::super::plan::RewriteResult;
+use super::tests::make_schema_with_bigint_pk;
+use super::*;
+use crate::backend::ShardingSchema;
+use crate::frontend::router::parser::StatementRewriteContext;
+use crate::frontend::{ClientRequest, PreparedStatements};
+use crate::net::messages::bind::{Format, Parameter};
+use crate::net::{Bind, Parse, ProtocolMessage, Query};
+use pgdog_config::Rewrite;
+
+fn split_plan(sql: &str, extended: bool, prepared: bool) -> RewritePlan {
+    let schema = ShardingSchema {
+        shards: 3,
+        rewrite: Rewrite {
+            enabled: true,
+            primary_key: RewriteMode::RewriteOmniGlobal,
+            split_inserts: RewriteMode::Rewrite,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let db_schema = make_schema_with_bigint_pk();
+    let mut prepared_statements = PreparedStatements::new();
+    let mut rewriter = StatementRewrite::new(StatementRewriteContext {
+        extended,
+        prepared,
+        prepared_statements: &mut prepared_statements,
+        schema: &schema,
+        db_schema: &db_schema,
+        user: "",
+        search_path: None,
+    });
+    let mut plan = RewritePlan::default();
+    make::owned(|mem| {
+        let mut ast = mem.parse(sql).expect("valid SQL");
+        plan = rewriter
+            .maybe_rewrite(ast.as_mut().into_iter().next().expect("statement"), mem)
+            .expect("rewrite succeeds");
+        ast
+    });
+    assert_eq!(plan.insert_split.len(), 2);
+    plan
+}
+
+#[tokio::test]
+async fn test_nextval_auto_id_simple_splits_use_resolved_values() {
+    for (columns, values) in [
+        ("name", "('a'), ('b')"),
+        ("name, id", "('a', DEFAULT), ('b', DEFAULT)"),
+        (
+            "name, id",
+            "('a', pgdog.nextval('users_id_seq')), ('b', pgdog.nextval('users_id_seq'))",
+        ),
+    ] {
+        let original = format!(
+            "INSERT INTO users ({columns}) VALUES {values} ON CONFLICT (id) DO NOTHING RETURNING id"
+        );
+        let plan = split_plan(&original, false, false);
+        let before = plan.stmt.clone();
+        let mut calls = Vec::new();
+        for first in [101, 103] {
+            let mut value = first;
+            let sql = plan
+                .rewrite_sequence_simple_with(async |call: &SequenceCall| {
+                    calls.push(call.clone());
+                    let result = value;
+                    value += 1;
+                    Ok(result)
+                })
+                .await
+                .expect("sequence rewrite succeeds")
+                .expect("rewritten SQL");
+            let request = ClientRequest::from(vec![ProtocolMessage::Query(Query::new(&sql))]);
+            let result = plan.apply_after_messages(&request).expect("split succeeds");
+            let RewriteResult::InsertSplit(splits) = result else {
+                panic!("expected insert splits");
+            };
+            assert_eq!(value, first + 2, "allocate exactly once per row");
+            let ProtocolMessage::Query(parent) = &request.messages[0] else {
+                panic!("expected query");
+            };
+            assert!(!parent.query().contains("pgdog.nextval"));
+            assert_eq!(splits.len(), 2);
+            for (split, (name, id)) in splits.iter().zip([("a", first), ("b", first + 1)]) {
+                let expected = format!(
+                    "INSERT INTO users (name, id) VALUES ('{name}', {id}::bigint) \
+                     ON CONFLICT (id) DO NOTHING RETURNING id"
+                );
+                let ProtocolMessage::Query(query) = &split.messages[0] else {
+                    panic!("expected query");
+                };
+                assert_eq!(query.query(), expected);
+                assert!(
+                    parent
+                        .query()
+                        .contains(&format!("('{name}', ({id})::bigint)"))
+                );
+                let ast = split.ast.as_ref().expect("routing AST");
+                assert_eq!(
+                    pg_raw_parse::deparse_stmts(&*ast.ast).expect("SQL"),
+                    expected
+                );
+                assert!(ast.rewrite_plan.is_empty(), "IDs already resolved");
+            }
+            assert_eq!(plan.stmt, before, "cached plan stays reusable");
+        }
+        assert_eq!(calls, vec![SequenceCall::Nextval("users_id_seq".into()); 4]);
+    }
+}
+
+#[tokio::test]
+async fn test_nextval_auto_id_extended_splits_keep_generated_parameters() {
+    for prepared in [false, true] {
+        for format in [Format::Text, Format::Binary] {
+            for (columns, values) in [
+                ("name", "($1), ($2)"),
+                ("name, id", "($1, DEFAULT), ($2, DEFAULT)"),
+                (
+                    "name, id",
+                    "($1, pgdog.nextval('users_id_seq')), ($2, pgdog.nextval('users_id_seq'))",
+                ),
+            ] {
+                let original =
+                    format!("INSERT INTO users ({columns}) VALUES {values} RETURNING id");
+                let plan = split_plan(&original, true, prepared);
+                let parse = Parse::named(if prepared { "auto_id_split" } else { "" }, &original);
+                let mut prepare_request =
+                    ClientRequest::from(vec![ProtocolMessage::Parse(parse.clone())]);
+                let result = plan
+                    .apply(&mut prepare_request)
+                    .await
+                    .expect("prepare succeeds");
+                assert!(matches!(result, RewriteResult::InPlace { .. }));
+
+                for separate_parse in [false, true] {
+                    let mut bind = Bind::new_params_codes(
+                        parse.name(),
+                        &[Parameter::new(b"a"), Parameter::new(b"b")],
+                        &[format],
+                    );
+                    let mut value = 200;
+                    plan.apply_generated_ids(&mut bind, async |call: &SequenceCall| {
+                        assert_eq!(call, &SequenceCall::Nextval("users_id_seq".into()));
+                        value += 1;
+                        Ok(value)
+                    })
+                    .await
+                    .expect("sequence values appended");
+                    let request = if separate_parse {
+                        let mut request = ClientRequest::from(vec![ProtocolMessage::Bind(bind)]);
+                        request.last_parse = Some(parse.clone());
+                        request
+                    } else {
+                        ClientRequest::from(vec![
+                            ProtocolMessage::Parse(parse.clone()),
+                            ProtocolMessage::Bind(bind),
+                        ])
+                    };
+                    let result = plan.apply_after_messages(&request).expect("split succeeds");
+                    assert_eq!(value, 202);
+                    let RewriteResult::InsertSplit(splits) = result else {
+                        panic!("expected insert splits");
+                    };
+                    for (split, (name, id)) in splits.iter().zip([(b"a", 201), (b"b", 202)]) {
+                        let query = split.query().expect("query lookup").expect("query");
+                        assert_eq!(
+                            query.query(),
+                            "INSERT INTO users (name, id) VALUES ($1, $2::bigint) RETURNING id"
+                        );
+                        let bind = split
+                            .messages
+                            .iter()
+                            .find_map(|message| match message {
+                                ProtocolMessage::Bind(bind) => Some(bind),
+                                _ => None,
+                            })
+                            .expect("bind");
+                        assert_eq!(bind.params_raw().len(), 2);
+                        assert_eq!(bind.params_raw()[0].data.as_ref(), name);
+                        let generated = bind.parameter(1).expect("format").expect("ID");
+                        assert_eq!(generated.bigint(), Some(id));
+                        assert_eq!(generated.format(), format);
+                        assert_eq!(bind.anonymous(), !prepared);
+                        assert!(
+                            split
+                                .ast
+                                .as_ref()
+                                .expect("AST")
+                                .rewrite_plan
+                                .generated_ids
+                                .is_empty()
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pgdog/src/frontend/router/parser/rewrite/statement/insert.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/insert.rs
@@ -110,6 +110,51 @@ pub(crate) fn build_split_requests(
         .collect()
 }
 
+/// Split a simple query after sequence calls have been resolved. Both the SQL
+/// and routing AST must use the values allocated for this execution.
+pub(super) fn build_resolved_split_requests(
+    query: &Query,
+    request: &ClientRequest,
+) -> Result<Vec<ClientRequest>, Error> {
+    let ast = pg_raw_parse::parse(query.query())?;
+    let Some(Node::InsertStmt(insert)) = ast.stmts().next() else {
+        return Err(Error::EmptyQuery);
+    };
+    split_insert_statements(insert)?
+        .into_iter()
+        .map(|(params, stmt)| {
+            let ast = Ast::new_record(&stmt).map_err(|e| Error::Cache(e.to_string()))?;
+            InsertSplit {
+                params,
+                stmt,
+                ast,
+                statement_name: None,
+            }
+            .build_request(request)
+        })
+        .collect()
+}
+
+fn split_insert_statements(
+    insert: &nodes::InsertStmt,
+) -> Result<Vec<(IndexSet<u16>, String)>, Error> {
+    let mut splits = Vec::new();
+    make::try_owned(|mem| {
+        let mut copy = mem.make_unique(insert);
+
+        if let Node::SelectStmt(select) = insert.select_stmt() {
+            for list in select.values_lists() {
+                let (params, select) = StatementRewrite::build_single_tuple_select(mem, list);
+                copy.as_mut().set_select_stmt(select.uncast());
+                splits.push((params, deparse(&*copy)?.as_str().to_string()));
+            }
+        }
+
+        Ok::<_, Error>(copy)
+    })?;
+    Ok(splits)
+}
+
 impl StatementRewrite<'_> {
     /// Split up multi-tuple INSERT statements into separate single-tuple statements
     /// for individual execution.
@@ -137,20 +182,7 @@ impl StatementRewrite<'_> {
             return Ok(());
         }
 
-        let mut splits = Vec::new();
-        make::try_owned(|mem| {
-            let mut copy = mem.make_unique(insert);
-
-            if let Node::SelectStmt(select) = insert.select_stmt() {
-                for list in select.values_lists() {
-                    let (params, select) = self.build_single_tuple_select(mem, list);
-                    copy.as_mut().set_select_stmt(select.uncast());
-                    splits.push((params, deparse(&*copy)?.as_str().to_string()));
-                }
-            }
-
-            Ok::<_, Error>(copy)
-        })?;
+        let splits = split_insert_statements(insert)?;
 
         if splits.len() <= 1 {
             return Ok(());
@@ -197,9 +229,8 @@ impl StatementRewrite<'_> {
     }
 
     /// Build a single-tuple INSERT from the original statement with just one values_list.
-    /// Returns the parameter positions (0-indexed) and the SQL string.
+    /// Returns the original parameter positions (1-indexed) and SELECT AST.
     fn build_single_tuple_select<'mem>(
-        &self,
         mem: make::MemoryToken<'mem>,
         values_list: Node<'_>,
     ) -> (IndexSet<u16>, make::Unique<'mem, &'mem nodes::SelectStmt>) {

--- a/pgdog/src/frontend/router/parser/rewrite/statement/nextval.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/nextval.rs
@@ -41,7 +41,7 @@ impl RewritePlan {
             .await
     }
 
-    async fn rewrite_sequence_simple_with(
+    pub(super) async fn rewrite_sequence_simple_with(
         &self,
         mut execute: impl AsyncFnMut(&SequenceCall) -> Result<i64, ee::Error>,
     ) -> Result<Option<String>, Error> {

--- a/pgdog/src/frontend/router/parser/rewrite/statement/plan.rs
+++ b/pgdog/src/frontend/router/parser/rewrite/statement/plan.rs
@@ -4,7 +4,7 @@ use crate::net::{Bind, Parse, ProtocolMessage, Query};
 use crate::unique_id::UniqueId;
 
 use super::super::ee;
-use super::insert::build_split_requests;
+use super::insert::{build_resolved_split_requests, build_split_requests};
 use super::nextval::SequenceCall;
 use super::offset::OffsetPlan;
 use super::{
@@ -178,10 +178,31 @@ impl RewritePlan {
             }
         }
 
+        self.apply_after_messages(request)
+    }
+
+    /// Build the execution plan after SQL and Bind values have been rewritten.
+    pub(super) fn apply_after_messages(
+        &self,
+        request: &ClientRequest,
+    ) -> Result<RewriteResult, Error> {
         // Only rewrite executable requests. Some clients prepare the statement
         // separately (e.g. go/pq with Parse, Describe, Sync). We don't need to rewrite
         // those since insert split will return the same row(s) as multi-tuple insert.
         if !self.insert_split.is_empty() && request.is_executable() {
+            if self
+                .generated_ids
+                .iter()
+                .any(|(_, source)| matches!(source, GeneratedId::Sequence(_)))
+                && let Some(query) = request.messages.iter().find_map(|message| match message {
+                    ProtocolMessage::Query(query) => Some(query),
+                    _ => None,
+                })
+            {
+                return Ok(RewriteResult::InsertSplit(build_resolved_split_requests(
+                    query, request,
+                )?));
+            }
             let requests = build_split_requests(&self.insert_split, request)?;
             return Ok(RewriteResult::InsertSplit(requests));
         }


### PR DESCRIPTION
`pgdog.nextval` was not being rewritten for insert splits.