### PR TITLE
fix: move connections on reload even when a replica is removed

### DIFF
--- a/pgdog/src/backend/databases.rs
+++ b/pgdog/src/backend/databases.rs
@@ -425,8 +425,8 @@ impl Databases {
 
             if let Some(dest) = dest
                 && cluster.can_move_conns_to(dest)
+                && cluster.move_conns_to(dest)?
             {
-                cluster.move_conns_to(dest)?;
                 moved += 1;
             }
         }

--- a/pgdog/src/backend/pool/address.rs
+++ b/pgdog/src/backend/pool/address.rs
@@ -195,6 +195,9 @@ impl Address {
             // Requires an allocation, which isn't very efficient
             // but this is an "edge case": how often are you changing passwords anyway?
             let mut other = other.clone();
+
+            // The database number will change if we remove a replica.
+            other.database_number = self.database_number;
             other.passwords = self.passwords.clone();
             self == &other
         } else {

--- a/pgdog/src/backend/pool/cluster.rs
+++ b/pgdog/src/backend/pool/cluster.rs
@@ -470,7 +470,7 @@ impl Cluster {
         let mut moved = false;
 
         for (from, to) in self.shards.iter().zip(other.shards.iter()) {
-            moved = moved | from.move_conns_to(to)?;
+            moved |= from.move_conns_to(to)?;
         }
 
         Ok(moved)

--- a/pgdog/src/backend/pool/cluster.rs
+++ b/pgdog/src/backend/pool/cluster.rs
@@ -462,20 +462,18 @@ impl Cluster {
     /// The two clusters have the same databases.
     pub(crate) fn can_move_conns_to(&self, other: &Cluster) -> bool {
         self.shards.len() == other.shards.len()
-            && self
-                .shards
-                .iter()
-                .zip(other.shards.iter())
-                .all(|(a, b)| a.can_move_conns_to(b))
     }
 
     /// Move connections from cluster to another, saving them.
-    pub(crate) fn move_conns_to(&self, other: &Cluster) -> Result<(), Error> {
+    /// Returns true if any `Pool`s were moved.
+    pub(crate) fn move_conns_to(&self, other: &Cluster) -> Result<bool, Error> {
+        let mut moved = false;
+
         for (from, to) in self.shards.iter().zip(other.shards.iter()) {
-            from.move_conns_to(to)?;
+            moved = moved | from.move_conns_to(to)?;
         }
 
-        Ok(())
+        Ok(moved)
     }
 
     /// Cancel a query executed by one of the shards.

--- a/pgdog/src/backend/pool/lb/mod.rs
+++ b/pgdog/src/backend/pool/lb/mod.rs
@@ -254,7 +254,11 @@ impl LoadBalancer {
     /// removals: each old target is paired with the new target that shares its
     /// address. New targets with no matching old target start empty; old targets
     /// with no match in the new config have their connections dropped.
-    pub(crate) fn move_conns_to(&self, destination: &LoadBalancer) -> Result<(), Error> {
+    ///
+    /// Returns the amount of `Pools` that moved from one replica to the other.
+    pub(crate) fn move_conns_to(&self, destination: &LoadBalancer) -> Result<usize, Error> {
+        let mut moved: usize = 0;
+
         for from in &self.targets {
             if let Some(to) = destination
                 .targets
@@ -262,6 +266,7 @@ impl LoadBalancer {
                 .find(|to| from.pool.has_compatible_address_with(&to.pool))
             {
                 from.pool.move_conns_to(&to.pool)?;
+                moved += 1;
 
                 // Carry over detected roles and LSN stats so the new load balancer
                 // doesn't briefly appear read-only before the role detector runs.
@@ -271,21 +276,7 @@ impl LoadBalancer {
         }
         destination.require_healthcheck_for_new_targets(&self.targets);
 
-        Ok(())
-    }
-
-    /// The two replica sets are referring to the same databases.
-    ///
-    /// Returns `true` when every target in `self` has a matching address in
-    /// `destination`. This allows replica additions (new targets start empty)
-    /// while still preserving connections to unchanged replicas.
-    pub(crate) fn can_move_conns_to(&self, destination: &LoadBalancer) -> bool {
-        self.targets.iter().all(|from| {
-            destination
-                .targets
-                .iter()
-                .any(|to| from.pool.has_compatible_address_with(&to.pool))
-        })
+        Ok(moved)
     }
 
     /// True if the LB has any target that can serve replica reads.

--- a/pgdog/src/backend/pool/lb/test.rs
+++ b/pgdog/src/backend/pool/lb/test.rs
@@ -13,13 +13,21 @@ use super::*;
 use monitor::Monitor;
 
 fn create_test_pool_config(host: &str, port: u16) -> PoolConfig {
+    create_test_pool_config_with_db_num(host, port, Default::default())
+}
+
+fn create_test_pool_config_with_db_num(
+    host: &str,
+    port: u16,
+    database_number: usize,
+) -> PoolConfig {
     PoolConfig {
-        address: test_addr(host, port),
+        address: test_addr(host, port, database_number),
         config: test_config(Default::default()),
     }
 }
 
-fn test_addr(host: &str, port: u16) -> Address {
+fn test_addr(host: &str, port: u16, database_number: usize) -> Address {
     Address {
         host: host.into(),
         port,
@@ -27,6 +35,7 @@ fn test_addr(host: &str, port: u16) -> Address {
         passwords: vec!["pgdog".into()],
         database_name: "pgdog".into(),
         configured_role: Role::Replica,
+        database_number,
         ..Default::default()
     }
 }
@@ -1236,79 +1245,51 @@ async fn test_set_role() {
 }
 
 #[tokio::test]
-async fn test_can_move_conns_to_same_config() {
-    let pool_config1 = create_test_pool_config("127.0.0.1", 5432);
-    let pool_config2 = create_test_pool_config("localhost", 5432);
-
-    let lb1 = LoadBalancer::new(
-        &None,
-        &[pool_config1.clone(), pool_config2.clone()],
-        LoadBalancingStrategy::Random,
-        ReadWriteSplit::IncludePrimary,
-        Default::default(),
-    );
-
-    let lb2 = LoadBalancer::new(
-        &None,
-        &[pool_config1, pool_config2],
-        LoadBalancingStrategy::Random,
-        ReadWriteSplit::IncludePrimary,
-        Default::default(),
-    );
-
-    assert!(lb1.can_move_conns_to(&lb2));
-}
-
-#[tokio::test]
-async fn test_can_move_conns_to_with_removed_replica() {
-    // Old LB has 2 replicas; new LB dropped one. The old replica with no
-    // matching address in the new LB makes this return false.
-    let pool_config1 = create_test_pool_config("127.0.0.1", 5432);
-    let pool_config2 = create_test_pool_config("localhost", 5432);
-
-    let lb1 = LoadBalancer::new(
-        &None,
-        &[pool_config1.clone(), pool_config2],
-        LoadBalancingStrategy::Random,
-        ReadWriteSplit::IncludePrimary,
-        Default::default(),
-    );
-
-    let lb2 = LoadBalancer::new(
-        &None,
-        &[pool_config1],
-        LoadBalancingStrategy::Random,
-        ReadWriteSplit::IncludePrimary,
-        Default::default(),
-    );
-
-    assert!(!lb1.can_move_conns_to(&lb2));
-}
-
-#[tokio::test]
-async fn test_can_move_conns_to_with_added_replica() {
-    // Old LB has 1 replica; new LB gained an extra one. Every old address
-    // still exists in the new LB, so connections can be preserved.
-    let pool_config1 = create_test_pool_config("127.0.0.1", 5432);
-    let pool_config2 = create_test_pool_config("localhost", 5432);
-
+async fn test_move_conns_to_with_removed_replica_matches_by_address() {
+    // Old LB: three replica [127.0.0.1, 8.8.8.8, 1.1.1.1]
+    // New LB: two replica [8.8.8.8, 1.1.1.1] (shifted backwards by 1; numbers changed)
+    // After they move, verify [8.8.8.8, 1.1.1.1] maintains its connections.
     let lb_old = LoadBalancer::new(
         &None,
-        std::slice::from_ref(&pool_config1),
+        &[
+            create_test_pool_config_with_db_num("127.0.0.1", 5432, 1),
+            create_test_pool_config_with_db_num("8.8.8.8", 5432, 2),
+            create_test_pool_config_with_db_num("1.1.1.1", 5432, 3),
+        ],
         LoadBalancingStrategy::Random,
         ReadWriteSplit::IncludePrimary,
         Default::default(),
     );
+    lb_old.launch();
 
     let lb_new = LoadBalancer::new(
         &None,
-        &[pool_config1, pool_config2],
+        &[
+            create_test_pool_config_with_db_num("8.8.8.8", 5432, 1),
+            create_test_pool_config_with_db_num("1.1.1.1", 5432, 2),
+        ],
         LoadBalancingStrategy::Random,
         ReadWriteSplit::IncludePrimary,
         Default::default(),
     );
+    lb_new.launch();
 
-    assert!(lb_old.can_move_conns_to(&lb_new));
+    // Record the role on the old target [8.8.8.8]; verify it was persisted.
+    lb_old.targets[1].set_role(Role::Primary);
+
+    // Verify [1.1.1.1, 8.8.8.8] moved connections
+    // (no actual connections here, but it passed the 'check')
+    assert_eq!(lb_old.move_conns_to(&lb_new).unwrap(), 2);
+
+    // The matching new target [8.8.8.8] should have inherited the role.
+    let new_target_for_existing = lb_new
+        .targets
+        .iter()
+        .find(|t| t.pool.addr().host == "8.8.8.8")
+        .expect("should have target for 8.8.8.8");
+    assert_eq!(new_target_for_existing.role(), Role::Primary);
+
+    lb_new.shutdown();
 }
 
 #[tokio::test]
@@ -1341,8 +1322,9 @@ async fn test_move_conns_to_with_added_replica_matches_by_address() {
     // Record the role on the old target so we can verify it was carried over.
     lb_old.targets[0].set_role(Role::Primary);
 
-    assert!(lb_old.can_move_conns_to(&lb_new));
-    lb_old.move_conns_to(&lb_new).unwrap();
+    // Verify [127.0.0.1] moved connections
+    // (no actual connections here, but it passed the 'check')
+    assert_eq!(lb_old.move_conns_to(&lb_new).unwrap(), 1);
 
     // The matching new target (same address) should have inherited the role.
     let new_target_for_existing = lb_new
@@ -1638,31 +1620,6 @@ async fn test_static_replica_only_does_not_wait_for_primary() {
         Err(Error::NoPrimary)
     ));
     assert!(started.elapsed() < Duration::from_millis(100));
-}
-
-#[tokio::test]
-async fn test_can_move_conns_to_different_addresses() {
-    let pool_config1 = create_test_pool_config("127.0.0.1", 5432);
-    let pool_config2 = create_test_pool_config("localhost", 5432);
-    let pool_config3 = create_test_pool_config("127.0.0.1", 5433);
-
-    let lb1 = LoadBalancer::new(
-        &None,
-        &[pool_config1, pool_config2],
-        LoadBalancingStrategy::Random,
-        ReadWriteSplit::IncludePrimary,
-        Default::default(),
-    );
-
-    let lb2 = LoadBalancer::new(
-        &None,
-        &[pool_config3.clone(), pool_config3],
-        LoadBalancingStrategy::Random,
-        ReadWriteSplit::IncludePrimary,
-        Default::default(),
-    );
-
-    assert!(!lb1.can_move_conns_to(&lb2));
 }
 
 #[tokio::test]
@@ -2486,7 +2443,7 @@ async fn test_params_returns_all_replicas_down_when_empty() {
 async fn ban_new_targets_until_health_check() {
     let old = setup_test_replicas();
     let new_config = PoolConfig {
-        address: test_addr("localhost", 2345),
+        address: test_addr("localhost", 2345, Default::default()),
         config: test_config(Config {
             require_healthcheck_on_discovery: true,
             ..Default::default()
@@ -2531,7 +2488,7 @@ async fn ban_new_targets_until_health_check() {
 async fn initial_healthcheck_banned_targets_stay_banned_on_reload() {
     let old = setup_test_replicas();
     let new_config = PoolConfig {
-        address: test_addr("localhost", 2345),
+        address: test_addr("localhost", 2345, Default::default()),
         config: test_config(Config {
             require_healthcheck_on_discovery: true,
             ..Default::default()

--- a/pgdog/src/backend/pool/shard/mod.rs
+++ b/pgdog/src/backend/pool/shard/mod.rs
@@ -101,16 +101,10 @@ impl Shard {
     ///
     /// This is done during configuration reloading, if no significant changes are made to
     /// the configuration.
-    pub(crate) fn move_conns_to(&self, destination: &Shard) -> Result<(), Error> {
-        self.lb.move_conns_to(&destination.lb)?;
-
-        Ok(())
-    }
-
-    /// Checks if the connection pools from this shard are compatible
-    /// with the other shard. If yes, they can be moved without closing them.
-    pub(crate) fn can_move_conns_to(&self, other: &Shard) -> bool {
-        self.lb.can_move_conns_to(&other.lb)
+    ///
+    /// Returns true if at least one `Pool` moved.
+    pub(crate) fn move_conns_to(&self, destination: &Shard) -> Result<bool, Error> {
+        Ok(self.lb.move_conns_to(&destination.lb)? >= 1)
     }
 
     /// Listen for notifications on channel.


### PR DESCRIPTION
Previously, if a reload occurred, and if a replica was removed, **all** connections for **all** `Pool`s (whether affiliated or not with the removed replica), would **not** be moved to the new `Pool`s.

This is because `Cluster::can_move_conns_to` asserted that **every** existing `Pool` (address) must be present in the new configuration before attempting to move any. 

To fix this,
- I removed all the upfront `has_compatible_address_with` checks, and since `LoadBalancer::move_conns_to` already uses `has_compatible_address_with` itself, no further changes were needed there.
- Additionally, I modified `Address::compatible` to account for `database_number` being different when a replica is removed.

Added a regression test for this. Removed some tests that asserted the old functionality.

Fixes https://github.com/pgdogdev/pgdog-enterprise/issues/615