### PR TITLE
feat: cross-account RDS IAM auth via server_iam_assume_role

### DIFF
--- a/.schema/users.schema.json
+++ b/.schema/users.schema.json
@@ -290,6 +290,13 @@
           "$ref": "#/$defs/ServerAuth",
           "default": "password"
         },
+        "server_iam_assume_role": {
+          "description": "IAM role ARN to assume (in the backend database's AWS account) before\ngenerating the RDS IAM auth token. Enables cross-account RDS IAM: the token\nis signed with the assumed role's credentials instead of PgDog's own\nambient identity. Only used when `server_auth = \"rds_iam\"`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "server_iam_region": {
           "description": "Optional region override for RDS IAM token generation.",
           "type": [

--- a/pgdog-config/src/users.rs
+++ b/pgdog-config/src/users.rs
@@ -835,56 +835,6 @@ vault_refresh_percent = 60
     }
 
     #[test]
-    fn test_server_iam_assume_role_parses() {
-        let source = r#"
-[[users]]
-name = "app"
-database = "tenant"
-server_auth = "rds_iam"
-server_iam_region = "us-west-2"
-server_iam_assume_role = "arn:aws:iam::111122223333:role/pgdog-rds-connect"
-"#;
-        let users: Users = toml::from_str(source).unwrap();
-        let user = users.users.first().unwrap();
-        assert_eq!(user.server_auth, ServerAuth::RdsIam);
-        assert_eq!(
-            user.server_iam_assume_role.as_deref(),
-            Some("arn:aws:iam::111122223333:role/pgdog-rds-connect")
-        );
-    }
-
-    #[test]
-    fn test_server_iam_assume_role_defaults_none() {
-        let source = r#"
-[[users]]
-name = "app"
-database = "tenant"
-server_auth = "rds_iam"
-"#;
-        let users: Users = toml::from_str(source).unwrap();
-        let user = users.users.first().unwrap();
-        assert!(user.server_iam_assume_role.is_none());
-    }
-
-    #[test]
-    fn test_server_iam_assume_role_warns_without_rds_iam_but_parses() {
-        // A misconfiguration (assume-role set but server_auth != rds_iam) is a
-        // warning, not a hard error — check() must not reject it.
-        let mut users = Users {
-            users: vec![User {
-                name: "app".into(),
-                database: "tenant".into(),
-                server_auth: ServerAuth::Password,
-                password: Some("p".into()),
-                server_iam_assume_role: Some("arn:aws:iam::111122223333:role/x".into()),
-                ..Default::default()
-            }],
-            ..Default::default()
-        };
-        users.check(&Config::default());
-    }
-
-    #[test]
     fn test_vault_path_appears_in_passwords_as_vault_static_role() {
         let user = User {
             name: "alice".into(),

--- a/pgdog-config/src/users.rs
+++ b/pgdog-config/src/users.rs
@@ -126,6 +126,13 @@ impl Users {
                 }
             }
 
+            if user.server_iam_assume_role.is_some() && user.server_auth != ServerAuth::RdsIam {
+                warn!(
+                    r#"user "{}" (database "{}") sets "server_iam_assume_role" but "server_auth" is not "rds_iam"; the assume-role will be ignored"#,
+                    user.name, user.database
+                );
+            }
+
             if !user.database.is_empty() && !user.databases.is_empty() {
                 warn!(
                     r#"user "{}" is configured for both "{}" and "{:?}", defaulting to "{:?}""#,
@@ -324,6 +331,11 @@ pub struct User {
     pub server_auth: ServerAuth,
     /// Optional region override for RDS IAM token generation.
     pub server_iam_region: Option<String>,
+    /// IAM role ARN to assume (in the backend database's AWS account) before
+    /// generating the RDS IAM auth token. Enables cross-account RDS IAM: the token
+    /// is signed with the assumed role's credentials instead of PgDog's own
+    /// ambient identity. Only used when `server_auth = "rds_iam"`.
+    pub server_iam_assume_role: Option<String>,
     /// Vault path used to fetch backend (server-side) database credentials,
     /// e.g. `database/creds/my-role` for `server_auth = "vault_dynamic"` or
     /// `database/static-creds/my-role` for `server_auth = "vault_static"`.
@@ -820,6 +832,56 @@ vault_refresh_percent = 60
             Some("database/static-creds/my-role")
         );
         assert_eq!(user.vault_refresh_percent, Some(60));
+    }
+
+    #[test]
+    fn test_server_iam_assume_role_parses() {
+        let source = r#"
+[[users]]
+name = "app"
+database = "tenant"
+server_auth = "rds_iam"
+server_iam_region = "us-west-2"
+server_iam_assume_role = "arn:aws:iam::111122223333:role/pgdog-rds-connect"
+"#;
+        let users: Users = toml::from_str(source).unwrap();
+        let user = users.users.first().unwrap();
+        assert_eq!(user.server_auth, ServerAuth::RdsIam);
+        assert_eq!(
+            user.server_iam_assume_role.as_deref(),
+            Some("arn:aws:iam::111122223333:role/pgdog-rds-connect")
+        );
+    }
+
+    #[test]
+    fn test_server_iam_assume_role_defaults_none() {
+        let source = r#"
+[[users]]
+name = "app"
+database = "tenant"
+server_auth = "rds_iam"
+"#;
+        let users: Users = toml::from_str(source).unwrap();
+        let user = users.users.first().unwrap();
+        assert!(user.server_iam_assume_role.is_none());
+    }
+
+    #[test]
+    fn test_server_iam_assume_role_warns_without_rds_iam_but_parses() {
+        // A misconfiguration (assume-role set but server_auth != rds_iam) is a
+        // warning, not a hard error — check() must not reject it.
+        let mut users = Users {
+            users: vec![User {
+                name: "app".into(),
+                database: "tenant".into(),
+                server_auth: ServerAuth::Password,
+                password: Some("p".into()),
+                server_iam_assume_role: Some("arn:aws:iam::111122223333:role/x".into()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        users.check(&Config::default());
     }
 
     #[test]

--- a/pgdog/src/backend/auth/azure_workload_identity.rs
+++ b/pgdog/src/backend/auth/azure_workload_identity.rs
@@ -60,6 +60,7 @@ mod tests {
             database_number: 0,
             server_auth: ServerAuth::AzureWorkloadIdentity,
             server_iam_region: None,
+            server_iam_assume_role: None,
             vault_path: Default::default(),
             vault_refresh_percent: None,
             configured_role: Role::Auto,

--- a/pgdog/src/backend/auth/rds_iam.rs
+++ b/pgdog/src/backend/auth/rds_iam.rs
@@ -50,22 +50,6 @@ fn resolve_region(addr: &Address) -> Result<String, Error> {
     })
 }
 
-/// Whether `addr` must sign its RDS IAM token with an assumed role (cross-account
-/// RDS IAM), and with what parameters. Returns `None` for the normal same-account
-/// path, where the token is signed with PgDog's ambient identity. Pure so the
-/// account-spanning decision is unit-testable without AWS.
-fn assume_role_plan(addr: &Address, region: &str) -> Option<AssumeRolePlan> {
-    let role_arn = addr.server_iam_assume_role.as_deref()?;
-    if role_arn.is_empty() {
-        return None;
-    }
-    Some(AssumeRolePlan {
-        role_arn: role_arn.to_owned(),
-        region: region.to_owned(),
-        session_name: IAM_ASSUME_ROLE_SESSION_NAME.to_owned(),
-    })
-}
-
 /// Parameters for the STS AssumeRole that precedes token generation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct AssumeRolePlan {
@@ -74,14 +58,32 @@ struct AssumeRolePlan {
     session_name: String,
 }
 
+impl AssumeRolePlan {
+    /// The plan to sign `addr`'s RDS IAM token with an assumed role (cross-account
+    /// RDS IAM), or `None` for the normal same-account path where the token is
+    /// signed with PgDog's ambient identity. Pure so the account-spanning decision
+    /// is unit-testable without AWS.
+    fn new(addr: &Address, region: &str) -> Option<Self> {
+        let role_arn = addr.server_iam_assume_role.as_deref()?;
+        if role_arn.is_empty() {
+            return None;
+        }
+        Some(Self {
+            role_arn: role_arn.to_owned(),
+            region: region.to_owned(),
+            session_name: IAM_ASSUME_ROLE_SESSION_NAME.to_owned(),
+        })
+    }
+}
+
 /// Build the AWS config used to sign the RDS IAM token.
 ///
 /// Same-account: PgDog's ambient identity (`load_defaults`). Cross-account: the
 /// ambient identity is used only as the *source* credentials to assume
 /// `server_iam_assume_role` in the database's account, and the token is signed
 /// with those assumed credentials.
-async fn sign_config(addr: &Address, region: &str) -> SdkConfig {
-    match assume_role_plan(addr, region) {
+async fn build_aws_sdk_config(addr: &Address, region: &str) -> SdkConfig {
+    match AssumeRolePlan::new(addr, region) {
         None => aws_config::load_defaults(BehaviorVersion::latest()).await,
         Some(plan) => {
             let base = aws_config::load_defaults(BehaviorVersion::latest()).await;
@@ -107,7 +109,7 @@ async fn sign_config(addr: &Address, region: &str) -> SdkConfig {
 /// directly — go through [`TokenCache::global`] instead.
 pub(crate) async fn token(addr: Address) -> Result<(String, SystemTime), Error> {
     let region = resolve_region(&addr)?;
-    let sdk_config = sign_config(&addr, &region).await;
+    let sdk_config = build_aws_sdk_config(&addr, &region).await;
 
     let config = AuthTokenConfig::builder()
         .hostname(addr.host.as_str())
@@ -164,20 +166,20 @@ mod tests {
         }
     }
 
-    // ── assume_role_plan (cross-account RDS IAM) ─────────────────────────────
+    // ── AssumeRolePlan::new (cross-account RDS IAM) ──────────────────────────
 
     #[test]
     fn test_assume_role_plan_none_when_unset() {
         // Same-account path: no assume-role, token signed with ambient identity.
         let addr = make_addr();
-        assert_eq!(assume_role_plan(&addr, "us-east-1"), None);
+        assert_eq!(AssumeRolePlan::new(&addr, "us-east-1"), None);
     }
 
     #[test]
     fn test_assume_role_plan_none_when_empty() {
         let mut addr = make_addr();
         addr.server_iam_assume_role = Some(String::new());
-        assert_eq!(assume_role_plan(&addr, "us-east-1"), None);
+        assert_eq!(AssumeRolePlan::new(&addr, "us-east-1"), None);
     }
 
     #[test]
@@ -186,7 +188,7 @@ mod tests {
         addr.server_iam_assume_role =
             Some("arn:aws:iam::111122223333:role/pgdog-rds-connect".into());
 
-        let plan = assume_role_plan(&addr, "us-west-2").expect("cross-account plan");
+        let plan = AssumeRolePlan::new(&addr, "us-west-2").expect("cross-account plan");
         assert_eq!(
             plan.role_arn,
             "arn:aws:iam::111122223333:role/pgdog-rds-connect"

--- a/pgdog/src/backend/auth/rds_iam.rs
+++ b/pgdog/src/backend/auth/rds_iam.rs
@@ -1,9 +1,14 @@
 use std::time::{Duration, SystemTime};
 
-use aws_config::{BehaviorVersion, Region};
+use aws_config::sts::AssumeRoleProvider;
+use aws_config::{BehaviorVersion, Region, SdkConfig};
 use aws_sdk_rds::auth_token::{AuthTokenGenerator, Config as AuthTokenConfig};
 
 use crate::backend::{Error, pool::Address};
+
+/// STS session name used when PgDog assumes a role to mint a cross-account RDS
+/// IAM token.
+const IAM_ASSUME_ROLE_SESSION_NAME: &str = "pgdog-rds-connect";
 
 fn infer_region_from_rds_host(host: &str) -> Option<String> {
     let host = host.to_ascii_lowercase();
@@ -45,6 +50,56 @@ fn resolve_region(addr: &Address) -> Result<String, Error> {
     })
 }
 
+/// Whether `addr` must sign its RDS IAM token with an assumed role (cross-account
+/// RDS IAM), and with what parameters. Returns `None` for the normal same-account
+/// path, where the token is signed with PgDog's ambient identity. Pure so the
+/// account-spanning decision is unit-testable without AWS.
+fn assume_role_plan(addr: &Address, region: &str) -> Option<AssumeRolePlan> {
+    let role_arn = addr.server_iam_assume_role.as_deref()?;
+    if role_arn.is_empty() {
+        return None;
+    }
+    Some(AssumeRolePlan {
+        role_arn: role_arn.to_owned(),
+        region: region.to_owned(),
+        session_name: IAM_ASSUME_ROLE_SESSION_NAME.to_owned(),
+    })
+}
+
+/// Parameters for the STS AssumeRole that precedes token generation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AssumeRolePlan {
+    role_arn: String,
+    region: String,
+    session_name: String,
+}
+
+/// Build the AWS config used to sign the RDS IAM token.
+///
+/// Same-account: PgDog's ambient identity (`load_defaults`). Cross-account: the
+/// ambient identity is used only as the *source* credentials to assume
+/// `server_iam_assume_role` in the database's account, and the token is signed
+/// with those assumed credentials.
+async fn sign_config(addr: &Address, region: &str) -> SdkConfig {
+    match assume_role_plan(addr, region) {
+        None => aws_config::load_defaults(BehaviorVersion::latest()).await,
+        Some(plan) => {
+            let base = aws_config::load_defaults(BehaviorVersion::latest()).await;
+            let provider = AssumeRoleProvider::builder(plan.role_arn)
+                .session_name(plan.session_name)
+                .region(Region::new(plan.region.clone()))
+                .configure(&base)
+                .build()
+                .await;
+            aws_config::defaults(BehaviorVersion::latest())
+                .region(Region::new(plan.region))
+                .credentials_provider(provider)
+                .load()
+                .await
+        }
+    }
+}
+
 /// Fetch a fresh RDS IAM token for `addr`.
 ///
 /// This is the raw fetcher passed to [`TokenCache::get_or_fetch`] and
@@ -52,7 +107,7 @@ fn resolve_region(addr: &Address) -> Result<String, Error> {
 /// directly — go through [`TokenCache::global`] instead.
 pub(crate) async fn token(addr: Address) -> Result<(String, SystemTime), Error> {
     let region = resolve_region(&addr)?;
-    let sdk_config = aws_config::load_defaults(BehaviorVersion::latest()).await;
+    let sdk_config = sign_config(&addr, &region).await;
 
     let config = AuthTokenConfig::builder()
         .hostname(addr.host.as_str())
@@ -101,11 +156,44 @@ mod tests {
             database_number: 0,
             server_auth: ServerAuth::RdsIam,
             server_iam_region: Some("us-east-1".into()),
+            server_iam_assume_role: None,
             vault_path: Default::default(),
             vault_refresh_percent: None,
             configured_role: Role::Auto,
             ..Default::default()
         }
+    }
+
+    // ── assume_role_plan (cross-account RDS IAM) ─────────────────────────────
+
+    #[test]
+    fn test_assume_role_plan_none_when_unset() {
+        // Same-account path: no assume-role, token signed with ambient identity.
+        let addr = make_addr();
+        assert_eq!(assume_role_plan(&addr, "us-east-1"), None);
+    }
+
+    #[test]
+    fn test_assume_role_plan_none_when_empty() {
+        let mut addr = make_addr();
+        addr.server_iam_assume_role = Some(String::new());
+        assert_eq!(assume_role_plan(&addr, "us-east-1"), None);
+    }
+
+    #[test]
+    fn test_assume_role_plan_set() {
+        let mut addr = make_addr();
+        addr.server_iam_assume_role =
+            Some("arn:aws:iam::111122223333:role/pgdog-rds-connect".into());
+
+        let plan = assume_role_plan(&addr, "us-west-2").expect("cross-account plan");
+        assert_eq!(
+            plan.role_arn,
+            "arn:aws:iam::111122223333:role/pgdog-rds-connect"
+        );
+        // Region flows from the resolved token region, not a hard-coded default.
+        assert_eq!(plan.region, "us-west-2");
+        assert_eq!(plan.session_name, IAM_ASSUME_ROLE_SESSION_NAME);
     }
 
     // ── infer_region_from_rds_host ───────────────────────────────────────────

--- a/pgdog/src/backend/auth/vault.rs
+++ b/pgdog/src/backend/auth/vault.rs
@@ -186,6 +186,7 @@ mod tests {
             passwords: vec![],
             server_auth: Default::default(),
             server_iam_region: None,
+            server_iam_assume_role: None,
             vault_path: vault_path.map(Into::into),
             vault_refresh_percent: None,
             database_number: 0,

--- a/pgdog/src/backend/pool/address.rs
+++ b/pgdog/src/backend/pool/address.rs
@@ -32,6 +32,9 @@ pub(crate) struct Address {
     pub(crate) server_auth: ServerAuth,
     /// Optional IAM region override.
     pub(crate) server_iam_region: Option<String>,
+    /// Optional IAM role ARN to assume before minting the RDS IAM token, for
+    /// cross-account RDS IAM.
+    pub(crate) server_iam_assume_role: Option<String>,
     /// Vault path to fetch dynamic credentials from.
     #[serde(default)]
     pub(crate) vault_path: Option<String>,
@@ -99,6 +102,7 @@ impl Address {
             },
             server_auth,
             server_iam_region: user.server_iam_region.clone(),
+            server_iam_assume_role: user.server_iam_assume_role.clone(),
             vault_path: user.server_vault_path.clone(),
             vault_refresh_percent: user.vault_refresh_percent,
             database_number,
@@ -214,6 +218,7 @@ impl Address {
             database_name: "pgdog".into(),
             server_auth: ServerAuth::Password,
             server_iam_region: None,
+            server_iam_assume_role: None,
             vault_path: None,
             vault_refresh_percent: None,
             database_number: 0,
@@ -744,5 +749,32 @@ mod test {
             cache.cached_ip_for_testing(hostname),
             Some(socket_addr.ip())
         );
+    }
+
+    #[test]
+    fn test_address_carries_assume_role_from_user() {
+        let database = Database {
+            name: "db".into(),
+            host: "db.example.com".into(),
+            port: 5432,
+            ..Default::default()
+        };
+        let user = User {
+            name: "app".into(),
+            database: "db".into(),
+            server_auth: ServerAuth::RdsIam,
+            server_iam_assume_role: Some("arn:aws:iam::111122223333:role/pgdog-rds-connect".into()),
+            ..Default::default()
+        };
+
+        let addr = Address::new(&database, &user, 0);
+
+        assert_eq!(addr.server_auth, ServerAuth::RdsIam);
+        assert_eq!(
+            addr.server_iam_assume_role.as_deref(),
+            Some("arn:aws:iam::111122223333:role/pgdog-rds-connect")
+        );
+        // External-identity server auth carries no static password.
+        assert!(addr.passwords.is_empty());
     }
 }


### PR DESCRIPTION
RDS IAM tokens are signed with PgDog's single ambient identity, and RDS IAM auth is evaluated in the database's own AWS account, so a backend in a different account can't be reached today (region can be overridden, but not account).

Add an optional per-user `server_iam_assume_role` (an IAM role ARN). When it is set and `server_auth = "rds_iam"`, PgDog assumes that role via STS and signs the auth token with the assumed credentials instead of the ambient identity.

- new `server_iam_assume_role` field on the user config
- rds_iam::token assumes the role (aws-config AssumeRoleProvider) when set; otherwise the path is unchanged (ambient identity)
- warn when the field is set without `server_auth = "rds_iam"`
- backward compatible: unset = current behavior; TokenCache/monitor refresh are unchanged
- unit tests for config parsing, Address plumbing, and the assume-role decision (pure, no AWS required)