### PR TITLE
fix: schema changed triggers & make callback async 

### DIFF
--- a/pgdog/src/frontend/client/query_engine/discard.rs
+++ b/pgdog/src/frontend/client/query_engine/discard.rs
@@ -32,7 +32,7 @@ impl QueryEngine {
                     self.check_lock();
                     // execute() cleaned up before temp tracking was cleared.
                     // Try again now that the backend is unpinned.
-                    self.cleanup_backend(context)?;
+                    self.cleanup_backend(context).await?;
                 }
                 return Ok(());
             }
@@ -47,7 +47,7 @@ impl QueryEngine {
                 self.backend.unlisten_all();
                 self.reset_session_params(context);
                 self.check_lock();
-                self.cleanup_backend(context)?;
+                self.cleanup_backend(context).await?;
             }
             DiscardTarget::Plans | DiscardTarget::Sequences | DiscardTarget::Temp => {}
         }

--- a/pgdog/src/frontend/client/query_engine/end_transaction.rs
+++ b/pgdog/src/frontend/client/query_engine/end_transaction.rs
@@ -64,7 +64,7 @@ impl QueryEngine {
             self.stats.transaction(true);
 
             // Disconnect from servers.
-            self.cleanup_backend(context)?;
+            self.cleanup_backend(context).await?;
 
             // Tell client we finished the transaction.
             self.end_not_connected(context, true, extended).await?;
@@ -88,7 +88,7 @@ impl QueryEngine {
             self.stats.transaction(true);
 
             // Disconnect from servers.
-            self.cleanup_backend(context)?;
+            self.cleanup_backend(context).await?;
 
             // Tell client we finished the transaction.
             self.end_not_connected(context, false, extended).await?;

--- a/pgdog/src/frontend/client/query_engine/hooks/schema.rs
+++ b/pgdog/src/frontend/client/query_engine/hooks/schema.rs
@@ -2,7 +2,7 @@ use tracing::debug;
 
 use crate::backend::{Error, databases::reload_from_existing};
 
-pub(crate) fn schema_changed() -> Result<(), Error> {
+pub(crate) async fn schema_changed() -> Result<(), Error> {
     debug!("schema change detected, refreshing schema cache");
     reload_from_existing()
 }

--- a/pgdog/src/frontend/client/query_engine/multi_step/update.rs
+++ b/pgdog/src/frontend/client/query_engine/multi_step/update.rs
@@ -100,7 +100,7 @@ impl<'a> UpdateMulti<'a> {
         // Just in case we change how transactions are
         // routed in the future.
         {
-            self.engine.cleanup_backend(context)?;
+            self.engine.cleanup_backend(context).await?;
             return Err(UpdateError::TransactionRequired.into());
         }
 

--- a/pgdog/src/frontend/client/query_engine/query.rs
+++ b/pgdog/src/frontend/client/query_engine/query.rs
@@ -270,7 +270,7 @@ impl QueryEngine {
         self.stats.sent(message.len());
 
         // Do this before flushing, because flushing can take time.
-        self.cleanup_backend(context)?;
+        self.cleanup_backend(context).await?;
 
         // Pipelined requests only return
         // one ReadyForQuery message.
@@ -324,7 +324,7 @@ impl QueryEngine {
         Ok(())
     }
 
-    pub(super) fn cleanup_backend(
+    pub(super) async fn cleanup_backend(
         &mut self,
         context: &mut QueryEngineContext<'_>,
     ) -> Result<(), Error> {
@@ -349,7 +349,7 @@ impl QueryEngine {
                     "schema change detected, reloading config [{}]",
                     self.backend.cluster()?.identifier(),
                 );
-                schema_changed()?;
+                schema_changed().await?;
             }
 
             self.router.reset();

--- a/pgdog/src/frontend/router/parser/query/ddl.rs
+++ b/pgdog/src/frontend/router/parser/query/ddl.rs
@@ -100,6 +100,7 @@ impl QueryParser {
             }
 
             Node::CreateFunctionStmt(stmt) => {
+                schema_changed = true;
                 let table = Table::try_from(stmt.funcname()).ok();
                 if let Some(table) = table {
                     shard = schema
@@ -111,6 +112,7 @@ impl QueryParser {
             }
 
             Node::CreateEnumStmt(stmt) => {
+                schema_changed = true;
                 let table = Table::try_from(stmt.type_name()).ok();
                 if let Some(table) = table {
                     shard = schema
@@ -126,6 +128,7 @@ impl QueryParser {
             }
 
             Node::RenameStmt(stmt) => {
+                schema_changed = true;
                 shard = Self::shard_ddl_table(stmt.relation(), schema)?.unwrap_or(Shard::All);
             }
 

--- a/pgdog/src/frontend/router/parser/query/ddl.rs
+++ b/pgdog/src/frontend/router/parser/query/ddl.rs
@@ -446,7 +446,7 @@ mod test {
             "CREATE FUNCTION shard_0.test_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql",
         );
         assert_eq!(command.route().shard(), &Shard::Direct(0));
-        assert!(!command.route().is_schema_changed());
+        assert!(command.route().is_schema_changed());
     }
 
     #[test]
@@ -455,21 +455,21 @@ mod test {
             "CREATE FUNCTION public.test_func() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql",
         );
         assert_eq!(command.route().shard(), &Shard::All);
-        assert!(!command.route().is_schema_changed());
+        assert!(command.route().is_schema_changed());
     }
 
     #[test]
     fn test_create_enum_sharded() {
         let command = parse_stmt("CREATE TYPE shard_1.mood AS ENUM ('sad', 'ok', 'happy')");
         assert_eq!(command.route().shard(), &Shard::Direct(1));
-        assert!(!command.route().is_schema_changed());
+        assert!(command.route().is_schema_changed());
     }
 
     #[test]
     fn test_create_enum_unsharded() {
         let command = parse_stmt("CREATE TYPE public.mood AS ENUM ('sad', 'ok', 'happy')");
         assert_eq!(command.route().shard(), &Shard::All);
-        assert!(!command.route().is_schema_changed());
+        assert!(command.route().is_schema_changed());
     }
 
     #[test]
@@ -492,14 +492,14 @@ mod test {
     fn test_rename_table_sharded() {
         let command = parse_stmt("ALTER TABLE shard_1.test RENAME TO new_test");
         assert_eq!(command.route().shard(), &Shard::Direct(1));
-        assert!(!command.route().is_schema_changed());
+        assert!(command.route().is_schema_changed());
     }
 
     #[test]
     fn test_rename_table_unsharded() {
         let command = parse_stmt("ALTER TABLE public.test RENAME TO new_test");
         assert_eq!(command.route().shard(), &Shard::All);
-        assert!(!command.route().is_schema_changed());
+        assert!(command.route().is_schema_changed());
     }
 
     #[test]


### PR DESCRIPTION
A few DDL statements didn't trigger schema reloading (incl. `CREATE TYPE`). Also made the callback async.